### PR TITLE
RestClient proxy test exclusion removed

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -91,7 +91,7 @@
         <!-- Force upgrade version used by maven-jaxb2-plugin. Needed to support Java 16 -->
         <version.lib.jaxb-runtime>3.0.2</version.lib.jaxb-runtime>
         <version.lib.jedis>3.6.3</version.lib.jedis>
-        <version.lib.jersey>3.0.6</version.lib.jersey>
+        <version.lib.jersey>3.0.8</version.lib.jersey>
         <version.lib.jgit>5.11.1.202105131744-r</version.lib.jgit>
         <version.lib.jsonp-impl>2.0.1</version.lib.jsonp-impl>
         <version.lib.junit>5.7.0</version.lib.junit>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -91,7 +91,7 @@
         <!-- Force upgrade version used by maven-jaxb2-plugin. Needed to support Java 16 -->
         <version.lib.jaxb-runtime>3.0.2</version.lib.jaxb-runtime>
         <version.lib.jedis>3.6.3</version.lib.jedis>
-        <version.lib.jersey>3.0.5</version.lib.jersey>
+        <version.lib.jersey>3.0.6</version.lib.jersey>
         <version.lib.jgit>5.11.1.202105131744-r</version.lib.jgit>
         <version.lib.jsonp-impl>2.0.1</version.lib.jsonp-impl>
         <version.lib.junit>5.7.0</version.lib.junit>

--- a/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
@@ -25,13 +25,5 @@
                 <exclude name="org.eclipse.microprofile.rest.client.tck.timeout"/>
             </package>
         </packages>
-        <classes>
-            <class name="org.eclipse.microprofile.rest.client.tck.ProxyServerTest">
-                <methods>
-                    <!--https://github.com/eclipse/microprofile-rest-client/pull/298-->
-                    <exclude name="testProxy"/>
-                </methods>
-            </class>
-        </classes>
     </test>
 </suite>

--- a/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <!--
-  Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+  Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Jersey dependency version bump to 3.0.8 was required to pass the RestClient proxy test