### PR TITLE
Option to allow the OIDC id_token to be stored in cookie and used as principal

### DIFF
--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -302,6 +302,7 @@ public final class OidcConfig {
     static final String DEFAULT_ATTEMPT_PARAM = "h_ra";
     static final int DEFAULT_MAX_REDIRECTS = 5;
     static final int DEFAULT_TIMEOUT_SECONDS = 30;
+    static final boolean DEFAULT_PUT_IDTOKEN_IN_COOKIE = false;
 
     private static final Logger LOGGER = Logger.getLogger(OidcConfig.class.getName());
     private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
@@ -340,6 +341,7 @@ public final class OidcConfig {
     private final WebClient appWebClient;
     private final URI introspectUri;
     private final Duration clientTimeout;
+    private final boolean putIdtokenInCookie;
 
     private OidcConfig(Builder builder) {
         this.clientId = builder.clientId;
@@ -369,6 +371,7 @@ public final class OidcConfig {
         this.generalClient = builder.generalClient;
         this.tokenEndpointAuthentication = builder.tokenEndpointAuthentication;
         this.clientTimeout = builder.clientTimeout;
+        this.putIdtokenInCookie = builder.putIdtokenInCookie;
 
         if (tokenEndpointAuthentication == ClientAuthentication.CLIENT_SECRET_POST) {
             // we should only store this if required
@@ -588,6 +591,16 @@ public final class OidcConfig {
      */
     public String cookieOptions() {
         return cookieOptions;
+    }
+
+    /**
+     * Retruns flag to store id token in cookie and use to build principal
+     *
+     * @return put id token in cookie flag
+     * @see Builder#putIdtokenInCookie(boolean)
+     */
+    public boolean putIdtokenInCookie(){
+        return putIdtokenInCookie;
     }
 
     /**
@@ -942,6 +955,7 @@ public final class OidcConfig {
         private boolean cookieHttpOnly = DEFAULT_COOKIE_HTTP_ONLY;
         private boolean cookieSecure = DEFAULT_COOKIE_SECURE;
         private String cookieSameSite = DEFAULT_COOKIE_SAME_SITE;
+        private boolean putIdtokenInCookie = DEFAULT_PUT_IDTOKEN_IN_COOKIE;
 
         private boolean useParam = DEFAULT_PARAM_USE;
         private String paramName = DEFAULT_PARAM_NAME;
@@ -1215,6 +1229,7 @@ public final class OidcConfig {
             config.get("cookie-http-only").asBoolean().ifPresent(this::cookieHttpOnly);
             config.get("cookie-secure").asBoolean().ifPresent(this::cookieSecure);
             config.get("cookie-same-site").asString().ifPresent(this::cookieSameSite);
+            config.get("put-idtoken-in-cookie").asBoolean().ifPresent(this::putIdtokenInCookie);
             config.get("query-param-use").asBoolean().ifPresent(this::useParam);
             config.get("query-param-name").asString().ifPresent(this::paramName);
             config.get("header-use").asBoolean().ifPresent(this::useHeader);
@@ -1514,6 +1529,20 @@ public final class OidcConfig {
         @ConfiguredOption(value = DEFAULT_COOKIE_PATH)
         public Builder cookiePath(String path) {
             this.cookiePath = path;
+            return this;
+        }
+
+        /**
+         * By default only the access_token is stored in the cookie.  Depending on
+         * OIDC provider it may not contain all of the needed profile fields.  If
+         * set to true the id_token will also be stored in the cookie and used to
+         * build the principal.
+         *
+         * @param putIdtokenInCookie flag to store and use id_token from OIDC Provider
+         * @return updated builder instance
+         */
+        public Builder putIdtokenInCookie(boolean putIdtokenInCookie){
+            this.putIdtokenInCookie = putIdtokenInCookie;
             return this;
         }
 

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.security.providers.oidc;
 
+import java.io.StringReader;
 import java.lang.annotation.Annotation;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -75,6 +76,10 @@ import io.helidon.security.spi.OutboundSecurityProvider;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.util.TokenHandler;
 import io.helidon.webclient.WebClientRequestBuilder;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
 
 import static io.helidon.security.providers.oidc.common.OidcConfig.postJsonResponse;
 
@@ -237,6 +242,7 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         List<String> missingLocations = new LinkedList<>();
 
         Optional<String> token = Optional.empty();
+        Optional<String> idToken = Optional.empty();
 
         try {
             if (oidcConfig.useHeader()) {
@@ -258,8 +264,17 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
             }
 
             if (oidcConfig.useCookie()) {
-                token = token
-                        .or(() -> findCookie(providerRequest.env().headers()));
+                Optional<String> cookieValue = findCookie(providerRequest.env().headers());
+                if(cookieValue.isPresent() && oidcConfig.putIdtokenInCookie()){
+                    JsonReader jr = Json.createReader(new StringReader(cookieValue.get()));
+                    JsonObject cookieJson = jr.readObject();
+                    jr.close();
+
+                    token = Optional.of(cookieJson.getString("access_token"));
+                    idToken = Optional.of(cookieJson.getString("id_token"));
+                }else {
+                    token = token.or(()->cookieValue);
+                }
 
                 if (token.isEmpty()) {
                     missingLocations.add("cookie");
@@ -271,7 +286,7 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         }
 
         if (token.isPresent()) {
-            return validateToken(providerRequest, token.get());
+            return validateToken(providerRequest, token.get(), idToken.orElse(token.get()));
         } else {
             LOGGER.finest(() -> "Missing token, could not find in either of: " + missingLocations);
             return CompletableFuture.completedFuture(errorResponse(providerRequest,
@@ -453,19 +468,29 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         return URLEncoder.encode(state, StandardCharsets.UTF_8);
     }
 
-    private CompletionStage<AuthenticationResponse> validateToken(ProviderRequest providerRequest, String token) {
-        SignedJwt signedJwt;
+    private CompletionStage<AuthenticationResponse> validateToken(ProviderRequest providerRequest, String token, String idToken) {
+        SignedJwt signedToken;
+        SignedJwt signedIdToken;
+        String tokenId = "Access";
         try {
-            signedJwt = SignedJwt.parseToken(token);
+            signedToken = SignedJwt.parseToken(token);
+            tokenId = "ID";
+            signedIdToken = SignedJwt.parseToken(idToken);
         } catch (Exception e) {
             //invalid token
-            LOGGER.log(Level.FINEST, "Could not parse inbound token", e);
-            return CompletableFuture.completedFuture(AuthenticationResponse.failed("Invalid token", e));
+            LOGGER.log(Level.FINEST, "Could not parse inbound "+tokenId+" token", e);
+            return CompletableFuture.completedFuture(AuthenticationResponse.failed("Invalid "+tokenId+" token", e));
         }
 
-        return jwtValidator.apply(signedJwt, Errors.collector())
+        // if token are not the same validate the id token
+        Errors.Collector errors = Errors.collector();
+        if(!token.equals(idToken)){
+            errors = jwtValidator.apply(signedIdToken,errors).await();
+        }
+
+        return jwtValidator.apply(signedToken, errors)
                 .map(it -> processValidationResult(providerRequest,
-                                                   signedJwt,
+                                                   signedToken,signedIdToken,
                                                    it))
                 .onErrorResume(t -> {
                     LOGGER.log(Level.FINEST, "Failed to validate request", t);
@@ -474,16 +499,19 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
     }
 
     private AuthenticationResponse processValidationResult(ProviderRequest providerRequest,
-                                                           SignedJwt signedJwt,
+                                                           SignedJwt signedToken,
+                                                           SignedJwt signedIdToken,
                                                            Errors.Collector collector) {
-        Jwt jwt = signedJwt.getJwt();
+        Jwt jwtToken = signedToken.getJwt();
+        Jwt jwtIdToken = signedIdToken.getJwt();
         Errors errors = collector.collect();
-        Errors validationErrors = jwt.validate(oidcConfig.issuer(), oidcConfig.audience());
+        Errors validationErrors = jwtToken.validate(oidcConfig.issuer(), oidcConfig.audience());
+        validationErrors.addAll(jwtIdToken.validate(oidcConfig.issuer(), oidcConfig.audience()));
 
         if (errors.isValid() && validationErrors.isValid()) {
 
             errors.log(LOGGER);
-            Subject subject = buildSubject(jwt, signedJwt);
+            Subject subject = buildSubject(jwtToken, jwtIdToken, signedToken);
 
             Set<String> scopes = subject.grantsByType("scope")
                     .stream()
@@ -557,15 +585,15 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         return CompletableFuture.completedFuture(OutboundSecurityResponse.empty());
     }
 
-    private Subject buildSubject(Jwt jwt, SignedJwt signedJwt) {
-        Principal principal = buildPrincipal(jwt);
+    private Subject buildSubject(Jwt jwtToken, Jwt jwtIdToken, SignedJwt signedJwt) {
+        Principal principal = buildPrincipal(jwtIdToken);
 
         TokenCredential.Builder builder = TokenCredential.builder();
-        jwt.issueTime().ifPresent(builder::issueTime);
-        jwt.expirationTime().ifPresent(builder::expTime);
-        jwt.issuer().ifPresent(builder::issuer);
+        jwtToken.issueTime().ifPresent(builder::issueTime);
+        jwtToken.expirationTime().ifPresent(builder::expTime);
+        jwtToken.issuer().ifPresent(builder::issuer);
         builder.token(signedJwt.tokenContent());
-        builder.addToken(Jwt.class, jwt);
+        builder.addToken(Jwt.class, jwtToken);
         builder.addToken(SignedJwt.class, signedJwt);
 
         Subject.Builder subjectBuilder = Subject.builder()
@@ -573,11 +601,11 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
                 .addPublicCredential(TokenCredential.class, builder.build());
 
         if (useJwtGroups) {
-            Optional<List<String>> userGroups = jwt.userGroups();
+            Optional<List<String>> userGroups = jwtToken.userGroups();
             userGroups.ifPresent(groups -> groups.forEach(group -> subjectBuilder.addGrant(Role.create(group))));
         }
 
-        Optional<List<String>> scopes = jwt.scopes();
+        Optional<List<String>> scopes = jwtToken.scopes();
         scopes.ifPresent(scopeList -> scopeList.forEach(scope -> subjectBuilder.addGrant(Grant.builder()
                                                                                                  .name(scope)
                                                                                                  .type("scope")

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcSupport.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcSupport.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.json.Json;
 import javax.json.JsonObject;
 
 import io.helidon.common.http.FormParams;
@@ -256,8 +257,17 @@ public final class OidcSupport implements Service {
         res.headers().add(Http.Header.LOCATION, state);
 
         if (oidcConfig.useCookie()) {
-            res.headers()
-                    .add("Set-Cookie", oidcConfig.cookieName() + "=" + tokenValue + oidcConfig.cookieOptions());
+            if(oidcConfig.putIdtokenInCookie()){
+                JsonObject cookieValue = Json.createObjectBuilder()
+                        .add("access_token", tokenValue)
+                        .add( "id_token", json.getString("id_token"))
+                        .build();
+                res.headers()
+                        .add("Set-Cookie", oidcConfig.cookieName() + "=" + cookieValue.toString() + oidcConfig.cookieOptions());
+            }else {
+                res.headers()
+                        .add("Set-Cookie", oidcConfig.cookieName() + "=" + tokenValue + oidcConfig.cookieOptions());
+            }
         }
 
         res.send();


### PR DESCRIPTION
Some OIDC providers don't return the actual profile in the access_token.  This option will allow the id_token from the token endpoint to be stored in the cookie and utilized to build the principal for use in context.