### PR TITLE
[2.x] Issue #4719 - Helidon DBClient does not trigger an Exception when no sane DB connection can be obtained

### DIFF
--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatementDml.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatementDml.java
@@ -54,7 +54,13 @@ class JdbcStatementDml extends JdbcStatement<DbStatementDml, Single<Long>> imple
                                    CompletableFuture<Long> queryFuture) {
 
         executorService().submit(() -> {
-            connection().thenAccept(conn -> callStatement(dbContext, conn, statementFuture, queryFuture));
+            connection()
+                    .thenAccept(conn -> callStatement(dbContext, conn, statementFuture, queryFuture))
+                    .exceptionally(t -> {
+                        statementFuture.completeExceptionally(t);
+                        queryFuture.completeExceptionally(t);
+                        return null;
+                    });
         });
 
         // the query future is reused, as it completes with the number of updated records


### PR DESCRIPTION
Signed-off-by: Tomas Kraus <tomas.kraus@oracle.com>

PR #4771 backport to 2.x