### PR TITLE
Cloud Functions (Google, Azure, OCI and AWS)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1052,6 +1052,37 @@
                 <artifactId>helidon-microprofile-tests-junit5</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
+            <!-- Cloud -->
+            <dependency>
+                <groupId>io.helidon.microprofile.cloud</groupId>
+                <artifactId>helidon-microprofile-cloud-common</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.cloud</groupId>
+                <artifactId>helidon-microprofile-cloud-google-cloud-http-function</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.cloud</groupId>
+                <artifactId>helidon-microprofile-cloud-google-cloud-background-function</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.cloud</groupId>
+                <artifactId>helidon-microprofile-cloud-azure-functions</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.cloud</groupId>
+                <artifactId>helidon-microprofile-cloud-aws-lambda-request</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.cloud</groupId>
+                <artifactId>helidon-microprofile-cloud-aws-lambda-stream</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
             <!-- Logging -->
             <dependency>
                 <groupId>io.helidon.logging</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -143,6 +143,10 @@
         <version.lib.zipkin.sender-urlconnection>2.12.0</version.lib.zipkin.sender-urlconnection>
         <version.lib.zipkin>2.12.5</version.lib.zipkin>
         <version.lib.zookeeper>3.5.7</version.lib.zookeeper>
+        <version.lib.google-cloud-functions-api>1.0.2</version.lib.google-cloud-functions-api>
+        <version.lib.google-cloud-functions-invoker>1.0.0-beta2</version.lib.google-cloud-functions-invoker>
+        <version.lib.azure-functions>1.4.0</version.lib.azure-functions>
+        <version.lib.aws-lambda-java-core>1.2.1</version.lib.aws-lambda-java-core>
     </properties>
 
     <dependencyManagement>
