### PR TITLE
Use OBJECT schema type with requiredProperties in Quickstart MP (master)

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/quickstart/files/src/main/java/__pkg__/GreetResource.java.mustache
+++ b/archetypes/helidon/src/main/archetype/mp/quickstart/files/src/main/java/__pkg__/GreetResource.java.mustache
@@ -97,7 +97,7 @@ public class GreetResource {
     @RequestBody(name = "greeting",
             required = true,
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(type = SchemaType.STRING, example = "{\"greeting\" : \"Hola\"}")))
+                    schema = @Schema(type = SchemaType.OBJECT, requiredProperties = { "greeting" })))
     @APIResponses({
             @APIResponse(name = "normal", responseCode = "204", description = "Greeting updated"),
             @APIResponse(name = "missing 'greeting'", responseCode = "400",

--- a/examples/integrations/micrometer/mp/src/main/java/io/helidon/examples/integrations/micrometer/mp/GreetResource.java
+++ b/examples/integrations/micrometer/mp/src/main/java/io/helidon/examples/integrations/micrometer/mp/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ public class GreetResource {
     @RequestBody(name = "greeting",
             required = true,
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(type = SchemaType.STRING, example = "{\"greeting\" : \"Hola\"}")))
+                    schema = @Schema(type = SchemaType.OBJECT, requiredProperties = { "greeting" })))
     @APIResponses({
             @APIResponse(name = "normal", responseCode = "204", description = "Greeting updated"),
             @APIResponse(name = "missing 'greeting'", responseCode = "400",

--- a/examples/microprofile/cors/src/main/java/io/helidon/microprofile/examples/cors/GreetResource.java
+++ b/examples/microprofile/cors/src/main/java/io/helidon/microprofile/examples/cors/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class GreetResource {
     @RequestBody(name = "greeting",
             required = true,
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(type = SchemaType.STRING, example = "{\"greeting\" : \"Hola\"}")))
+                    schema = @Schema(type = SchemaType.OBJECT, requiredProperties = { "greeting" })))
     @APIResponses({
             @APIResponse(name = "normal", responseCode = "204", description = "Greeting updated"),
             @APIResponse(name = "missing 'greeting'", responseCode = "400",

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -109,7 +109,7 @@ public class GreetResource {
     @RequestBody(name = "greeting",
             required = true,
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(type = SchemaType.STRING, example = "{\"greeting\" : \"Hola\"}")))
+                    schema = @Schema(type = SchemaType.OBJECT, requiredProperties = { "greeting" })))
     @APIResponses({
             @APIResponse(name = "normal", responseCode = "204", description = "Greeting updated"),
             @APIResponse(name = "missing 'greeting'", responseCode = "400",

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ public class GreetResource {
     @RequestBody(name = "greeting",
             required = true,
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(type = SchemaType.STRING, example = "{\"greeting\" : \"Hola\"}")))
+                    schema = @Schema(type = SchemaType.OBJECT, requiredProperties = { "greeting" })))
     @APIResponses({
             @APIResponse(name = "normal", responseCode = "204", description = "Greeting updated"),
             @APIResponse(name = "missing 'greeting'", responseCode = "400",

--- a/tests/integration/native-image/mp-3/src/main/java/io/helidon/tests/integration/nativeimage/mp3/GreetResource.java
+++ b/tests/integration/native-image/mp-3/src/main/java/io/helidon/tests/integration/nativeimage/mp3/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class GreetResource {
     @RequestBody(name = "greeting",
             required = true,
             content = @Content(mediaType = "application/json",
-                    schema = @Schema(type = SchemaType.STRING, example = "{\"greeting\" : \"Hola\"}")))
+                    schema = @Schema(type = SchemaType.OBJECT, requiredProperties = { "greeting" })))
     @APIResponses({
             @APIResponse(name = "normal", responseCode = "204", description = "Greeting updated"),
             @APIResponse(name = "missing 'greeting'", responseCode = "400",


### PR DESCRIPTION
Use OBJECT schema type with requiredProperties. Drop example as it requires Jackson on classpath.

Updates to examples, tests and archetypes.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>