### PR TITLE
3.x - MP Config - CDI TCK Synthetic Observers Fix

### DIFF
--- a/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -60,6 +60,7 @@ import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
 import jakarta.enterprise.inject.spi.ProcessBean;
 import jakarta.enterprise.inject.spi.ProcessObserverMethod;
+import jakarta.enterprise.inject.spi.ProcessSyntheticObserverMethod;
 import jakarta.enterprise.inject.spi.WithAnnotations;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -135,6 +136,9 @@ public class ConfigCdiExtension implements Extension {
 
     private <X> void harvestConfigPropertyInjectionPointsFromEnabledObserverMethod(@Observes ProcessObserverMethod<?, X> event,
                                                                                    BeanManager beanManager) {
+        // Synthetic events won't have an annotated method
+        if (event instanceof ProcessSyntheticObserverMethod) return;
+
         AnnotatedMethod<X> annotatedMethod = event.getAnnotatedMethod();
         List<AnnotatedParameter<X>> annotatedParameters = annotatedMethod.getParameters();
         if (annotatedParameters != null) {

--- a/microprofile/config/src/test/java/io/helidon/microprofile/config/SyntheticInjectionTest.java
+++ b/microprofile/config/src/test/java/io/helidon/microprofile/config/SyntheticInjectionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.config;
+
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for synthetic bean injection
+ */
+@HelidonTest
+@AddExtension(SyntheticInjectionTest.MyExtension.class)
+class SyntheticInjectionTest {
+
+    /**
+     * Make sure that the registration of synthetic observers doesn't break the config extension.
+     */
+    @Test
+    void testSyntheticObserver() {
+        assertTrue(MyExtension.observerCalled, "Synthetic observer wasn't registered");
+    }
+
+    public static class MyExtension implements Extension {
+
+        private static volatile boolean observerCalled = false;
+
+        void registerSyntheticObserver(@Observes AfterBeanDiscovery event) {
+            event.addObserverMethod()
+                    .addQualifier(Initialized.Literal.of(ApplicationScoped.class))
+                    .observedType(Object.class)
+                    .notifyWith((context) -> observerCalled = true);
+        }
+    }
+
+}


### PR DESCRIPTION
The CDI TCK will fail against any container with the ConfigCdiExtension registered as synthetic observers don't contain any annotated method, which causes a NPE during the 'ProcessObserverMethod'.

These synthetic events can be safely ignored, as it isn't a valid use of MP Config.

Note that this was discovered when using the MP Config implementation in GlassFish.