@@ -1421,7 +1425,27 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
+            <!-- Cloud -->
+            <dependency>
+                <groupId>com.google.cloud.functions</groupId>
+                <artifactId>functions-framework-api</artifactId>
+                <version>${version.lib.google-cloud-functions-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud.functions.invoker</groupId>
+                <artifactId>java-function-invoker</artifactId>
+                <version>${version.lib.google-cloud-functions-invoker}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure.functions</groupId>
+                <artifactId>azure-functions-java-library</artifactId>
+                <version>${version.lib.azure-functions}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-lambda-java-core</artifactId>
+                <version>${version.lib.aws-lambda-java-core}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/docs-internal/microprofile-cloud.md
+++ b/docs-internal/microprofile-cloud.md
@@ -1,0 +1,125 @@
+# Microprofile Cloud Proposal
+
+## Proposal
+
+The API integrates Helidon with the next different Cloud Function providers.
+1. Google Cloud Functions
+2. Microsoft Azure Functions
+3. AWS Lambda Functions
+4. OCI FN
+
+The user needs to identify the function that he wants to deploy in the cloud. Normally this function is specified as a command line argument when the application is deployed.
+
+Function classes are implementations of cloud provider interfaces (note these are not implementations of java.util.Function). These functions are instanced and executed by the cloud, so we need to start Helidon to make sure the user can make use of it.
+
+## Helidon functions
+
+There are the functions that the cloud will instantiate and invoke.
+
+They have to start Helidon and prepare the user function. There is one Helidon function for each type of cloud interface.
+
+## Common
+
+This section is the core of every cloud provider.
+
+### CommonCloudFunction<T>
+
+This is an abstract class that all the other Helidon functions will extend. The purpose of this class is:
+
+1. Start Helidon (Main.main(new String[0])) the first time the function is invoked.
+2. Instance the user function from the annotated @CloudFunction taking care of dependencies. This refers to <T>.
+
+## Google Cloud Functions
+
+It is possible to upload a Maven project and it is required to specify an entry point. The entry point must be one of these:
+ - io.helidon.microprofile.cloud.googlecloudfunctions.http.GoogleCloudHttpFunction
+ - io.helidon.microprofile.cloud.googlecloudfunctions.background.GoogleCloudBackgroundFunction
+
+### GoogleCloudHttpFunction extends CommonCloudFunction<HttpFunction> implements HttpFunction
+
+User function requirements:
+ - Implements com.google.cloud.functions.HttpFunction.
+ - Can be instanced by CDI container.
+ - It is annotated with @CloudFunction
+
+Entry point: io.helidon.microprofile.cloud.googlecloudfunctions.http.GoogleCloudHttpFunction
+
+### GoogleCloudBackgroundFunction<T> extends CommonCloudFunction<BackgroundFunction<T>> implements RawBackgroundFunction
+
+User function requirements:
+ - Implements com.google.cloud.functions.BackgroundFunction.
+ - Can be instanced by CDI container.
+ - It is annotated with @CloudFunction
+
+Entry point: io.helidon.microprofile.cloud.googlecloudfunctions.background.GoogleCloudBackgroundFunction
+
+## Microsoft Azure Functions
+
+Azure works different than Google, AWS and OCI. There is no entry point to specify because Azure will discover Azure annotations.
+
+This is one problem, because we need to initialize Helidon CDI before the request reaches the user code.
+
+### AzureCloudFunction<I, O> extends CommonCloudFunction<AzureEmptyFunction>
+
+The user will need to extend AzureCloudFunction class instead of annotating the function with @CloudFunction.
+
+Then he can declare the Azure function on this extension, but Helidon is not initialized at this point. So he will need to:
+
+1. Invoke the super method handleRequest in the Azure function method.
+2. Implement the abstract method 'abstract O execute(I input, ExecutionContext context)'. Here is where Helidon is initialized.
+
+## AWS Lambda Functions
+
+In AWS an unique jar file needs to be uploaded, containing the function. This is a problem because some resources could be overwritten when the fat jar is created.
+
+The entry point must be one of these:
+ - io.helidon.microprofile.cloud.awslambda.request.AWSLambdaRequestFunction
+ - io.helidon.microprofile.cloud.awslambda.stream.AWSLambdaStreamFunction
+
+### AWSLambdaRequestFunction<I, O> extends CommonCloudFunction<RequestHandler<I, O>> implements RequestHandler<I, O>
+
+User function requirements:
+ - Implements com.amazonaws.services.lambda.runtime.RequestHandler.
+ - Can be instanced by CDI container.
+ - It is annotated with @CloudFunction
+
+Entry point: io.helidon.microprofile.cloud.awslambda.request.AWSLambdaRequestFunction
+
+### AWSLambdaStreamFunction extends CommonCloudFunction<RequestStreamHandler> implements RequestStreamHandler
+
+User function requirements:
+ - Implements com.amazonaws.services.lambda.runtime.RequestStreamHandler.
+ - Can be instanced by CDI container.
+ - It is annotated with @CloudFunction
+
+Entry point: io.helidon.microprofile.cloud.awslambda.stream.AWSLambdaStreamFunction
+
+## OCI FN
+
+OCI is based on FN. The function needs to be specified in a func.yaml.
+
+OCI reads the input and output parameters of the function in runtime, so it is not able to know the type of the generic types.
+
+### OCIFunction<I, O> extends CommonCloudFunction<Function<I, O>> implements Function<I, O>
+
+User function requirements:
+ - Implements java.util.Function.
+ - Can be instanced by CDI container.
+ - It is annotated with @CloudFunction
+
+OCIFunction cannot be specified as entry point because in runtime it is not possible to obtain the types of the input and output.
+
+The user needs to create the entry point by his own, extending OCIFunction and declaring the types.
+
+For example, if the user's function input and output are String, he will need to create the class:
+
+```
+package user.custom.function;
+
+public class StringTypedOCIFunction extends OCIFunction<String, String> {}
+```
+And then specify in the func.yaml:
+
+```
+cmd: user.custom.function.StringTypedOCIFunction::apply
+```

--- a/microprofile/cloud/aws-lambda-request/pom.xml
+++ b/microprofile/cloud/aws-lambda-request/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-microprofile-cloud-project</artifactId>
+        <groupId>io.helidon.microprofile.cloud</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-microprofile-cloud-aws-lambda-request</artifactId>
+    <name>Helidon Microprofile Cloud AWS Lambda Request</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.cloud</groupId>
+            <artifactId>helidon-microprofile-cloud-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/cloud/aws-lambda-request/src/main/java/io/helidon/microprofile/cloud/awslambda/request/AWSLambdaRequestFunction.java
+++ b/microprofile/cloud/aws-lambda-request/src/main/java/io/helidon/microprofile/cloud/awslambda/request/AWSLambdaRequestFunction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.awslambda.request;
+
+import io.helidon.microprofile.cloud.common.CommonCloudFunction;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+/**
+ *
+ * Helidon AWS Lambda Request Function implementation of com.amazonaws.services.lambda.runtime.RequestHandler.
+ * This is the class that should be specified as entry point in AWS
+ *
+ * @param <I> input of the function
+ * @param <O> output of the function
+ */
+public class AWSLambdaRequestFunction<I, O> extends CommonCloudFunction<RequestHandler<I, O>> implements RequestHandler<I, O> {
+
+    @Override
+    public O handleRequest(I input, Context context) {
+        return delegate().handleRequest(input, context);
+    }
+
+}

--- a/microprofile/cloud/aws-lambda-request/src/main/java/io/helidon/microprofile/cloud/awslambda/request/package-info.java
+++ b/microprofile/cloud/aws-lambda-request/src/main/java/io/helidon/microprofile/cloud/awslambda/request/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Package Cloud.
+ */
+package io.helidon.microprofile.cloud.awslambda.request;

--- a/microprofile/cloud/aws-lambda-request/src/main/java/module-info.java
+++ b/microprofile/cloud/aws-lambda-request/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * AWS Lambda Request.
+ */
+module io.helidon.microprofile.cloud.awslambda.request {
+    requires java.logging;
+    requires io.helidon.common;
+    requires io.helidon.microprofile.cloud.common;
+    requires transitive aws.lambda.java.core;
+
+    exports io.helidon.microprofile.cloud.awslambda.request;
+}

--- a/microprofile/cloud/aws-lambda-request/src/test/java/io/helidon/microprofile/cloud/awslambda/request/AWSLambdaRequestFunctionTest.java
+++ b/microprofile/cloud/aws-lambda-request/src/test/java/io/helidon/microprofile/cloud/awslambda/request/AWSLambdaRequestFunctionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.awslambda.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.amazonaws.services.lambda.runtime.Context;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class AWSLambdaRequestFunctionTest {
+
+    @Test
+    public void example() {
+        String input = "This is a test string";
+        int expected = input.length();
+        Context context = Mockito.mock(Context.class);
+        int result = new AWSLambdaRequestFunction<String, Integer>().handleRequest(input, context);
+        assertEquals(expected, result);
+    }
+
+}

--- a/microprofile/cloud/aws-lambda-request/src/test/java/io/helidon/microprofile/cloud/awslambda/request/Example.java
+++ b/microprofile/cloud/aws-lambda-request/src/test/java/io/helidon/microprofile/cloud/awslambda/request/Example.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.awslambda.request;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.helidon.microprofile.cloud.common.CloudFunction;
+
+@CloudFunction("Example")
+@ApplicationScoped
+public class Example implements RequestHandler<String, Integer> {
+
+    @Inject
+    private LengthService lengthService;
+
+    @Override
+    public Integer handleRequest(String input, Context context) {
+        return lengthService.length(input);
+    }
+
+    @ApplicationScoped
+    public static class LengthService {
+
+        public int length(String input) {
+            return input.length();
+        }
+    }
+    
+}

--- a/microprofile/cloud/aws-lambda-request/src/test/java/io/helidon/microprofile/cloud/awslambda/request/OtherFunction.java
+++ b/microprofile/cloud/aws-lambda-request/src/test/java/io/helidon/microprofile/cloud/awslambda/request/OtherFunction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cloud.awslambda.request;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import io.helidon.microprofile.cloud.common.CloudFunction;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@CloudFunction
+@ApplicationScoped
+public class OtherFunction implements RequestHandler<String, Integer> {
+
+    @Override
+    public Integer handleRequest(String input, Context context) {
+        throw new UnsupportedOperationException("This function is not in the microprofile-config.properties");
+    }
+
+}

--- a/microprofile/cloud/aws-lambda-request/src/test/resources/META-INF/beans.xml
+++ b/microprofile/cloud/aws-lambda-request/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/cloud/aws-lambda-request/src/test/resources/META-INF/microprofile-config.properties
+++ b/microprofile/cloud/aws-lambda-request/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+helidon.cloud.function.value=Example
+

--- a/microprofile/cloud/aws-lambda-request/src/test/resources/logging.properties
+++ b/microprofile/cloud/aws-lambda-request/src/test/resources/logging.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#All attributes details
+handlers=io.helidon.common.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+#All log level details
+.level=INFO
+io.helidon.microprofile.cloud.level=FINE
+
+

--- a/microprofile/cloud/aws-lambda-stream/pom.xml
+++ b/microprofile/cloud/aws-lambda-stream/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-microprofile-cloud-project</artifactId>
+        <groupId>io.helidon.microprofile.cloud</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-microprofile-cloud-aws-lambda-stream</artifactId>
+    <name>Helidon Microprofile Cloud AWS Lambda Stream</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.cloud</groupId>
+            <artifactId>helidon-microprofile-cloud-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/cloud/aws-lambda-stream/src/main/java/io/helidon/microprofile/cloud/awslambda/stream/AWSLambdaStreamFunction.java
+++ b/microprofile/cloud/aws-lambda-stream/src/main/java/io/helidon/microprofile/cloud/awslambda/stream/AWSLambdaStreamFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.awslambda.stream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import io.helidon.microprofile.cloud.common.CommonCloudFunction;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+
+/**
+ * Helidon AWS Lambda Stream Function implementation of com.amazonaws.services.lambda.runtime.RequestStreamHandler.
+ * This is the class that should be specified as entry point in AWS
+ *
+ */
+public class AWSLambdaStreamFunction extends CommonCloudFunction<RequestStreamHandler> implements RequestStreamHandler {
+
+    @Override
+    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+        delegate().handleRequest(input, output, context);
+    }
+
+}

