### PR TITLE
New Features proposal.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -661,6 +661,21 @@
                 <artifactId>helidon-common-testing-http-junit5</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.helidon.common.features</groupId>
+                <artifactId>helidon-common-features-api</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.common.features</groupId>
+                <artifactId>helidon-common-features-processor</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.common.features</groupId>
+                <artifactId>helidon-common-features</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
 
             <!-- db client -->
             <dependency>

--- a/common/features/api/pom.xml
+++ b/common/features/api/pom.xml
@@ -29,4 +29,17 @@
     
     <artifactId>helidon-common-features-api</artifactId>
     <name>Helidon Common Features API</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- This module is Java 11, we must remove enable-preview from parent project -->
+                    <additionalOptions combine.self="override"/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/features/api/pom.xml
+++ b/common/features/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,30 +21,12 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon</groupId>
-        <artifactId>helidon-project</artifactId>
+        <groupId>io.helidon.common.features</groupId>
+        <artifactId>helidon-common-features-project</artifactId>
         <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>io.helidon.common</groupId>
-    <artifactId>helidon-common-project</artifactId>
-    <packaging>pom</packaging>
-    <name>Helidon Common Project</name>
-
-    <modules>
-        <module>common</module>
-        <module>reactive</module>
-        <module>configurable</module>
-        <module>key-util</module>
-        <module>http</module>
-        <module>context</module>
-        <module>mapper</module>
-        <module>media-type</module>
-        <module>crypto</module>
-        <module>parameters</module>
-        <module>buffers</module>
-        <module>socket</module>
-        <module>uri</module>
-        <module>testing</module>
-        <module>features</module>
-    </modules>
+    
+    <artifactId>helidon-common-features-api</artifactId>
+    <name>Helidon Common Features API</name>
 </project>

