### PR TITLE
Mappable values

### DIFF
--- a/common/http/pom.xml
+++ b/common/http/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>helidon-common-context</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-mapper</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/http/src/main/java/io/helidon/common/http/FormParamsImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/FormParamsImpl.java
@@ -40,7 +40,7 @@ class FormParamsImpl extends ReadOnlyParameters implements FormParams {
             MediaType.TEXT_PLAIN, preparePattern("\n"));
 
     private FormParamsImpl(Map<String, List<String>> params) {
-        super(params);
+        super("FormParam", params);
     }
 
     FormParamsImpl(FormParams.Builder builder) {

--- a/common/http/src/main/java/io/helidon/common/http/FormParamsImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/FormParamsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/http/src/main/java/io/helidon/common/http/HashParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/HashParameters.java
@@ -39,14 +39,23 @@ public class HashParameters implements Parameters {
     private static final List<String> EMPTY_STRING_LIST = Collections.emptyList();
 
     private final ConcurrentMap<String, List<String>> content;
+    private final String name;
 
     /**
-     * Creates a new instance.
+     * Creates a new named instance.
+     *
+     * @param name name of these parameters
      */
-    protected HashParameters() {
-        this((Parameters) null);
+    protected HashParameters(String name) {
+        this(name, (Parameters) null);
     }
 
+    /**
+     * Creates a new instance with default name.
+     */
+    protected HashParameters() {
+        this("HashParameters");
+    }
     /**
      * Creates a new instance from provided data.
      * Initial data are copied.
@@ -54,6 +63,19 @@ public class HashParameters implements Parameters {
      * @param initialContent initial content.
      */
     protected HashParameters(Map<String, List<String>> initialContent) {
+        this("HashParameters", initialContent);
+    }
+
+    /**
+     * Creates a new instance from provided data.
+     * Initial data are copied.
+     *
+     * @param name name of these parameters
+     * @param initialContent initial content.
+     */
+    protected HashParameters(String name, Map<String, List<String>> initialContent) {
+        this.name = name;
+
         if (initialContent == null) {
             content = new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER);
         } else {
@@ -82,7 +104,18 @@ public class HashParameters implements Parameters {
      * @param initialContent initial content.
      */
     protected HashParameters(Parameters initialContent) {
-        this(initialContent == null ? null : initialContent.toMap());
+        this("HashParameters", initialContent);
+    }
+
+    /**
+     * Creates a new instance from provided data.
+     * Initial data is copied.
+     *
+     * @param name name of these parameters
+     * @param initialContent initial content.
+     */
+    protected HashParameters(String name, Parameters initialContent) {
+        this(name, initialContent == null ? null : initialContent.toMap());
     }
 
     /**
@@ -91,7 +124,17 @@ public class HashParameters implements Parameters {
      * @return a new instance of {@link HashParameters}.
      */
     public static HashParameters create() {
-        return new HashParameters();
+        return create("Parameters");
+    }
+
+    /**
+     * Creates a new named empty instance {@link HashParameters}.
+     *
+     * @param name name of these parameters (such as QueryParam, PathParam, Header)
+     * @return a new named instance of {@link HashParameters}.
+     */
+    public static HashParameters create(String name) {
+        return new HashParameters(name);
     }
 
     /**
@@ -198,6 +241,11 @@ public class HashParameters implements Parameters {
                 return Collections.unmodifiableList(result);
             }
         }
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override

--- a/common/http/src/main/java/io/helidon/common/http/HashParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/HashParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/http/src/main/java/io/helidon/common/http/HttpRequest.java
+++ b/common/http/src/main/java/io/helidon/common/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/http/src/main/java/io/helidon/common/http/HttpRequest.java
+++ b/common/http/src/main/java/io/helidon/common/http/HttpRequest.java
@@ -19,6 +19,8 @@ package io.helidon.common.http;
 import java.net.URI;
 import java.util.List;
 
+import io.helidon.common.mapper.ValueProvider;
+
 /**
  * Common attributes of an HTTP Request, that are used both in server requests and in client requests.
  */
@@ -96,6 +98,24 @@ public interface HttpRequest {
          * @return a parameter value or {@code null} if not exist
          */
         String param(String name);
+
+        /**
+         * Returns value of single parameter resolved from path pattern.
+         *
+         * @param name a parameter name
+         * @return a parameter value provider
+         */
+        default ValueProvider parameter(String name) {
+            String value = param(name);
+
+            String valueName = "PathParam(" + name + ")";
+
+            if (value == null) {
+                return ValueProvider.empty(valueName);
+            } else {
+                return ValueProvider.create(valueName, value);
+            }
+        }
 
         /**
          * Returns path as a list of its segments.

--- a/common/http/src/main/java/io/helidon/common/http/ParameterValueProvider.java
+++ b/common/http/src/main/java/io/helidon/common/http/ParameterValueProvider.java
@@ -32,7 +32,7 @@ class ParameterValueProvider implements ValueProvider {
     ParameterValueProvider(String name, List<String> values) {
         this.name = name;
         this.values = values;
-        this.mapperManager = MapperManager.create();
+        this.mapperManager = MapperManager.shared();
     }
 
     @Override

--- a/common/http/src/main/java/io/helidon/common/http/ParameterValueProvider.java
+++ b/common/http/src/main/java/io/helidon/common/http/ParameterValueProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.http;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.Value;
+import io.helidon.common.mapper.ValueProvider;
+
+class ParameterValueProvider implements ValueProvider {
+    private final String name;
+    private final List<String> values;
+    private final MapperManager mapperManager;
+
+    ParameterValueProvider(String name, List<String> values) {
+        this.name = name;
+        this.values = values;
+        this.mapperManager = MapperManager.create();
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public <T> Value<T> as(Class<T> type) {
+        return Value.create(name, mapperManager.map(values.get(0), String.class, type));
+    }
+
+    @Override
+    public <T> Value<T> as(GenericType<T> genericType) {
+        return Value.create(name, mapperManager.map(values.get(0), STRING_TYPE, genericType));
+    }
+
+    @Override
+    public <T> Value<List<T>> asList(Class<T> elementType) {
+        List<T> result = new LinkedList<>();
+
+        for (String value : values) {
+            result.add(mapperManager.map(value, String.class, elementType));
+        }
+
+        return Value.create(name, result);
+    }
+}

--- a/common/http/src/main/java/io/helidon/common/http/Parameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public interface Parameters {
     List<String> all(String name);
 
     /**
-     * Named query parameter with methods for typed retrieval of value(s).
+     * Named parameter with methods for typed retrieval of value(s).
      *
      * @param name name of the parameter
      * @return value provider with methods for typed accessors

--- a/common/http/src/main/java/io/helidon/common/http/Parameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/Parameters.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
+import io.helidon.common.mapper.ValueProvider;
+
 /**
  * Parameters represents {@code key : value} pairs where {@code key} is a {@code String} with potentially multiple values.
  * <p>
@@ -82,6 +84,29 @@ public interface Parameters {
      * @throws NullPointerException if name is {@code null}
      */
     List<String> all(String name);
+
+    /**
+     * Named query parameter with methods for typed retrieval of value(s).
+     *
+     * @param name name of the parameter
+     * @return value provider with methods for typed accessors
+     */
+    default ValueProvider get(String name) {
+        String valueName = name() + "(" + name + ")";
+
+        if (this.first(name).isEmpty()) {
+            return ValueProvider.empty(name);
+        }
+        return new ParameterValueProvider(valueName, all(name));
+    }
+
+    /**
+     * Name of these parameters.
+     * Used to construct {@link io.helidon.common.mapper.ValueProvider} in method {@link #get(String)}
+     *
+     * @return name
+     */
+    String name();
 
     /**
      * Associates specified values with the specified key (optional operation).

--- a/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
@@ -37,6 +37,7 @@ public class ReadOnlyParameters implements Parameters {
      */
     private static final ReadOnlyParameters EMPTY = new ReadOnlyParameters((Parameters) null);
 
+    private final String name;
     private final Map<String, List<String>> data;
 
     /**
@@ -45,6 +46,17 @@ public class ReadOnlyParameters implements Parameters {
      * @param data multi-map data to copy.
      */
     public ReadOnlyParameters(Map<String, List<String>> data) {
+        this("ReadOnly", data);
+    }
+
+    /**
+     * Creates an instance from provided multi-map.
+     *
+     * @param name name of these parameters
+     * @param data multi-map data to copy.
+     */
+    public ReadOnlyParameters(String name, Map<String, List<String>> data) {
+        this.name = name;
         this.data = copyMultimapAsImutable(data);
     }
 
@@ -55,6 +67,16 @@ public class ReadOnlyParameters implements Parameters {
      */
     public ReadOnlyParameters(Parameters parameters) {
         this(parameters == null ? null : parameters.toMap());
+    }
+
+    /**
+     * Creates an instance from provided multi-map.
+     *
+     * @param name name of these parameters
+     * @param parameters parameters to copy.
+     */
+    public ReadOnlyParameters(String name, Parameters parameters) {
+        this(name, parameters == null ? null : parameters.toMap());
     }
 
     /**
@@ -81,6 +103,11 @@ public class ReadOnlyParameters implements Parameters {
             data.forEach((k, v) -> h.put(k, Collections.unmodifiableList(new ArrayList<>(v))));
             return Collections.unmodifiableMap(h);
         }
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override

--- a/common/http/src/main/java/io/helidon/common/http/UnmodifiableParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/UnmodifiableParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/http/src/main/java/io/helidon/common/http/UnmodifiableParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/UnmodifiableParameters.java
@@ -107,4 +107,8 @@ class UnmodifiableParameters implements Parameters {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public String name() {
+        return parameters.name();
+    }
 }

--- a/common/http/src/main/java/module-info.java
+++ b/common/http/src/main/java/module-info.java
@@ -22,6 +22,7 @@ module io.helidon.common.http {
     requires io.helidon.common;
     requires io.helidon.common.context;
     requires io.helidon.common.reactive;
+    requires io.helidon.common.mapper;
 
     exports io.helidon.common.http;
 }

--- a/common/mapper/pom.xml
+++ b/common/mapper/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>helidon-common-service-loader</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/mapper/src/main/java/io/helidon/common/mapper/BackedValue.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/BackedValue.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+class BackedValue<T> extends EmptyValue<T> {
+    private final T value;
+
+    BackedValue(String name, T value) {
+        super(name);
+        this.value = value;
+    }
+
+    @Override
+    public Optional<T> asOptional() throws MapperException {
+        return Optional.of(value);
+    }
+
+    @Override
+    public <N> Value<N> as(Function<T, N> mapper) {
+        N result = mapper.apply(value);
+        if (result == null) {
+            return new EmptyValue<>(name());
+        }
+        return new BackedValue<>(name(), result);
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/BackedValue.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/BackedValue.java
@@ -16,6 +16,7 @@
 
 package io.helidon.common.mapper;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -39,5 +40,25 @@ class BackedValue<T> extends EmptyValue<T> {
             return new EmptyValue<>(name());
         }
         return new BackedValue<>(name(), result);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BackedValue<?> that = (BackedValue<?>) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), value);
     }
 }

--- a/common/mapper/src/main/java/io/helidon/common/mapper/BackedValueProvider.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/BackedValueProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import io.helidon.common.GenericType;
+
+class BackedValueProvider implements ValueProvider {
+    private final MapperManager mapperManager;
+    private final String name;
+    private final String value;
+
+    BackedValueProvider(MapperManager mapperManager, String name, String value) {
+        this.mapperManager = mapperManager;
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public <T> Value<T> as(Class<T> type) {
+        return Value.create(name, mapperManager.map(value, String.class, type));
+    }
+
+    @Override
+    public <T> Value<T> as(GenericType<T> genericType) {
+        return Value.create(name, mapperManager.map(value, STRING_TYPE, genericType));
+    }
+
+    @Override
+    public <T> Value<List<T>> asList(Class<T> elementType) {
+        if (value.contains(",")) {
+            String[] values = value.split(",");
+            List<T> result = new LinkedList<>();
+            for (String value : values) {
+                T typedValue = mapperManager.map(value, String.class, elementType);
+                result.add(typedValue);
+            }
+            return Value.create(name, result);
+        } else {
+            return Value.create(name, List.of(mapperManager.map(value, String.class, elementType)));
+        }
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/BuiltInMappers.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/BuiltInMappers.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.helidon.common.mapper.spi.MapperProvider;
+
+class BuiltInMappers implements MapperProvider {
+    private static final Map<ClassPair, Mapper<?, ?>> MAPPERS;
+
+    static {
+        Map<ClassPair, Mapper<?, ?>> mappers = new HashMap<>();
+        addStringMapper(mappers, URI.class, BuiltInMappers::asUri);
+        addStringMapper(mappers, Byte.class, BuiltInMappers::asByte);
+
+        MAPPERS = Map.copyOf(mappers);
+    }
+
+    private static <T> void addStringMapper(Map<ClassPair, Mapper<?, ?>> mappers,
+                                            Class<T> targetType,
+                                            Function<String, T> mapperFx) {
+        Mapper<String, T> mapper = mapperFx::apply;
+        mappers.put(new ClassPair(String.class, targetType), mapper);
+    }
+
+    private static Byte asByte(String value) {
+        return Byte.parseByte(value);
+    }
+
+    private static URI asUri(String value) {
+        return URI.create(value);
+    }
+
+    @Override
+    public <SOURCE, TARGET> Optional<Mapper<?, ?>> mapper(Class<SOURCE> sourceClass, Class<TARGET> targetClass) {
+        return Optional.empty();
+    }
+
+    private static final class ClassPair {
+        private final Class<?> source;
+        private final Class<?> target;
+
+        ClassPair(Class<?> source, Class<?> target) {
+            this.source = source;
+            this.target = target;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ClassPair classPair = (ClassPair) o;
+            return source.equals(classPair.source) && target.equals(classPair.target);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(source, target);
+        }
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/BuiltInMappers.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/BuiltInMappers.java
@@ -16,24 +16,99 @@
 
 package io.helidon.common.mapper;
 
+import java.io.File;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
+import io.helidon.common.context.Contexts;
 import io.helidon.common.mapper.spi.MapperProvider;
 
+/*
+ * Built in mapper that are "clean" to use across all components.
+ * This does not contain many of date/time mapping, as that is context sensitive (e.g. you need a different
+ * format depending on the component used).
+ */
 class BuiltInMappers implements MapperProvider {
     private static final Map<ClassPair, Mapper<?, ?>> MAPPERS;
 
     static {
         Map<ClassPair, Mapper<?, ?>> mappers = new HashMap<>();
-        addStringMapper(mappers, URI.class, BuiltInMappers::asUri);
+        // basic types
+        addStringMapper(mappers, Boolean.class, BuiltInMappers::asBoolean);
         addStringMapper(mappers, Byte.class, BuiltInMappers::asByte);
+        addStringMapper(mappers, Short.class, BuiltInMappers::asShort);
+        addStringMapper(mappers, Integer.class, BuiltInMappers::asInt);
+        addStringMapper(mappers, Long.class, BuiltInMappers::asLong);
+        addStringMapper(mappers, Float.class, BuiltInMappers::asFloat);
+        addStringMapper(mappers, Double.class, BuiltInMappers::asDouble);
+        addStringMapper(mappers, Character.class, BuiltInMappers::asChar);
+        addStringMapper(mappers, Class.class, BuiltInMappers::asClass);
+        //javax.math
+        addStringMapper(mappers, BigDecimal.class, BuiltInMappers::asBigDecimal);
+        addStringMapper(mappers, BigInteger.class, BuiltInMappers::asBigInteger);
+        //java.io
+        addStringMapper(mappers, File.class, BuiltInMappers::asFile);
+        //java.nio
+        addStringMapper(mappers, Path.class, BuiltInMappers::asPath);
+        addStringMapper(mappers, Charset.class, BuiltInMappers::asCharset);
+        //java.net
+        addStringMapper(mappers, URI.class, BuiltInMappers::asUri);
+        addStringMapper(mappers, URL.class, BuiltInMappers::asUrl);
+        //java.util
+        addStringMapper(mappers, Pattern.class, BuiltInMappers::asPattern);
+        addStringMapper(mappers, UUID.class, BuiltInMappers::asUUID);
+        //time/date operations
+        addStringMapper(mappers, Duration.class, BuiltInMappers::asDuration);
+        addStringMapper(mappers, Period.class, BuiltInMappers::asPeriod);
+        // time/date formatted operations
+        addStringMapper(mappers, LocalDate.class, );
+        addStringMapper(mappers, LocalDateTime.class, BuiltInMappers::asLocalDateTime);
+        addStringMapper(mappers, LocalTime.class, BuiltInMappers::asLocalTime);
+        addStringMapper(mappers, ZonedDateTime.class, BuiltInMappers::asZonedDateTime);
+        addStringMapper(mappers, ZoneId.class, BuiltInMappers::asZoneId);
+        addStringMapper(mappers, ZoneOffset.class, BuiltInMappers::asZoneOffset);
+        addStringMapper(mappers, Instant.class, BuiltInMappers::asInstant);
+        addStringMapper(mappers, OffsetTime.class, BuiltInMappers::asOffsetTime);
+        addStringMapper(mappers, OffsetDateTime.class, BuiltInMappers::asOffsetDateTime);
+        addStringMapper(mappers, YearMonth.class, BuiltInMappers::asYearMonth);
 
         MAPPERS = Map.copyOf(mappers);
+    }
+
+    private static <T> T parseCalendarType(String stringValue,
+                                           Function<String, T> baseParser,
+                                           BiFunction<String, DateTimeFormatter, T> formattedParser) {
+        return Contexts.context()
+                .flatMap(it -> it.get(Mapper.class.getComponentType() + ".format", String.class))
+                .map(it -> formattedParser.apply(stringValue, DateTimeFormatter.ofPattern(it)))
+                .orElseGet(() -> baseParser.apply(stringValue));
     }
 
     private static <T> void addStringMapper(Map<ClassPair, Mapper<?, ?>> mappers,
@@ -43,16 +118,230 @@ class BuiltInMappers implements MapperProvider {
         mappers.put(new ClassPair(String.class, targetType), mapper);
     }
 
-    private static Byte asByte(String value) {
-        return Byte.parseByte(value);
+    /**
+     * Maps {@code stringValue} to {@code byte}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code byte}
+     */
+    private static Byte asByte(String stringValue) {
+        return Byte.parseByte(stringValue);
     }
 
-    private static URI asUri(String value) {
-        return URI.create(value);
+    /**
+     * Maps {@code stringValue} to {@code short}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code short}
+     */
+    private static Short asShort(String stringValue) {
+        return Short.parseShort(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code int}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code int}
+     */
+    private static Integer asInt(String stringValue) {
+        return Integer.parseInt(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code long}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code long}
+     */
+    private static Long asLong(String stringValue) {
+        return Long.parseLong(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code float}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code float}
+     */
+    private static Float asFloat(String stringValue) {
+        return Float.parseFloat(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code double}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code double}
+     */
+    private static Double asDouble(String stringValue) {
+        return Double.parseDouble(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code boolean}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code boolean}
+     */
+    private static Boolean asBoolean(String stringValue) {
+        final String lower = stringValue.toLowerCase();
+        // according to microprofile config specification (section Built-in Converters)
+        switch (lower) {
+        case "true":
+        case "1":
+        case "yes":
+        case "y":
+        case "on":
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code char}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code char}
+     */
+    private static Character asChar(String stringValue) {
+        if (stringValue.length() != 1) {
+            throw new IllegalArgumentException("Cannot convert to 'char'. The value must be just single character, "
+                                                       + "but was '" + stringValue + "'.");
+        }
+        return stringValue.charAt(0);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code Class<?>}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code Class<?>}
+     */
+    private static Class<?> asClass(String stringValue) {
+        try {
+            return Class.forName(stringValue);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code UUID}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code UUID}
+     */
+    private static UUID asUUID(String stringValue) {
+        return UUID.fromString(stringValue);
+    }
+
+    private static Duration asDuration(String durationString) {
+        return Duration.parse(durationString);
+    }
+
+    private static Period asPeriod(String periodString) {
+        return Period.parse(periodString);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code BigDecimal}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code BigDecimal}
+     */
+    private static BigDecimal asBigDecimal(String stringValue) {
+        return new BigDecimal(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code BigInteger}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code BigInteger}
+     */
+    private static BigInteger asBigInteger(String stringValue) {
+        return new BigInteger(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code File}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code File}
+     */
+    private static File asFile(String stringValue) {
+        return new File(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code Path}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code Path}
+     */
+    private static Path asPath(String stringValue) {
+        return Paths.get(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code Charset}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code Charset}
+     */
+    private static Charset asCharset(String stringValue) {
+        return Charset.forName(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code Pattern}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code Pattern}
+     */
+    private static Pattern asPattern(String stringValue) {
+        return Pattern.compile(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code URI}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code URI}
+     */
+    private static URI asUri(String stringValue) {
+        return URI.create(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code URL}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code URL}
+     */
+    private static URL asUrl(String stringValue) {
+        try {
+            return new URL(stringValue);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    private static String asString(Object object) {
+        return String.valueOf(object);
     }
 
     @Override
     public <SOURCE, TARGET> Optional<Mapper<?, ?>> mapper(Class<SOURCE> sourceClass, Class<TARGET> targetClass) {
+        Mapper<?, ?> mapper = MAPPERS.get(new ClassPair(sourceClass, targetClass));
+        if (mapper != null) {
+            return Optional.of(mapper);
+        }
+        if (targetClass.equals(String.class)) {
+            return Optional.of(BuiltInMappers::asString);
+        }
         return Optional.empty();
     }
 

--- a/common/mapper/src/main/java/io/helidon/common/mapper/EmptyValue.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/EmptyValue.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+class EmptyValue<T> implements Value<T> {
+    private final String name;
+
+    EmptyValue(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Optional<T> asOptional() throws MapperException {
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <N> Value<N> as(Function<T, N> mapper) {
+        return (Value<N>) this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EmptyValue<?> that = (EmptyValue<?>) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/EmptyValueProvider.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/EmptyValueProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.List;
+
+import io.helidon.common.GenericType;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class EmptyValueProvider implements ValueProvider {
+
+    private final Value value;
+
+    EmptyValueProvider(String name) {
+        this.value = Value.empty(name);
+    }
+
+    @Override
+    public String name() {
+        return value.name();
+    }
+
+    @Override
+    public <T> Value<T> as(Class<T> type) {
+        return (Value<T>) value;
+    }
+
+    @Override
+    public <T> Value<T> as(GenericType<T> genericType) {
+        return (Value<T>) value;
+    }
+
+    @Override
+    public <T> Value<List<T>> asList(Class<T> elementType) {
+        return (Value<List<T>>) value;
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/Mapper.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/Mapper.java
@@ -27,6 +27,17 @@ import java.util.function.Function;
 @FunctionalInterface
 public interface Mapper<SOURCE, TARGET> extends Function<SOURCE, TARGET> {
     /**
+     * A mapper that returns the same instance.
+     *
+     * @param <SOURCE> type of source
+     * @param <TARGET> type of target
+     * @return mapper that returns the source without any mapping
+     */
+    static <SOURCE extends TARGET, TARGET> Mapper<SOURCE, TARGET> noop() {
+        return MapperManagerImpl.noopMapper();
+    }
+
+    /**
      * Map an instance of source type to an instance of target type.
      *
      * @param source object to map

--- a/common/mapper/src/main/java/io/helidon/common/mapper/MapperManager.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MapperManager.java
@@ -40,6 +40,14 @@ import io.helidon.common.serviceloader.HelidonServiceLoader;
  */
 public interface MapperManager {
     /**
+     * Classifier for format. A custom format can be used for parsing a formatted type (such as date time types)
+     * if this classifier is configured with {@link io.helidon.common.context.Context#register(Object, Object)}.
+     * The format may be a String (should be supported by any formatted parser), or of the specific type,
+     * such as {@link java.time.format.DateTimeFormatter}, which may be supported by a subset of parsers only.
+     */
+    String FORMAT_CLASSIFIER = MapperManagerImpl.class.getName() + ".format";
+
+    /**
      * Shared instance of a mapper manager.
      * This instance is used by components that do not have access to a specific mapper manager.
      *
@@ -275,7 +283,7 @@ public interface MapperManager {
          * @return updated builder
          */
         public Builder useBuiltIn(boolean useBuiltIn) {
-            this.useBuiltIn = true;
+            this.useBuiltIn = useBuiltIn;
             return this;
         }
 

--- a/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
@@ -29,6 +29,7 @@ import io.helidon.common.mapper.spi.MapperProvider;
  * Implementation of {@link io.helidon.common.mapper.MapperManager}.
  */
 final class MapperManagerImpl implements MapperManager {
+    @SuppressWarnings("rawtypes") private static final Mapper NOOP = o -> o;
     private static final Map<Class<?>, Class<?>> REPLACED_TYPES = new HashMap<>();
 
     static {
@@ -48,6 +49,11 @@ final class MapperManagerImpl implements MapperManager {
 
     MapperManagerImpl(Builder builder) {
         this.providers = builder.mapperProviders();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <SOURCE extends TARGET, TARGET> Mapper<SOURCE, TARGET> noopMapper() {
+        return NOOP;
     }
 
     private static <SOURCE, TARGET> Mapper<SOURCE, TARGET> notFoundMapper(GenericType<SOURCE> sourceType,
@@ -125,7 +131,7 @@ final class MapperManagerImpl implements MapperManager {
                         GenericType<TARGET> targetGenericType = GenericType.create(targetType);
                         if (targetType.isAssignableFrom(sourceType)) {
                             // the same type
-                            return it -> it;
+                            return noopMapper();
                         }
                         if (fromTypes) {
                             return notFoundMapper(sourceGenericType, targetGenericType);

--- a/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
@@ -65,8 +65,8 @@ final class MapperManagerImpl implements MapperManager {
                                                    GenericType<?> targetType,
                                                    Throwable throwable) {
 
-        throw new MapperException(GenericType.create(sourceType),
-                                  GenericType.create(targetType),
+        throw new MapperException(sourceType,
+                                  targetType,
                                   "Failed to map source of class '" + source.getClass().getName() + "'",
                                   throwable);
     }
@@ -81,6 +81,10 @@ final class MapperManagerImpl implements MapperManager {
                     .orElseGet(() -> {
                         GenericType<SOURCE> sourceGenericType = GenericType.create(sourceType);
                         GenericType<TARGET> targetGenericType = GenericType.create(targetType);
+                        if (targetType.isAssignableFrom(sourceType)) {
+                            // the same type
+                            return it -> it;
+                        }
                         if (fromTypes) {
                             return notFoundMapper(sourceGenericType, targetGenericType);
                         }
@@ -101,6 +105,9 @@ final class MapperManagerImpl implements MapperManager {
                         // and then by classes (unless we are already called from findMapper(Class, Class)
                         if (!fromClasses && (sourceType.isClass() && targetType.isClass())) {
                             return findMapper((Class<SOURCE>) sourceType.rawType(), (Class<TARGET>) targetType.rawType(), true);
+                        }
+                        if (sourceType.equals(targetType)) {
+                            return it -> it;
                         }
                         return notFoundMapper(sourceType, targetType);
                     });

--- a/common/mapper/src/main/java/io/helidon/common/mapper/SharedManagerHandler.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/SharedManagerHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+final class SharedManagerHandler {
+    private static final AtomicReference<MapperManager> SHARED = new AtomicReference<>(MapperManager.builder()
+                                                                                               .useBuiltIn(true)
+                                                                                               .build());
+
+    private SharedManagerHandler() {
+    }
+
+    static MapperManager get() {
+        return SHARED.get();
+    }
+
+    static void set(MapperManager manager) {
+        SHARED.set(manager);
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/SharedManagerHandler.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/SharedManagerHandler.java
@@ -16,21 +16,22 @@
 
 package io.helidon.common.mapper;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Objects;
 
 final class SharedManagerHandler {
-    private static final AtomicReference<MapperManager> SHARED = new AtomicReference<>(MapperManager.builder()
-                                                                                               .useBuiltIn(true)
-                                                                                               .build());
+    private static volatile MapperManager sharedInstance = MapperManager.builder()
+            .useBuiltIn(true)
+            .build();
 
     private SharedManagerHandler() {
     }
 
     static MapperManager get() {
-        return SHARED.get();
+        return sharedInstance;
     }
 
     static void set(MapperManager manager) {
-        SHARED.set(manager);
+        Objects.requireNonNull(manager);
+        sharedInstance = manager;
     }
 }

--- a/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * A typed value with support for mapping (conversion) to other types.
+ *
+ * @param <T> type of the value
+ */
+public interface Value<T> {
+    /**
+     * Create an empty value.
+     * Empty value is not backed and all of its methods consider it is empty.
+     *
+     * @param name name of the value
+     * @param <T> type of the value
+     * @return an empty value
+     */
+    static <T> Value<T> empty(String name) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        return new EmptyValue<>(name);
+    }
+
+    /**
+     * Create a value backed by data.
+     *
+     * @param name name of the value
+     * @param value value, must not be null
+     * @param <T> type of the value
+     * @return a value backed by data
+     */
+    static <T> Value<T> create(String name, T value) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        return new BackedValue<>(name, value);
+    }
+
+    /**
+     * Name of this value, to potentially troubleshoot the source of it.
+     *
+     * @return name of this value, such as "QueryParam("param-name")"
+     */
+    String name();
+
+    /**
+     * Typed value as {@link java.util.Optional}.
+     * Returns a {@link java.util.Optional#empty() empty} if this value does not have a backing value present.
+     * As this class implements all methods of {@link java.util.Optional}, this is only a utility method if an actual
+     * {@link java.util.Optional} instance is needed ({@code Optional} itself is {code final}).
+     *
+     * @return value as {@link java.util.Optional}, {@link java.util.Optional#empty() empty} in case the value does not have
+     * a direct value
+     * @throws io.helidon.common.mapper.MapperException in case the value cannot be converted to the expected type
+     * @see #get()
+     */
+    Optional<T> asOptional() throws MapperException;
+
+    /**
+     * Typed value.
+     * Throws {@link java.util.NoSuchElementException} if the direct value is missing.
+     *
+     * @return direct value converted to the expected type
+     * @throws java.util.NoSuchElementException  in case there is no value
+     * @throws io.helidon.common.mapper.MapperException in case the value cannot be converted to the expected type
+     */
+    default T get() throws MapperException, NoSuchElementException {
+        return asOptional()
+                .orElseThrow(() -> new NoSuchElementException(name() + " does not have a value."));
+    }
+
+    /**
+     * Convert this {@code Value} to a different type using a mapper function.
+     *
+     * @param mapper mapper to map the type of this {@code Value} to a type of the returned {@code Value}
+     * @param <N>    type of the returned {@code Value}
+     * @return a new value with the new type
+     */
+    <N> Value<N> as(Function<T, N> mapper);
+
+    // it is a pity that Optional is not an interface :(
+
+    /**
+     * If the underlying {@code Optional} does not have a value, set it to the
+     * {@code Optional} produced by the supplying function.
+     *
+     * @param supplier the supplying function that produces an {@code Optional}
+     * @return returns current value using {@link #asOptional()} if present,
+     *   otherwise value produced by the supplying function.
+     * @throws NullPointerException if the supplying function is {@code null} or
+     *                              produces a {@code null} result
+     */
+    default Optional<T> or(Supplier<? extends Optional<T>> supplier) {
+        return asOptional().or(supplier);
+    }
+
+    /**
+     * Return {@code true} if there is a value present, otherwise {@code false}.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @return {@code true} if there is a value present, otherwise {@code false}
+     * @see java.util.Optional#isPresent()
+     */
+    default boolean isPresent() {
+        return asOptional().isPresent();
+    }
+
+    /**
+     * Return {@code false} if there is a value present, otherwise {@code true}.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @return {@code false} if there is a value present, otherwise {@code true}
+     * @see java.util.Optional#isEmpty() ()
+     */
+    default boolean isEmpty() {
+        return asOptional().isEmpty();
+    }
+
+    /**
+     * If a value is present, performs the given action with the value,
+     * otherwise performs the given empty-based action.
+     *
+     * @param action      the action to be performed, if a value is present
+     * @param emptyAction the empty-based action to be performed, if no value is
+     *                    present
+     * @throws NullPointerException if a value is present and the given action
+     *                              is {@code null}, or no value is present and the given empty-based
+     *                              action is {@code null}.
+     */
+    default void ifPresentOrElse(Consumer<T> action, Runnable emptyAction) {
+        asOptional().ifPresentOrElse(action, emptyAction);
+    }
+
+    /**
+     * If a value is present, invoke the specified consumer with the value,
+     * otherwise do nothing.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param consumer block to be executed if a value is present
+     * @throws NullPointerException if value is present and {@code consumer} is
+     *                              null
+     * @see Optional#ifPresent(Consumer)
+     */
+    default void ifPresent(Consumer<? super T> consumer) {
+        asOptional().ifPresent(consumer);
+    }
+
+    /**
+     * If a value is present, and the value matches the given predicate,
+     * return an {@code Optional} describing the value, otherwise return an
+     * empty {@code Optional}.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param predicate a predicate to apply to the value, if present
+     * @return an {@code Optional} describing the value of this {@code Optional}
+     * if a value is present and the value matches the given predicate,
+     * otherwise an empty {@code Optional}
+     * @throws NullPointerException if the predicate is null
+     * @see Optional#filter(java.util.function.Predicate)
+     */
+    default Optional<T> filter(Predicate<? super T> predicate) {
+        return asOptional().filter(predicate);
+    }
+
+    /**
+     * If a value is present, apply the provided mapping function to it,
+     * and if the result is non-null, return an {@code Optional} describing the
+     * result.  Otherwise return an empty {@code Optional}.
+     *
+     * @param <U>    The type of the result of the mapping function
+     * @param mapper a mapping function to apply to the value, if present
+     * @return an {@code Optional} describing the result of applying a mapping
+     * function to the value of this {@code Optional}, if a value is present,
+     * otherwise an empty {@code Optional}
+     * @throws NullPointerException if the mapping function is null
+     *
+     *                              <p>
+     *                              Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     * @see Optional#map(Function)
+     */
+    default <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
+        return asOptional().map(mapper);
+    }
+
+    /**
+     * If a value is present, apply the provided {@code Optional}-bearing
+     * mapping function to it, return that result, otherwise return an empty
+     * {@code Optional}.  This method is similar to {@link #map(Function)},
+     * but the provided mapper is one whose result is already an {@code Optional},
+     * and if invoked, {@code flatMap} does not wrap it with an additional
+     * {@code Optional}.
+     *
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param <U>    The type parameter to the {@code Optional} returned by
+     * @param mapper a mapping function to apply to the value, if present
+     *               the mapping function
+     * @return the result of applying an {@code Optional}-bearing mapping
+     * function to the value of this {@code Optional}, if a value is present,
+     * otherwise an empty {@code Optional}
+     * @throws NullPointerException if the mapping function is null or returns
+     *                              a null result
+     * @see Optional#flatMap(Function)
+     */
+    default <U> Optional<U> flatMap(Function<? super T, Optional<U>> mapper) {
+        return asOptional().flatMap(mapper);
+    }
+
+    /**
+     * Return the value if present, otherwise return {@code other}.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param other the value to be returned if there is no value present, may
+     *              be null
+     * @return the value, if present, otherwise {@code other}
+     * @see Optional#orElse(Object)
+     */
+    default T orElse(T other) {
+        return asOptional().orElse(other);
+    }
+
+    /**
+     * Return the value if present, otherwise invoke {@code other} and return
+     * the result of that invocation.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param other a {@code Supplier} whose result is returned if no value
+     *              is present
+     * @return the value if present otherwise the result of {@code other.get()}
+     * @throws NullPointerException if value is not present and {@code other} is
+     *                              null
+     * @see Optional#orElseGet(Supplier)
+     */
+    default T orElseGet(Supplier<? extends T> other) {
+        return asOptional().orElseGet(other);
+    }
+
+    /**
+     * Return the contained value, if present, otherwise throw an exception
+     * to be created by the provided supplier.
+     *
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param <X>               Type of the exception to be thrown
+     * @param exceptionSupplier The supplier which will return the exception to
+     *                          be thrown
+     * @return the present value
+     * @throws X                    if there is no value present
+     * @throws NullPointerException if no value is present and
+     *                              {@code exceptionSupplier} is null
+     * @see Optional#orElseThrow(Supplier)
+     */
+    default <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+        return asOptional().orElseThrow(exceptionSupplier);
+    }
+
+    /**
+     * If a value is present, returns a sequential {@link java.util.stream.Stream} containing
+     * only that value, otherwise returns an empty {@code Stream}.
+     *
+     * @return the optional value as a {@code Stream}
+     */
+    default Stream<T> stream() {
+        return asOptional().stream();
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
@@ -229,7 +229,7 @@ public interface Value<T> {
      *                              a null result
      * @see Optional#flatMap(Function)
      */
-    default <U> Optional<U> flatMap(Function<? super T, Optional<U>> mapper) {
+    default <U> Optional<U> flatMap(Function<? super T, Optional<? extends U>> mapper) {
         return asOptional().flatMap(mapper);
     }
 

--- a/common/mapper/src/main/java/io/helidon/common/mapper/ValueProvider.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/ValueProvider.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.List;
+
+import io.helidon.common.GenericType;
+
+/**
+ * A provider of values that can be mapped to other types.
+ */
+public interface ValueProvider {
+    /**
+     * Generic type for {@link java.lang.String}.
+     */
+    GenericType<String> STRING_TYPE = GenericType.create(String.class);
+
+    /**
+     * A value provider with no value.
+     *
+     * @param name name of the value
+     * @return empty value provider
+     */
+    static ValueProvider empty(String name) {
+        return new EmptyValueProvider(name);
+    }
+
+    /**
+     * A value provider with value and default {@link io.helidon.common.mapper.MapperManager}.
+     *
+     * @param name name of the value
+     * @param value value content
+     * @return value provider
+     */
+    static ValueProvider create(String name, String value) {
+        return create(MapperManager.create(), name, value);
+    }
+
+    /**
+     * A value provider with value and explicit mapper manager.
+     *
+     * @param mapperManager mapper manager to use to obtain mappers for types
+     * @param name name of the value
+     * @param value value content
+     * @return value provider
+     */
+    static ValueProvider create(MapperManager mapperManager, String name, String value) {
+        return new BackedValueProvider(mapperManager, name, value);
+    }
+
+    /**
+     * Name of the value, to potentially troubleshoot the source of it.
+     *
+     * @return name of this value, such as "QueryParam("param-name")"
+     */
+    String name();
+
+    /**
+     * Typed value as a {@link io.helidon.common.mapper.Value}.
+     *
+     * @param type type class
+     * @param <T>  type
+     * @return typed value
+     *
+     * @see io.helidon.common.mapper.Value#map(java.util.function.Function)
+     * @see io.helidon.common.mapper.Value#get()
+     * @see io.helidon.common.mapper.Value#orElse(Object)
+     */
+    <T> Value<T> as(Class<T> type);
+
+    /**
+     * Typed value as a {@link Value} for a generic type.
+     * If appropriate mapper exists, returns a properly typed generic instance.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     * Value<Map<String, Integer>> myMapValue = config.as(new GenericType<Map<String, Integer>>(){});
+     * myMapValue.ifPresent(map -> {
+     *      Integer port = map.get("service.port");
+     *  }
+     * }
+     * </pre>
+     *
+     * @param genericType a (usually anonymous) instance of generic type to prevent type erasure
+     * @param <T>         type of the returned value
+     * @return properly typed value
+     */
+    <T> Value<T> as(GenericType<T> genericType);
+
+    // shortcut methods
+
+    /**
+     * Boolean typed value.
+     *
+     * @return typed value
+     */
+    default Value<Boolean> asBoolean() {
+        return as(Boolean.class);
+    }
+
+    /**
+     * String typed value.
+     *
+     * @return typed value
+     */
+    default Value<String> asString() {
+        return as(String.class);
+    }
+
+    /**
+     * Integer typed value.
+     *
+     * @return typed value
+     */
+    default Value<Integer> asInt() {
+        return as(Integer.class);
+    }
+
+    /**
+     * Long typed value.
+     *
+     * @return typed value
+     */
+    default Value<Long> asLong() {
+        return as(Long.class);
+    }
+
+    /**
+     * Double typed value.
+     *
+     * @return typed value
+     */
+    default Value<Double> asDouble() {
+        return as(Double.class);
+    }
+
+    /**
+     * Returns list of specified type.
+     *
+     * @param elementType class of each element in the list
+     * @param <T>  type of list elements
+     * @return a typed list with values
+     * @throws io.helidon.common.mapper.MapperException in case of problem to map to target type
+     */
+    <T> Value<List<T>> asList(Class<T> elementType);
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/ValueProvider.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/ValueProvider.java
@@ -47,7 +47,7 @@ public interface ValueProvider {
      * @return value provider
      */
     static ValueProvider create(String name, String value) {
-        return create(MapperManager.create(), name, value);
+        return create(MapperManager.shared(), name, value);
     }
 
     /**

--- a/common/mapper/src/main/java/module-info.java
+++ b/common/mapper/src/main/java/module-info.java
@@ -21,6 +21,7 @@ module io.helidon.common.mapper {
     requires java.logging;
     requires transitive io.helidon.common;
     requires transitive io.helidon.common.serviceloader;
+    requires io.helidon.common.context;
 
     exports io.helidon.common.mapper;
     exports io.helidon.common.mapper.spi;

--- a/common/mapper/src/test/java/io/helidon/common/mapper/BackedValueTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/BackedValueTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BackedValueTest {
+    @Test
+    void testAsOptionalString() {
+        String name = "name";
+        String stringValue = "value";
+        BackedValue<String> value = new BackedValue<>(name, stringValue);
+
+        assertThat(value.name(), is(name));
+        assertThat(value.asOptional(), is(Optional.of(stringValue)));
+    }
+    @Test
+    void testAsMapperToString() {
+        String name = "name";
+        int intValue = 42;
+        String stringValue = "42";
+        BackedValue<Integer> value = new BackedValue<>(name, intValue);
+
+        Value<String> asString = value.as(String::valueOf);
+        assertThat(asString.name(), is(name));
+        assertThat(asString.get(), is(stringValue));
+    }
+
+    @Test
+    void testAsMapperToNull() {
+        String name = "name";
+        int intValue = 42;
+        BackedValue<Integer> value = new BackedValue<>(name, intValue);
+
+        Value<String> asString = value.as(it -> null);
+        assertThat(asString.name(), is(name));
+        assertThat(asString.asOptional(), is(Optional.empty()));
+    }
+}

--- a/common/mapper/src/test/java/io/helidon/common/mapper/ClassPairTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/ClassPairTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import io.helidon.common.mapper.BuiltInMappers.ClassPair;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+// class pair is used as a key for mapping
+class ClassPairTest {
+    @Test
+    void testSameInstance() {
+        ClassPair first = new ClassPair(TestClass.class, TestClass.class);
+
+        assertThat("Same instance must be equal", first.equals(first), is(true));
+    }
+
+    @Test
+    void testEqual() {
+        ClassPair first = new ClassPair(TestClass.class, TestClass.class);
+        ClassPair second = new ClassPair(TestClass.class, TestClass.class);
+
+        assertThat("Must be equal", first.equals(second), is(true));
+        assertThat("Must be equal", second.equals(first), is(true));
+        assertThat("Same hash code", first.hashCode(), is(second.hashCode()));
+    }
+
+    @Test
+    void testUnEqual() {
+        ClassPair first = new ClassPair(TestClass.class, TestClass.class);
+        ClassPair second = new ClassPair(TestClass.class, ClassPairTest.class);
+
+        assertThat("Must be equal", first.equals(second), is(false));
+        assertThat("Must be equal", second.equals(first), is(false));
+    }
+
+    @Test
+    void testDifferentClassWithSameHash() {
+        ClassPair first = new ClassPair(TestClass.class, TestClass.class);
+        TestClass second = new TestClass(first.hashCode());
+
+        assertThat("Must not be equal", first.equals(second), is(false));
+        assertThat("Must not be equal", second.equals(first), is(false));
+        assertThat("Same hash code", first.hashCode(), is(second.hashCode()));
+    }
+
+    private static class TestClass {
+        private final int hashCode;
+
+        private TestClass(int hashCode) {
+            this.hashCode = hashCode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestClass testClass = (TestClass) o;
+            return hashCode == testClass.hashCode;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.hashCode;
+        }
+    }
+}

--- a/common/mapper/src/test/java/io/helidon/common/mapper/EmptyValueTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/EmptyValueTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class EmptyValueTest {
+    @Test
+    void testAsOptionalString() {
+        String name = "name";
+        EmptyValue<String> value = new EmptyValue<>(name);
+
+        assertThat(value.name(), is(name));
+        assertThat(value.asOptional(), is(Optional.empty()));
+    }
+    @Test
+    void testAsMapperToString() {
+        String name = "name";
+        EmptyValue<String> value = new EmptyValue<>(name);
+
+        Value<String> asString = value.as(String::valueOf);
+        assertThat(asString.name(), is(name));
+        assertThat(asString.asOptional(), is(Optional.empty()));
+    }
+}

--- a/common/mapper/src/test/java/io/helidon/common/mapper/MapperManagerTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/MapperManagerTest.java
@@ -27,14 +27,31 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ServiceLoader;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
 import io.helidon.common.GenericType;
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
 import io.helidon.common.mapper.spi.MapperProvider;
 import io.helidon.common.serviceloader.HelidonServiceLoader;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -45,15 +62,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Unit test for {@link MapperManager}.
  */
 class MapperManagerTest {
-    @Test
-    void testBuiltIns() throws MalformedURLException {
-        MapperManager mm = MapperManager.builder(HelidonServiceLoader.builder(ServiceLoader.load(MapperProvider.class))
-                                                         .useSystemServiceLoader(false)
-                                                         .build())
+    private static MapperManager mm;
+
+    @BeforeAll
+    static void createMapperManager() {
+        mm = MapperManager.builder(HelidonServiceLoader.builder(ServiceLoader.load(MapperProvider.class))
+                                           .useSystemServiceLoader(false)
+                                           .build())
                 .useBuiltIn(true)
                 .build();
+    }
 
-        test(mm,"true", Boolean.class, true);
+    @Test
+    void testBuiltIns() throws MalformedURLException {
+        test(mm, "true", Boolean.class, true);
         test(mm, "true", Boolean.class, true);
         test(mm, "1", Boolean.class, true);
         test(mm, "yes", Boolean.class, true);
@@ -68,6 +90,7 @@ class MapperManagerTest {
         test(mm, "42", Float.class, 42f);
         test(mm, "42", Double.class, 42.0);
         test(mm, "a", Character.class, 'a');
+        test(mm, "a", Character.TYPE, 'a');
         test(mm, MapperManager.class.getName(), Class.class, MapperManager.class);
         test(mm, "42", BigDecimal.class, new BigDecimal("42"));
         test(mm, "42", BigInteger.class, new BigInteger("42"));
@@ -76,21 +99,204 @@ class MapperManagerTest {
         test(mm, "UTF-8", Charset.class, StandardCharsets.UTF_8);
         test(mm, "http://localhost:8080/path", URI.class, URI.create("http://localhost:8080/path"));
         test(mm, "http://localhost:8080/path", URL.class, URI.create("http://localhost:8080/path").toURL());
+        test(mm, "+1000", ZoneOffset.class, ZoneOffset.ofHours(10));
+        test(mm, "Europe/Prague", ZoneId.class, ZoneId.of("Europe/Prague"));
         UUID uuid = UUID.randomUUID();
         test(mm, uuid.toString(), UUID.class, uuid);
         Duration duration = Duration.ofMinutes(79);
         test(mm, duration.toString(), Duration.class, duration);
+        Period period = Period.ofDays(27);
+        test(mm, period.toString(), Period.class, period);
 
         // pattern does not have equals implemented
         String regex = ".*\\d.*?";
         Pattern pattern = mm.map(regex, String.class, Pattern.class);
         assertThat("From String to Pattern", pattern.pattern(), is(regex));
-
     }
 
-    private <T> void test(MapperManager mm, String stringValue, Class<T> type, T expected) {
-        T mappedValue = mm.map(stringValue, String.class, type);
-        assertThat("From String to " + type.getName(), mappedValue, is(expected));
+    @Test
+    void testAssignableTypeWorksWithoutMapper() {
+        String myString = "some string";
+        CharSequence result = mm.map(myString, String.class, CharSequence.class);
+        assertThat(result, is(myString));
+
+        BigInteger bigInt = new BigInteger("1025");
+        Number number = mm.map(bigInt, BigInteger.class, Number.class);
+        assertThat(number, is(bigInt));
+    }
+
+    @Test
+    void testWrongTypes() {
+        assertThrows(MapperException.class, () -> mm.map("two", String.class, Character.class));
+        assertThrows(MapperException.class, () -> mm.map("wrong.class.native", String.class, Class.class));
+        assertThrows(MapperException.class, () -> mm.map("wrong url ", String.class, URL.class));
+    }
+
+    @Test
+    void testDefaultAsString() {
+        int number = 478;
+        String result = mm.map(number, Integer.TYPE, String.class);
+        assertThat(result, is("478"));
+    }
+
+    @Test
+    void testYearMonth() {
+        YearMonth it = mm.map("2010-12", String.class, YearMonth.class);
+        assertYearMonth(it);
+    }
+
+    @Test
+    void testYearMonthPattern() {
+        YearMonth it = withPattern("dd.MM.yyyy",
+                                   () -> mm.map("24.12.2010", String.class, YearMonth.class));
+        assertYearMonth(it);
+    }
+
+    @Test
+    void testYearMonthFormatter() {
+        YearMonth it = withFormatter("dd.MM.yyyy",
+                                     () -> mm.map("24.12.2010", String.class, YearMonth.class));
+        assertYearMonth(it);
+    }
+
+    @Test
+    void testOffsetTime() {
+        OffsetTime it = mm.map("14:28:45+01:00", String.class, OffsetTime.class);
+        assertOffsetTime(it);
+    }
+
+    @Test
+    void testOffsetTimePattern() {
+        OffsetTime it = withPattern("HH.mm.ss.x",
+                                    () -> mm.map("14.28.45.+01", String.class, OffsetTime.class));
+        assertOffsetTime(it);
+    }
+
+    @Test
+    void testOffsetTimeFormatter() {
+        OffsetTime it = withFormatter("HH.mm.ss.x",
+                                      () -> mm.map("14.28.45.+01", String.class, OffsetTime.class));
+        assertOffsetTime(it);
+    }
+
+    @Test
+    void testOffsetDateTime() {
+        OffsetDateTime it = mm.map("2010-12-24T14:28:45+01:00", String.class, OffsetDateTime.class);
+        assertOffsetDateTime(it);
+    }
+
+    @Test
+    void testOffsetDateTimePattern() {
+        OffsetDateTime it = withPattern("dd.MM.yyyy.HH.mm.ss.x",
+                                        () -> mm.map("24.12.2010.14.28.45.+01", String.class, OffsetDateTime.class));
+        assertOffsetDateTime(it);
+    }
+
+    @Test
+    void testOffsetDateTimeFormatter() {
+        OffsetDateTime it = withFormatter("dd.MM.yyyy.HH.mm.ss.x",
+                                          () -> mm.map("24.12.2010.14.28.45.+01", String.class, OffsetDateTime.class));
+        assertOffsetDateTime(it);
+    }
+
+    @Test
+    void testInstant() {
+        Instant it = mm.map("2010-12-24T14:28:45Z", String.class, Instant.class);
+        assertInstant(it);
+    }
+
+    @Test
+    void testInstantPattern() {
+        Instant it = withPattern("dd.MM.yyyy.HH.mm.ss.X",
+                                 () -> mm.map("24.12.2010.14.28.45.Z", String.class, Instant.class));
+        assertInstant(it);
+    }
+
+    @Test
+    void testInstantFormatter() {
+        Instant it = withFormatter("dd.MM.yyyy.HH.mm.ss.X",
+                                   () -> mm.map("24.12.2010.14.28.45.Z", String.class, Instant.class));
+        assertInstant(it);
+    }
+
+    @Test
+    void testZonedDateTime() {
+        ZonedDateTime it = mm.map("2010-12-24T14:28:45+01:00[Europe/Prague]", String.class, ZonedDateTime.class);
+        assertZonedDateTime(it);
+    }
+
+    @Test
+    void testZonedDateTimePattern() {
+        ZonedDateTime it = withPattern("dd.MM.yyyy.HH.mm.ss.x.VV",
+                                       () -> mm.map("24.12.2010.14.28.45.+01.Europe/Prague", String.class, ZonedDateTime.class));
+        assertZonedDateTime(it);
+    }
+
+    @Test
+    void testZonedDateTimeFormatter() {
+        ZonedDateTime it = withFormatter("dd.MM.yyyy.HH.mm.ss.x.VV",
+                                         () -> mm.map("24.12.2010.14.28.45.+01.Europe/Prague",
+                                                      String.class,
+                                                      ZonedDateTime.class));
+        assertZonedDateTime(it);
+    }
+
+    @Test
+    void testLocalTime() {
+        LocalTime it = mm.map("14:28:45", String.class, LocalTime.class);
+        assertLocalTime(it);
+    }
+
+    @Test
+    void testLocalTimePattern() {
+        LocalTime it = withPattern("HH.mm.ss",
+                                   () -> mm.map("14.28.45", String.class, LocalTime.class));
+        assertLocalTime(it);
+    }
+
+    @Test
+    void testLocalTimeFormatter() {
+        LocalTime it = withFormatter("HH.mm.ss",
+                                     () -> mm.map("14.28.45", String.class, LocalTime.class));
+        assertLocalTime(it);
+    }
+
+    @Test
+    void testLocalDateTime() {
+        LocalDateTime it = mm.map("2010-12-24T14:28:45", String.class, LocalDateTime.class);
+        assertLocalDateTime(it);
+    }
+
+    @Test
+    void testLocalDateTimePattern() {
+        LocalDateTime it = withPattern("dd.MM.yyyy.HH.mm.ss",
+                                       () -> mm.map("24.12.2010.14.28.45", String.class, LocalDateTime.class));
+        assertLocalDateTime(it);
+    }
+
+    @Test
+    void testLocalDateTimeFormatter() {
+        LocalDateTime it = withFormatter("dd.MM.yyyy.HH.mm.ss",
+                                         () -> mm.map("24.12.2010.14.28.45", String.class, LocalDateTime.class));
+        assertLocalDateTime(it);
+    }
+
+    @Test
+    void testLocalDate() {
+        LocalDate it = mm.map("2010-12-24", String.class, LocalDate.class);
+        assertLocalDate(it);
+    }
+
+    @Test
+    void testLocalDatePattern() {
+        LocalDate it = withPattern("dd.MM.yyyy", () -> mm.map("24.12.2010", String.class, LocalDate.class));
+        assertLocalDate(it);
+    }
+
+    @Test
+    void testLocalDateFormatter() {
+        LocalDate it = withFormatter("dd.MM.yyyy", () -> mm.map("24.12.2010", String.class, LocalDate.class));
+        assertLocalDate(it);
     }
 
     @Test
@@ -193,6 +399,87 @@ class MapperManagerTest {
         assertThat(stringResult, is("42"));
         stringResult = mm.map((short) 42, ServiceLoaderMapper2.SHORT_TYPE, ServiceLoaderMapper2.STRING_TYPE);
         assertThat(stringResult, is("42"));
+    }
+
+    private void assertYearMonth(YearMonth it) {
+        assertThat("Month", it.getMonth(), is(Month.DECEMBER));
+        assertThat("Year", it.getYear(), is(2010));
+    }
+
+    private void assertOffsetTime(OffsetTime it) {
+        assertThat("Seconds", it.getSecond(), is(45));
+        assertThat("Minutes", it.getMinute(), is(28));
+        assertThat("Hours", it.getHour(), is(14));
+        assertThat("Offset", it.getOffset(), is(ZoneOffset.ofHours(1)));
+    }
+
+    private void assertOffsetDateTime(OffsetDateTime it) {
+        assertThat("Seconds", it.getSecond(), is(45));
+        assertThat("Minutes", it.getMinute(), is(28));
+        assertThat("Hours", it.getHour(), is(14));
+        assertThat("Day of month", it.getDayOfMonth(), is(24));
+        assertThat("Month", it.getMonth(), is(Month.DECEMBER));
+        assertThat("Year", it.getYear(), is(2010));
+        assertThat("Offset", it.getOffset(), is(ZoneOffset.ofHours(1)));
+    }
+
+    private void assertInstant(Instant instant) {
+        OffsetDateTime it = instant.atOffset(ZoneOffset.UTC);
+        assertThat("Seconds", it.getSecond(), is(45));
+        assertThat("Minutes", it.getMinute(), is(28));
+        assertThat("Hours", it.getHour(), is(14));
+        assertThat("Day of month", it.getDayOfMonth(), is(24));
+        assertThat("Month", it.getMonth(), is(Month.DECEMBER));
+        assertThat("Year", it.getYear(), is(2010));
+    }
+
+    private void assertZonedDateTime(ZonedDateTime it) {
+        assertThat("Seconds", it.getSecond(), is(45));
+        assertThat("Minutes", it.getMinute(), is(28));
+        assertThat("Hours", it.getHour(), is(14));
+        assertThat("Day of month", it.getDayOfMonth(), is(24));
+        assertThat("Month", it.getMonth(), is(Month.DECEMBER));
+        assertThat("Year", it.getYear(), is(2010));
+        assertThat("Offset", it.getOffset(), is(ZoneOffset.ofHours(1)));
+        assertThat("ZoneId", it.getZone(), is(ZoneId.of("Europe/Prague")));
+    }
+
+    private void assertLocalDate(LocalDate it) {
+        assertThat("Day of month", it.getDayOfMonth(), is(24));
+        assertThat("Month", it.getMonth(), is(Month.DECEMBER));
+        assertThat("Year", it.getYear(), is(2010));
+    }
+
+    private void assertLocalDateTime(LocalDateTime it) {
+        assertThat("Seconds", it.getSecond(), is(45));
+        assertThat("Minutes", it.getMinute(), is(28));
+        assertThat("Hours", it.getHour(), is(14));
+        assertThat("Day of month", it.getDayOfMonth(), is(24));
+        assertThat("Month", it.getMonth(), is(Month.DECEMBER));
+        assertThat("Year", it.getYear(), is(2010));
+    }
+
+    private void assertLocalTime(LocalTime it) {
+        assertThat("Seconds", it.getSecond(), is(45));
+        assertThat("Minutes", it.getMinute(), is(28));
+        assertThat("Hours", it.getHour(), is(14));
+    }
+
+    private <T> T withPattern(String format, Callable<T> callable) {
+        Context context = Context.create();
+        context.register(MapperManager.FORMAT_CLASSIFIER, format);
+        return Contexts.runInContext(context, callable);
+    }
+
+    private <T> T withFormatter(String format, Callable<T> callable) {
+        Context context = Context.create();
+        context.register(MapperManager.FORMAT_CLASSIFIER, DateTimeFormatter.ofPattern(format));
+        return Contexts.runInContext(context, callable);
+    }
+
+    private <T> void test(MapperManager mm, String stringValue, Class<T> type, T expected) {
+        T mappedValue = mm.map(stringValue, String.class, type);
+        assertThat("From String to " + type.getName(), mappedValue, is(expected));
     }
 
     private static final class NotMappedType {

--- a/common/mapper/src/test/java/io/helidon/common/mapper/ValueProviderTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/ValueProviderTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.helidon.common.GenericType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ValueProviderTest {
+    @Test
+    void testEmpty() {
+        String name = "QueryParam(query)";
+        Value<Object> empty = Value.empty(name);
+
+        ValueProvider provider = ValueProvider.empty(name);
+
+        assertThat(provider.name(), is(name));
+        assertThat(provider.asBoolean(), is(empty));
+        assertThat(provider.asDouble(), is(empty));
+        assertThat(provider.asInt(), is(empty));
+        assertThat(provider.asLong(), is(empty));
+        assertThat(provider.asString(), is(empty));
+        assertThat(provider.asList(String.class), is(empty));
+        assertThat(provider.as(String.class), is(empty));
+        assertThat(provider.as(ValueProvider.STRING_TYPE), is(empty));
+    }
+
+    @Test
+    void testValue() {
+        GenericType<List<MyType>> myListType = new GenericType<>() { };
+        MapperManager manager = MapperManager.builder()
+                .addMapper(Boolean::parseBoolean, String.class, Boolean.class)
+                .addMapper(Double::parseDouble, String.class, Double.class)
+                .addMapper(Integer::parseInt, String.class, Integer.class)
+                .addMapper(Long::parseLong, String.class, Long.class)
+                .addMapper(MyType::new, String.class, MyType.class)
+                .addMapper(string -> List.of(new MyType(string)), ValueProvider.STRING_TYPE, myListType)
+                .build();
+
+        String name = "Answer";
+        String value = "42";
+        MyType myTypeValue = new MyType("42");
+        ValueProvider provider = ValueProvider.create(manager, name, value);
+
+        assertThat(provider.name(), is(name));
+        assertThat(provider.asBoolean().get(), is(false));
+        assertThat(provider.asDouble().get(), is(42.0));
+        assertThat(provider.asInt().get(), is(42));
+        assertThat(provider.asLong().get(), is(42L));
+        assertThat(provider.asString().get(), is(value));
+        assertThat(provider.asList(String.class).get(), is(List.of(value)));
+        assertThat(provider.as(String.class).get(), is(value));
+        assertThat(provider.as(ValueProvider.STRING_TYPE).get(), is(value));
+        assertThat(provider.as(MyType.class).get(), is(myTypeValue));
+        assertThat(provider.as(myListType).get(), is(List.of(myTypeValue)));
+        assertThat(provider.as(CharSequence.class).get(), is(value));
+    }
+
+    @Test
+    void testList() {
+        GenericType<List<MyType>> myListType = new GenericType<>() { };
+        MapperManager manager = MapperManager.builder()
+                .addMapper(Boolean::parseBoolean, String.class, Boolean.class)
+                .addMapper(Double::parseDouble, String.class, Double.class)
+                .addMapper(Integer::parseInt, String.class, Integer.class)
+                .addMapper(Long::parseLong, String.class, Long.class)
+                .addMapper(MyType::new, String.class, MyType.class)
+                .addMapper(string -> List.of(new MyType(string)), ValueProvider.STRING_TYPE, myListType)
+                .build();
+
+        String name = "Answer";
+        String value = "42,42,41,43";
+        ValueProvider provider = ValueProvider.create(manager, name, value);
+
+        assertThat(provider.name(), is(name));
+        assertThat(provider.asBoolean().get(), is(false));
+        assertThrows(MapperException.class, () -> provider.asDouble().get());
+        assertThrows(MapperException.class, () -> provider.asInt().get());
+        assertThrows(MapperException.class, () -> provider.asLong().get());
+        assertThat(provider.asString().get(), is(value));
+        assertThat(provider.asList(String.class).get(), hasItems("42", "42", "41", "43"));
+        assertThat(provider.as(String.class).get(), is(value));
+        assertThat(provider.as(ValueProvider.STRING_TYPE).get(), is(value));
+        assertThat(provider.as(MyType.class).get(), is(new MyType(value)));
+        assertThat(provider.as(myListType).get(), hasItems(new MyType(value)));
+        assertThat(provider.as(CharSequence.class).get(), is(value));
+    }
+
+    static final class MyType {
+        private final String message;
+
+        MyType(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MyType myType = (MyType) o;
+            return message.equals(myType.message);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(message);
+        }
+
+        @Override
+        public String toString() {
+            return message;
+        }
+    }
+}

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import io.helidon.common.GenericType;
+import io.helidon.common.mapper.ValueProvider;
 import io.helidon.config.spi.ConfigFilter;
 import io.helidon.config.spi.ConfigMapper;
 import io.helidon.config.spi.ConfigMapperProvider;
@@ -238,7 +239,7 @@ import io.helidon.config.spi.OverrideSource;
  * config system merges these together so that values from config sources with higher priority have
  * precedence over values from config sources with lower priority.
  */
-public interface Config {
+public interface Config extends ValueProvider {
     /**
      * Returns empty instance of {@code Config}.
      *
@@ -680,6 +681,7 @@ public interface Config {
      * @param <T>         type of the returned value
      * @return properly typed config value
      */
+    @Override
     <T> ConfigValue<T> as(GenericType<T> genericType);
 
     /**
@@ -693,6 +695,7 @@ public interface Config {
      * @see ConfigValue#get()
      * @see ConfigValue#orElse(Object)
      */
+    @Override
     <T> ConfigValue<T> as(Class<T> type);
 
     /**
@@ -713,6 +716,7 @@ public interface Config {
      *
      * @return typed value
      */
+    @Override
     default ConfigValue<Boolean> asBoolean() {
         return as(Boolean.class);
     }
@@ -722,6 +726,7 @@ public interface Config {
      *
      * @return typed value
      */
+    @Override
     default ConfigValue<String> asString() {
         return as(String.class);
     }
@@ -731,6 +736,7 @@ public interface Config {
      *
      * @return typed value
      */
+    @Override
     default ConfigValue<Integer> asInt() {
         return as(Integer.class);
     }
@@ -740,6 +746,7 @@ public interface Config {
      *
      * @return typed value
      */
+    @Override
     default ConfigValue<Long> asLong() {
         return as(Long.class);
     }
@@ -749,6 +756,7 @@ public interface Config {
      *
      * @return typed value
      */
+    @Override
     default ConfigValue<Double> asDouble() {
         return as(Double.class);
     }
@@ -761,6 +769,7 @@ public interface Config {
      * @return a typed list with values
      * @throws ConfigMappingException in case of problem to map property value.
      */
+    @Override
     <T> ConfigValue<List<T>> asList(Class<T> type) throws ConfigMappingException;
 
     /**

--- a/config/config/src/main/java/io/helidon/config/ConfigValue.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/config/src/main/java/module-info.java
+++ b/config/config/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module io.helidon.config {
     requires transitive io.helidon.common.media.type;
 
     requires io.helidon.common.serviceloader;
+    requires io.helidon.common.mapper;
 
     exports io.helidon.config;
     exports io.helidon.config.spi;

--- a/docs-internal/generic-mapping-2.md
+++ b/docs-internal/generic-mapping-2.md
@@ -1,0 +1,28 @@
+# Generic Mapping Proposal (Continued)
+
+Provide an API to map an arbitrary Java type to another arbitrary Java type and use it in Helidon.
+
+## Proposal
+
+New API classes and behavior:
+
+- `ValueProvider` - a named provider of types `Value`s (similar to a config node) 
+- `Value` - a named value that has methods of `Optional` + a mapping method return typed `Value` (similar to `ConfigValue`)
+    The name is useful for errors (e.g. parsing exception), as it should read similar to 
+    "Failed to map QueryParam(request-count) to Integer"
+- built in mappers for common types
+
+
+Value provider can either use the shared `MapperManager` accessible through `MapperManager.shared()` (and configurable by user)
+or an explicit mapper manager (if desired so by a component).
+
+- `Config` should extends `ValueProvider` 
+- `ConfigValue` should extend `Value`
+- HTTP `Parameters` should have a new method `ValueProvider get(String name)`
+  (this will enable typed access to headers, query parameters, form parameters) 
+- HTTP `Path` currently has method `String param(String name)` - this should either be changed to 
+    `ValueProvider param(String name)`, or a new method should be created (such as `ValueProvider parameter(String))`)
+    for backward compatibility
+- Built in mappers should allow modification of format through Helidon Context (using a custom classifier)
+- mapping of types that are compatible (such as String -> CharSequence) should work even without a mapper
+- mapping of primitive types should use mappers for their boxed types

--- a/examples/webserver/fault-tolerance/src/main/java/io/helidon/webserver/examples/faulttolerance/FtService.java
+++ b/examples/webserver/fault-tolerance/src/main/java/io/helidon/webserver/examples/faulttolerance/FtService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/webserver/fault-tolerance/src/main/java/io/helidon/webserver/examples/faulttolerance/FtService.java
+++ b/examples/webserver/fault-tolerance/src/main/java/io/helidon/webserver/examples/faulttolerance/FtService.java
@@ -74,7 +74,7 @@ public class FtService implements Service {
     }
 
     private void timeoutHandler(ServerRequest request, ServerResponse response) {
-        long sleep = Long.parseLong(request.path().param("millis"));
+        long sleep = request.path().parameter("millis").asLong().get();
 
         timeout.invoke(() -> sleep(sleep))
                 .thenAccept(response::send)
@@ -82,7 +82,7 @@ public class FtService implements Service {
     }
 
     private void retryHandler(ServerRequest request, ServerResponse response) {
-        int count = Integer.parseInt(request.path().param("count"));
+        int count = request.path().parameter("count").asInt().get();
 
         AtomicInteger call = new AtomicInteger(1);
         AtomicInteger failures = new AtomicInteger();

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientQueryParams.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientQueryParams.java
@@ -152,6 +152,11 @@ class WebClientQueryParams implements Parameters {
         return rawParams.toMap();
     }
 
+    @Override
+    public String name() {
+        return "ClientQueryParam";
+    }
+
     void skipEncoding() {
         this.skipEncoding = true;
     }

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeadersImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeadersImpl.java
@@ -263,6 +263,11 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
         return Collections.unmodifiableMap(new HashMap<>(headers));
     }
 
+    @Override
+    public String name() {
+        return "ClientRequestHeader";
+    }
+
     private List<String> iterableToList(Iterable<String> iterable) {
         return StreamSupport
                 .stream(iterable.spliterator(), false)

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeadersImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeadersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientResponseHeadersImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientResponseHeadersImpl.java
@@ -34,7 +34,7 @@ import io.helidon.common.http.SetCookie;
 class WebClientResponseHeadersImpl extends ReadOnlyParameters implements WebClientResponseHeaders {
 
     private WebClientResponseHeadersImpl(Map<String, List<String>> headers) {
-        super(headers);
+        super("ClientResponseHeader", headers);
     }
 
     /**

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientResponseHeadersImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientResponseHeadersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/UriComponent.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/UriComponent.java
@@ -64,7 +64,7 @@ final class UriComponent {
      * @return the multivalued map of query parameters.
      */
     static Parameters decodeQuery(String query, boolean decodeNames, boolean decodeValues) {
-        Parameters queryParameters = HashParameters.create();
+        Parameters queryParameters = HashParameters.create("QueryParam");
 
         if (query == null || query.isEmpty()) {
             return queryParameters;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/UriComponent.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/UriComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves #1897 (mappable query params and path params)
Related to #1789 (align mappers)

Added `Value` and `ValueProvider` to `mapper` module.
It is now used in various HTTP classes (Headers, query parameters etc.) and in Config (`ConfigValue`).

Added support for a shared `MapperManager` that can be custom registered by user.
Mapping to basic types is built-in (String -> a lot of types), including date types. Format can be overridden through context if desired (see `MapperManager.FORMAT_CLASSIFIER`).

The changes are fully backward compatible - we have to decide how to approach this (e.g. do we want to keep all the methods, or do we want to change signatures in the future?).

Created as a draft until we agree on approach.