--- a/microprofile/cloud/aws-lambda-stream/src/main/java/io/helidon/microprofile/cloud/awslambda/stream/package-info.java
+++ b/microprofile/cloud/aws-lambda-stream/src/main/java/io/helidon/microprofile/cloud/awslambda/stream/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Package Cloud.
+ */
+package io.helidon.microprofile.cloud.awslambda.stream;

--- a/microprofile/cloud/aws-lambda-stream/src/main/java/module-info.java
+++ b/microprofile/cloud/aws-lambda-stream/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * AWS Lambda Stream.
+ */
+module io.helidon.microprofile.cloud.awslambda.stream {
+    requires java.logging;
+    requires io.helidon.common;
+    requires io.helidon.microprofile.cloud.common;
+    requires transitive aws.lambda.java.core;
+
+    exports io.helidon.microprofile.cloud.awslambda.stream;
+}

--- a/microprofile/cloud/aws-lambda-stream/src/test/java/io/helidon/microprofile/cloud/awslambda/stream/AWSLambdaStreamFunctionTest.java
+++ b/microprofile/cloud/aws-lambda-stream/src/test/java/io/helidon/microprofile/cloud/awslambda/stream/AWSLambdaStreamFunctionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.awslambda.stream;
+
+import com.amazonaws.services.lambda.runtime.Context;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class AWSLambdaStreamFunctionTest {
+
+    @Test
+    public void example() throws IOException {
+        InputStream input = Mockito.mock(InputStream.class);
+        OutputStream output = Mockito.mock(OutputStream.class);
+        Context context = Mockito.mock(Context.class);
+        new AWSLambdaStreamFunction().handleRequest(input, output, context);
+        Mockito.verify(input).close();
+    }
+
+}

--- a/microprofile/cloud/aws-lambda-stream/src/test/java/io/helidon/microprofile/cloud/awslambda/stream/Example.java
+++ b/microprofile/cloud/aws-lambda-stream/src/test/java/io/helidon/microprofile/cloud/awslambda/stream/Example.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.awslambda.stream;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.helidon.microprofile.cloud.common.CloudFunction;
+
+@CloudFunction
+@ApplicationScoped
+public class Example implements RequestStreamHandler {
+
+    @Inject
+    private Service service;
+    
+    @Override
+    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+        service.closeInput(input);
+    }
+
+    @ApplicationScoped
+    public static class Service {
+
+        public void closeInput(InputStream input) throws IOException {
+            input.close();
+        }
+    }
+
+}

--- a/microprofile/cloud/aws-lambda-stream/src/test/resources/META-INF/beans.xml
+++ b/microprofile/cloud/aws-lambda-stream/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/cloud/aws-lambda-stream/src/test/resources/logging.properties
+++ b/microprofile/cloud/aws-lambda-stream/src/test/resources/logging.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#All attributes details
+handlers=io.helidon.common.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+#All log level details
+.level=INFO
+io.helidon.microprofile.cloud.level=FINE
+
+

--- a/microprofile/cloud/azure-functions/pom.xml
+++ b/microprofile/cloud/azure-functions/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-microprofile-cloud-project</artifactId>
+        <groupId>io.helidon.microprofile.cloud</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-microprofile-cloud-azure-functions</artifactId>
+    <name>Helidon Microprofile Azure Functions</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.cloud</groupId>
+            <artifactId>helidon-microprofile-cloud-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure.functions</groupId>
+            <artifactId>azure-functions-java-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/cloud/azure-functions/src/main/java/io/helidon/microprofile/cloud/azurefunctions/AzureCloudFunction.java
+++ b/microprofile/cloud/azure-functions/src/main/java/io/helidon/microprofile/cloud/azurefunctions/AzureCloudFunction.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.azurefunctions;
+
+import java.util.logging.Logger;
+
+import javax.enterprise.inject.spi.CDI;
+
+import io.helidon.microprofile.cloud.common.CommonCloudFunction;
+
+import com.microsoft.azure.functions.ExecutionContext;
+
+/**
+ * Every Azure function must extend this class.
+ * In case you need to create more Azure functions you will need to create new classes extending this one.
+ *
+ * @param <I> input of the function
+ * @param <O> output of the function
+ */
+public abstract class AzureCloudFunction<I, O> extends CommonCloudFunction<AzureEmptyFunction> {
+
+    private static final Logger LOGGER = Logger.getLogger(AzureCloudFunction.class.getName());
+
+    /**
+     * This method must be executed inside the Azure function.
+     * It will initialize Helidon and will delegate in {@link #execute(Object, ExecutionContext)}
+     *
+     * @param input the input of the function
+     * @param context context the Azure context
+     * @return the output of the function
+     */
+    protected O handleRequest(I input, ExecutionContext context) {
+        // Initialize Helidon
+        AzureEmptyFunction emptyFunction = delegate();
+        LOGGER.fine(() -> emptyFunction.getClass() + " is ignored");
+        // Get instance of AzureCloudFunction with injections
+        AzureCloudFunction<I, O> injected = CDI.current().select(getClass()).get();
+        return injected.execute(input, context);
+    }
+
+    /**
+     * To be implemented with the user business logic. Every injection in this class
+     * will be accessible inside this method.
+     *
+     * @param input the input of the function
+     * @param context the Azure context
+     * @return the output of the function
+     */
+    protected abstract O execute(I input, ExecutionContext context);
+
+}