--- a/common/features/api/src/main/java/io/helidon/common/features/api/Aot.java
+++ b/common/features/api/src/main/java/io/helidon/common/features/api/Aot.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.features.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declaration of support for ahead of time compilation using native image.
+ */
+@Target(ElementType.MODULE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Aot {
+    /**
+     * Whether AOT is supported by this component or not.
+     * @return whether AOT is supported, defaults to {@code true}
+     */
+    boolean value() default true;
+
+    /**
+     * Description of AOT support, such as when AOT is supported, but with limitations.
+     * @return description
+     */
+    String description() default "";
+}

--- a/common/features/api/src/main/java/io/helidon/common/features/api/Experimental.java
+++ b/common/features/api/src/main/java/io/helidon/common/features/api/Experimental.java
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Extension for Graal VM native image to correctly build Helidon applications.
- */
-module io.helidon.graal.nativeimage {
-    requires io.helidon.config;
-    requires io.github.classgraph;
-    requires io.helidon.config.mp;
-    requires svm;
-    requires org.graalvm.sdk;
-    requires jakarta.json;
-    requires io.helidon.common.features.api;
-    requires io.helidon.common.features;
 
-    exports io.helidon.integrations.graal.nativeimage.extension;
+package io.helidon.common.features.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for experimental modules.
+ */
+@Target(ElementType.MODULE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Experimental {
 }

--- a/common/features/api/src/main/java/io/helidon/common/features/api/Feature.java
+++ b/common/features/api/src/main/java/io/helidon/common/features/api/Feature.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.features.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A Helidon feature annotation to be placed on module in module-info.java.
+ */
+@Target(ElementType.MODULE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Feature {
+    /**
+     * Name of this feature.
+     *
+     * @return name
+     */
+    String value();
+
+    /**
+     * Path of this feature (a feature path). If this is a top level feature, it can be omitted and
+     * the {@link #value()} would be used instead.
+     *
+     * @return feature path
+     */
+    String[] path() default {};
+
+    /**
+     * Description of this feature, to be displayed when details are printed during startup.
+     * Should be reasonably short
+     * @return description
+     */
+    String description();
+
+    /**
+     * Which flavors will this feature be printed in.
+     *
+     * @return flavors to print this feature, leave empty for any flavor.
+     */
+    HelidonFlavor[] in() default {};
+
+    /**
+     * Flavors not supported by this feature - e.g. the set up is invalid, if this feature is
+     * added to classpath of this flavor.
+     *
+     * @return flavors that are not compatible with this feature
+     */
+    HelidonFlavor[] notIn() default {};
+}

--- a/common/features/api/src/main/java/io/helidon/common/features/api/Feature.java
+++ b/common/features/api/src/main/java/io/helidon/common/features/api/Feature.java
@@ -62,5 +62,5 @@ public @interface Feature {
      *
      * @return flavors that are not compatible with this feature
      */
-    HelidonFlavor[] notIn() default {};
+    HelidonFlavor[] invalidIn() default {};
 }

--- a/common/features/api/src/main/java/io/helidon/common/features/api/HelidonFlavor.java
+++ b/common/features/api/src/main/java/io/helidon/common/features/api/HelidonFlavor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Extension for Graal VM native image to correctly build Helidon applications.
- */
-module io.helidon.graal.nativeimage {
-    requires io.helidon.config;
-    requires io.github.classgraph;
-    requires io.helidon.config.mp;
-    requires svm;
-    requires org.graalvm.sdk;
-    requires jakarta.json;
-    requires io.helidon.common.features.api;
-    requires io.helidon.common.features;
 
-    exports io.helidon.integrations.graal.nativeimage.extension;
+package io.helidon.common.features.api;
+
+/**
+ * Flavors of Helidon.
+ */
+public enum HelidonFlavor {
+    /**
+     * The "Standard Edition" flavor.
+     */
+    SE,
+    /**
+     * The "MicroProfile" flavor.
+     */
+    MP,
+    /**
+     * The Loom based blocking flavor.
+     */
+    NIMA
 }

--- a/common/features/api/src/main/java/io/helidon/common/features/api/Incubating.java
+++ b/common/features/api/src/main/java/io/helidon/common/features/api/Incubating.java
@@ -26,5 +26,5 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.MODULE)
 @Retention(RetentionPolicy.SOURCE)
-public @interface Experimental {
+public @interface Incubating {
 }

--- a/common/features/api/src/main/java/io/helidon/common/features/api/package-info.java
+++ b/common/features/api/src/main/java/io/helidon/common/features/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-package io.helidon.common.features.api;
-
 /**
- * Flavors of Helidon.
+ * API required to describe features in module descriptor.
+ *
+ * @see io.helidon.common.features.api.Feature
  */
-public enum HelidonFlavor {
-    /**
-     * The "Standard Edition" flavor.
-     */
-    SE,
-    /**
-     * The "MicroProfile" flavor.
-     */
-    MP,
-    /**
-     * The Loom based blocking flavor.
-     */
-    NIMA
-}
+package io.helidon.common.features.api;

--- a/common/features/api/src/main/java/module-info.java
+++ b/common/features/api/src/main/java/module-info.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * API required to describe features in module descriptor.
+ *
+ * @see io.helidon.common.features.api.Feature
+ */
 module io.helidon.common.features.api {
     exports io.helidon.common.features.api;
 }

--- a/common/features/api/src/main/java/module-info.java
+++ b/common/features/api/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module io.helidon.common.features.api {
+    exports io.helidon.common.features.api;
+}

--- a/common/features/features/pom.xml
+++ b/common/features/features/pom.xml
@@ -40,4 +40,17 @@
             <artifactId>helidon-common-features-api</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- This module is Java 11, we must remove enable-preview from parent project -->
+                    <additionalOptions combine.self="override"/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/features/features/pom.xml
+++ b/common/features/features/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,30 +21,23 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon</groupId>
-        <artifactId>helidon-project</artifactId>
+        <groupId>io.helidon.common.features</groupId>
+        <artifactId>helidon-common-features-project</artifactId>
         <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>io.helidon.common</groupId>
-    <artifactId>helidon-common-project</artifactId>
-    <packaging>pom</packaging>
-    <name>Helidon Common Project</name>
 
-    <modules>
-        <module>common</module>
-        <module>reactive</module>
-        <module>configurable</module>
-        <module>key-util</module>
-        <module>http</module>
-        <module>context</module>
-        <module>mapper</module>
-        <module>media-type</module>
-        <module>crypto</module>
-        <module>parameters</module>
-        <module>buffers</module>
-        <module>socket</module>
-        <module>uri</module>
-        <module>testing</module>
-        <module>features</module>
-    </modules>
+    <artifactId>helidon-common-features</artifactId>
+    <name>Helidon Common Features</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/common/features/features/src/main/java/io/helidon/common/features/FeatureCatalog.java
+++ b/common/features/features/src/main/java/io/helidon/common/features/FeatureCatalog.java
@@ -35,7 +35,44 @@ import io.helidon.common.features.api.HelidonFlavor;
 final class FeatureCatalog {
     private static final System.Logger LOGGER = System.getLogger(FeatureCatalog.class.getName());
     private static final HelidonFlavor[] NO_FLAVORS = new HelidonFlavor[0];
+/*
 
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+                        <path>
+                            <groupId>io.helidon.config</groupId>
+                            <artifactId>helidon-config-metadata-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+
+
+
+        @Feature(value = "Health", description = "Health check API")
+        requires static io.helidon.common.features.api;
+ */
     static {
         add("io.helidon.grpc.client",
             FeatureDescriptor.builder()
@@ -53,10 +90,6 @@ final class FeatureCatalog {
               "Metrics",
               "Metrics for gRPC client",
               "grpcClient", "Metrics");
-        addSe("io.helidon.health",
-              "Health",
-              "Health checks support",
-              "Health");
         addSe("io.helidon.reactive.media.jsonp",
               "JSON-P",
               "Media support for Jakarta JSON Processing",
@@ -112,14 +145,6 @@ final class FeatureCatalog {
               "OpenAPI",
               "Open API support",
               "OpenAPI");
-        addSe("io.helidon.security",
-              "Security",
-              "Security support",
-              "Security");
-        addSe("io.helidon.tracing",
-              "Tracing",
-              "Tracing support",
-              "Tracing");
         addSe("io.helidon.webserver",
               "WebServer",
               "Helidon WebServer",

--- a/common/features/features/src/main/java/io/helidon/common/features/FeatureDescriptor.java
+++ b/common/features/features/src/main/java/io/helidon/common/features/FeatureDescriptor.java
@@ -33,7 +33,7 @@ final class FeatureDescriptor implements Comparable<FeatureDescriptor> {
     private final String description;
     private final boolean nativeSupported;
     private final String nativeDescription;
-    private final boolean experimental;
+    private final boolean incubating;
     private final String module;
 
     private FeatureDescriptor(Builder builder) {
@@ -44,7 +44,7 @@ final class FeatureDescriptor implements Comparable<FeatureDescriptor> {
         this.description = builder.description;
         this.nativeSupported = builder.nativeSupported;
         this.nativeDescription = builder.nativeDescription;
-        this.experimental = builder.experimental;
+        this.incubating = builder.experimental;
         this.module = builder.module;
     }
 
@@ -136,8 +136,8 @@ final class FeatureDescriptor implements Comparable<FeatureDescriptor> {
         return String.join("/", path());
     }
 
-    boolean experimental() {
-        return experimental;
+    boolean incubating() {
+        return incubating;
     }
 
     boolean hasFlavor(HelidonFlavor expected) {

--- a/common/features/features/src/main/java/io/helidon/common/features/HelidonFeatures.java
+++ b/common/features/features/src/main/java/io/helidon/common/features/HelidonFeatures.java
@@ -61,7 +61,7 @@ import io.helidon.common.features.api.HelidonFlavor;
  */
 public final class HelidonFeatures {
     private static final System.Logger LOGGER = System.getLogger(HelidonFeatures.class.getName());
-    private static final System.Logger EXPERIMENTAL = System.getLogger(HelidonFeatures.class.getName() + ".experimental");
+    private static final System.Logger INCUBATING = System.getLogger(HelidonFeatures.class.getName() + ".incubating");
     private static final System.Logger INVALID = System.getLogger(HelidonFeatures.class.getName() + ".invalid");
     private static final AtomicBoolean PRINTED = new AtomicBoolean();
     private static final AtomicBoolean SCANNED = new AtomicBoolean();
@@ -219,11 +219,11 @@ public final class HelidonFeatures {
             }
 
             if (!allExperimental.isEmpty()) {
-                EXPERIMENTAL.log(Level.INFO,
-                                 "You are using experimental features. These APIs may change, please follow changelog!");
+                INCUBATING.log(Level.INFO,
+                               "You are using Incubating features. These APIs may change, please follow changelog!");
                 allExperimental
-                        .forEach(it -> EXPERIMENTAL.log(Level.INFO,
-                                                        "\tExperimental feature: "
+                        .forEach(it -> INCUBATING.log(Level.INFO,
+                                                      "\tIncubating feature: "
                                                                 + it.name()
                                                                 + " ("
                                                                 + it.stringPath()
@@ -241,7 +241,7 @@ public final class HelidonFeatures {
     }
 
     private static void gatherExperimental(List<FeatureDescriptor> allExperimental, Node node) {
-        if (node.descriptor != null && node.descriptor.experimental()) {
+        if (node.descriptor != null && node.descriptor.incubating()) {
             allExperimental.add(node.descriptor);
         }
         node.children().values().forEach(it -> gatherExperimental(allExperimental, it));
@@ -303,7 +303,7 @@ public final class HelidonFeatures {
             } else {
                 suffix = "\t";
             }
-            String experimental = feat.experimental() ? "Experimental - " : "";
+            String experimental = feat.incubating() ? "Incubating - " : "";
             String nativeDesc = "";
             if (!feat.nativeSupported()) {
                 nativeDesc = " (NOT SUPPORTED in native image)";

--- a/common/features/features/src/main/java/io/helidon/common/features/HelidonFeatures.java
+++ b/common/features/features/src/main/java/io/helidon/common/features/HelidonFeatures.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import io.helidon.common.NativeImageHelper;
-import io.helidon.common.features.api.Feature;
 import io.helidon.common.features.api.HelidonFlavor;
 
 /**

--- a/common/features/features/src/main/java/io/helidon/common/features/package-info.java
+++ b/common/features/features/src/main/java/io/helidon/common/features/package-info.java
@@ -13,18 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Extension for Graal VM native image to correctly build Helidon applications.
- */
-module io.helidon.graal.nativeimage {
-    requires io.helidon.config;
-    requires io.github.classgraph;
-    requires io.helidon.config.mp;
-    requires svm;
-    requires org.graalvm.sdk;
-    requires jakarta.json;
-    requires io.helidon.common.features.api;
-    requires io.helidon.common.features;
 
-    exports io.helidon.integrations.graal.nativeimage.extension;
-}
+/**
+ * Feature support for Helidon flavors.
+ *
+ * @see io.helidon.common.features.HelidonFeatures
+ */
+package io.helidon.common.features;

--- a/common/features/features/src/main/java/module-info.java
+++ b/common/features/features/src/main/java/module-info.java
@@ -13,18 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Extension for Graal VM native image to correctly build Helidon applications.
- */
-module io.helidon.graal.nativeimage {
-    requires io.helidon.config;
-    requires io.github.classgraph;
-    requires io.helidon.config.mp;
-    requires svm;
-    requires org.graalvm.sdk;
-    requires jakarta.json;
-    requires io.helidon.common.features.api;
-    requires io.helidon.common.features;
 
-    exports io.helidon.integrations.graal.nativeimage.extension;
+/**
+ * Feature catalog.
+ */
+module io.helidon.common.features {
+    requires io.helidon.common;
+    requires io.helidon.common.features.api;
+
+    exports io.helidon.common.features;
 }

--- a/common/features/pom.xml
+++ b/common/features/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,30 +21,26 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon</groupId>
-        <artifactId>helidon-project</artifactId>
+        <groupId>io.helidon.common</groupId>
+        <artifactId>helidon-common-project</artifactId>
         <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>io.helidon.common</groupId>
-    <artifactId>helidon-common-project</artifactId>
+
+    <groupId>io.helidon.common.features</groupId>
+    <artifactId>helidon-common-features-project</artifactId>
+    <name>Helidon Common Features Project</name>
+
+    <properties>
+        <!-- Helidon features should be backward compatible with Java 11 -->
+        <version.java>11</version.java>
+    </properties>
+
     <packaging>pom</packaging>
-    <name>Helidon Common Project</name>
 
     <modules>
-        <module>common</module>
-        <module>reactive</module>
-        <module>configurable</module>
-        <module>key-util</module>
-        <module>http</module>
-        <module>context</module>
-        <module>mapper</module>
-        <module>media-type</module>
-        <module>crypto</module>
-        <module>parameters</module>
-        <module>buffers</module>
-        <module>socket</module>
-        <module>uri</module>
-        <module>testing</module>
+        <module>api</module>
         <module>features</module>
+        <module>processor</module>
     </modules>
 </project>

--- a/common/features/processor/pom.xml
+++ b/common/features/processor/pom.xml
@@ -38,6 +38,14 @@
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- This module is Java 11, we must remove enable-preview from parent project -->
+                    <additionalOptions combine.self="override"/>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/common/features/processor/pom.xml
+++ b/common/features/processor/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,30 +21,23 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon</groupId>
-        <artifactId>helidon-project</artifactId>
+        <groupId>io.helidon.common.features</groupId>
+        <artifactId>helidon-common-features-project</artifactId>
         <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>io.helidon.common</groupId>
-    <artifactId>helidon-common-project</artifactId>
-    <packaging>pom</packaging>
-    <name>Helidon Common Project</name>
+    <artifactId>helidon-common-features-processor</artifactId>
+    <name>Helidon Common Features Annotation Processor</name>
 
-    <modules>
-        <module>common</module>
-        <module>reactive</module>
-        <module>configurable</module>
-        <module>key-util</module>
-        <module>http</module>
-        <module>context</module>
-        <module>mapper</module>
-        <module>media-type</module>
-        <module>crypto</module>
-        <module>parameters</module>
-        <module>buffers</module>
-        <module>socket</module>
-        <module>uri</module>
-        <module>testing</module>
-        <module>features</module>
-    </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/features/processor/src/main/java/io/helidon/common/features/processor/FeatureHandler.java
+++ b/common/features/processor/src/main/java/io/helidon/common/features/processor/FeatureHandler.java
@@ -31,18 +31,14 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
-import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import javax.tools.StandardLocation;
 
 class FeatureHandler {
     private static final String META_FILE = "META-INF/helidon/feature-metadata.properties";
     private final ModuleDescriptor descriptor = new ModuleDescriptor();
-    private Elements elementUtils;
     private Messager messager;
     private Filer filer;
-    private Types typeUtils;
 
     FeatureHandler() {
     }
@@ -51,8 +47,6 @@ class FeatureHandler {
         // get compiler utilities
         messager = processingEnv.getMessager();
         filer = processingEnv.getFiler();
-        typeUtils = processingEnv.getTypeUtils();
-        elementUtils = processingEnv.getElementUtils();
     }
 
     boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/common/features/processor/src/main/java/io/helidon/common/features/processor/FeatureHandler.java
+++ b/common/features/processor/src/main/java/io/helidon/common/features/processor/FeatureHandler.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.features.processor;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import javax.tools.StandardLocation;
+
+class FeatureHandler {
+    private static final String META_FILE = "META-INF/helidon/feature-metadata.properties";
+    private final ModuleDescriptor descriptor = new ModuleDescriptor();
+    private Elements elementUtils;
+    private Messager messager;
+    private Filer filer;
+    private Types typeUtils;
+
+    FeatureHandler() {
+    }
+
+    void init(ProcessingEnvironment processingEnv) {
+        // get compiler utilities
+        messager = processingEnv.getMessager();
+        filer = processingEnv.getFiler();
+        typeUtils = processingEnv.getTypeUtils();
+        elementUtils = processingEnv.getElementUtils();
+    }
+
+    boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        try {
+            return doProcess(annotations, roundEnv);
+        } catch (Exception e) {
+            messager.printMessage(Diagnostic.Kind.ERROR, "Failed to process feature metadata annotation processor. "
+                    + e.getClass().getName() + ": " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private boolean doProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        Set<? extends Element> modules = roundEnv.getElementsAnnotatedWithAny(annotations.toArray(new TypeElement[0]));
+        for (Element module : modules) {
+            processModule(module);
+        }
+
+        if (roundEnv.processingOver()) {
+            storeMetadata();
+        }
+
+        return false;
+    }
+
+    private void processModule(Element moduleElement) {
+        if (moduleElement.getKind() != ElementKind.MODULE) {
+            return;
+        }
+        ModuleElement module = (ModuleElement) moduleElement;
+        List<? extends AnnotationMirror> annotations = module.getAnnotationMirrors();
+        String moduleName = module.getQualifiedName().toString();
+        if (descriptor.name() != null && !moduleName.equals(descriptor.name())) {
+            throw new IllegalStateException("Only one module can be compiled at a single time. Compiling both "
+                                                    + moduleName + ", and " + descriptor.name());
+        }
+        descriptor.moduleName(moduleName);
+        descriptor.name(moduleName);
+
+        for (AnnotationMirror annotation : annotations) {
+            switch (annotation.getAnnotationType().asElement().toString()) {
+            case FeatureProcessor.AOT_CLASS:
+                annotation.getElementValues()
+                        .forEach((method, value) -> {
+                            if (method.getSimpleName().contentEquals("supported")) {
+                                descriptor.aotSupported((boolean) value.getValue());
+                            } else if (method.getSimpleName().contentEquals("description")) {
+                                descriptor.aotDescription((String) value.getValue());
+                            }
+                        });
+                break;
+            case FeatureProcessor.EXPERIMENTAL_CLASS:
+                descriptor.experimental(true);
+                break;
+            case FeatureProcessor.FEATURE_CLASS:
+                annotation.getElementValues()
+                        .forEach((method, value) -> {
+                            if (method.getSimpleName().contentEquals("value")) {
+                                descriptor.name((String) value.getValue());
+                            } else if (method.getSimpleName().contentEquals("description")) {
+                                descriptor.description((String) value.getValue());
+                            } else if (method.getSimpleName().contentEquals("path")) {
+                                Object pathValue = value.getValue();
+                                List<? extends AnnotationValue> values = (List<? extends AnnotationValue>) pathValue;
+                                String[] array = new String[values.size()];
+                                for (int i = 0; i < array.length; i++) {
+                                    array[i] = (String) values.get(i).getValue();
+                                }
+                                descriptor.path(array);
+
+                            } else if (method.getSimpleName().contentEquals("in")) {
+                                descriptor.in(enumList(value.getValue()));
+                            } else if (method.getSimpleName().contentEquals("notIn")) {
+                                descriptor.notIn(enumList(value.getValue()));
+                            }
+                        });
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    private String[] enumList(Object value) {
+        // HelidonFlavor[]
+        List theValue = (List) value;
+        String[] array = new String[theValue.size()];
+        for (int i = 0; i < array.length; i++) {
+            array[i] = String.valueOf(theValue.get(i));
+        }
+        return array;
+    }
+
+    private void storeMetadata() {
+        try (PrintWriter metaWriter = new PrintWriter(filer.createResource(StandardLocation.CLASS_OUTPUT,
+                                                                           "",
+                                                                           META_FILE)
+                                                              .openWriter())) {
+
+            descriptor.write(metaWriter);
+        } catch (IOException e) {
+            messager.printMessage(Diagnostic.Kind.ERROR, "Failed to write feature metadata: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/common/features/processor/src/main/java/io/helidon/common/features/processor/FeatureProcessor.java
+++ b/common/features/processor/src/main/java/io/helidon/common/features/processor/FeatureProcessor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.features.processor;
+
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Annotation processor.
+ */
+public class FeatureProcessor extends AbstractProcessor {
+    static final String ANNOTATIONS_PACKAGE = "io.helidon.common.features.api.";
+    static final String AOT_CLASS = ANNOTATIONS_PACKAGE + "Aot";
+    static final String EXPERIMENTAL_CLASS = ANNOTATIONS_PACKAGE + "Experimental";
+    static final String FEATURE_CLASS = ANNOTATIONS_PACKAGE + "Feature";
+
+    private FeatureHandler handler;
+
+    /**
+     * Public constructor required for service loader.
+     */
+    public FeatureProcessor() {
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(AOT_CLASS,
+                      EXPERIMENTAL_CLASS,
+                      FEATURE_CLASS);
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+
+        handler = new FeatureHandler();
+        handler.init(processingEnv);
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return handler.process(annotations, roundEnv);
+    }
+}

--- a/common/features/processor/src/main/java/io/helidon/common/features/processor/ModuleDescriptor.java
+++ b/common/features/processor/src/main/java/io/helidon/common/features/processor/ModuleDescriptor.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.features.processor;
+
+import java.io.PrintWriter;
+
+class ModuleDescriptor {
+    private boolean aotSupported = true;
+    private String aotDescription;
+
+    private boolean experimental = false;
+
+    private String[] in;
+    private String[] notIn;
+
+    private String name;
+    private String description;
+    private String[] path;
+    private String moduleName;
+
+    ModuleDescriptor moduleName(String moduleName) {
+        this.moduleName = moduleName;
+        return this;
+    }
+
+    ModuleDescriptor aotSupported(boolean aotSupported) {
+        this.aotSupported = aotSupported;
+        return this;
+    }
+
+    ModuleDescriptor aotDescription(String aotDescription) {
+        this.aotDescription = aotDescription;
+        return this;
+    }
+
+    ModuleDescriptor experimental(boolean experimental) {
+        this.experimental = experimental;
+        return this;
+    }
+
+    ModuleDescriptor notIn(String[] notIn) {
+        this.notIn = notIn;
+        return this;
+    }
+
+    ModuleDescriptor in(String[] in) {
+        this.in = in;
+        return this;
+    }
+
+    ModuleDescriptor name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    String name() {
+        return name;
+    }
+
+    ModuleDescriptor description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    ModuleDescriptor path(String[] path) {
+        this.path = path;
+        return this;
+    }
+
+    void write(PrintWriter metaWriter) {
+        write(metaWriter, "m", moduleName);
+        write(metaWriter, "n", name);
+        write(metaWriter, "d", description);
+        write(metaWriter, "aotd", aotDescription);
+        write(metaWriter, "in", in);
+        write(metaWriter, "not", notIn);
+
+        if (path != null && path.length != 0) {
+            if (path.length != 1 || !name.equals(path[0])) {
+                write(metaWriter, "p", path);
+            }
+        }
+
+        if (!aotSupported) {
+            write(metaWriter, "aot", false);
+        }
+
+        if (experimental) {
+            write(metaWriter, "e", true);
+        }
+    }
+
+    private void write(PrintWriter pw, String key, boolean value) {
+        write(pw, key, String.valueOf(value));
+    }
+
+    private void write(PrintWriter pw, String key, String[] value) {
+        if (value == null || value.length == 0) {
+            return;
+        }
+        write(pw, key, String.join(",", value));
+    }
+
+    private void write(PrintWriter pw, String key, String value) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        pw.print(key);
+        pw.print('=');
+        pw.println(value);
+    }
+}

--- a/common/features/processor/src/main/java/io/helidon/common/features/processor/package-info.java
+++ b/common/features/processor/src/main/java/io/helidon/common/features/processor/package-info.java
@@ -13,18 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Extension for Graal VM native image to correctly build Helidon applications.
- */
-module io.helidon.graal.nativeimage {
-    requires io.helidon.config;
-    requires io.github.classgraph;
-    requires io.helidon.config.mp;
-    requires svm;
-    requires org.graalvm.sdk;
-    requires jakarta.json;
-    requires io.helidon.common.features.api;
-    requires io.helidon.common.features;
 
-    exports io.helidon.integrations.graal.nativeimage.extension;
-}
+/**
+ * Processor of feature annotations on {@code module-info.java}.
+ */
+package io.helidon.common.features.processor;

--- a/common/features/processor/src/main/java/module-info.java
+++ b/common/features/processor/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
-package io.helidon.common;
-
 /**
- * Flavors of Helidon.
+ * Annotation processor generating metadata for Helidon features.
  */
-public enum HelidonFlavor {
-    /**
-     * The "Standard Edition" flavor.
-     */
-    SE,
-    /**
-     * The "MicroProfile" flavor.
-     */
-    MP
+module io.helidon.common.features.processor {
+    requires java.compiler;
+
+    exports io.helidon.common.features.processor;
+
+    provides javax.annotation.processing.Processor with io.helidon.common.features.processor.FeatureProcessor;
 }

--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -51,8 +51,22 @@
             <artifactId>helidon-common-media-type</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <!-- this is required to add the processor to reactor at the right time -->
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-metadata-processor</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <!-- this is required to add the processor to reactor at the right time -->
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-processor</artifactId>
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>

--- a/config/config/src/main/java/module-info.java
+++ b/config/config/src/main/java/module-info.java
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.config.PropertiesConfigParser;
 
 /**
@@ -21,6 +23,7 @@ import io.helidon.config.PropertiesConfigParser;
  *
  * @see io.helidon.config
  */
+@Feature(value = "Config", description = "Configuration module", in = {HelidonFlavor.NIMA, HelidonFlavor.SE})
 module io.helidon.config {
 
     requires java.logging;
@@ -29,6 +32,9 @@ module io.helidon.config {
 
     requires transitive io.helidon.common;
     requires transitive io.helidon.common.media.type;
+
+    requires static io.helidon.common.features.api;
+
 
     exports io.helidon.config;
     exports io.helidon.config.spi;

--- a/examples/logging/jul/README.md
+++ b/examples/logging/jul/README.md
@@ -23,7 +23,7 @@ Expected output should be similar to the following:
 2020.11.19 15:37:28 INFO io.helidon.common.LogConfig Thread[main,5,main]: Logging at initialization configured using classpath: /logging.properties ""
 2020.11.19 15:37:28 INFO io.helidon.examples.logging.jul.Main Thread[main,5,main]: Starting up "startup"
 2020.11.19 15:37:28 INFO io.helidon.examples.logging.jul.Main Thread[pool-1-thread-1,5,main]: Running on another thread "propagated"
-2020.11.19 15:37:28 INFO io.helidon.common.HelidonFeatures Thread[features-thread,5,main]: Helidon SE 2.2.0 features: [Config, WebServer] ""
+2020.11.19 15:37:28 INFO io.helidon.common.features.HelidonFeatures Thread[features-thread,5,main]: Helidon SE 2.2.0 features: [Config, WebServer] ""
 2020.11.19 15:37:28 INFO io.helidon.reactive.webserver.NettyWebServer Thread[nioEventLoopGroup-2-1,10,main]: Channel '@default' started: [id: 0x8a5f5634, L:/0:0:0:0:0:0:0:0:8080] ""
 ```
 
@@ -47,6 +47,6 @@ Expected output should be similar to the following:
 2020.11.19 15:38:14 INFO io.helidon.common.LogConfig Thread[main,5,main]: Logging at runtime configured using classpath: /logging.properties ""
 2020.11.19 15:38:14 INFO io.helidon.examples.logging.jul.Main Thread[main,5,main]: Starting up "startup"
 2020.11.19 15:38:14 INFO io.helidon.examples.logging.jul.Main Thread[pool-1-thread-1,5,main]: Running on another thread "propagated"
-2020.11.19 15:38:14 INFO io.helidon.common.HelidonFeatures Thread[features-thread,5,main]: Helidon SE 2.2.0 features: [Config, WebServer] ""
+2020.11.19 15:38:14 INFO io.helidon.common.features.HelidonFeatures Thread[features-thread,5,main]: Helidon SE 2.2.0 features: [Config, WebServer] ""
 2020.11.19 15:38:14 INFO io.helidon.reactive.webserver.NettyWebServer Thread[nioEventLoopGroup-2-1,10,main]: Channel '@default' started: [id: 0x2b929906, L:/0:0:0:0:0:0:0:0:8080] ""
 ```

--- a/examples/logging/log4j/README.md
+++ b/examples/logging/log4j/README.md
@@ -26,7 +26,7 @@ Expected output should be similar to the following:
 15:44:48.596 INFO  [main] io.helidon.examples.logging.log4j.Main - Starting up "startup"
 15:44:48.598 INFO  [main] io.helidon.examples.logging.log4j.Main - Using JUL logger "startup"
 15:44:48.600 INFO  [pool-2-thread-1] io.helidon.examples.logging.log4j.Main - Running on another thread "propagated"
-15:44:48.704 INFO  [features-thread] io.helidon.common.HelidonFeatures - Helidon SE 2.2.0 features: [Config, WebServer] ""
+15:44:48.704 INFO  [features-thread] io.helidon.common.features.HelidonFeatures - Helidon SE 2.2.0 features: [Config, WebServer] ""
 15:44:48.801 INFO  [nioEventLoopGroup-2-1] io.helidon.reactive.webserver.NettyWebServer - Channel '@default' started: [id: 0xa215c23d, L:/0:0:0:0:0:0:0:0:8080] ""
 ```
 

--- a/examples/logging/logback-aot/README.md
+++ b/examples/logging/logback-aot/README.md
@@ -21,7 +21,7 @@ Expected output should be similar to the following (for both hotspot and native)
 15:40:44.240 INFO  [main] i.h.examples.logging.slf4j.Main - Starting up startup
 15:40:44.241 INFO  [main] i.h.examples.logging.slf4j.Main - Using JUL logger startup
 15:40:44.245 INFO  [pool-1-thread-1] i.h.examples.logging.slf4j.Main - Running on another thread propagated
-15:40:44.395 INFO  [features-thread] io.helidon.common.HelidonFeatures - Helidon SE 2.2.0 features: [Config, WebServer]
+15:40:44.395 INFO  [features-thread] io.helidon.common.features.HelidonFeatures - Helidon SE 2.2.0 features: [Config, WebServer]
 15:40:44.538 INFO  [nioEventLoopGroup-2-1] io.helidon.reactive.webserver.NettyWebServer - Channel '@default' started: [id: 0x8e516487, L:/0:0:0:0:0:0:0:0:8080]
 ```
 

--- a/examples/logging/slf4j/README.md
+++ b/examples/logging/slf4j/README.md
@@ -13,7 +13,7 @@ Expected output should be similar to the following (for both hotspot and native)
 15:40:44.240 INFO  [main] i.h.examples.logging.slf4j.Main - Starting up startup
 15:40:44.241 INFO  [main] i.h.examples.logging.slf4j.Main - Using JUL logger startup
 15:40:44.245 INFO  [pool-1-thread-1] i.h.examples.logging.slf4j.Main - Running on another thread propagated
-15:40:44.395 INFO  [features-thread] io.helidon.common.HelidonFeatures - Helidon SE 2.2.0 features: [Config, WebServer]
+15:40:44.395 INFO  [features-thread] io.helidon.common.features.HelidonFeatures - Helidon SE 2.2.0 features: [Config, WebServer]
 15:40:44.538 INFO  [nioEventLoopGroup-2-1] io.helidon.reactive.webserver.NettyWebServer - Channel '@default' started: [id: 0x8e516487, L:/0:0:0:0:0:0:0:0:8080]
 ```
 

--- a/integrations/graal/native-image-extension/pom.xml
+++ b/integrations/graal/native-image-extension/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>helidon-config-mp</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
         </dependency>

--- a/integrations/graal/native-image-extension/src/main/java/io/helidon/integrations/graal/nativeimage/extension/HelidonReflectionFeature.java
+++ b/integrations/graal/native-image-extension/src/main/java/io/helidon/integrations/graal/nativeimage/extension/HelidonReflectionFeature.java
@@ -32,9 +32,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.helidon.common.HelidonFeatures;
 import io.helidon.common.LogConfig;
 import io.helidon.common.Reflected;
+import io.helidon.common.features.HelidonFeatures;
 import io.helidon.config.mp.MpConfigProviderResolver;
 
 import com.oracle.svm.core.jdk.Resources;

--- a/microprofile/cdi/pom.xml
+++ b/microprofile/cdi/pom.xml
@@ -62,7 +62,10 @@
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-context</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/microprofile/cdi/src/main/java/module-info.java
+++ b/microprofile/cdi/src/main/java/module-info.java
@@ -28,8 +28,11 @@ module io.helidon.microprofile.cdi {
     requires jakarta.cdi;
 
     requires io.helidon.common;
+    requires io.helidon.common.features.api;
+    requires io.helidon.common.features;
     requires io.helidon.config;
     requires io.helidon.config.mp;
+
 
     requires weld.core.impl;
     requires weld.spi;

--- a/nima/observe/health/pom.xml
+++ b/nima/observe/health/pom.xml
@@ -58,6 +58,12 @@
             <artifactId>helidon-nima-http-media-jsonp</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.nima.testing.junit5</groupId>
             <artifactId>helidon-nima-testing-junit5-webserver</artifactId>
             <scope>test</scope>
@@ -73,4 +79,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/nima/observe/health/src/main/java/module-info.java
+++ b/nima/observe/health/src/main/java/module-info.java
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.health.spi.HealthCheckProvider;
 import io.helidon.nima.observe.health.HealthObserveProvider;
 import io.helidon.nima.observe.spi.ObserveProvider;
@@ -21,6 +23,7 @@ import io.helidon.nima.observe.spi.ObserveProvider;
 /**
  * Health checks for Níma observability.
  */
+@Feature(value = "Health", description = "Health check support", in = HelidonFlavor.NIMA)
 module io.helidon.nima.observe.health {
     requires java.management;
 
@@ -29,6 +32,7 @@ module io.helidon.nima.observe.health {
     requires io.helidon.nima.webserver;
     requires io.helidon.nima.http.media.jsonp;
     requires io.helidon.nima.servicecommon;
+    requires static io.helidon.common.features.api;
 
     exports io.helidon.nima.observe.health;
 

--- a/nima/webserver/webserver/pom.xml
+++ b/nima/webserver/webserver/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>helidon-nima-http-encoding</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -67,4 +73,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRouting.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRouting.java
@@ -118,7 +118,7 @@ public final class HttpRouting implements Routing {
     /**
      * Fluent API builder for {@link io.helidon.nima.webserver.http.HttpRouting}.
      */
-    public static class Builder implements HttpRules, io.helidon.common.Builder<Builder, HttpRouting> {
+    public static final class Builder implements HttpRules, io.helidon.common.Builder<Builder, HttpRouting> {
         private final List<Filter> filters = new LinkedList<>();
         private final ServiceRules rootRules = new ServiceRules();
 
@@ -142,13 +142,15 @@ public final class HttpRouting implements Routing {
         }
 
         @Override
-        public Builder register(Supplier<? extends HttpService>... service) {
+        @SafeVarargs
+        public final Builder register(Supplier<? extends HttpService>... service) {
             rootRules.register(service);
             return this;
         }
 
         @Override
-        public Builder register(String path, Supplier<? extends HttpService>... service) {
+        @SafeVarargs
+        public final Builder register(String path, Supplier<? extends HttpService>... service) {
             rootRules.register(path, service);
             return this;
         }

--- a/nima/webserver/webserver/src/main/java/module-info.java
+++ b/nima/webserver/webserver/src/main/java/module-info.java
@@ -23,7 +23,7 @@ import io.helidon.nima.webserver.spi.ServerConnectionProvider;
 /**
  * Loom based WebServer.
  */
-@Feature(value = "WebServer", description = "Níma Web Server", notIn = HelidonFlavor.SE)
+@Feature(value = "WebServer", description = "Níma Web Server", invalidIn = HelidonFlavor.SE)
 module io.helidon.nima.webserver {
     requires transitive io.helidon.common.buffers;
     requires transitive io.helidon.common.socket;

--- a/nima/webserver/webserver/src/main/java/module-info.java
+++ b/nima/webserver/webserver/src/main/java/module-info.java
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.nima.webserver.http1.Http1ConnectionProvider;
 import io.helidon.nima.webserver.http1.spi.Http1UpgradeProvider;
 import io.helidon.nima.webserver.spi.ServerConnectionProvider;
@@ -21,6 +23,7 @@ import io.helidon.nima.webserver.spi.ServerConnectionProvider;
 /**
  * Loom based WebServer.
  */
+@Feature(value = "WebServer", description = "Níma Web Server", notIn = HelidonFlavor.SE)
 module io.helidon.nima.webserver {
     requires transitive io.helidon.common.buffers;
     requires transitive io.helidon.common.socket;
@@ -33,6 +36,7 @@ module io.helidon.nima.webserver {
 
     requires jakarta.annotation;
     requires io.helidon.common.uri;
+    requires static io.helidon.common.features.api;
 
     // provides multiple packages due to intentional cyclic dependency
     // we want to support HTTP/1.1 by default (we could fully separate it, but the API would be harder to use

--- a/reactive/health/pom.xml
+++ b/reactive/health/pom.xml
@@ -72,6 +72,14 @@
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-metadata</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -99,4 +107,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/reactive/health/src/main/java/module-info.java
+++ b/reactive/health/src/main/java/module-info.java
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.HelidonFlavor;
+
 /**
  * Microprofile configuration module.
  */
+@Feature(value = "Health", description = "Health check support", in = HelidonFlavor.SE)
 module io.helidon.reactive.health {
     requires java.logging;
 
@@ -25,11 +29,12 @@ module io.helidon.reactive.health {
     requires transitive microprofile.health.api;
     requires io.helidon.reactive.webserver;
     requires io.helidon.servicecommon.rest;
-    requires static io.helidon.config.metadata;
     requires io.helidon.reactive.webserver.cors;
     requires io.helidon.reactive.media.jsonp;
     requires jakarta.json;
     requires io.helidon.reactive.faulttolerance;
+    requires static io.helidon.config.metadata;
+    requires static io.helidon.common.features.api;
 
     exports io.helidon.reactive.health;
     provides org.eclipse.microprofile.health.spi.HealthCheckResponseProvider

--- a/reactive/webserver/webserver/pom.xml
+++ b/reactive/webserver/webserver/pom.xml
@@ -87,10 +87,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-metadata-processor</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -170,6 +168,18 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <failOnWarning>true</failOnWarning>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.config</groupId>
+                            <artifactId>helidon-config-metadata-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/NettyWebServer.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/NettyWebServer.java
@@ -40,11 +40,11 @@ import java.util.logging.Logger;
 
 import javax.net.ssl.SSLContext;
 
-import io.helidon.common.HelidonFeatures;
-import io.helidon.common.HelidonFlavor;
 import io.helidon.common.SerializationConfig;
 import io.helidon.common.Version;
 import io.helidon.common.context.Context;
+import io.helidon.common.features.HelidonFeatures;
+import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.media.common.MessageBodyReaderContext;
 import io.helidon.reactive.media.common.MessageBodyWriterContext;

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ServerConfiguration.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ServerConfiguration.java
@@ -211,7 +211,7 @@ public interface ServerConfiguration extends SocketConfiguration {
     }
 
     /**
-     * Whether to print details of {@link io.helidon.common.HelidonFeatures}.
+     * Whether to print details of {@link io.helidon.common.features.HelidonFeatures}.
      *
      * @return whether to print details
      */
@@ -575,7 +575,7 @@ public interface ServerConfiguration extends SocketConfiguration {
          *
          * @param print whether to print details or not
          * @return updated builder instance
-         * @see io.helidon.common.HelidonFeatures
+         * @see io.helidon.common.features.HelidonFeatures
          */
         public Builder printFeatureDetails(boolean print) {
             this.printFeatureDetails = print;

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/WebServer.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/WebServer.java
@@ -765,7 +765,7 @@ public interface WebServer {
          *
          * @param shouldPrint whether to print details or not
          * @return updated builder instance
-         * @see io.helidon.common.HelidonFeatures
+         * @see io.helidon.common.features.HelidonFeatures
          */
         @ConfiguredOption(key = "features.print-details", value = "false")
         public Builder printFeatureDetails(boolean shouldPrint) {

--- a/reactive/webserver/webserver/src/main/java/module-info.java
+++ b/reactive/webserver/webserver/src/main/java/module-info.java
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
+import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.reactive.webserver.spi.UpgradeCodecProvider;
 
 /**
  * Reactive web server.
  */
+@Feature(value = "WebServer",
+         description = "Reactive Web Server",
+         in = HelidonFlavor.SE,
+         notIn = {HelidonFlavor.NIMA, HelidonFlavor.MP})
 module io.helidon.reactive.webserver {
     requires io.helidon.common;
     requires transitive io.helidon.reactive.media.common;
@@ -31,7 +37,10 @@ module io.helidon.reactive.webserver {
     requires transitive io.helidon.tracing.config;
     requires transitive io.helidon.tracing;
     requires io.helidon.logging.common;
+    requires io.helidon.common.features;
+    requires io.helidon.common.features.api;
     requires static io.helidon.config.metadata;
+
 
     requires java.logging;
     requires io.netty.handler;

--- a/reactive/webserver/webserver/src/main/java/module-info.java
+++ b/reactive/webserver/webserver/src/main/java/module-info.java
@@ -24,7 +24,7 @@ import io.helidon.reactive.webserver.spi.UpgradeCodecProvider;
 @Feature(value = "WebServer",
          description = "Reactive Web Server",
          in = HelidonFlavor.SE,
-         notIn = {HelidonFlavor.NIMA, HelidonFlavor.MP})
+         invalidIn = {HelidonFlavor.NIMA, HelidonFlavor.MP})
 module io.helidon.reactive.webserver {
     requires io.helidon.common;
     requires transitive io.helidon.reactive.media.common;

--- a/security/security/pom.xml
+++ b/security/security/pom.xml
@@ -65,8 +65,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-metadata-processor</artifactId>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -101,6 +101,18 @@
                     <compilerArgs>
                         <compilerArg>--enable-preview</compilerArg>
                     </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.config</groupId>
+                            <artifactId>helidon-config-metadata-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/security/security/src/main/java/module-info.java
+++ b/security/security/src/main/java/module-info.java
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
+import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.HelidonFlavor;
+
 /**
  * Java for cloud security module.
  *
  * @see io.helidon.security.Security
  * @see io.helidon.security.SecurityContext
  */
+@Feature(value = "Security", description = "Security support", in = {HelidonFlavor.SE, HelidonFlavor.NIMA})
 module io.helidon.security {
     requires java.logging;
 
@@ -27,6 +31,8 @@ module io.helidon.security {
     requires transitive io.helidon.common.configurable;
     requires transitive io.helidon.common.reactive;
     requires transitive io.helidon.config;
+
+    requires static io.helidon.common.features.api;
     requires static io.helidon.config.metadata;
 
     requires transitive io.helidon.tracing;

--- a/tracing/tracing/pom.xml
+++ b/tracing/tracing/pom.xml
@@ -52,8 +52,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-metadata-processor</artifactId>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -68,4 +68,27 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.config</groupId>
+                            <artifactId>helidon-config-metadata-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tracing/tracing/src/main/java/module-info.java
+++ b/tracing/tracing/src/main/java/module-info.java
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
+import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.HelidonFlavor;
+
 /**
  * Opentracing support for helidon, with an abstraction API and SPI for tracing collectors.
+ *
  * @see io.helidon.tracing.spi.TracerProvider
  * @see io.helidon.tracing.TracerBuilder
  */
+@Feature(value = "Tracing", description = "Tracing support", in = {HelidonFlavor.SE, HelidonFlavor.NIMA})
 module io.helidon.tracing {
     requires io.helidon.common;
     requires io.helidon.config;
 
+    requires static io.helidon.common.features.api;
     requires static io.helidon.config.metadata;
 
     exports io.helidon.tracing;


### PR DESCRIPTION
Features are now an annotation on a module (see config and webservers).

When you run MP with this setup (WebServer is configured NOT to be in MP, there is not a single MP module):
```
Helidon MP 4.0.0-SNAPSHOT has no registered features
io.helidon.common.features.HelidonFeatures features - Invalid modules are used:
        Module "io.helidon.reactive.webserver" (WebServer) is not designed for Helidon MP, it should only be used in Helidon [SE]
```

When you run SE with this setup:
```
Helidon SE 4.0.0-SNAPSHOT features: [Config, WebServer]
```

Example of generated file for webserver. Names are shortened to reduce size (not for user interaction) (`META-INF/helidon/native-image/reflection-config.json`):
```
m=io.helidon.reactive.webserver
n=WebServer
d=Reactive Web Server
in=SE
not=NIMA,MP
```
module, name, description, in, not-in


TODO:
 - move all features that are in old catalogue to annotations (and add in/not-in as required)
 