### PR TITLE
3.x upgrade reactive streams

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -2726,21 +2726,28 @@ Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
 License Identifier: Apache-2.0
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Reactive Streams  Public Domain
-Other FOSS License
+Reactive Streams  Reactive Streams
+MIT-0
 Used by: [helidon-dbclient-mongodb, helidon-microprofile-reactive-streams]
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+MIT No Attribution
 
-/************************************************************************
- * Licensed under Public Domain (CC0)                                    *
- *                                                                       *
- * To the extent possible under law, the person who associated CC0 with  *
- * this code has waived all copyright and related or neighboring         *
- * rights to this code.                                                  *
- *                                                                       *
- * You should have received a copy of the CC0 legalcode along with this  *
- * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.*
- ************************************************************************/
+Copyright 2014 Reactive Streams
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 Simple Logging Facade for Java (SLF4J)  QOS.ch

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -41,7 +41,7 @@
         <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
         <version.lib.byte-buddy>1.11.20</version.lib.byte-buddy>
-        <version.lib.reactivestreams>1.0.3</version.lib.reactivestreams>
+        <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
@@ -1245,11 +1245,6 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-dns</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver-dns</artifactId>
                 <version>${version.lib.netty}</version>
             </dependency>
             <dependency>

--- a/etc/HELIDON_THIRD_PARTY_LICENSES.xml
+++ b/etc/HELIDON_THIRD_PARTY_LICENSES.xml
@@ -3074,26 +3074,33 @@ License Identifier: Apache-2.0
 </attribution>
         </dependency>
         <dependency>
-            <id>111054</id>
-            <name>Reactive Streams</name>
-            <version>1.0.3</version>
-            <licensor>Public Domain</licensor>
-            <licenseName>Other FOSS License</licenseName>
+            <id>129267</id>
+            <name>reactive-streams</name>
+            <version>1.0.4</version>
+            <licensor>Reactive Streams</licensor>
+            <licenseName>MIT-0</licenseName>
             <consumers>
                 <consumer>helidon-dbclient-mongodb</consumer>
                 <consumer>helidon-microprofile-reactive-streams</consumer>
             </consumers>
-            <attribution>
-/************************************************************************
- * Licensed under Public Domain (CC0)                                    *
- *                                                                       *
- * To the extent possible under law, the person who associated CC0 with  *
- * this code has waived all copyright and related or neighboring         *
- * rights to this code.                                                  *
- *                                                                       *
- * You should have received a copy of the CC0 legalcode along with this  *
- * work. If not, see &lt;http://creativecommons.org/publicdomain/zero/1.0/&gt;.*
- ************************************************************************/
+            <attribution>MIT No Attribution
+
+Copyright 2014 Reactive Streams
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 </attribution>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgrade reactive-streams to 1.0.4 which changes license from CC-0 to MIT-0
Remove duplicate entry for netty-resolver-dns from dependencyManagement