### PR TITLE
[skip ci] Update README.md, remove notes about internal maven repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,14 @@ $ mvn validate  -Pcheckstyle
 
 **Copyright**
 
-The copyright plugin does not fail the build so you will
-need to look for "Wrong copyright" or "No copyright" messages.
 ```bash
 # Cd to the component you want to check
 $ mvn validate  -Pcopyright
 ```
 
 **Spotbugs**
+
 ```bash
 # Cd to the component you want to check
 $ mvn verify  -Pspotbugs
 ```
-

--- a/docs/src/main/docs/getting-started/03_managing-dependencies.adoc
+++ b/docs/src/main/docs/getting-started/03_managing-dependencies.adoc
@@ -46,11 +46,6 @@ Add the following snippet to your pom.xml file in order to import the Helidon BO
 </dependencyManagement>
 ----
 
-These artifacts are not available in
- https://search.maven.org/[Maven Central] yet, so you need to configure the
- internal Helidon repository, if you haven't already. See
- <<getting-started/01_prerequisites.adoc#maven-repo-configuration, Maven Repository Configuration>>.
-
 == Using Helidon Component Dependencies
 
 Once you have imported the BOM, you can declare dependencies on Helidon components


### PR DESCRIPTION
update copyright check notes - remove the note about the plugin not failing the build, this was fixed by Tomas
remove note about the artifacts not being available in maven central