### PR TITLE
Support for Forwarded, X-Forwarded-Host, X-Forwarded-Proto headers

### DIFF
--- a/common/http/pom.xml
+++ b/common/http/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/common/http/src/main/java/io/helidon/common/http/Forwarded.java
+++ b/common/http/src/main/java/io/helidon/common/http/Forwarded.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.http;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import io.helidon.common.buffers.BufferData;
+
+import static io.helidon.common.http.Http.Header.FORWARDED;
+
+/**
+ * A representation of the {@link Http.Header#FORWARDED} HTTP header.
+ */
+public class Forwarded {
+    private static final System.Logger LOGGER = System.getLogger(Forwarded.class.getName());
+    private final Optional<String> by;
+    private final Optional<String> forClient;
+    private final Optional<String> host;
+    private final Optional<String> proto;
+
+    private Forwarded(String by, String forClient, String host, String proto) {
+        this.by = Optional.ofNullable(by);
+        this.forClient = Optional.ofNullable(forClient);
+        this.host = Optional.ofNullable(host);
+        this.proto = Optional.ofNullable(proto);
+    }
+
+    /**
+     * Create forwarded from a value of a single forwarded header, such as {@code by=a.b.c;for=d.e.f;host=host;proto=https}.
+     *
+     * @param string string representation of a single forwarded header
+     * @return forwarded parsed from the string
+     * @see #create(Headers)
+     */
+    public static Forwarded create(String string) {
+        // first split by semicolon, as that separates the directives
+        String[] directives = string.split(";");
+        String by = null;
+        String forClient = null;
+        String host = null;
+        String proto = null;
+
+        for (String directive : directives) {
+            int index = directive.indexOf('=');
+            if (index == -1 && !directive.isEmpty()) {
+                throw new IllegalArgumentException("Invalid Forwarded header");
+            }
+            String name = directive.substring(0, index);
+            String value = unquote(directive.substring(index + 1));
+            switch (name.toLowerCase(Locale.ROOT)) {
+            case "by":
+                by = value;
+                break;
+            case "for":
+                forClient = value;
+                break;
+            case "host":
+                host = value;
+                break;
+            case "proto":
+                proto = value;
+                break;
+            default:
+                if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+                    BufferData nameBytes = BufferData.create(name.getBytes(StandardCharsets.UTF_8));
+                    BufferData valueBytes = BufferData.create(value.getBytes(StandardCharsets.UTF_8));
+                    LOGGER.log(System.Logger.Level.DEBUG, "Encountered unknown directive of Forwarded header: \n"
+                            + nameBytes.debugDataHex() + "\nValue:\n" + valueBytes.debugDataHex());
+                }
+                break;
+            }
+        }
+        return new Forwarded(by, forClient, host, proto);
+    }
+
+    /**
+     * Parse forwarded header(s) from the provided headers.
+     *
+     * @param headers header to process
+     * @return list of forwarded headers, will be empty if the header does not exist.
+     */
+    public static List<Forwarded> create(Headers headers) {
+        if (headers.contains(FORWARDED)) {
+            return headers.get(FORWARDED)
+                    .allValues()
+                    .stream()
+                    .flatMap(it -> Arrays.stream(it.split(",")))
+                    .map(String::trim)
+                    .map(Forwarded::create)
+                    .toList();
+        }
+        return List.of();
+    }
+
+    /**
+     * {@code by} directive of the forwarded header.
+     *
+     * @return by directive
+     */
+    public Optional<String> by() {
+        return by;
+    }
+
+    /**
+     * {@code for} directive of the forwarded header.
+     *
+     * @return for directive
+     */
+    public Optional<String> forClient() {
+        return forClient;
+    }
+
+    /**
+     * {@code host} directive of the forwarded header. The host of the original request.
+     *
+     * @return host directive
+     */
+    public Optional<String> host() {
+        return host;
+    }
+
+    /**
+     * {@code proto} directive of the forwarded header. The protocol of the original request (http or https).
+     *
+     * @return proto directive
+     */
+    public Optional<String> proto() {
+        return proto;
+    }
+
+    private static String unquote(String string) {
+        if (string.indexOf('"') == 0 && string.lastIndexOf('"') == string.length() - 1) {
+            return string.substring(1, string.length() - 1);
+        }
+        return string;
+    }
+}

