### PR TITLE
Remove bad javax.injects exclusion

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -866,10 +866,6 @@
                 <version>${version.lib.weld}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.injects</groupId>
-                        <artifactId>javax.inject</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>org.jboss.spec.javax.transaction</groupId>
                         <artifactId>jboss-transaction-api_1.3_spec</artifactId>
                     </exclusion>


### PR DESCRIPTION
Fix for #3316. This wasn't doing anything and does not appear to be needed as `weld-jta` was not dragging in `javax.inject` anymore.