### PR TITLE
Upgrade Spotbugs to 4.4.2 (through plugin upgrade to 4.4.2.2).

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiFromOutputStream.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiFromOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,10 @@ public class MultiFromOutputStream extends OutputStream implements Multi<ByteBuf
 
     void timeout(long timeout) {
         this.timeout = timeout;
+    }
+
+    void timeout(Duration duration) {
+        this.timeout = duration.toMillis();
     }
 
     /**

--- a/integrations/neo4j/health/etc/spotbugs/exclude.xml
+++ b/integrations/neo4j/health/etc/spotbugs/exclude.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/4.4.2/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <!-- Bug failed on bytecode representation, not source -->
+        <Class name="io.helidon.integrations.neo4j.health.Neo4jHealthCheck"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
+
+</FindBugsFilter>

--- a/integrations/neo4j/health/pom.xml
+++ b/integrations/neo4j/health/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>helidon-integrations-neo4j-health</artifactId>
     <name>Helidon Neo4j Health Integrations</name>
 
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.neo4j.driver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.plugin.scm-publish-plugin>3.0.0</version.plugin.scm-publish-plugin>
         <version.plugin.shade>3.0.0</version.plugin.shade>
         <version.plugin.source>3.0.1</version.plugin.source>
-        <version.plugin.spotbugs>4.2.0</version.plugin.spotbugs>
+        <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
         <version.plugin.dependency-check>6.0.2</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0-M5</version.plugin.surefire>
@@ -495,6 +495,7 @@
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <version>${version.plugin.spotbugs}</version>
                     <configuration>
+                        <omitVisitors>FindReturnRef</omitVisitors>
                         <skip>${spotbugs.skip}</skip>
                         <threshold>${spotbugs.threshold}</threshold>
                         <!--suppress UnresolvedMavenProperty -->


### PR DESCRIPTION
Associated changes.


Changes done to existing classes because of spotbugs failures.
Disabled the `FindReturnRef` visitor, as it creates a lot of false positives (such as marking usage of `Set` in a private constructor as referencing a mutable object, even though the only caller is using `Set.of` to create the instance.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>