--- a/microprofile/cloud/azure-functions/src/main/java/io/helidon/microprofile/cloud/azurefunctions/AzureEmptyFunction.java
+++ b/microprofile/cloud/azure-functions/src/main/java/io/helidon/microprofile/cloud/azurefunctions/AzureEmptyFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cloud.azurefunctions;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.helidon.microprofile.cloud.common.CloudFunction;
+
+/**
+ * Helidon Cloud Functions requires one @CloudFunction to be declared.
+ *
+ * This is an empty class to bypass that restriction.
+ *
+ */
+@CloudFunction("AzureEmptyFunction")
+@ApplicationScoped
+class AzureEmptyFunction {
+
+}

--- a/microprofile/cloud/azure-functions/src/main/java/io/helidon/microprofile/cloud/azurefunctions/package-info.java
+++ b/microprofile/cloud/azure-functions/src/main/java/io/helidon/microprofile/cloud/azurefunctions/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Package Cloud.
+ */
+package io.helidon.microprofile.cloud.azurefunctions;

--- a/microprofile/cloud/azure-functions/src/main/java/module-info.java
+++ b/microprofile/cloud/azure-functions/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Azure Functions.
+ */
+module io.helidon.microprofile.cloud.azurefunctions {
+    requires java.logging;
+    requires io.helidon.common;
+    requires io.helidon.microprofile.cloud.common;
+    requires transitive azure.functions.java.library;
+    requires jakarta.enterprise.cdi.api;
+
+    exports io.helidon.microprofile.cloud.azurefunctions;
+}

--- a/microprofile/cloud/azure-functions/src/main/resources/META-INF/beans.xml
+++ b/microprofile/cloud/azure-functions/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/cloud/azure-functions/src/main/resources/META-INF/microprofile-config.properties
+++ b/microprofile/cloud/azure-functions/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# In Azure this is ignored because there is no user interface
+helidon.cloud.function.value=AzureEmptyFunction
+

--- a/microprofile/cloud/azure-functions/src/test/java/io/helidon/microprofile/cloud/azurefunctions/AzureFunctionTest.java
+++ b/microprofile/cloud/azure-functions/src/test/java/io/helidon/microprofile/cloud/azurefunctions/AzureFunctionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.azurefunctions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpRequestMessage;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class AzureFunctionTest {
+
+    @Test
+    public void sample() {
+        String message = "This is a test";
+        int expected = message.hashCode();
+        HttpRequestMessage<Optional<String>> request = Mockito.mock(HttpRequestMessage.class);
+        ExecutionContext context = Mockito.mock(ExecutionContext.class);
+        Optional<String> optional = Optional.of(message);
+        Mockito.when(request.getBody()).thenReturn(optional);
+        int result = new SampleFunction().execute(request, context);
+        assertEquals(expected, result);
+    }
+
+}