--- a/common/http/src/main/java/io/helidon/common/http/HeaderEnum.java
+++ b/common/http/src/main/java/io/helidon/common/http/HeaderEnum.java
@@ -93,6 +93,8 @@ enum HeaderEnum implements Http.HeaderName {
     X_HELIDON_CN("X-HELIDON-CN"),
     X_FORWARDED_FOR("X-Forwarded-For"),
     X_FORWARDED_HOST("X-Forwarded-Host"),
+    X_FORWARDED_PORT("X-Forwarded-Port"),
+    X_FORWARDED_PREFIX("X-Forwarded-Prefix"),
     X_FORWARDED_PROTO("X-Forwarded-Proto");
 
     private static final Map<String, Http.HeaderName> BY_NAME;

--- a/common/http/src/main/java/io/helidon/common/http/HeaderEnum.java
+++ b/common/http/src/main/java/io/helidon/common/http/HeaderEnum.java
@@ -90,7 +90,10 @@ enum HeaderEnum implements Http.HeaderName {
     VARY("Vary"),
     WARNING("Warning"),
     WWW_AUTHENTICATE("WWW-Authenticate"),
-    X_HELIDON_CN("X-HELIDON-CN");
+    X_HELIDON_CN("X-HELIDON-CN"),
+    X_FORWARDED_FOR("X-Forwarded-For"),
+    X_FORWARDED_HOST("X-Forwarded-Host"),
+    X_FORWARDED_PROTO("X-Forwarded-Proto");
 
     private static final Map<String, Http.HeaderName> BY_NAME;
     private static final Map<String, Http.HeaderName> BY_CAP_NAME;

--- a/common/http/src/main/java/io/helidon/common/http/Http.java
+++ b/common/http/src/main/java/io/helidon/common/http/Http.java
@@ -1510,6 +1510,16 @@ public final class Http {
          */
         public static final HeaderName X_FORWARDED_HOST = HeaderEnum.X_FORWARDED_HOST;
         /**
+         * The {@code X-Forwarded-Port} header name.
+         * Used to represent the original port requested by a client, when request passed through a proxy server.
+         */
+        public static final HeaderName X_FORWARDED_PORT = HeaderEnum.X_FORWARDED_PORT;
+        /**
+         * The {@code X-Forwarded-Prefix} header name.
+         * Used to represent the original path prefix requested by a client, when request passed through a proxy server.
+         */
+        public static final HeaderName X_FORWARDED_PREFIX = HeaderEnum.X_FORWARDED_PREFIX;
+        /**
          * The {@code X-Forwarded-Proto} header name.
          * Used to represent the original protocol used by a client, when request passed through a proxy server.
          */

--- a/common/http/src/main/java/io/helidon/common/http/Http.java
+++ b/common/http/src/main/java/io/helidon/common/http/Http.java
@@ -1499,6 +1499,21 @@ public final class Http {
          * This header will be removed if it is part of the request.
          */
         public static final HeaderName X_HELIDON_CN = HeaderEnum.X_HELIDON_CN;
+        /**
+         * The {@code X-Forwarded-For} header name.
+         * Used to represent the original host requested by a client, when request passed through a proxy server.
+         */
+        public static final HeaderName X_FORWARDED_FOR = HeaderEnum.X_FORWARDED_FOR;
+        /**
+         * The {@code X-Forwarded-Host} header name.
+         * Used to represent the original host requested by a client, when request passed through a proxy server.
+         */
+        public static final HeaderName X_FORWARDED_HOST = HeaderEnum.X_FORWARDED_HOST;
+        /**
+         * The {@code X-Forwarded-Proto} header name.
+         * Used to represent the original protocol used by a client, when request passed through a proxy server.
+         */
+        public static final HeaderName X_FORWARDED_PROTO = HeaderEnum.X_FORWARDED_PROTO;
 
         private Header() {
         }

--- a/common/http/src/test/java/io/helidon/common/http/ForwardedTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/ForwardedTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.http;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+class ForwardedTest {
+    @Test
+    void testForOnly() {
+        String header = "for=\"_mdn\"";
+        Forwarded forwarded = Forwarded.create(header);
+
+        assertThat(forwarded.by(), is(optionalEmpty()));
+        assertThat(forwarded.host(), is(optionalEmpty()));
+        assertThat(forwarded.proto(), is(optionalEmpty()));
+        assertThat(forwarded.forClient(), optionalValue(is("_mdn")));
+    }
+
+    @Test
+    void testForCaseInsensitive() {
+        String header = "For=\"[2001:db8:cafe::17]:4711\"";
+        Forwarded forwarded = Forwarded.create(header);
+
+        assertThat(forwarded.by(), is(optionalEmpty()));
+        assertThat(forwarded.host(), is(optionalEmpty()));
+        assertThat(forwarded.proto(), is(optionalEmpty()));
+        assertThat(forwarded.forClient(), optionalValue(is("[2001:db8:cafe::17]:4711")));
+    }
+
+    @Test
+    void testForProtoAndBy() {
+        String header = "for=192.0.2.60;proto=http;by=203.0.113.43";
+        Forwarded forwarded = Forwarded.create(header);
+
+        assertThat(forwarded.by(), optionalValue(is("203.0.113.43")));
+        assertThat(forwarded.host(), is(optionalEmpty()));
+        assertThat(forwarded.proto(), optionalValue(is("http")));
+        assertThat(forwarded.forClient(), optionalValue(is("192.0.2.60")));
+    }
+
+    @Test
+    void testAll() {
+        String header = "for=192.0.2.60;proto=http;by=203.0.113.43;Host=10.10.10.10";
+        Forwarded forwarded = Forwarded.create(header);
+
+        assertThat(forwarded.by(), optionalValue(is("203.0.113.43")));
+        assertThat(forwarded.host(), optionalValue(is("10.10.10.10")));
+        assertThat(forwarded.proto(), optionalValue(is("http")));
+        assertThat(forwarded.forClient(), optionalValue(is("192.0.2.60")));
+    }
+
+    @Test
+    void testMultiValuesCommaSeparated() {
+        HeadersWritable<?> headers = HeadersWritable.create()
+                .add(Http.Header.FORWARDED, "for=192.0.2.60;proto=http;by=203.0.113.43;Host=10.10.10.10,by=\"192.0.2.60\"");
+        List<Forwarded> forwardedList = Forwarded.create(headers);
+
+        assertThat(forwardedList, hasSize(2));
+        Forwarded forwarded = forwardedList.get(0);
+
+        assertThat(forwarded.by(), optionalValue(is("203.0.113.43")));
+        assertThat(forwarded.host(), optionalValue(is("10.10.10.10")));
+        assertThat(forwarded.proto(), optionalValue(is("http")));
+        assertThat(forwarded.forClient(), optionalValue(is("192.0.2.60")));
+
+        forwarded = forwardedList.get(1);
+        assertThat(forwarded.by(), optionalValue(is("192.0.2.60")));
+        assertThat(forwarded.host(), is(optionalEmpty()));
+        assertThat(forwarded.proto(), is(optionalEmpty()));
+        assertThat(forwarded.forClient(), is(optionalEmpty()));
+    }
+
+    @Test
+    void testMultiValues() {
+        HeadersWritable<?> headers = HeadersWritable.create()
+                .add(Http.Header.FORWARDED, "for=192.0.2.60;proto=http;by=203.0.113.43;Host=10.10.10.10",
+                     "by=\"192.0.2.60\"");
+        List<Forwarded> forwardedList = Forwarded.create(headers);
+
+        assertThat(forwardedList, hasSize(2));
+        Forwarded forwarded = forwardedList.get(0);
+
+        assertThat(forwarded.by(), optionalValue(is("203.0.113.43")));
+        assertThat(forwarded.host(), optionalValue(is("10.10.10.10")));
+        assertThat(forwarded.proto(), optionalValue(is("http")));
+        assertThat(forwarded.forClient(), optionalValue(is("192.0.2.60")));
+
+        forwarded = forwardedList.get(1);
+        assertThat(forwarded.by(), optionalValue(is("192.0.2.60")));
+        assertThat(forwarded.host(), is(optionalEmpty()));
+        assertThat(forwarded.proto(), is(optionalEmpty()));
+        assertThat(forwarded.forClient(), is(optionalEmpty()));
+    }
+
+    @Test
+    void testMultiValuesAndCommaSeparated() {
+        HeadersWritable<?> headers = HeadersWritable.create()
+                .add(Http.Header.FORWARDED, "for=192.0.2.60;proto=http;by=203.0.113.43;Host=10.10.10.10",
+                     "by=\"192.0.2.60\",for=\"14.22.11.22\"");
+        List<Forwarded> forwardedList = Forwarded.create(headers);
+
+        assertThat(forwardedList, hasSize(3));
+        Forwarded forwarded = forwardedList.get(0);
+
+        assertThat(forwarded.by(), optionalValue(is("203.0.113.43")));
+        assertThat(forwarded.host(), optionalValue(is("10.10.10.10")));
+        assertThat(forwarded.proto(), optionalValue(is("http")));
+        assertThat(forwarded.forClient(), optionalValue(is("192.0.2.60")));
+
+        forwarded = forwardedList.get(1);
+        assertThat(forwarded.by(), optionalValue(is("192.0.2.60")));
+        assertThat(forwarded.host(), is(optionalEmpty()));
+        assertThat(forwarded.proto(), is(optionalEmpty()));
+        assertThat(forwarded.forClient(), is(optionalEmpty()));
+
+        forwarded = forwardedList.get(2);
+        assertThat(forwarded.by(), is(optionalEmpty()));
+        assertThat(forwarded.host(), is(optionalEmpty()));
+        assertThat(forwarded.proto(), is(optionalEmpty()));
+        assertThat(forwarded.forClient(), optionalValue(is("14.22.11.22")));
+    }
+}

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerRequest.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerRequest.java
@@ -30,13 +30,14 @@ import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http.media.ReadableEntity;
 import io.helidon.nima.http2.Http2Headers;
 import io.helidon.nima.webserver.ConnectionContext;
+import io.helidon.nima.webserver.http.HttpRequestBase;
 import io.helidon.nima.webserver.http.RoutedPath;
 import io.helidon.nima.webserver.http.RoutingRequest;
 
 /**
  * HTTP/2 server request.
  */
-class Http2ServerRequest implements RoutingRequest {
+class Http2ServerRequest extends HttpRequestBase implements RoutingRequest {
     private static final Runnable NO_OP_RUNNABLE = () -> {
     };
     private final Http2Headers http2Headers;
@@ -57,6 +58,7 @@ class Http2ServerRequest implements RoutingRequest {
                        ContentDecoder decoder,
                        int requestId,
                        Supplier<BufferData> entitySupplier) {
+        super(ctx);
         this.ctx = ctx;
         this.originalPrologue = prologue;
         this.http2Headers = headers;
@@ -86,11 +88,6 @@ class Http2ServerRequest implements RoutingRequest {
     }
 
     @Override
-    public RoutedPath path() {
-        return path;
-    }
-
-    @Override
     public ReadableEntity content() {
         return entity.get();
     }
@@ -116,6 +113,11 @@ class Http2ServerRequest implements RoutingRequest {
     }
 
     @Override
+    public RoutedPath path() {
+        return path;
+    }
+
+    @Override
     public UriQuery query() {
         return prologue().query();
     }
@@ -128,11 +130,6 @@ class Http2ServerRequest implements RoutingRequest {
     @Override
     public PeerInfo localPeer() {
         return ctx.localPeer();
-    }
-
-    @Override
-    public String authority() {
-        return authority;
     }
 
     @Override
@@ -153,5 +150,10 @@ class Http2ServerRequest implements RoutingRequest {
     public RoutingRequest prologue(HttpPrologue newPrologue) {
         this.prologue = newPrologue;
         return this;
+    }
+
+    @Override
+    protected String host() {
+        return authority;
     }
 }

--- a/nima/testing/junit5/webserver/src/main/java/io/helidon/nima/testing/junit5/webserver/DirectClientConnection.java
+++ b/nima/testing/junit5/webserver/src/main/java/io/helidon/nima/testing/junit5/webserver/DirectClientConnection.java
@@ -16,6 +16,7 @@
 
 package io.helidon.nima.testing.junit5.webserver;
 
+import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -24,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.http.Http;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.nima.http.encoding.ContentEncodingContext;
 import io.helidon.nima.http.media.MediaContext;
@@ -44,13 +46,16 @@ class DirectClientConnection implements ClientConnection {
     private final DataReader serverReader;
     private final DataWriter serverWriter;
     private final DirectSocket socket;
+    private final List<Http.HeaderName> authorityHeaders;
 
     DirectClientConnection(PeerInfo clientPeer,
                            PeerInfo localPeer,
                            Router router,
-                           boolean isTls) {
+                           boolean isTls,
+                           List<Http.HeaderName> authorityHeaders) {
 
         this.router = router;
+        this.authorityHeaders = authorityHeaders;
         this.socket = new DirectSocket(localPeer, clientPeer, isTls);
 
         ArrayBlockingQueue<byte[]> serverToClient = new ArrayBlockingQueue<>(1024);
@@ -152,7 +157,8 @@ class DirectClientConnection implements ClientConnection {
                 "unit-channel",
                 SimpleHandlers.builder().build(),
                 socket,
-                -1);
+                -1,
+                authorityHeaders);
 
         ServerConnection connection = Http1ConnectionProvider.builder()
                 .build()

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/MultiPortTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/MultiPortTest.java
@@ -148,8 +148,10 @@ class MultiPortTest {
                                               .any((req, res) -> {
                                                   res.status(Http.Status.MOVED_PERMANENTLY_301)
                                                           .header(Header.LOCATION.withValue(
-                                                                  String.format("http://%s:%s%s",
-                                                                                host(req.authority()),
+                                                                  String.format("%s://%s:%s%s",
+                                                                                req.usedProtocol(),
+                                                                                // we want to redirect to a different port
+                                                                                host(req.usedAuthority()),
                                                                                 server.port(),
                                                                                 req.path().absolute().rawPathNoParams())))
                                                           .send();

--- a/nima/webserver/cors/src/main/java/io/helidon/nima/webserver/cors/RequestAdapterNima.java
+++ b/nima/webserver/cors/src/main/java/io/helidon/nima/webserver/cors/RequestAdapterNima.java
@@ -40,7 +40,7 @@ class RequestAdapterNima implements CorsSupportBase.RequestAdapter<ServerRequest
 
     @Override
     public String authority() {
-        return request.authority();
+        return request.usedAuthority();
     }
 
     @Override

--- a/nima/webserver/tracing/src/main/java/io/helidon/nima/webserver/tracing/TracingSupport.java
+++ b/nima/webserver/tracing/src/main/java/io/helidon/nima/webserver/tracing/TracingSupport.java
@@ -99,7 +99,11 @@ public class TracingSupport {
 
             try (Scope ignored = span.activate()) {
                 span.tag(Tag.HTTP_METHOD.create(prologue.method().text()));
-                span.tag(Tag.HTTP_URL.create(prologue.protocol() + "://" + req.authority() + "/" + prologue.uriPath().path()));
+                span.tag(Tag.HTTP_URL.create(req.usedProtocol()
+                                                     + "://"
+                                                     + req.usedAuthority()
+                                                     + "/"
+                                                     + prologue.uriPath().path()));
                 span.tag(Tag.HTTP_VERSION.create(prologue.protocolVersion()));
 
                 chain.proceed();

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionContext.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionContext.java
@@ -16,10 +16,12 @@
 
 package io.helidon.nima.webserver;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.http.Http;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.SocketContext;
 import io.helidon.nima.http.encoding.ContentEncodingContext;
@@ -44,6 +46,7 @@ public interface ConnectionContext extends SocketContext {
      * @param simpleHandlers         error handling configuration
      * @param socket                 socket to obtain information about peers
      * @param maxPayloadSize         maximal size of a payload entity
+     * @param authorityHeaders
      * @return a new context
      */
     static ConnectionContext create(MediaContext mediaContext,
@@ -56,7 +59,8 @@ public interface ConnectionContext extends SocketContext {
                                     String channelId,
                                     SimpleHandlers simpleHandlers,
                                     HelidonSocket socket,
-                                    long maxPayloadSize) {
+                                    long maxPayloadSize,
+                                    List<Http.HeaderName> authorityHeaders) {
         return new ConnectionContextImpl(mediaContext,
                                          contentEncodingContext,
                                          sharedExecutor,
@@ -67,7 +71,8 @@ public interface ConnectionContext extends SocketContext {
                                          channelId,
                                          simpleHandlers,
                                          socket,
-                                         maxPayloadSize);
+                                         maxPayloadSize,
+                                         authorityHeaders);
     }
 
     /**
@@ -125,4 +130,16 @@ public interface ConnectionContext extends SocketContext {
      * @return simple handlers
      */
     SimpleHandlers simpleHandlers();
+
+    /**
+     * Headers that can be used to obtain authority. Níma semantically understands the following headers (in order of use):
+     * {@link io.helidon.common.http.Http.Header#HOST} (or HTTP/2 authority pseudo-header),
+     * {@link io.helidon.common.http.Http.Header#FORWARDED} (using the Host directive),
+     * {@link io.helidon.common.http.Http.Header#X_FORWARDED_HOST},
+     * or {@link io.helidon.common.http.Http.Header#X_FORWARDED_FOR}.
+     * Any other header defined will be used verbatim.
+     *
+     * @return list of header names to use to obtain authority
+     */
+    List<Http.HeaderName> authorityHeaders();
 }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionContextImpl.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionContextImpl.java
@@ -16,11 +16,13 @@
 
 package io.helidon.nima.webserver;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.http.Http;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.nima.http.encoding.ContentEncodingContext;
@@ -39,6 +41,7 @@ final class ConnectionContextImpl implements ConnectionContext {
     private final SimpleHandlers simpleHandlers;
     private final HelidonSocket socket;
     private final long maxPayloadSize;
+    private List<Http.HeaderName> authorityHeaders;
 
     ConnectionContextImpl(MediaContext mediaContext,
                           ContentEncodingContext contentEncodingContext,
@@ -50,7 +53,8 @@ final class ConnectionContextImpl implements ConnectionContext {
                           String childSocketId,
                           SimpleHandlers simpleHandlers,
                           HelidonSocket socket,
-                          long maxPayloadSize) {
+                          long maxPayloadSize,
+                          List<Http.HeaderName> authorityHeaders) {
         this.mediaContext = mediaContext;
         this.contentEncodingContext = contentEncodingContext;
         this.sharedExecutor = sharedExecutor;
@@ -62,6 +66,7 @@ final class ConnectionContextImpl implements ConnectionContext {
         this.simpleHandlers = simpleHandlers;
         this.socket = socket;
         this.maxPayloadSize = maxPayloadSize;
+        this.authorityHeaders = authorityHeaders;
     }
 
     @Override
@@ -127,6 +132,11 @@ final class ConnectionContextImpl implements ConnectionContext {
     @Override
     public String childSocketId() {
         return childSocketId;
+    }
+
+    @Override
+    public List<Http.HeaderName> authorityHeaders() {
+        return authorityHeaders;
     }
 
     @Override

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionHandler.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionHandler.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.http.Http;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.SocketWriter;
 import io.helidon.nima.http.encoding.ContentEncodingContext;
@@ -64,7 +65,8 @@ class ConnectionHandler implements Runnable {
                       Router router,
                       int writeQueueLength,
                       long maxPayloadSize,
-                      SimpleHandlers simpleHandlers) {
+                      SimpleHandlers simpleHandlers,
+                      List<Http.HeaderName> authorityHeaders) {
         this.connectionProviders = connectionProviders;
         this.providerCandidates = connectionProviders.providerCandidates();
         this.serverChannelId = serverChannelId;
@@ -82,7 +84,8 @@ class ConnectionHandler implements Runnable {
                                             channelId,
                                             simpleHandlers,
                                             socket,
-                                            maxPayloadSize);
+                                            maxPayloadSize,
+                                            authorityHeaders);
     }
 
     @Override

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ServerListener.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ServerListener.java
@@ -34,6 +34,7 @@ import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 
+import io.helidon.common.http.Http;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PlainSocket;
 import io.helidon.common.socket.SocketOptions;
@@ -66,7 +67,7 @@ class ServerListener {
     private final MediaContext mediaContext = MediaContext.create();
     private final ContentEncodingContext contentEncodingContext = ContentEncodingContext.create();
     private final LoomServer server;
-
+    private final List<Http.HeaderName> authorityHeaders;
     private volatile boolean running;
     private volatile int connectedPort;
     private volatile ServerSocket serverSocket;
@@ -83,6 +84,7 @@ class ServerListener {
         this.listenerConfig = listenerConfig;
         this.router = router;
         this.connectionOptions = listenerConfig.connectionOptions();
+        this.authorityHeaders = listenerConfig.authorityHeaders();
 
         this.serverThread = Thread.ofPlatform()
                 .allowSetThreadLocals(true)
@@ -235,7 +237,8 @@ class ServerListener {
                                                     router,
                                                     listenerConfig.writeQueueLength(),
                                                     listenerConfig.maxPayloadSize(),
-                                                    simpleHandlers);
+                                                    simpleHandlers,
+                                                    authorityHeaders);
 
                     readerExecutor.submit(handler);
                 } catch (Exception e) {

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRequest.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRequest.java
@@ -71,12 +71,27 @@ public interface HttpRequest {
     PeerInfo localPeer();
 
     /**
-     * The content of the {@link io.helidon.common.http.Http.Header#HOST} header
-     * or {@code authority} pseudo header (HTTP/2).
+     * The authority requested (host and optional port). This is authority as may be obtained from
+     * {@link io.helidon.common.http.Http.Header#HOST} (or HTTP/2 authority pseudo-header),
+     * {@link io.helidon.common.http.Http.Header#FORWARDED},
+     * {@link io.helidon.common.http.Http.Header#X_FORWARDED_HOST}
+     *  - depending on server configuration
+     * Authority can be used for redirections.
+     * The underlying headers are not modified, so if you need access to the actual requested host, you can still
+     * use the {@link Http.Header#HOST}.
      *
      * @return authority of this request
      */
-    String authority();
+    String usedAuthority();
+
+    /**
+     * The protocol used in the original request.
+     * This is obtained from socket information, {@link io.helidon.common.http.Http.Header#FORWARDED},
+     * or {@link io.helidon.common.http.Http.Header#X_FORWARDED_PROTO}.
+     * Protocol can be used for redirections.
+     * @return used protocol
+     */
+    String usedProtocol();
 
     /**
      * Replace (or set) a request header.

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRequestBase.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRequestBase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.nima.webserver.http;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.helidon.common.http.Forwarded;
+import io.helidon.common.http.HeadersServerRequest;
+import io.helidon.common.http.Http;
+import io.helidon.nima.webserver.ConnectionContext;
+
+import static io.helidon.common.http.Http.Header.FORWARDED;
+import static io.helidon.common.http.Http.Header.X_FORWARDED_FOR;
+import static io.helidon.common.http.Http.Header.X_FORWARDED_HOST;
+import static io.helidon.common.http.Http.Header.X_FORWARDED_PROTO;
+
+/**
+ * Base of server requests with common features.
+ */
+public abstract class HttpRequestBase implements HttpRequest {
+    private final ConnectionContext ctx;
+
+    // cache if requested at least once
+    private String authority;
+    private String protocol;
+
+    protected HttpRequestBase(ConnectionContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String usedAuthority() {
+        if (authority == null) {
+            HeadersServerRequest headers = headers();
+            for (Http.HeaderName name : ctx.authorityHeaders()) {
+                if (Http.Header.HOST.equals(name)) {
+                    authority = host();
+                    break;
+                }
+                if (FORWARDED.equals(name)) {
+                    List<Forwarded> forwardedList = Forwarded.create(headers);
+                    if (!forwardedList.isEmpty()) {
+                        authority = forwardedList.get(0)
+                                .host()
+                                .orElse(null);
+                        if (authority != null) {
+                            break;
+                        }
+                    }
+                }
+                if (X_FORWARDED_HOST.equals(name)) {
+                    if (headers.contains(X_FORWARDED_HOST)) {
+                        authority = headers.get(X_FORWARDED_HOST).value();
+                        break;
+                    }
+                }
+                if (X_FORWARDED_FOR.equals(name)) {
+                    if (headers.contains(X_FORWARDED_FOR)) {
+                        // may be comma separated with optional space
+                        authority = headers.get(X_FORWARDED_FOR).allValues()
+                                .stream()
+                                .flatMap(it -> Arrays.stream(it.split(",")))
+                                .findFirst()
+                                .map(String::trim)
+                                .orElse(null);
+                        if (authority != null) {
+                            break;
+                        }
+                    }
+                }
+            }
+            if (authority == null) {
+                authority = host();
+            }
+        }
+
+        return authority;
+    }
+
+    @Override
+    public String usedProtocol() {
+        if (protocol == null) {
+            String foundProtocol = null;
+
+            HeadersServerRequest headers = headers();
+            if (headers.contains(FORWARDED)) {
+                List<Forwarded> forwardedList = Forwarded.create(headers);
+                if (!forwardedList.isEmpty()) {
+                    foundProtocol = forwardedList.get(0)
+                            .proto()
+                            .orElse(null);
+                }
+            }
+
+            if (foundProtocol == null) {
+                if (headers.contains(X_FORWARDED_PROTO)) {
+                    foundProtocol = headers.get(X_FORWARDED_PROTO).value();
+                }
+            }
+            if (foundProtocol == null) {
+                foundProtocol = ctx.isSecure() ? "https" : "http";
+            }
+
+            this.protocol = foundProtocol;
+        }
+
+        return protocol;
+    }
+
+    /**
+     * The content of the Host header or authority pseudo header.
+     *
+     * @return host
+     */
+    protected abstract String host();
+}

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerRequest.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerRequest.java
@@ -24,6 +24,7 @@ import io.helidon.nima.http.media.ReadableEntity;
 public interface ServerRequest extends HttpRequest {
     /**
      * Whether this request was over a secure protocol (TLS).
+     * This only returns if the last step was over secure protocol. If a reverse proxy is used, check {@link #usedProtocol()}.
      *
      * @return whether this is a secure request
      */

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerRequest.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerRequest.java
@@ -46,8 +46,6 @@ abstract class Http1ServerRequest extends HttpRequestBase implements RoutingRequ
     private HeadersWritable<?> writable;
 
     private HttpPrologue newPrologue;
-    // cached authority
-    private String authority;
 
     Http1ServerRequest(ConnectionContext ctx,
                        HttpPrologue prologue,

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerRequest.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerRequest.java
@@ -29,13 +29,14 @@ import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.webserver.ConnectionContext;
+import io.helidon.nima.webserver.http.HttpRequestBase;
 import io.helidon.nima.webserver.http.RoutedPath;
 import io.helidon.nima.webserver.http.RoutingRequest;
 
 /**
  * Http 1 server request base.
  */
-abstract class Http1ServerRequest implements RoutingRequest {
+abstract class Http1ServerRequest extends HttpRequestBase implements RoutingRequest {
     private final HeadersServerRequest headers;
     private final ConnectionContext ctx;
     private final HttpPrologue prologue;
@@ -45,11 +46,14 @@ abstract class Http1ServerRequest implements RoutingRequest {
     private HeadersWritable<?> writable;
 
     private HttpPrologue newPrologue;
+    // cached authority
+    private String authority;
 
     Http1ServerRequest(ConnectionContext ctx,
                        HttpPrologue prologue,
                        Headers headers,
                        int requestId) {
+        super(ctx);
         this.ctx = ctx;
         this.prologue = prologue;
         this.headers = HeadersServerRequest.create(headers);
@@ -142,11 +146,6 @@ abstract class Http1ServerRequest implements RoutingRequest {
     }
 
     @Override
-    public String authority() {
-        return headers.get(Http.Header.HOST).value();
-    }
-
-    @Override
     public void header(Http.HeaderValue header) {
         if (writable == null) {
             writable = HeadersWritable.create(headers);
@@ -164,5 +163,10 @@ abstract class Http1ServerRequest implements RoutingRequest {
     public Http1ServerRequest prologue(HttpPrologue newPrologue) {
         this.newPrologue = newPrologue;
         return this;
+    }
+
+    @Override
+    protected String host() {
+        return headers().get(Http.Header.HOST).value();
     }
 }


### PR DESCRIPTION
 to get used authority and protocol.

This should be used for redirections and CORS.

Related to #4725 