--- a/microprofile/cloud/azure-functions/src/test/java/io/helidon/microprofile/cloud/azurefunctions/SampleFunction.java
+++ b/microprofile/cloud/azure-functions/src/test/java/io/helidon/microprofile/cloud/azurefunctions/SampleFunction.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cloud.azurefunctions;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class SampleFunction extends AzureCloudFunction<String, Integer> {
+
+    @Inject
+    private MyService myService;
+
+    @FunctionName("getHashCode")
+    public Integer execute(@HttpTrigger(name = "req", methods = {HttpMethod.GET,
+            HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+        ExecutionContext context) {
+        return super.handleRequest(request.getBody().get(), context);
+    }
+
+    @Override
+    protected Integer execute(String input, ExecutionContext context) {
+        return myService.hashCode(input);
+    }
+
+    @ApplicationScoped
+    public static class MyService {
+
+        public int hashCode(String str) {
+            return str.hashCode();
+        }
+
+    }
+
+}

--- a/microprofile/cloud/azure-functions/src/test/resources/META-INF/beans.xml
+++ b/microprofile/cloud/azure-functions/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/cloud/azure-functions/src/test/resources/logging.properties
+++ b/microprofile/cloud/azure-functions/src/test/resources/logging.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#All attributes details
+handlers=io.helidon.common.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+#All log level details
+.level=INFO
+io.helidon.microprofile.cloud.level=FINE
+com.google.cloud.level=FINE
+

--- a/microprofile/cloud/common/pom.xml
+++ b/microprofile/cloud/common/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-microprofile-cloud-project</artifactId>
+        <groupId>io.helidon.microprofile.cloud</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-microprofile-cloud-common</artifactId>
+    <name>Helidon Microprofile Cloud Common</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.cdi</groupId>
+            <artifactId>helidon-microprofile-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/CloudFunction.java
+++ b/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/CloudFunction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specify a class that is intended to use as a cloud function.
+ *
+ * A cloud function is a class that implements one of these interfaces:
+ * - com.amazonaws.services.lambda.runtime.RequestHandler
+ * - com.amazonaws.services.lambda.runtime.RequestStreamHandler
+ * - com.google.cloud.functions.BackgroundFunction
+ * - com.google.cloud.functions.HttpFunction
+ *
+ * Only one cloud function will be loaded. If Helidon finds more than one, it will load the function
+ * having the {@link #value()} equals to the property {@link CloudFunctionCdiExtension#CLOUD_FUNCTION}
+ *
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CloudFunction {
+
+    /**
+     * Discriminates this CloudFunction from others. This allows to deploy an application having more than
+     * one classes annotated with @CloudFunction instead of having multiple Maven modules for each one.
+     * @return the value of the CloudFuntion
+     */
+    String value() default "";
+
+}

--- a/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/CloudFunctionCdiExtension.java
+++ b/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/CloudFunctionCdiExtension.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cloud.common;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.WithAnnotations;
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * MicroProfile Cloud Function CDI Extension.
+ */
+public class CloudFunctionCdiExtension implements Extension {
+
+    private static final Logger LOGGER = Logger.getLogger(CloudFunctionCdiExtension.class.getName());
+
+    private static final String CLOUD_FUNCTION = "helidon.cloud.function.value";
+
+    private Map<String, Class<?>> functionClasses = new HashMap<>();
+
+    private void registerCloudFunctionHolder(@Observes AfterBeanDiscovery after, BeanManager manager) {
+        after.addBean().types(CloudFunctionHolder.class)
+        .qualifiers(new AnnotationLiteral<Default>() {}, new AnnotationLiteral<Any>() {})
+        .scope(ApplicationScoped.class).name(CloudFunctionHolder.class.getName()).beanClass(CloudFunctionHolder.class)
+        .createWith(creationalContext -> {
+            Optional<String> configFunction = ConfigProvider.getConfig().getOptionalValue(CLOUD_FUNCTION, String.class);
+            Class<?> functionClass = null;
+            if (configFunction.isPresent()) {
+                LOGGER.fine(() -> CLOUD_FUNCTION + " = " + configFunction.get());
+                functionClass = functionClasses.get(configFunction.get());
+            } else {
+                functionClass = functionClasses.get("");
+            }
+            Object instance = functionClass == null ? null : manager.createInstance().select(functionClass).get();
+            return new CloudFunctionHolder(Optional.ofNullable(instance));
+        });
+    }
+
+    private void registerCloudFunction(@Observes @WithAnnotations(CloudFunction.class) ProcessAnnotatedType<?> patEvent) {
+        Class<?> javaClass = patEvent.getAnnotatedType().getJavaClass();
+        LOGGER.fine(() -> "@CloudFunction found in " + javaClass);
+        functionClasses.put(javaClass.getAnnotation(CloudFunction.class).value(), javaClass);
+    }
+}

--- a/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/CloudFunctionHolder.java
+++ b/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/CloudFunctionHolder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cloud.common;
+
+import java.util.Optional;
+
+/**
+ * This class to holds the cloudFunction instance obtained from {@link CloudFunctionCdiExtension}.
+ *
+ */
+class CloudFunctionHolder {
+
+    // Instance provided by CloudFunctionCdiExtension
+    private final Optional<Object> cloudFunction;
+
+    CloudFunctionHolder(Optional<Object> cloudFunction) {
+        this.cloudFunction = cloudFunction;
+    }
+
+    /**
+     * Returns the cloudFunction provided by {@link CloudFunctionCdiExtension}.
+     * @return the cloud function.
+     */
+    Optional<Object> cloudFunction() {
+        return cloudFunction;
+    }
+
+}

--- a/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/CommonCloudFunction.java
+++ b/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/CommonCloudFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.common;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import javax.enterprise.inject.spi.CDI;
+
+import io.helidon.microprofile.cdi.Main;
+
+/**
+ * Contains common functionality to be extended by every cloud implementations.
+ *
+ * @param <T> the delegate type
+ */
+public abstract class CommonCloudFunction<T> {
+
+    /**
+     * First time is invoked it initializes Helidon and creates a delegated instance.
+     * Next invocations will reuse the same instance.
+     *
+     * @return the implementation of specific cloud interface
+     */
+    @SuppressWarnings("unchecked")
+    protected T delegate() {
+        return (T) LazyHelidonInitializer.DELEGATE;
+    }
+
+    /**
+     * Avoids Helidon is initialized in case CommonCloudFunction is never used.
+     *
+     */
+    private static class LazyHelidonInitializer {
+
+        private static final Logger LOGGER = Logger.getLogger(LazyHelidonInitializer.class.getName());
+        private static final Object DELEGATE;
+
+        static {
+            Main.main(new String[0]);
+            LOGGER.fine(() -> "Helidon is started");
+            Optional<Object> optional = CDI.current().select(CloudFunctionHolder.class).get().cloudFunction();
+            if (optional.isPresent()) {
+                DELEGATE = optional.get();
+            } else {
+                throw new IllegalStateException("No class annotated with @CloudFunction was found");
+            }
+            LOGGER.fine(() -> "Delegate is " + DELEGATE);
+        }
+
+    }
+
+}

--- a/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/package-info.java
+++ b/microprofile/cloud/common/src/main/java/io/helidon/microprofile/cloud/common/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Utilities for Cloud handling.
+ */
+package io.helidon.microprofile.cloud.common;

--- a/microprofile/cloud/common/src/main/java/module-info.java
+++ b/microprofile/cloud/common/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for Cloud.
+ */
+module io.helidon.microprofile.cloud.common {
+    requires java.logging;
+    requires io.helidon.common;
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
+    requires transitive io.helidon.config;
+    requires microprofile.config.api;
+    requires io.helidon.microprofile.cdi;
+    exports io.helidon.microprofile.cloud.common;
+    provides javax.enterprise.inject.spi.Extension with io.helidon.microprofile.cloud.common.CloudFunctionCdiExtension; 
+}

--- a/microprofile/cloud/google-cloud-background-functions/pom.xml
+++ b/microprofile/cloud/google-cloud-background-functions/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-microprofile-cloud-project</artifactId>
+        <groupId>io.helidon.microprofile.cloud</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-microprofile-cloud-google-cloud-background-functions</artifactId>
+    <name>Helidon Microprofile Cloud Google Cloud Background Functions</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.cloud</groupId>
+            <artifactId>helidon-microprofile-cloud-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.functions</groupId>
+            <artifactId>functions-framework-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.jersey</groupId>
+            <artifactId>helidon-jersey-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.functions.invoker</groupId>
+            <artifactId>java-function-invoker</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/cloud/google-cloud-background-functions/src/main/java/io/helidon/microprofile/cloud/googlecloudfunctions/background/GoogleCloudBackgroundFunction.java
+++ b/microprofile/cloud/google-cloud-background-functions/src/main/java/io/helidon/microprofile/cloud/googlecloudfunctions/background/GoogleCloudBackgroundFunction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.googlecloudfunctions.background;
+
+import java.util.logging.Logger;
+
+import io.helidon.microprofile.cloud.common.CommonCloudFunction;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.functions.BackgroundFunction;
+import com.google.cloud.functions.Context;
+import com.google.cloud.functions.RawBackgroundFunction;
+
+/**
+ * Helidon Google Cloud Function implementation of com.google.cloud.functions.RawBackgroundFunction.
+ * This is the class that should be specified as entry point in gcloud
+ *
+ * @param <T> the type of the event
+ */
+public class GoogleCloudBackgroundFunction<T> extends CommonCloudFunction<BackgroundFunction<T>> implements RawBackgroundFunction {
+
+    private static final Logger LOGGER = Logger.getLogger(GoogleCloudBackgroundFunction.class.getName());
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public void accept(String event, Context context) throws Exception {
+        LOGGER.fine(() -> "Event: " + event);
+        T type = MAPPER.readValue(event, new TypeReference<T>(){});
+        delegate().accept(type, context);
+    }
+
+}

--- a/microprofile/cloud/google-cloud-background-functions/src/main/java/io/helidon/microprofile/cloud/googlecloudfunctions/background/package-info.java
+++ b/microprofile/cloud/google-cloud-background-functions/src/main/java/io/helidon/microprofile/cloud/googlecloudfunctions/background/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Google Cloud Functions.
+ */
+package io.helidon.microprofile.cloud.googlecloudfunctions.background;

--- a/microprofile/cloud/google-cloud-background-functions/src/main/java/module-info.java
+++ b/microprofile/cloud/google-cloud-background-functions/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Google Cloud Functions Background.
+ */
+module io.helidon.microprofile.cloud.googlecloudfunctions.background {
+    requires java.logging;
+    requires io.helidon.common;
+    requires transitive functions.framework.api;
+    requires io.helidon.microprofile.cloud.common;
+    requires static com.fasterxml.jackson.databind;
+
+    exports io.helidon.microprofile.cloud.googlecloudfunctions.background;
+}

--- a/microprofile/cloud/google-cloud-background-functions/src/test/java/io/helidon/microprofile/cloud/googlecloudfunctions/background/LocalServerTestSupport.java
+++ b/microprofile/cloud/google-cloud-background-functions/src/test/java/io/helidon/microprofile/cloud/googlecloudfunctions/background/LocalServerTestSupport.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.googlecloudfunctions.background;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.cloud.functions.invoker.runner.Invoker;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class LocalServerTestSupport {
+
+    private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool();
+    private static final String SERVER_READY_STRING = "Started ServerConnector";
+    private static AtomicInteger nextPort = new AtomicInteger(8080);
+
+    private LocalServerTestSupport() {
+    }
+
+    static ServerProcess startServer(Class<?> helidonFunction, String type) throws InterruptedException, IOException {
+
+        // Get the Java class path.
+        String myClassPath = System.getProperty("java.class.path");
+        assertNotNull(myClassPath);
+
+        // Setup the Java Process command line string
+        List<String> command = Arrays.asList(getJavaCommand(), "-classpath", myClassPath, Invoker.class.getName());
+        ProcessBuilder processBuilder = new ProcessBuilder().command(command).redirectErrorStream(true);
+
+        // Set environment variables.
+        Map<String, String> environment = new HashMap<>();
+        environment.put("PORT", String.valueOf(nextPort.getAndIncrement()));
+        environment.put("K_SERVICE", "test-function");
+        environment.put("FUNCTION_SIGNATURE_TYPE", type);
+        environment.put("FUNCTION_TARGET", helidonFunction.getName());
+        processBuilder.environment().putAll(environment);
+
+        // Start the process and monitor the output logs in a separate thread.
+        // Once the SERVER_READY_STRING is found in the logs, we know we are ready.
+        Process serverProcess = processBuilder.start();
+        CountDownLatch ready = new CountDownLatch(1);
+
+        EXECUTOR.submit(() -> monitorOutput(serverProcess.getInputStream(), ready));
+        boolean serverReady = ready.await(5, TimeUnit.SECONDS);
+        if (!serverReady) {
+            serverProcess.destroy();
+            throw new AssertionError("Server never became ready");
+        }
+
+        return new ServerProcess(serverProcess);
+    }
+
+    private static void monitorOutput(InputStream processOutput, CountDownLatch ready) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(processOutput))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(SERVER_READY_STRING)) {
+                    ready.countDown();
+                }
+                System.out.println(line);
+                if (line.contains("WARNING")) {
+                    throw new AssertionError("Found warning in server output:\n" + line);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Returns the path to the java executable.
+     */
+    private static String getJavaCommand() {
+        File javaHome = new File(System.getProperty("java.home"));
+        assertTrue(javaHome.exists());
+        File javaBin = new File(javaHome, "bin");
+        File javaCommand = new File(javaBin, "java");
+        assertTrue(javaCommand.exists());
+        return javaCommand.toString();
+    }
+
+    static class ServerProcess implements AutoCloseable {
+        private final Process process;
+
+        ServerProcess(Process process) {
+            this.process = process;
+        }
+
+        Process process() {
+            return process;
+        }
+
+        @Override
+        public void close() {
+            process().destroy();
+        }
+    }
+}

--- a/microprofile/cloud/google-cloud-background-functions/src/test/java/io/helidon/microprofile/cloud/googlecloudfunctions/background/SampleTest.java
+++ b/microprofile/cloud/google-cloud-background-functions/src/test/java/io/helidon/microprofile/cloud/googlecloudfunctions/background/SampleTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cloud.googlecloudfunctions.background;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+import io.helidon.microprofile.cloud.common.CloudFunction;
+
+import com.google.cloud.functions.BackgroundFunction;
+import com.google.cloud.functions.Context;
+
+import org.glassfish.jersey.logging.LoggingFeature;
+import org.junit.jupiter.api.Test;
+
+@CloudFunction
+@ApplicationScoped
+public class SampleTest implements BackgroundFunction<Map<String, List<String>>> {
+
+    private static final int SOCKET_PORT = 18888;
+    
+    @Inject
+    private MyService myService;
+
+    @Override
+    public void accept(Map<String, List<String>> event, Context context) throws Exception {
+        // Let know the client that the event was received
+        try (Socket client = new Socket()) {
+            client.connect(new InetSocketAddress("localhost", SOCKET_PORT));
+            ObjectOutputStream oos = new ObjectOutputStream(client.getOutputStream());
+            oos.writeObject(myService.first(event));
+            oos.flush();
+        }
+    }
+
+    @Test
+    public void example() throws IOException, InterruptedException {
+        EventConfirmation confirmation = new EventConfirmation();
+        ExecutorService service = Executors.newSingleThreadExecutor();
+        service.submit(confirmation);
+        try (LocalServerTestSupport.ServerProcess process = LocalServerTestSupport
+                .startServer(GoogleCloudBackgroundFunction.class, "event")) {
+            Map<String, Map<String, List<String>>> event = new HashMap<>();
+            Map<String, List<String>> data = new HashMap<>();
+            data.put("0", Arrays.asList("test 0"));
+            data.put("1", Arrays.asList("test 1"));
+            event.put("data", data);
+            Response response = ClientBuilder.newClient().register(LoggingFeature.class)
+                    .target("http://localhost:8080/").request().post(Entity.json(event));
+            assertEquals(200, response.getStatus());
+        }
+        assertEquals("test 0", confirmation.result);
+    }
+
+    @ApplicationScoped
+    public static class MyService {
+
+        public String first(Map<String, List<String>> event) {
+            return event.get("0").get(0);
+        }
+
+    }
+
+    private static class EventConfirmation implements Runnable {
+
+        private volatile String result;
+        
+        @Override
+        public void run() {
+            try(ServerSocket server = new ServerSocket(SOCKET_PORT)) {
+                try (Socket socket = server.accept() ){
+                    ObjectInputStream ois = new ObjectInputStream(socket.getInputStream());
+                    String message = (String) ois.readObject();
+                    result = message;
+                }
+            } catch (IOException | ClassNotFoundException e) {
+                result = e.getMessage();
+            }
+        }
+        
+    }
+
+}

--- a/microprofile/cloud/google-cloud-background-functions/src/test/resources/META-INF/beans.xml
+++ b/microprofile/cloud/google-cloud-background-functions/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/cloud/google-cloud-background-functions/src/test/resources/logging.properties
+++ b/microprofile/cloud/google-cloud-background-functions/src/test/resources/logging.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#All attributes details
+handlers=io.helidon.common.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+#All log level details
+.level=INFO
+io.helidon.microprofile.cloud.level=FINE
+com.google.cloud.level=FINE
+

--- a/microprofile/cloud/google-cloud-http-functions/pom.xml
+++ b/microprofile/cloud/google-cloud-http-functions/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-microprofile-cloud-project</artifactId>
+        <groupId>io.helidon.microprofile.cloud</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-microprofile-cloud-google-cloud-http-functions</artifactId>
+    <name>Helidon Microprofile Cloud Google Cloud HTTP Functions</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.cloud</groupId>
+            <artifactId>helidon-microprofile-cloud-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.functions</groupId>
+            <artifactId>functions-framework-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.jersey</groupId>
+            <artifactId>helidon-jersey-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.functions.invoker</groupId>
+            <artifactId>java-function-invoker</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/cloud/google-cloud-http-functions/src/main/java/io/helidon/microprofile/cloud/googlecloudfunctions/http/GoogleCloudHttpFunction.java
+++ b/microprofile/cloud/google-cloud-http-functions/src/main/java/io/helidon/microprofile/cloud/googlecloudfunctions/http/GoogleCloudHttpFunction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.googlecloudfunctions.http;
+
+import io.helidon.microprofile.cloud.common.CommonCloudFunction;
+
+import com.google.cloud.functions.HttpFunction;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+
+/**
+ * Helidon Google Cloud Function implementation of com.google.cloud.functions.HttpFunction.
+ * This is the class that should be specified as entry point in gcloud
+ *
+ */
+public class GoogleCloudHttpFunction extends CommonCloudFunction<HttpFunction> implements HttpFunction {
+
+    @Override
+    public void service(HttpRequest request, HttpResponse response) throws Exception {
+        delegate().service(request, response);
+    }
+
+}

--- a/microprofile/cloud/google-cloud-http-functions/src/main/java/io/helidon/microprofile/cloud/googlecloudfunctions/http/package-info.java
+++ b/microprofile/cloud/google-cloud-http-functions/src/main/java/io/helidon/microprofile/cloud/googlecloudfunctions/http/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Google Cloud Functions.
+ */
+package io.helidon.microprofile.cloud.googlecloudfunctions.http;

--- a/microprofile/cloud/google-cloud-http-functions/src/main/java/module-info.java
+++ b/microprofile/cloud/google-cloud-http-functions/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Google Cloud Functions HTTP.
+ */
+module io.helidon.microprofile.cloud.googlecloudfunctions.http {
+    requires java.logging;
+    requires io.helidon.common;
+    requires transitive functions.framework.api;
+    requires io.helidon.microprofile.cloud.common;
+
+    exports io.helidon.microprofile.cloud.googlecloudfunctions.http;
+}

--- a/microprofile/cloud/google-cloud-http-functions/src/test/java/io/helidon/microprofile/cloud/googlecloudfunctions/http/LocalServerTestSupport.java
+++ b/microprofile/cloud/google-cloud-http-functions/src/test/java/io/helidon/microprofile/cloud/googlecloudfunctions/http/LocalServerTestSupport.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.googlecloudfunctions.http;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.cloud.functions.invoker.runner.Invoker;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class LocalServerTestSupport {
+
+    private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool();
+    private static final String SERVER_READY_STRING = "Started ServerConnector";
+    private static AtomicInteger nextPort = new AtomicInteger(8080);
+
+    private LocalServerTestSupport() {
+    }
+
+    static ServerProcess startServer(Class<?> helidonFunction, String type) throws InterruptedException, IOException {
+
+        // Get the Java class path.
+        String myClassPath = System.getProperty("java.class.path");
+        assertNotNull(myClassPath);
+
+        // Setup the Java Process command line string
+        List<String> command = Arrays.asList(getJavaCommand(), "-classpath", myClassPath, Invoker.class.getName());
+        ProcessBuilder processBuilder = new ProcessBuilder().command(command).redirectErrorStream(true);
+
+        // Set environment variables.
+        Map<String, String> environment = new HashMap<>();
+        environment.put("PORT", String.valueOf(nextPort.getAndIncrement()));
+        environment.put("K_SERVICE", "test-function");
+        environment.put("FUNCTION_SIGNATURE_TYPE", type);
+        environment.put("FUNCTION_TARGET", helidonFunction.getName());
+        processBuilder.environment().putAll(environment);
+
+        // Start the process and monitor the output logs in a separate thread.
+        // Once the SERVER_READY_STRING is found in the logs, we know we are ready.
+        Process serverProcess = processBuilder.start();
+        CountDownLatch ready = new CountDownLatch(1);
+
+        EXECUTOR.submit(() -> monitorOutput(serverProcess.getInputStream(), ready));
+        boolean serverReady = ready.await(5, TimeUnit.SECONDS);
+        if (!serverReady) {
+            serverProcess.destroy();
+            throw new AssertionError("Server never became ready");
+        }
+
+        return new ServerProcess(serverProcess);
+    }
+
+    private static void monitorOutput(InputStream processOutput, CountDownLatch ready) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(processOutput))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(SERVER_READY_STRING)) {
+                    ready.countDown();
+                }
+                System.out.println(line);
+                if (line.contains("WARNING")) {
+                    throw new AssertionError("Found warning in server output:\n" + line);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Returns the path to the java executable.
+     */
+    private static String getJavaCommand() {
+        File javaHome = new File(System.getProperty("java.home"));
+        assertTrue(javaHome.exists());
+        File javaBin = new File(javaHome, "bin");
+        File javaCommand = new File(javaBin, "java");
+        assertTrue(javaCommand.exists());
+        return javaCommand.toString();
+    }
+
+    static class ServerProcess implements AutoCloseable {
+        private final Process process;
+
+        ServerProcess(Process process) {
+            this.process = process;
+        }
+
+        Process process() {
+            return process;
+        }
+
+        @Override
+        public void close() {
+            process().destroy();
+        }
+    }
+}

--- a/microprofile/cloud/google-cloud-http-functions/src/test/java/io/helidon/microprofile/cloud/googlecloudfunctions/http/SampleTest.java
+++ b/microprofile/cloud/google-cloud-http-functions/src/test/java/io/helidon/microprofile/cloud/googlecloudfunctions/http/SampleTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cloud.googlecloudfunctions.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.cloud.functions.HttpFunction;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+import io.helidon.microprofile.cloud.common.CloudFunction;
+
+import org.junit.jupiter.api.Test;
+
+@CloudFunction
+@ApplicationScoped
+public class SampleTest implements HttpFunction {
+
+    @Inject
+    private MyService myService;
+
+    @Override
+    public void service(HttpRequest request, HttpResponse response) throws Exception {
+        String value = request.getReader().readLine();
+        response.getWriter().write(myService.toUpperCase(value));
+    }
+
+    @Test
+    public void example() throws IOException, InterruptedException {
+        try (LocalServerTestSupport.ServerProcess process = LocalServerTestSupport.startServer(GoogleCloudHttpFunction.class, "http")) {
+            Response response = ClientBuilder.newClient().target("http://localhost:8080/").request().post(Entity.json("test"));
+            assertEquals("TEST", response.readEntity(String.class));
+            assertEquals(200, response.getStatus());
+            response = ClientBuilder.newClient().target("http://localhost:8080/").request().post(Entity.json("test2"));
+            assertEquals("TEST2", response.readEntity(String.class));
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyService {
+
+        public String toUpperCase(String str) {
+            return str.toUpperCase();
+        }
+
+    }
+
+}

--- a/microprofile/cloud/google-cloud-http-functions/src/test/resources/META-INF/beans.xml
+++ b/microprofile/cloud/google-cloud-http-functions/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/cloud/oci-functions/pom.xml
+++ b/microprofile/cloud/oci-functions/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-microprofile-cloud-project</artifactId>
+        <groupId>io.helidon.microprofile.cloud</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-microprofile-cloud-oci-functions</artifactId>
+    <name>Helidon Microprofile Cloud OCI Functions</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.cloud</groupId>
+            <artifactId>helidon-microprofile-cloud-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/cloud/oci-functions/src/main/java/io/helidon/microprofile/cloud/ocifunctions/OCIFunction.java
+++ b/microprofile/cloud/oci-functions/src/main/java/io/helidon/microprofile/cloud/ocifunctions/OCIFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.ocifunctions;
+
+import java.util.function.Function;
+
+import io.helidon.microprofile.cloud.common.CommonCloudFunction;
+
+/**
+ *
+ * Helidon OCI Function.
+ * This is the class that should be specified as entry point in OCI FN
+ *
+ * @param <I> input of the function
+ * @param <O> output of the function
+ */
+public class OCIFunction<I, O> extends CommonCloudFunction<Function<I, O>> implements Function<I, O> {
+
+    @Override
+    public O apply(I i) {
+        return delegate().apply(i);
+    }
+
+}

--- a/microprofile/cloud/oci-functions/src/main/java/io/helidon/microprofile/cloud/ocifunctions/package-info.java
+++ b/microprofile/cloud/oci-functions/src/main/java/io/helidon/microprofile/cloud/ocifunctions/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * OCI Functions.
+ */
+package io.helidon.microprofile.cloud.ocifunctions;

--- a/microprofile/cloud/oci-functions/src/main/java/module-info.java
+++ b/microprofile/cloud/oci-functions/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OCI Functions.
+ */
+module io.helidon.microprofile.cloud.ocifunctions {
+    requires java.logging;
+    requires io.helidon.common;
+    requires io.helidon.microprofile.cloud.common;
+
+    exports io.helidon.microprofile.cloud.ocifunctions;
+}

--- a/microprofile/cloud/oci-functions/src/test/java/io/helidon/microprofile/cloud/ocifunctions/Example.java
+++ b/microprofile/cloud/oci-functions/src/test/java/io/helidon/microprofile/cloud/ocifunctions/Example.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.ocifunctions;
+
+import java.util.function.Function;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.helidon.microprofile.cloud.common.CloudFunction;
+
+@CloudFunction
+@ApplicationScoped
+public class Example implements Function<String, Integer> {
+
+    @Inject
+    private LengthService lengthService;
+
+    @Override
+    public Integer apply(String input) {
+        return lengthService.length(input);
+    }
+
+    @ApplicationScoped
+    public static class LengthService {
+
+        public int length(String input) {
+            return input.length();
+        }
+    }
+
+}

--- a/microprofile/cloud/oci-functions/src/test/java/io/helidon/microprofile/cloud/ocifunctions/OCIFunctionTest.java
+++ b/microprofile/cloud/oci-functions/src/test/java/io/helidon/microprofile/cloud/ocifunctions/OCIFunctionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cloud.ocifunctions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class OCIFunctionTest {
+
+    @Test
+    public void example() {
+        String input = "This is a test string";
+        int expected = input.length();
+        int result = new OCIFunction<String, Integer>().apply(input);
+        assertEquals(expected, result);
+    }
+
+}

--- a/microprofile/cloud/oci-functions/src/test/resources/META-INF/beans.xml
+++ b/microprofile/cloud/oci-functions/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/cloud/pom.xml
+++ b/microprofile/cloud/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-microprofile-project</artifactId>
+        <groupId>io.helidon.microprofile</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <groupId>io.helidon.microprofile.cloud</groupId>
+    <artifactId>helidon-microprofile-cloud-project</artifactId>
+    <name>Helidon Cloud</name>
+
+    <description>
+        Helidon wrapping of Cloud modules.
+    </description>
+
+    <modules>
+        <module>common</module>
+        <module>google-cloud-http-functions</module>
+        <module>google-cloud-background-functions</module>
+        <module>azure-functions</module>
+        <module>aws-lambda-request</module>
+        <module>aws-lambda-stream</module>
+        <module>oci-functions</module>
+    </modules>
+
+</project>

--- a/microprofile/pom.xml
+++ b/microprofile/pom.xml
@@ -53,6 +53,7 @@
         <module>reactive-streams</module>
         <module>messaging</module>
         <module>cors</module>
+		<module>cloud</module>
         <module>graphql</module>
         <module>scheduling</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>
         <version.plugin.wiremock>2.14.0</version.plugin.wiremock>
+        <version.plugin.azure-functions>1.8.0</version.plugin.azure-functions>
 
         <version.helidon-cli>2.2.0</version.helidon-cli>
 


### PR DESCRIPTION
This is a copy of https://github.com/oracle/helidon/pull/2365 but changing the dates to 2021

The maven copyright plugins is not working properly because my changes belong to 2020. After some rebases some files were updated to 2021, but my commit is on top of them with the date 2020. That made the plugin to fail.