### PR TITLE
4.x - Dbclient Integration Tests Fixed

### DIFF
--- a/etc/scripts/includes/mysql.sh
+++ b/etc/scripts/includes/mysql.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/scripts/includes/mysql.sh
+++ b/etc/scripts/includes/mysql.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,5 +33,6 @@ readonly DOCKER_ENV="-e MYSQL_USER=${DB_USER} -e MYSQL_DATABASE=${DB_NAME} -e MY
 readonly DOCKER_IMG='mysql:8'
 
 readonly DB_PROFILE='mysql'
+readonly DB_PROPERTY='db=mysql'
 
 echo " - Database URL: ${DB_URL}"

--- a/etc/scripts/includes/pgsql.sh
+++ b/etc/scripts/includes/pgsql.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/scripts/includes/pgsql.sh
+++ b/etc/scripts/includes/pgsql.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,5 +31,6 @@ readonly DOCKER_ENV="-e POSTGRES_USER=${DB_USER} -e POSTGRES_DB=${DB_NAME} -e PO
 readonly DOCKER_IMG='postgres'
 
 readonly DB_PROFILE='pgsql'
+readonly DB_PROPERTY='db=pgsql'
 
 echo " - Database URL: ${DB_URL}"

--- a/tests/integration/dbclient/appl/pom.xml
+++ b/tests/integration/dbclient/appl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/pom.xml
+++ b/tests/integration/dbclient/appl/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.reactive.webserver</groupId>
             <artifactId>helidon-reactive-webserver</artifactId>
         </dependency>
@@ -65,6 +69,10 @@
         <dependency>
             <groupId>io.helidon.reactive.media</groupId>
             <artifactId>helidon-reactive-media-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.reactive.health</groupId>
+            <artifactId>helidon-reactive-health</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.reactive.dbclient</groupId>
@@ -85,6 +93,15 @@
         <dependency>
             <groupId>io.helidon.tests.integration.tools</groupId>
             <artifactId>helidon-tests-integration-tools-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.reactive.metrics</groupId>
+            <artifactId>helidon-reactive-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.reactive.webclient</groupId>
+            <artifactId>helidon-reactive-webclient</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.tests.integration.tools</groupId>
@@ -108,11 +125,6 @@
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.reactive.webclient</groupId>
-            <artifactId>helidon-reactive-webclient</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -240,7 +252,40 @@
         </profile>
 
         <profile>
+            <id>h2</id>
+            <activation>
+                <property>
+                    <name>!db</name>
+                </property>
+            </activation>
+            <properties>
+                <app.config>h2.yaml</app.config>
+                <db.database>test</db.database>
+                <db.user>sa</db.user>
+                <db.password/>
+                <db.url>jdbc:h2:mem:${db.database};INIT=SET TRACE_LEVEL_FILE=4;DATABASE_TO_UPPER=FALSE</db.url>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>io.helidon.integrations.db</groupId>
+                    <artifactId>h2</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <id>mysql</id>
+            <activation>
+                <property>
+                    <name>db</name>
+                    <value>mysql</value>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.helidon.integrations.db</groupId>
@@ -257,6 +302,12 @@
 
         <profile>
             <id>pgsql</id>
+            <activation>
+                <property>
+                    <name>db</name>
+                    <value>pgsql</value>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.helidon.integrations.db</groupId>

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/AbstractService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/AbstractService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/AbstractService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/AbstractService.java
@@ -20,9 +20,9 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import io.helidon.reactive.dbclient.DbClient;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.Service;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
 
 /**
  * Common web service code for testing application.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/AbstractService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/AbstractService.java
@@ -17,7 +17,6 @@ package io.helidon.tests.integration.dbclient.appl;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.logging.Logger;
 
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.webserver.ServerRequest;
@@ -28,8 +27,6 @@ import io.helidon.tests.integration.tools.service.RemoteTestException;
  * Common web service code for testing application.
  */
 public abstract class AbstractService implements Service {
-
-    private static final Logger LOGGER = Logger.getLogger(AbstractService.class.getName());
 
     /** Query parameter for name of Pokemon, Type, etc.  */
     public static final String QUERY_NAME_PARAM = "name";
@@ -50,7 +47,7 @@ public abstract class AbstractService implements Service {
      * @param dbClient DbClient instance
      * @param statements statements from configuration file
      */
-    public AbstractService(final DbClient dbClient, final Map<String, String> statements) {
+    public AbstractService(DbClient dbClient, Map<String, String> statements) {
         this.dbClient = dbClient;
         this.statements = statements;
     }
@@ -70,7 +67,7 @@ public abstract class AbstractService implements Service {
      * @param name statement configuration property name
      * @return statement from configuration file
      */
-    public String statement(final String name) {
+    public String statement(String name) {
         return statements.get(name);
     }
 
@@ -82,7 +79,7 @@ public abstract class AbstractService implements Service {
      * @return query parameter value
      * @throws RemoteTestException when no parameter with given name exists in request
      */
-    public static final String param( final ServerRequest request, final String name) {
+    public static String param(ServerRequest request, String name) {
         Optional<String> maybeParam = request.queryParams().first(name);
         if (maybeParam.isPresent()) {
             return maybeParam.get();

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/ApplMain.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/ApplMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/ApplMain.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/ApplMain.java
@@ -15,10 +15,9 @@
  */
 package io.helidon.tests.integration.dbclient.appl;
 
+import java.lang.System.Logger.Level;
 import java.util.Map;
-import java.util.logging.Logger;
 
-import io.helidon.logging.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.reactive.dbclient.DbClient;
@@ -29,7 +28,9 @@ import io.helidon.reactive.dbclient.metrics.DbClientMetrics;
 import io.helidon.reactive.health.HealthSupport;
 import io.helidon.reactive.media.jsonb.JsonbSupport;
 import io.helidon.reactive.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.reactive.metrics.MetricsSupport;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.WebServer;
 import io.helidon.tests.integration.dbclient.appl.health.HealthCheckService;
 import io.helidon.tests.integration.dbclient.appl.interceptor.InterceptorService;
 import io.helidon.tests.integration.dbclient.appl.mapping.MapperService;
@@ -48,8 +49,6 @@ import io.helidon.tests.integration.dbclient.appl.transaction.TransactionGetServ
 import io.helidon.tests.integration.dbclient.appl.transaction.TransactionInsertService;
 import io.helidon.tests.integration.dbclient.appl.transaction.TransactionQueriesService;
 import io.helidon.tests.integration.dbclient.appl.transaction.TransactionUpdateService;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.WebServer;
 
 /**
  * Main class.
@@ -57,7 +56,7 @@ import io.helidon.reactive.webserver.WebServer;
  */
 public class ApplMain {
 
-    private static final Logger LOGGER = Logger.getLogger(ApplMain.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(ApplMain.class.getName());
 
     private static final String CONFIG_PROPERTY_NAME="app.config";
 
@@ -76,7 +75,7 @@ public class ApplMain {
                                     .statementTypes(DbStatementType.GET))
                 .build();
         final HealthSupport health = HealthSupport.builder()
-                .addLiveness(DbClientHealthCheck
+                .add(DbClientHealthCheck
                         .builder(dbClient)
                         //.dml()
                         .statementName("ping")
@@ -123,8 +122,7 @@ public class ApplMain {
                 .build();
 
         // Prepare routing for the server
-        final WebServer.Builder serverBuilder = WebServer.builder()
-                .routing(routing)
+        final WebServer.Builder serverBuilder = WebServer.builder(routing)
                 // Get webserver config from the "server" section of application.yaml
                 .config(config.get("server"));
 
@@ -161,9 +159,8 @@ public class ApplMain {
         } else {
             configFile = System.getProperty(CONFIG_PROPERTY_NAME, DEFAULT_CONFIG_FILE);
         }
-        LOGGER.info(() -> String.format("Configuration file: %s", configFile));
+        LOGGER.log(Level.INFO, () -> String.format("Configuration file: %s", configFile));
 
-        LogConfig.configureRuntime();
         startServer(configFile);
 
     }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/ApplMain.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/ApplMain.java
@@ -62,7 +62,7 @@ public class ApplMain {
 
     private static final String DEFAULT_CONFIG_FILE="test.yaml";
 
-    private static WebServer startServer(final String configFile) {
+    private static void startServer(String configFile) {
 
         final Config config = Config.create(ConfigSources.classpath(configFile));
         final Config dbConfig = config.get("db");
@@ -134,16 +134,13 @@ public class ApplMain {
         exitResource.setServer(server);
 
         // Start the server and print some info.
-        server.start().thenAccept(ws -> {
-            System.out.println(
-                    "WEB server is up! http://localhost:" + ws.port() + "/");
-        });
+        server.start()
+                .thenAccept(ws -> System.out.println("WEB server is up! http://localhost:" + ws.port() + "/"));
 
         // Server threads are not daemon. NO need to block. Just react.
-        server.whenShutdown().thenRun(
-                () -> System.out.println("WEB server is DOWN. Good bye!"));
+        server.whenShutdown()
+                .thenRun(() -> System.out.println("WEB server is DOWN. Good bye!"));
 
-        return server;
     }
 
     /**

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/InitService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/InitService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/InitService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/InitService.java
@@ -20,22 +20,21 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObjectBuilder;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
+import io.helidon.health.HealthCheck;
+import io.helidon.health.HealthCheckResponse;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.health.DbClientHealthCheck;
-import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
-import io.helidon.tests.integration.dbclient.appl.model.Type;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.reactive.webserver.Service;
+import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
+import io.helidon.tests.integration.dbclient.appl.model.Type;
 
-import org.eclipse.microprofile.health.HealthCheck;
-import org.eclipse.microprofile.health.HealthCheckResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 import static io.helidon.tests.integration.tools.service.AppResponse.okStatus;
@@ -103,7 +102,7 @@ public class InitService implements Service {
                                 dbClient,
                                 dbConfig.get("health-check"));
         HealthCheckResponse checkResponse = check.call();
-        HealthCheckResponse.Status checkState = checkResponse.getStatus();
+        HealthCheckResponse.Status checkState = checkResponse.status();
         final JsonObjectBuilder data = Json.createObjectBuilder();
         data.add("state", checkState.name());
         response.send(okStatus(data.build()));

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/VerifyService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/VerifyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/VerifyService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/VerifyService.java
@@ -15,7 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl;
 
-import java.util.logging.Logger;
+import java.lang.System.Logger.Level;
 
 import io.helidon.config.Config;
 import io.helidon.reactive.dbclient.DbClient;
@@ -38,12 +38,12 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class VerifyService  implements Service {
 
-    private static final Logger LOGGER = Logger.getLogger(VerifyService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(VerifyService.class.getName());
 
     private final DbClient dbClient;
     private final Config config;
 
-    VerifyService(final DbClient dbClient, final Config config) {
+    VerifyService(DbClient dbClient, Config config) {
         this.dbClient = dbClient;
         this.config = config;
     }
@@ -57,18 +57,18 @@ public class VerifyService  implements Service {
     }
 
     // Get Pokemon by ID and return its data.
-    private void getPokemonById(final ServerRequest request, final ServerResponse response) {
+    private void getPokemonById(ServerRequest request, ServerResponse response) {
         try {
-            final String idStr = AbstractService.param(request, QUERY_ID_PARAM);
-            final int id = Integer.parseInt(idStr);
-            final JsonObjectBuilder pokemonBuilder = Json.createObjectBuilder();
+            String idStr = AbstractService.param(request, QUERY_ID_PARAM);
+            int id = Integer.parseInt(idStr);
+            JsonObjectBuilder pokemonBuilder = Json.createObjectBuilder();
             dbClient.execute(
                     exec -> exec
                             .namedGet("get-pokemon-by-id", id))
                     .thenAccept(
                             data -> data.ifPresentOrElse(
                                     row -> {
-                                        final JsonArrayBuilder typesBuilder = Json.createArrayBuilder();
+                                        JsonArrayBuilder typesBuilder = Json.createArrayBuilder();
                                         pokemonBuilder.add("name", row.column("name").as(String.class));
                                         pokemonBuilder.add("id", row.column("id").as(Integer.class));
                                         dbClient.execute(
@@ -97,21 +97,23 @@ public class VerifyService  implements Service {
     }
 
     // Get database type.
-    private void getDatabaseType(final ServerRequest request, final ServerResponse response) {
+    private void getDatabaseType(ServerRequest request, ServerResponse response) {
         JsonObjectBuilder job = Json.createObjectBuilder();
         job.add("type", dbClient.dbType());
         response.send(AppResponse.okStatus(job.build()));
     }
 
     // Get server configuration parameter.
-    private void getConfigParam(final ServerRequest request, final ServerResponse response) {
-        final String name;
+    private void getConfigParam(ServerRequest request, ServerResponse response) {
+        String name;
         try {
             name = AbstractService.param(request, AbstractService.QUERY_NAME_PARAM);
         } catch (RemoteTestException ex) {
-            LOGGER.fine(() -> String.format(
-                    "Error in VerifyService.getConfigParam on server: %s",
-                    ex.getMessage()));
+            LOGGER.log(Level.WARNING,
+                       String.format(
+                               "Error in VerifyService.getConfigParam on server: %s",
+                               ex.getMessage()),
+                       ex);
             response.send(exceptionStatus(ex));
             return;
         }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/VerifyService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/VerifyService.java
@@ -17,19 +17,19 @@ package io.helidon.tests.integration.dbclient.appl;
 
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-
 import io.helidon.config.Config;
 import io.helidon.reactive.dbclient.DbClient;
-import io.helidon.tests.integration.tools.service.AppResponse;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.reactive.webserver.Service;
+import io.helidon.tests.integration.tools.service.AppResponse;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import static io.helidon.tests.integration.dbclient.appl.AbstractService.QUERY_ID_PARAM;
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/dbmapper/DbClientMapperProvider.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/dbmapper/DbClientMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/dbmapper/DbClientMapperProvider.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/dbmapper/DbClientMapperProvider.java
@@ -17,12 +17,12 @@ package io.helidon.tests.integration.dbclient.appl.dbmapper;
 
 import java.util.Optional;
 
-import jakarta.json.JsonObject;
-
 import io.helidon.reactive.dbclient.DbMapper;
 import io.helidon.reactive.dbclient.spi.DbMapperProvider;
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.dbclient.appl.model.RangePoJo;
+
+import jakarta.json.JsonObject;
 
 /**
  * Provides DB Client mappers.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/dbmapper/DbRowToJsonObjectMapper.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/dbmapper/DbRowToJsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/dbmapper/DbRowToJsonObjectMapper.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/dbmapper/DbRowToJsonObjectMapper.java
@@ -24,15 +24,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import io.helidon.reactive.dbclient.DbColumn;
+import io.helidon.reactive.dbclient.DbMapper;
+import io.helidon.reactive.dbclient.DbRow;
+
 import jakarta.json.Json;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
-
-import io.helidon.reactive.dbclient.DbColumn;
-import io.helidon.reactive.dbclient.DbMapper;
-import io.helidon.reactive.dbclient.DbRow;
 
 // This implementation is limited only to conversions required by jUnit tests.
 /**

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/health/HealthCheckService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/health/HealthCheckService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/health/HealthCheckService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/health/HealthCheckService.java
@@ -15,8 +15,8 @@
  */
 package io.helidon.tests.integration.dbclient.appl.health;
 
+import java.lang.System.Logger.Level;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import io.helidon.config.Config;
 import io.helidon.health.HealthCheck;
@@ -40,7 +40,7 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class HealthCheckService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(HealthCheckService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(HealthCheckService.class.getName());
 
     private final Config dbConfig;
 
@@ -95,9 +95,11 @@ public class HealthCheckService extends AbstractService {
                 job.add("status", state.name());
                 response.send(AppResponse.okStatus(job.build()));
             } catch (Throwable t) {
-                LOGGER.warning(() -> String.format(
-                        "Error in HealthCheckService.testHealthCheck on server: %s",
-                        t.getMessage()));
+                LOGGER.log(Level.WARNING,
+                           String.format(
+                                   "Error in HealthCheckService.testHealthCheck on server: %s",
+                                   t.getMessage()),
+                           t);
                 response.send(exceptionStatus(t));
             }
 
@@ -105,8 +107,7 @@ public class HealthCheckService extends AbstractService {
     }
 
     // Verify health check implementation with default settings.
-    private void testHealthCheck(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running test HealthCheckService.testHealthCheck on server");
+    private void testHealthCheck(ServerRequest request, ServerResponse response) {
         Thread thread = new Thread(
                 new HealthCheckThread(
                         request,
@@ -119,15 +120,16 @@ public class HealthCheckService extends AbstractService {
     }
 
     // Verify health check implementation with builder and custom name.
-    private void testHealthCheckWithName(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running test HealthCheckService.testHealthCheckWithName on server");
+    private void testHealthCheckWithName(ServerRequest request, ServerResponse response) {
         final String name;
         try {
             name = param(request, QUERY_NAME_PARAM);
         } catch (RemoteTestException ex) {
-            LOGGER.fine(() -> String.format(
-                    "Error in HealthCheckService.testHealthCheckWithName on server: %s",
-                    ex.getMessage()));
+            LOGGER.log(Level.WARNING,
+                       () -> String.format(
+                               "Error in HealthCheckService.testHealthCheckWithName on server: %s",
+                               ex.getMessage()),
+                       ex);
             response.send(exceptionStatus(ex));
             return;
         }
@@ -144,8 +146,7 @@ public class HealthCheckService extends AbstractService {
     }
 
     // Verify health check implementation using custom DML named statement.
-    private void testHealthCheckWithCustomNamedDML(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running test HealthCheckService.testHealthCheckWithCustomNamedDML on server");
+    private void testHealthCheckWithCustomNamedDML(ServerRequest request, ServerResponse response) {
         Config cfgStatement = dbConfig.get("statements.ping-dml");
         if (!cfgStatement.exists()) {
             response.send(exceptionStatus(new RemoteTestException("Missing statements.ping-dml configuration parameter.")));
@@ -164,8 +165,7 @@ public class HealthCheckService extends AbstractService {
     }
 
     // Verify health check implementation using custom DML statement.
-    private void testHealthCheckWithCustomDML(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running test HealthCheckService.testHealthCheckWithCustomDML on server");
+    private void testHealthCheckWithCustomDML(ServerRequest request, ServerResponse response) {
         Config cfgStatement = dbConfig.get("statements.ping-dml");
         if (!cfgStatement.exists()) {
             response.send(exceptionStatus(new RemoteTestException("Missing statements.ping-dml configuration parameter.")));
@@ -184,8 +184,7 @@ public class HealthCheckService extends AbstractService {
     }
 
     // Verify health check implementation using custom query named statement.
-    private void testHealthCheckWithCustomNamedQuery(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running test HealthCheckService.testHealthCheckWithCustomNamedQuery on server");
+    private void testHealthCheckWithCustomNamedQuery(ServerRequest request, ServerResponse response) {
         Config cfgStatement = dbConfig.get("statements.ping-query");
         if (!cfgStatement.exists()) {
             response.send(exceptionStatus(new RemoteTestException("Missing statements.ping-query configuration parameter.")));
@@ -204,8 +203,7 @@ public class HealthCheckService extends AbstractService {
     }
 
     // Verify health check implementation using custom query statement.
-    private void testHealthCheckWithCustomQuery(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running test HealthCheckService.testHealthCheckWithCustomQuery on server");
+    private void testHealthCheckWithCustomQuery(ServerRequest request, ServerResponse response) {
         Config cfgStatement = dbConfig.get("statements.ping-query");
         if (!cfgStatement.exists()) {
             response.send(exceptionStatus(new RemoteTestException("Missing statements.ping-query configuration parameter.")));

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/health/HealthCheckService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/health/HealthCheckService.java
@@ -18,21 +18,20 @@ package io.helidon.tests.integration.dbclient.appl.health;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObjectBuilder;
-
 import io.helidon.config.Config;
+import io.helidon.health.HealthCheck;
+import io.helidon.health.HealthCheckResponse;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.health.DbClientHealthCheck;
-import io.helidon.tests.integration.dbclient.appl.AbstractService;
-import io.helidon.tests.integration.tools.service.AppResponse;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
+import io.helidon.tests.integration.dbclient.appl.AbstractService;
+import io.helidon.tests.integration.tools.service.AppResponse;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
 
-import org.eclipse.microprofile.health.HealthCheck;
-import org.eclipse.microprofile.health.HealthCheckResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 
@@ -91,8 +90,8 @@ public class HealthCheckService extends AbstractService {
             try {
                 JsonObjectBuilder job = Json.createObjectBuilder();
                 HealthCheckResponse hcResponse = check.call();
-                HealthCheckResponse.Status state = hcResponse.getStatus();
-                job.add("name", hcResponse.getName());
+                HealthCheckResponse.Status state = hcResponse.status();
+                job.add("name", check.name());
                 job.add("status", state.name());
                 response.send(AppResponse.okStatus(job.build()));
             } catch (Throwable t) {

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/interceptor/InterceptorService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/interceptor/InterceptorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/interceptor/InterceptorService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/interceptor/InterceptorService.java
@@ -16,7 +16,6 @@
 package io.helidon.tests.integration.dbclient.appl.interceptor;
 
 import java.util.Map;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
@@ -43,8 +42,6 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class InterceptorService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(InterceptorService.class.getName());
-
     private final DbClientService interceptor;
 
     /**
@@ -54,7 +51,7 @@ public class InterceptorService extends AbstractService {
      * @param statements statements from configuration file
      * @param interceptor DbClientService interceptor instance used in test
      */
-    public InterceptorService(final DbClient dbClient, final Map<String, String> statements, final DbClientService interceptor) {
+    public InterceptorService(DbClient dbClient, Map<String, String> statements, DbClientService interceptor) {
         super(dbClient, statements);
         this.interceptor = interceptor;
     }
@@ -90,8 +87,7 @@ public class InterceptorService extends AbstractService {
     }
 
     // Check that statement interceptor was called before statement execution.
-    private void testStatementInterceptor(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running Interceptor.testStatementInterceptor on server");
+    private void testStatementInterceptor(ServerRequest request, ServerResponse response) {
         Multi<DbRow> rows = dbClient().execute(exec -> exec
                 .createNamedQuery("select-pokemon-named-arg")
                 .addParam("name", Pokemon.POKEMONS.get(6).getName())

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/interceptor/InterceptorService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/interceptor/InterceptorService.java
@@ -18,23 +18,23 @@ package io.helidon.tests.integration.dbclient.appl.interceptor;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbClientService;
 import io.helidon.reactive.dbclient.DbClientServiceContext;
 import io.helidon.reactive.dbclient.DbRow;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/mapping/MapperService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/mapping/MapperService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/mapping/MapperService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/mapping/MapperService.java
@@ -22,22 +22,22 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.dbclient.appl.model.Type;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.dbclient.appl.model.Type.TYPES;
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/mapping/MapperService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/mapping/MapperService.java
@@ -15,12 +15,12 @@
  */
 package io.helidon.tests.integration.dbclient.appl.mapping;
 
+import java.lang.System.Logger.Level;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
@@ -47,7 +47,7 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class MapperService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(MapperService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(MapperService.class.getName());
 
     private interface TestDMLFunction extends Function<Pokemon, Single<Long>> {}
 
@@ -57,7 +57,7 @@ public class MapperService extends AbstractService {
      * @param dbClient DbClient instance
      * @param statements statements from configuration file
      */
-    public MapperService(final DbClient dbClient, final Map<String, String> statements) {
+    public MapperService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -75,13 +75,12 @@ public class MapperService extends AbstractService {
     }
 
     private void executeInsertTest(
-            final ServerRequest request,
-            final ServerResponse response,
-            final String testName,
-            final String pokemonName,
-            final List<Type> pokemonTypes,
-            final TestDMLFunction test) {
-        LOGGER.fine(() -> String.format("Running Mapper.%s on server", testName));
+            ServerRequest request,
+            ServerResponse response,
+            String testName,
+            String pokemonName,
+            List<Type> pokemonTypes,
+            TestDMLFunction test) {
         try {
             String idStr = param(request, QUERY_ID_PARAM);
             int id = Integer.parseInt(idStr);
@@ -95,17 +94,16 @@ public class MapperService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException | NumberFormatException ex) {
-            LOGGER.fine(() -> String.format("Error in Mapper.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in Mapper.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
     }
 
     private void executeUpdateTest(
-            final ServerRequest request,
-            final ServerResponse response,
-            final String testName,
-            final TestDMLFunction test) {
-        LOGGER.fine(() -> String.format("Running Mapper.%s on server", testName));
+            ServerRequest request,
+            ServerResponse response,
+            String testName,
+            TestDMLFunction test) {
         try {
             String name = param(request, QUERY_NAME_PARAM);
             String idStr = param(request, QUERY_ID_PARAM);
@@ -121,17 +119,16 @@ public class MapperService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException | NumberFormatException ex) {
-            LOGGER.fine(() -> String.format("Error in Mapper.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in Mapper.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
     }
 
     private void executeDeleteTest(
-            final ServerRequest request,
-            final ServerResponse response,
-            final String testName,
-            final TestDMLFunction test) {
-        LOGGER.fine(() -> String.format("Running Mapper.%s on server", testName));
+            ServerRequest request,
+            ServerResponse response,
+            String testName,
+            TestDMLFunction test) {
         try {
             String idStr = param(request, QUERY_ID_PARAM);
             int id = Integer.parseInt(idStr);
@@ -145,13 +142,13 @@ public class MapperService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException | NumberFormatException ex) {
-            LOGGER.fine(() -> String.format("Error in Mapper.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in Mapper.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
     }
 
     // Verify insertion of PoJo instance using indexed mapping.
-    private void testInsertWithOrderMapping(final ServerRequest request, final ServerResponse response) {
+    private void testInsertWithOrderMapping(ServerRequest request, ServerResponse response) {
         executeInsertTest(
                 request,
                 response,
@@ -167,7 +164,7 @@ public class MapperService extends AbstractService {
     }
 
     // Verify insertion of PoJo instance using named mapping.
-    private void testInsertWithNamedMapping(final ServerRequest request, final ServerResponse response) {
+    private void testInsertWithNamedMapping(ServerRequest request, ServerResponse response) {
         executeInsertTest(
                 request,
                 response,
@@ -183,7 +180,7 @@ public class MapperService extends AbstractService {
     }
 
     // Verify update of PoJo instance using indexed mapping.
-    private void testUpdateWithOrderMapping(final ServerRequest request, final ServerResponse response) {
+    private void testUpdateWithOrderMapping(ServerRequest request, ServerResponse response) {
         executeUpdateTest(request, response, "testUpdateWithOrderMapping",
                 (pokemon) -> dbClient().execute(
                         exec -> exec
@@ -194,7 +191,7 @@ public class MapperService extends AbstractService {
     }
 
     // Verify update of PoJo instance using named mapping.
-    private void testUpdateWithNamedMapping(final ServerRequest request, final ServerResponse response) {
+    private void testUpdateWithNamedMapping(ServerRequest request, ServerResponse response) {
         executeUpdateTest(request, response, "testUpdateWithNamedMapping",
                 (pokemon) -> dbClient().execute(
                         exec -> exec
@@ -205,7 +202,7 @@ public class MapperService extends AbstractService {
     }
 
     // Verify delete of PoJo instance using indexed mapping.
-    private void testDeleteWithOrderMapping(final ServerRequest request, final ServerResponse response) {
+    private void testDeleteWithOrderMapping(ServerRequest request, ServerResponse response) {
         executeDeleteTest(request, response, "testDeleteWithOrderMapping",
                 (pokemon) -> dbClient().execute(
                         exec -> exec
@@ -216,7 +213,7 @@ public class MapperService extends AbstractService {
     }
 
     // Verify delete of PoJo instance using named mapping.
-    private void testDeleteWithNamedMapping(final ServerRequest request, final ServerResponse response) {
+    private void testDeleteWithNamedMapping(ServerRequest request, ServerResponse response) {
         executeDeleteTest(request, response, "testDeleteWithNamedMapping",
                 (pokemon) -> dbClient().execute(
                         exec -> exec
@@ -229,8 +226,7 @@ public class MapperService extends AbstractService {
     // Query and Get calls are here just once so no common executor code is needed.
 
     // Verify query of PoJo instance as a result using mapping.
-    private void testQueryWithMapping(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running Mapper.testQueryWithMapping on server");
+    private void testQueryWithMapping(ServerRequest request, ServerResponse response) {
         try {
             String name = param(request, QUERY_NAME_PARAM);
             Multi<DbRow> rows = dbClient().execute(exec -> exec
@@ -252,14 +248,13 @@ public class MapperService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException ex) {
-            LOGGER.fine(() -> "Error in Mapper.testQueryWithMapping on server");
+            LOGGER.log(Level.WARNING, "Error in Mapper.testQueryWithMapping on server", ex);
             response.send(exceptionStatus(ex));
         }
     }
 
     // Verify get of PoJo instance as a result using mapping.
-    private void testGetWithMapping(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine(() -> "Running Mapper.testGetWithMapping on server");
+    private void testGetWithMapping(ServerRequest request, ServerResponse response) {
         try {
             String name = param(request, QUERY_NAME_PARAM);
             Single<Optional<DbRow>> future = dbClient().execute(exec -> exec
@@ -277,7 +272,7 @@ public class MapperService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException ex) {
-            LOGGER.fine(() -> "Error in Mapper.testGetWithMapping on server");
+            LOGGER.log(Level.WARNING, "Error in Mapper.testGetWithMapping on server", ex);
             response.send(exceptionStatus(ex));
         }
     }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/model/Pokemon.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/model/Pokemon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/model/Pokemon.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/model/Pokemon.java
@@ -162,7 +162,7 @@ public class Pokemon {
         // IDs reserved for mapping tests with insert are 103 - 104
     }
 
-    public static final List<Type> typesList(Type... types) {
+    public static List<Type> typesList(Type... types) {
         if (types == null) {
             return null;
         }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/model/Pokemon.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/model/Pokemon.java
@@ -15,20 +15,19 @@
  */
 package io.helidon.tests.integration.dbclient.appl.model;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.helidon.reactive.dbclient.DbMapper;
+import io.helidon.reactive.dbclient.DbRow;
+
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-
-import io.helidon.reactive.dbclient.DbMapper;
-import io.helidon.reactive.dbclient.DbRow;
 
 import static io.helidon.tests.integration.dbclient.appl.model.Type.TYPES;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/result/FlowControlService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/result/FlowControlService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/result/FlowControlService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/result/FlowControlService.java
@@ -18,7 +18,6 @@ package io.helidon.tests.integration.dbclient.appl.result;
 import java.lang.System.Logger.Level;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/result/FlowControlService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/result/FlowControlService.java
@@ -22,20 +22,20 @@ import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.Type;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/result/FlowControlService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/result/FlowControlService.java
@@ -15,12 +15,12 @@
  */
 package io.helidon.tests.integration.dbclient.appl.result;
 
+import java.lang.System.Logger.Level;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbClient;
@@ -45,7 +45,7 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
 public class FlowControlService extends AbstractService {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(FlowControlService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(FlowControlService.class.getName());
 
     /**
      * Creates an instance of web resource to test proper flow control handling in query processing.
@@ -53,7 +53,7 @@ public class FlowControlService extends AbstractService {
      * @param dbClient DbClient instance
      * @param statements statements from configuration file
      */
-    public FlowControlService(final DbClient dbClient, final Map<String, String> statements) {
+    public FlowControlService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -101,27 +101,27 @@ public class FlowControlService extends AbstractService {
             // Initially request 3 DbRows.
             requested = REQUESTS[reqIdx];
             remaining = REQUESTS[reqIdx++];
-            LOGGER.finer(() -> String.format("Requesting first rows: %d", requested));
+            LOGGER.log(Level.DEBUG, () -> String.format("Requesting first rows: %d", requested));
             this.subscription.request(requested);
         }
 
         @Override
-        public void onNext(final DbRow dbRow) {
+        public void onNext(DbRow dbRow) {
             final Type type = new Type(dbRow.column(1).as(Integer.class), dbRow.column(2).as(String.class));
             total++;
             if (remaining > 0) {
                 remaining -= 1;
-                LOGGER.finer(() -> String.format(
+                LOGGER.log(Level.DEBUG, () -> String.format(
                         "NEXT: tot: %d req: %d rem: %d type: %s", total, requested, remaining, type.toString()));
                 if (remaining == 0 && reqIdx < REQUESTS.length) {
-                    LOGGER.finer(() -> String.format("Notifying main thread to request more rows"));
+                    LOGGER.log(Level.DEBUG, () -> "Notifying main thread to request more rows");
                     synchronized (this) {
                         this.notify();
                     }
                 }
                 // Shall not recieve dbRow when not requested!
             } else {
-                LOGGER.warning(() -> String.format(
+                LOGGER.log(Level.WARNING, () -> String.format(
                         "NEXT: tot: %d req: %d rem: %d type: %s", total, requested, remaining, type.toString()));
                 throw new RemoteTestException(String.format("Recieved unexpected row: %s", type.toString()));
             }
@@ -130,13 +130,13 @@ public class FlowControlService extends AbstractService {
         @Override
         public void onError(Throwable throwable) {
             error = throwable.getMessage();
-            LOGGER.warning(() -> String.format("EXCEPTION: %s", throwable.getMessage()));
+            LOGGER.log(Level.WARNING, String.format("EXCEPTION: %s", throwable.getMessage()), throwable);
             finished = true;
         }
 
         @Override
         public void onComplete() {
-            LOGGER.finer(() -> String.format("COMPLETE: tot: %d req: %d rem: %d", total, requested, remaining));
+            LOGGER.log(Level.DEBUG, () -> String.format("COMPLETE: tot: %d req: %d rem: %d", total, requested, remaining));
             finished = true;
             synchronized (this) {
                 this.notify();
@@ -150,7 +150,7 @@ public class FlowControlService extends AbstractService {
         private void requestNext() {
             if (reqIdx < REQUESTS.length) {
                 requested = remaining = REQUESTS[reqIdx++];
-                LOGGER.finer(() -> String.format("Requesting more rows: %d", requested));
+                LOGGER.log(Level.DEBUG, () -> String.format("Requesting more rows: %d", requested));
                 this.subscription.request(requested);
             } else {
                 throw new RemoteTestException("Can't request more rows, processing shall be finished now.");
@@ -164,15 +164,12 @@ public class FlowControlService extends AbstractService {
      */
     private static final class SourceDataThread implements Runnable {
 
-        private final ServerRequest request;
         private final ServerResponse response;
         private final DbClient dbClient;
 
         private SourceDataThread(
-                final ServerRequest request,
                 final ServerResponse response,
                 final DbClient dbClient) {
-            this.request = request;
             this.response = response;
             this.dbClient = dbClient;
         }
@@ -203,11 +200,11 @@ public class FlowControlService extends AbstractService {
                                         Type.TYPES.get(id).getName(),
                                         name));
                     }
-                    LOGGER.fine(() -> type.toString());
+                    LOGGER.log(Level.DEBUG, type::toString);
                 });
                 response.send(AppResponse.okStatus(JsonObject.EMPTY_JSON_OBJECT));
             } catch (RemoteTestException ex) {
-                LOGGER.fine("Sending error response.");
+                LOGGER.log(Level.DEBUG, "Sending error response.");
                 response.send(exceptionStatus(ex));
             }
         }
@@ -217,8 +214,7 @@ public class FlowControlService extends AbstractService {
     // Source data verification test.
     // Testing code is blocking so it's running in a separate thread.
     private void testSourceData(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine("Running FlowControl.testSourceData on server");
-        Thread thread = new Thread(new SourceDataThread(request, response, dbClient()));
+        Thread thread = new Thread(new SourceDataThread(response, dbClient()));
         thread.start();
     }
 
@@ -227,24 +223,20 @@ public class FlowControlService extends AbstractService {
      */
     private static final class FlowControlThread implements Runnable {
 
-        private final ServerRequest request;
         private final ServerResponse response;
         private final DbClient dbClient;
 
         private FlowControlThread(
-                final ServerRequest request,
                 final ServerResponse response,
                 final DbClient dbClient) {
-            this.request = request;
             this.response = response;
             this.dbClient = dbClient;
         }
 
         @Override
-        @SuppressWarnings("SleepWhileInLoop")
+        @SuppressWarnings({"SleepWhileInLoop", "BusyWait", "SynchronizationOnLocalVariableOrMethodParameter"})
         public void run() {
             try {
-                CompletableFuture<Long> rowsFuture = new CompletableFuture<>();
                 TestSubscriber subscriber = new TestSubscriber();
                 Multi<DbRow> rows = dbClient.execute(exec -> exec
                         .namedQuery("select-types"));
@@ -263,20 +255,20 @@ public class FlowControlService extends AbstractService {
                         Thread.sleep(500);
                         subscriber.requestNext();
                     } else {
-                        LOGGER.finer(() -> String.format("All requests were already done."));
+                        LOGGER.log(Level.DEBUG, "All requests were already done.");
                     }
                 }
                 if (subscriber.error != null) {
                     throw new RemoteTestException(subscriber.error);
                 }
-                LOGGER.fine("Sending OK response.");
+                LOGGER.log(Level.DEBUG, "Sending OK response.");
                 JsonObjectBuilder job = Json.createObjectBuilder();
                 job.add("requested", subscriber.requested);
                 job.add("remaining", subscriber.remaining);
                 job.add("total", subscriber.total);
                 response.send(AppResponse.okStatus(job.build()));
             } catch (RemoteTestException | InterruptedException ex) {
-                LOGGER.fine("Sending error response.");
+                LOGGER.log(Level.DEBUG, "Sending error response.", ex);
                 response.send(exceptionStatus(ex));
             }
         }
@@ -285,9 +277,8 @@ public class FlowControlService extends AbstractService {
 
     // Flow control test.
     // Testing code is blocking so it's running in a separate thread.
-    private void testFlowControl(final ServerRequest request, final ServerResponse response) {
-        LOGGER.fine("Running FlowControl.testFlowControl on server");
-        Thread thread = new Thread(new FlowControlThread(request, response, dbClient()));
+    private void testFlowControl(ServerRequest request, ServerResponse response) {
+        Thread thread = new Thread(new FlowControlThread(response, dbClient()));
         thread.start();
     }
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleDeleteService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleDeleteService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleDeleteService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleDeleteService.java
@@ -19,16 +19,16 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
-import io.helidon.tests.integration.dbclient.appl.AbstractService;
-import io.helidon.tests.integration.tools.service.AppResponse;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
+import io.helidon.tests.integration.dbclient.appl.AbstractService;
+import io.helidon.tests.integration.tools.service.AppResponse;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
+
+import jakarta.json.Json;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleDeleteService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleDeleteService.java
@@ -15,9 +15,9 @@
  */
 package io.helidon.tests.integration.dbclient.appl.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
@@ -37,7 +37,7 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class SimpleDeleteService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleUpdateService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleUpdateService.class.getName());
 
     // Internal functional interface used to implement testing code.
     // Method call: apply(srcPokemon, updatedPokemon)
@@ -49,7 +49,7 @@ public class SimpleDeleteService extends AbstractService {
      * @param dbClient DbClient instance
      * @param statements statements from configuration file
      */
-    public SimpleDeleteService(final DbClient dbClient, final Map<String, String> statements) {
+    public SimpleDeleteService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -73,8 +73,7 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Common test execution code
-    private void executeTest(final ServerRequest request, final ServerResponse response, final String testName, final TestFunction test) {
-        LOGGER.fine(() -> String.format("Running SimpleDeleteService.%s on server", testName));
+    private void executeTest(ServerRequest request, ServerResponse response, String testName, TestFunction test) {
         try {
             String idStr = param(request, QUERY_ID_PARAM);
             int id = Integer.parseInt(idStr);
@@ -87,13 +86,13 @@ public class SimpleDeleteService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException | NumberFormatException ex) {
-            LOGGER.fine(() -> String.format("Error in SimpleDeleteService.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in SimpleDeleteService.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
     }
 
     // Verify {@code createNamedDelete(String, String)} API method with ordered parameters.
-    private void testCreateNamedDeleteStrStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedDeleteStrStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedDeleteStrStrOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
@@ -103,7 +102,7 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code createNamedDelete(String)} API method with named parameters.
-    private void testCreateNamedDeleteStrNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedDeleteStrNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedDeleteStrNamedArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
@@ -113,7 +112,7 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code createNamedDelete(String)} API method with ordered parameters.
-    private void testCreateNamedDeleteStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedDeleteStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedDeleteStrOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
@@ -123,8 +122,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code createDelete(String)} API method with named parameters.
-    private void testCreateDeleteNamedArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testCreateDeleteNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateDeleteNamedArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                 .createDelete(statement("delete-pokemon-named-arg"))
@@ -133,7 +132,7 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code createDelete(String)} API method with ordered parameters.
-    private void testCreateDeleteOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateDeleteOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateDeleteOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
@@ -143,8 +142,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code namedDelete(String)} API method with ordered parameters.
-    private void testNamedDeleteOrderArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testNamedDeleteOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testNamedDeleteOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                 .namedDelete("delete-pokemon-order-arg", id)
@@ -152,8 +151,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code delete(String)} API method with ordered parameters.
-    private void testDeleteOrderArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testDeleteOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDeleteOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                 .delete(statement("delete-pokemon-order-arg"), id)
@@ -163,8 +162,8 @@ public class SimpleDeleteService extends AbstractService {
     // DML delete
 
     // Verify {@code createNamedDmlStatement(String, String)} API method with delete with ordered parameters.
-    private void testCreateNamedDmlWithDeleteStrStrOrderArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testCreateNamedDmlWithDeleteStrStrOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedDmlWithDeleteStrStrOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                                 .createNamedDmlStatement("delete-mudkip", statement("delete-pokemon-order-arg"))
@@ -174,8 +173,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code createNamedDmlStatement(String)} API method with delete with named parameters.
-    private void testCreateNamedDmlWithDeleteStrNamedArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testCreateNamedDmlWithDeleteStrNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedDmlWithDeleteStrNamedArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                                 .createNamedDmlStatement("delete-pokemon-named-arg")
@@ -185,8 +184,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code createNamedDmlStatement(String)} API method with delete with ordered parameters.
-    private void testCreateNamedDmlWithDeleteStrOrderArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testCreateNamedDmlWithDeleteStrOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedDmlWithDeleteStrOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                                 .createNamedDmlStatement("delete-pokemon-order-arg")
@@ -196,8 +195,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code createDmlStatement(String)} API method with delete with named parameters.
-    private void testCreateDmlWithDeleteNamedArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testCreateDmlWithDeleteNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateDmlWithDeleteNamedArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                                 .createDmlStatement(statement("delete-pokemon-named-arg"))
@@ -207,8 +206,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code createDmlStatement(String)} API method with delete with ordered parameters.
-    private void testCreateDmlWithDeleteOrderArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testCreateDmlWithDeleteOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateDmlWithDeleteOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                                 .createDmlStatement(statement("delete-pokemon-order-arg"))
@@ -218,8 +217,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code namedDml(String)} API method with delete with ordered parameters.
-    private void testNamedDmlWithDeleteOrderArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testNamedDmlWithDeleteOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testNamedDmlWithDeleteOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                                 .namedDml("delete-pokemon-order-arg", id)
@@ -227,8 +226,8 @@ public class SimpleDeleteService extends AbstractService {
     }
 
     // Verify {@code dml(String)} API method with delete with ordered parameters.
-    private void testDmlWithDeleteOrderArgs(final ServerRequest request, final ServerResponse response) {
-        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+    private void testDmlWithDeleteOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlWithDeleteOrderArgs",
                 (id) -> dbClient().execute(
                         exec -> exec
                                 .dml(statement("delete-pokemon-order-arg"), id)

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleGetService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleGetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleGetService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleGetService.java
@@ -15,10 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.appl.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
@@ -39,7 +39,7 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class SimpleGetService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleGetService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleGetService.class.getName());
 
     private interface TestFunction extends Function<String, Single<Optional<DbRow>>> {}
 
@@ -49,7 +49,7 @@ public class SimpleGetService extends AbstractService {
      * @param dbClient DbClient instance
      * @param statements statements from configuration file
      */
-    public SimpleGetService(final DbClient dbClient, final Map<String, String> statements) {
+    public SimpleGetService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -72,7 +72,6 @@ public class SimpleGetService extends AbstractService {
             final String testName,
             final TestFunction test
     ) {
-        LOGGER.fine(() -> String.format("Running SimpleGetService.%s on server", testName));
         try {
             String name = param(request, QUERY_NAME_PARAM);
             test.apply(name)
@@ -87,13 +86,13 @@ public class SimpleGetService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException ex) {
-            LOGGER.fine(() -> String.format("Error in SimpleGetService.%s on server", testName));
+            LOGGER.log(Level.WARNING, () -> String.format("Error in SimpleGetService.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
     }
 
     // Verify {@code createNamedGet(String, String)} API method with named parameters.
-    private void testCreateNamedGetStrStrNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedGetStrStrNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -103,7 +102,7 @@ public class SimpleGetService extends AbstractService {
     }
 
     // Verify {@code createNamedGet(String)} API method with named parameters.
-    private void testCreateNamedGetStrNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedGetStrNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedGetStrNamedArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -113,7 +112,7 @@ public class SimpleGetService extends AbstractService {
     }
 
     // Verify {@code createNamedGet(String)} API method with ordered parameters.
-    private void testCreateNamedGetStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedGetStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedGetStrOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -123,7 +122,7 @@ public class SimpleGetService extends AbstractService {
     }
 
     // Verify {@code createGet(String)} API method with named parameters.
-    private void testCreateGetNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateGetNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateGetNamedArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -133,7 +132,7 @@ public class SimpleGetService extends AbstractService {
     }
 
     //Verify {@code createGet(String)} API method with ordered parameters.
-    private void testCreateGetOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateGetOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateGetOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -144,7 +143,7 @@ public class SimpleGetService extends AbstractService {
 
     // Verify {@code namedGet(String)} API method with ordered parameters passed
     // directly to the {@code query} method.
-    private void testNamedGetStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testNamedGetStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testNamedGetStrOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -154,7 +153,7 @@ public class SimpleGetService extends AbstractService {
 
     // Verify {@code get(String)} API method with ordered parameters passed
     // directly to the {@code query} method.
-    private void testGetStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testGetStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testGetStrOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleGetService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleGetService.java
@@ -20,17 +20,17 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
-import io.helidon.tests.integration.dbclient.appl.AbstractService;
-import io.helidon.tests.integration.tools.service.AppResponse;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
+import io.helidon.tests.integration.dbclient.appl.AbstractService;
+import io.helidon.tests.integration.tools.service.AppResponse;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
+
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleInsertService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleInsertService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleInsertService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleInsertService.java
@@ -15,10 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.appl.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
@@ -38,7 +38,7 @@ import static io.helidon.tests.integration.dbclient.appl.model.Type.TYPES;
  */
 public class SimpleInsertService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleUpdateService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleUpdateService.class.getName());
 
     // Internal functional interface used to implement testing code.
     // Method call: apply(srcPokemon, updatedPokemon)
@@ -50,7 +50,7 @@ public class SimpleInsertService extends AbstractService {
      * @param dbClient DbClient instance
      * @param statements statements from configuration file
      */
-    public SimpleInsertService(final DbClient dbClient, final Map<String, String> statements) {
+    public SimpleInsertService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -75,13 +75,12 @@ public class SimpleInsertService extends AbstractService {
 
     // Common test execution code
     private void executeTest(
-            final ServerRequest request,
-            final ServerResponse response,
-            final String testName,
-            final String pokemonName,
-            final List<Type> pokemonTypes,
-            final TestFunction test) {
-        LOGGER.fine(() -> String.format("Running SimpleInsertService.%s on server", testName));
+            ServerRequest request,
+            ServerResponse response,
+            String testName,
+            String pokemonName,
+            List<Type> pokemonTypes,
+            TestFunction test) {
         try {
             String idStr = param(request, QUERY_ID_PARAM);
             int id = Integer.parseInt(idStr);
@@ -95,13 +94,13 @@ public class SimpleInsertService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException | NumberFormatException ex) {
-            LOGGER.fine(() -> String.format("Error in SimpleInsertService.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in SimpleInsertService.%s on server", testName), ex);
             response.send(AppResponse.exceptionStatus(ex));
         }
     }
 
     // Verify {@code createNamedInsert(String, String)} API method with named parameters.
-    private void testCreateNamedInsertStrStrNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedInsertStrStrNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
@@ -118,7 +117,7 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code createNamedInsert(String)} API method with named parameters.
-    private void testCreateNamedInsertStrNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedInsertStrNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
@@ -135,7 +134,7 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code createNamedInsert(String)} API method with ordered parameters.
-    private void testCreateNamedInsertStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedInsertStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
@@ -152,7 +151,7 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code createInsert(String)} API method with named parameters.
-    private void testCreateInsertNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateInsertNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
@@ -169,7 +168,7 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code createInsert(String)} API method with ordered parameters.
-    private void testCreateInsertOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateInsertOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
@@ -186,7 +185,7 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code namedInsert(String)} API method with ordered parameters passed directly to the {@code insert} method.
-    private void testNamedInsertOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testNamedInsertOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
@@ -203,7 +202,7 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code insert(String)} API method with ordered parameters passed directly to the {@code insert} method.
-    private void testInsertOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testInsertOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
@@ -221,11 +220,11 @@ public class SimpleInsertService extends AbstractService {
     // DML insert
 
     // Verify {@code createNamedDmlStatement(String, String)} API method with insert with named parameters.
-    private void testCreateNamedDmlWithInsertStrStrNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedDmlWithInsertStrStrNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
-                "testNamedInsertOrderArgs",
+                "testCreateNamedDmlWithInsertStrStrNamedArgs",
                 "Torchic",
                 Pokemon.typesList(TYPES.get(10)),
                 (pokemon) -> dbClient().execute(
@@ -238,11 +237,11 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code createNamedDmlStatement(String)} API method with insert with named parameters.
-    private void testCreateNamedDmlWithInsertStrNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedDmlWithInsertStrNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
-                "testNamedInsertOrderArgs",
+                "testCreateNamedDmlWithInsertStrNamedArgs",
                 "Combusken",
                 Pokemon.typesList(TYPES.get(2), TYPES.get(10)),
                 (pokemon) -> dbClient().execute(
@@ -255,11 +254,11 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code createNamedDmlStatement(String)} API method with insert with ordered parameters.
-    private void testCreateNamedDmlWithInsertStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedDmlWithInsertStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
-                "testNamedInsertOrderArgs",
+                "testCreateNamedDmlWithInsertStrOrderArgs",
                 "Treecko",
                 Pokemon.typesList(TYPES.get(12)),
                 (pokemon) -> dbClient().execute(
@@ -272,11 +271,11 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code createDmlStatement(String)} API method with insert with named parameters.
-    private void testCreateDmlWithInsertNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateDmlWithInsertNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
-                "testNamedInsertOrderArgs",
+                "testCreateDmlWithInsertNamedArgs",
                 "Grovyle",
                 Pokemon.typesList(TYPES.get(12)),
                 (pokemon) -> dbClient().execute(
@@ -289,11 +288,11 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code createDmlStatement(String)} API method with insert with ordered parameters.
-    private void testCreateDmlWithInsertOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateDmlWithInsertOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
-                "testNamedInsertOrderArgs",
+                "testCreateDmlWithInsertOrderArgs",
                 "Sceptile",
                 Pokemon.typesList(TYPES.get(12)),
                 (pokemon) -> dbClient().execute(
@@ -306,11 +305,11 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code namedDml(String)} API method with insert with ordered parameters passed directly
-    private void testNamedDmlWithInsertOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testNamedDmlWithInsertOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
-                "testNamedInsertOrderArgs",
+                "testNamedDmlWithInsertOrderArgs",
                 "Snover",
                 Pokemon.typesList(TYPES.get(12), TYPES.get(15)),
                 (pokemon) -> dbClient().execute(
@@ -322,11 +321,11 @@ public class SimpleInsertService extends AbstractService {
     }
 
     // Verify {@code dml(String)} API method with insert with ordered parameters passed directly
-    private void testDmlWithInsertOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testDmlWithInsertOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(
                 request,
                 response,
-                "testNamedInsertOrderArgs",
+                "testDmlWithInsertOrderArgs",
                 "Abomasnow",
                 Pokemon.typesList(TYPES.get(12), TYPES.get(15)),
                 (pokemon) -> dbClient().execute(

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleInsertService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleInsertService.java
@@ -22,14 +22,14 @@ import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.dbclient.appl.model.Type;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
 
 import static io.helidon.tests.integration.dbclient.appl.model.Type.TYPES;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleQueryService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleQueryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleQueryService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleQueryService.java
@@ -19,19 +19,19 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
-import io.helidon.tests.integration.dbclient.appl.AbstractService;
-import io.helidon.tests.integration.tools.service.AppResponse;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
+import io.helidon.tests.integration.dbclient.appl.AbstractService;
+import io.helidon.tests.integration.tools.service.AppResponse;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleQueryService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleQueryService.java
@@ -15,9 +15,9 @@
  */
 package io.helidon.tests.integration.dbclient.appl.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbClient;
@@ -40,11 +40,11 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class SimpleQueryService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleQueryService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleQueryService.class.getName());
 
     private interface TestFunction extends Function<String, Multi<DbRow>> {}
 
-    public SimpleQueryService(final DbClient dbClient, final Map<String, String> statements) {
+    public SimpleQueryService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -62,12 +62,11 @@ public class SimpleQueryService extends AbstractService {
 
     // Common test execution code
     private void executeTest(
-            final ServerRequest request,
-            final ServerResponse response,
-            final String testName,
-            final TestFunction test
+            ServerRequest request,
+            ServerResponse response,
+            String testName,
+            TestFunction test
     ) {
-        LOGGER.fine(() -> String.format("Running SimpleQueryService.%s on server", testName));
         try {
             String name = param(request, QUERY_NAME_PARAM);
             Multi<DbRow> future = test.apply(name);
@@ -79,13 +78,13 @@ public class SimpleQueryService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException ex) {
-            LOGGER.fine(() -> String.format("Error in SimpleQueryService.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in SimpleQueryService.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
     }
 
     // Verify {@code createNamedQuery(String, String)} API method with ordered
-    private JsonObject testCreateNamedQueryStrStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedQueryStrStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedQueryStrStrOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -93,11 +92,10 @@ public class SimpleQueryService extends AbstractService {
                                 .addParam(name)
                                 .execute())
         );
-        return null;
     }
 
     // Verify {@code createNamedQuery(String)} API method with named parameters.
-    private JsonObject testCreateNamedQueryStrNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedQueryStrNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedQueryStrNamedArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -105,11 +103,10 @@ public class SimpleQueryService extends AbstractService {
                                 .addParam("name", name)
                                 .execute())
         );
-        return null;
     }
 
     // Verify {@code createNamedQuery(String)} API method with ordered
-    private JsonObject testCreateNamedQueryStrOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateNamedQueryStrOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateNamedQueryStrOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -117,11 +114,10 @@ public class SimpleQueryService extends AbstractService {
                                 .addParam(name)
                                 .execute())
         );
-        return null;
     }
 
     // Verify {@code createQuery(String)} API method with named parameters.
-    private JsonObject testCreateQueryNamedArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateQueryNamedArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateQueryNamedArgs",
                 name -> dbClient().execute(
                         exec -> exec
@@ -129,38 +125,34 @@ public class SimpleQueryService extends AbstractService {
                                 .addParam("name", name)
                                 .execute())
         );
-        return null;
     }
 
     // Verify {@code createQuery(String)} API method with ordered parameters.
-    private JsonObject testCreateQueryOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testCreateQueryOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testCreateQueryOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec
                                 .createQuery(statement("select-pokemon-order-arg"))
                                 .addParam(name)
                                 .execute()));
-        return null;
     }
 
     // Verify {@code namedQuery(String)} API method with ordered parameters
-    private JsonObject testNamedQueryOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testNamedQueryOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testNamedQueryOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec
                                 .namedQuery("select-pokemon-order-arg", name))
         );
-        return null;
     }
 
     // Verify {@code query(String)} API method with ordered parameters passed
-    private JsonObject testQueryOrderArgs(final ServerRequest request, final ServerResponse response) {
+    private void testQueryOrderArgs(ServerRequest request, ServerResponse response) {
         executeTest(request, response, "testQueryOrderArgs",
                 name -> dbClient().execute(
                         exec -> exec
                                 .query(statement("select-pokemon-order-arg"), name))
         );
-        return null;
     }
 
 }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleUpdateService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleUpdateService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleUpdateService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleUpdateService.java
@@ -15,9 +15,9 @@
  */
 package io.helidon.tests.integration.dbclient.appl.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
@@ -30,7 +30,6 @@ import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
 
 import jakarta.json.Json;
-import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 
@@ -39,13 +38,13 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class SimpleUpdateService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleUpdateService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleUpdateService.class.getName());
 
     // Internal functional interface used to implement testing code.
     // Method call: apply(srcPokemon, updatedPokemon)
     private interface TestFunction extends Function<Pokemon, Single<Long>> {}
 
-    public SimpleUpdateService(final DbClient dbClient, final Map<String, String> statements) {
+    public SimpleUpdateService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -69,8 +68,7 @@ public class SimpleUpdateService extends AbstractService {
     }
 
     // Common test execution code
-    private JsonObject executeTest(final ServerRequest request, final ServerResponse response, final String testName, final TestFunction test) {
-        LOGGER.fine(() -> String.format("Running SimpleUpdateService.%s on server", testName));
+    private void executeTest(ServerRequest request, ServerResponse response, String testName, TestFunction test) {
         try {
             String name = param(request, QUERY_NAME_PARAM);
             String idStr = param(request, QUERY_ID_PARAM);
@@ -86,168 +84,169 @@ public class SimpleUpdateService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException | NumberFormatException ex) {
-            LOGGER.fine(() -> String.format("Error in SimpleUpdateService.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in SimpleUpdateService.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
-        return null;
     }
 
     // Verify {@code createNamedUpdate(String, String)} API method with ordered parameters.
-    private JsonObject testCreateNamedUpdateStrStrNamedArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedUpdate("update-spearow", statement("update-pokemon-named-arg"))
-                                .addParam("name", updatedPokemon.getName()).addParam("id", updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateNamedUpdateStrStrNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedUpdate("update-spearow", statement("update-pokemon-named-arg"))
+                                    .addParam("name", updatedPokemon.getName()).addParam("id", updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code createNamedUpdate(String)} API method with named parameters.
-    private JsonObject testCreateNamedUpdateStrNamedArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedUpdate("update-pokemon-named-arg")
-                                .addParam("name", updatedPokemon.getName()).addParam("id", updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateNamedUpdateStrNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedUpdateStrNamedArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedUpdate("update-pokemon-named-arg")
+                                    .addParam("name", updatedPokemon.getName()).addParam("id", updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
 
     // Verify {@code createNamedUpdate(String)} API method with ordered parameters.
-    private JsonObject testCreateNamedUpdateStrOrderArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedUpdate("update-pokemon-order-arg")
-                                .addParam(updatedPokemon.getName()).addParam(updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateNamedUpdateStrOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedUpdateStrOrderArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedUpdate("update-pokemon-order-arg")
+                                    .addParam(updatedPokemon.getName()).addParam(updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code createUpdate(String)} API method with named parameters.
-    private JsonObject testCreateUpdateNamedArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateUpdateNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createUpdate(statement("update-pokemon-named-arg"))
-                                .addParam("name", updatedPokemon.getName()).addParam("id", updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateUpdateNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateUpdateNamedArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createUpdate(statement("update-pokemon-named-arg"))
+                                    .addParam("name", updatedPokemon.getName()).addParam("id", updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code createUpdate(String)} API method with ordered parameters.
-    private JsonObject testCreateUpdateOrderArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createUpdate(statement("update-pokemon-order-arg"))
-                                .addParam(updatedPokemon.getName()).addParam(updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateUpdateOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateUpdateOrderArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createUpdate(statement("update-pokemon-order-arg"))
+                                    .addParam(updatedPokemon.getName()).addParam(updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code namedUpdate(String)} API method with ordered parameters passed directly to the {@code namedQuery} method.
-    private JsonObject testNamedUpdateNamedArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testNamedUpdateNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .namedUpdate("update-pokemon-order-arg", updatedPokemon.getName(), updatedPokemon.getId())
-                ));
+    private void testNamedUpdateNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testNamedUpdateNamedArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .namedUpdate("update-pokemon-order-arg", updatedPokemon.getName(), updatedPokemon.getId())
+                    ));
     }
 
     // Verify {@code update(String)} API method with ordered parameters passed directly to the {@code query} method.
-    private JsonObject testUpdateOrderArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .update(statement("update-pokemon-order-arg"), updatedPokemon.getName(), updatedPokemon.getId())
-                ));
+    private void testUpdateOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testUpdateOrderArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .update(statement("update-pokemon-order-arg"),
+                                            updatedPokemon.getName(),
+                                            updatedPokemon.getId())
+                    ));
     }
 
     // DML update
 
     // Verify {@code createNamedDmlStatement(String, String)} API method with update with named parameters.
-    private JsonObject testCreateNamedDmlWithUpdateStrStrNamedArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedDmlStatement("update-piplup", statement("update-pokemon-named-arg"))
-                                .addParam("name", updatedPokemon.getName())
-                                .addParam("id", updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateNamedDmlWithUpdateStrStrNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedDmlWithUpdateStrStrNamedArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedDmlStatement("update-piplup", statement("update-pokemon-named-arg"))
+                                    .addParam("name", updatedPokemon.getName())
+                                    .addParam("id", updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code createNamedDmlStatement(String)} API method with update with named parameters.
-    private JsonObject testCreateNamedDmlWithUpdateStrNamedArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedDmlStatement("update-pokemon-named-arg")
-                                .addParam("name", updatedPokemon.getName())
-                                .addParam("id", updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateNamedDmlWithUpdateStrNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedDmlWithUpdateStrNamedArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedDmlStatement("update-pokemon-named-arg")
+                                    .addParam("name", updatedPokemon.getName())
+                                    .addParam("id", updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code createNamedDmlStatement(String)} API method with update with ordered parameters.
-    private JsonObject testCreateNamedDmlWithUpdateStrOrderArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedDmlStatement("update-pokemon-order-arg")
-                                .addParam(updatedPokemon.getName())
-                                .addParam(updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateNamedDmlWithUpdateStrOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateNamedDmlWithUpdateStrOrderArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedDmlStatement("update-pokemon-order-arg")
+                                    .addParam(updatedPokemon.getName())
+                                    .addParam(updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code createDmlStatement(String)} API method with update with named parameters.
-    private JsonObject testCreateDmlWithUpdateNamedArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createDmlStatement(statement("update-pokemon-named-arg"))
-                                .addParam("name", updatedPokemon.getName())
-                                .addParam("id", updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateDmlWithUpdateNamedArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateDmlWithUpdateNamedArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createDmlStatement(statement("update-pokemon-named-arg"))
+                                    .addParam("name", updatedPokemon.getName())
+                                    .addParam("id", updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code createDmlStatement(String)} API method with update with ordered parameters.
-    private JsonObject testCreateDmlWithUpdateOrderArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createDmlStatement(statement("update-pokemon-order-arg"))
-                                .addParam(updatedPokemon.getName())
-                                .addParam(updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testCreateDmlWithUpdateOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testCreateDmlWithUpdateOrderArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createDmlStatement(statement("update-pokemon-order-arg"))
+                                    .addParam(updatedPokemon.getName())
+                                    .addParam(updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code namedDml(String)} API method with update with ordered parameters passed directly
-    private JsonObject testNamedDmlWithUpdateOrderArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .namedDml("update-pokemon-order-arg",
-                                        updatedPokemon.getName(),
-                                        updatedPokemon.getId())
-                ));
+    private void testNamedDmlWithUpdateOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testNamedDmlWithUpdateOrderArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .namedDml("update-pokemon-order-arg",
+                                              updatedPokemon.getName(),
+                                              updatedPokemon.getId())
+                    ));
     }
 
     // Verify {@code dml(String)} API method with update with ordered parameters passed directly
-    private JsonObject testDmlWithUpdateOrderArgs(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testUpdateOrderArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .dml(statement("update-pokemon-order-arg"),
-                                        updatedPokemon.getName(),
-                                        updatedPokemon.getId())
-                ));
+    private void testDmlWithUpdateOrderArgs(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlWithUpdateOrderArgs",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .dml(statement("update-pokemon-order-arg"),
+                                         updatedPokemon.getName(),
+                                         updatedPokemon.getId())
+                    ));
     }
 
 }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleUpdateService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/simple/SimpleUpdateService.java
@@ -19,18 +19,18 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/DmlStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/DmlStatementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/DmlStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/DmlStatementService.java
@@ -15,12 +15,12 @@
  */
 package io.helidon.tests.integration.dbclient.appl.statement;
 
+import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
@@ -33,7 +33,6 @@ import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
 
 import jakarta.json.Json;
-import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 
@@ -42,13 +41,13 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class DmlStatementService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(DmlStatementService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(DmlStatementService.class.getName());
 
     // Internal functional interface used to implement testing code.
     // Method call: apply(srcPokemon, updatedPokemon)
     private interface TestFunction extends Function<Pokemon, Single<Long>> {}
 
-    public DmlStatementService(final DbClient dbClient, final Map<String, String> statements) {
+    public DmlStatementService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -65,8 +64,7 @@ public class DmlStatementService extends AbstractService {
     }
 
     // Common test execution code
-    private JsonObject executeTest(final ServerRequest request, final ServerResponse response, final String testName, final TestFunction test) {
-        LOGGER.fine(() -> String.format("Running SimpleUpdateService.%s on server", testName));
+    private void executeTest(ServerRequest request, ServerResponse response, String testName, TestFunction test) {
         try {
             String name = param(request, QUERY_NAME_PARAM);
             String idStr = param(request, QUERY_ID_PARAM);
@@ -82,99 +80,98 @@ public class DmlStatementService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException | NumberFormatException ex) {
-            LOGGER.fine(() -> String.format("Error in SimpleUpdateService.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in SimpleUpdateService.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
-        return null;
     }
 
     // Verify {@code params(Object... parameters)} parameters setting method.
-    private JsonObject testDmlArrayParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedDmlStatement("update-pokemon-order-arg")
-                                .params(updatedPokemon.getName(), updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testDmlArrayParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlArrayParams",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedDmlStatement("update-pokemon-order-arg")
+                                    .params(updatedPokemon.getName(), updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code params(List<?>)} parameters setting method.
-    private JsonObject testDmlListParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> {
-                            List<Object> params = new ArrayList<>(2);
-                            params.add(updatedPokemon.getName());
-                            params.add(updatedPokemon.getId());
-                            return exec
-                                    .createNamedDmlStatement("update-pokemon-order-arg")
-                                    .params(params)
-                                    .execute();
-                        }
-                ));
+    private void testDmlListParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlListParams",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> {
+                                List<Object> params = new ArrayList<>(2);
+                                params.add(updatedPokemon.getName());
+                                params.add(updatedPokemon.getId());
+                                return exec
+                                        .createNamedDmlStatement("update-pokemon-order-arg")
+                                        .params(params)
+                                        .execute();
+                            }
+                    ));
     }
 
     // Verify {@code params(Map<?>)} parameters setting method.
-    private JsonObject testDmlMapParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> {
-                            Map<String, Object> params = new HashMap<>(2);
-                            params.put("name", updatedPokemon.getName());
-                            params.put("id", updatedPokemon.getId());
-                            return exec
-                                    .createNamedDmlStatement("update-pokemon-named-arg")
-                                    .params(params)
-                                    .execute();
-                        }
-                ));
+    private void testDmlMapParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlMapParams",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> {
+                                Map<String, Object> params = new HashMap<>(2);
+                                params.put("name", updatedPokemon.getName());
+                                params.put("id", updatedPokemon.getId());
+                                return exec
+                                        .createNamedDmlStatement("update-pokemon-named-arg")
+                                        .params(params)
+                                        .execute();
+                            }
+                    ));
     }
 
     // Verify {@code addParam(Object parameter)} parameters setting method.
-    private JsonObject testDmlOrderParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedDmlStatement("update-pokemon-order-arg")
-                                .addParam(updatedPokemon.getName())
-                                .addParam(updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testDmlOrderParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlOrderParam",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedDmlStatement("update-pokemon-order-arg")
+                                    .addParam(updatedPokemon.getName())
+                                    .addParam(updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code addParam(String name, Object parameter)} parameters setting method.
-    private JsonObject testDmlNamedParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedDmlStatement("update-pokemon-named-arg")
-                                .addParam("name", updatedPokemon.getName())
-                                .addParam("id", updatedPokemon.getId())
-                                .execute()
-                ));
+    private void testDmlNamedParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlNamedParam",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedDmlStatement("update-pokemon-named-arg")
+                                    .addParam("name", updatedPokemon.getName())
+                                    .addParam("id", updatedPokemon.getId())
+                                    .execute()
+                    ));
     }
 
     // Verify {@code namedParam(Object parameters)} mapped parameters setting method.
-    private JsonObject testDmlMappedNamedParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedDmlStatement("update-pokemon-named-arg")
-                                .namedParam(updatedPokemon)
-                                .execute()
-                ));
+    private void testDmlMappedNamedParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlMappedNamedParam",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedDmlStatement("update-pokemon-named-arg")
+                                    .namedParam(updatedPokemon)
+                                    .execute()
+                    ));
     }
 
     // Verify {@code indexedParam(Object parameters)} mapped parameters setting method.
-    private JsonObject testDmlMappedOrderParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedUpdateStrStrNamedArgs",
-                (updatedPokemon) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedDmlStatement("update-pokemon-order-arg")
-                                .indexedParam(updatedPokemon)
-                                .execute()
-                ));
+    private void testDmlMappedOrderParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testDmlMappedOrderParam",
+                    (updatedPokemon) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedDmlStatement("update-pokemon-order-arg")
+                                    .indexedParam(updatedPokemon)
+                                    .execute()
+                    ));
     }
 
 }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/DmlStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/DmlStatementService.java
@@ -22,18 +22,18 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/GetStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/GetStatementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/GetStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/GetStatementService.java
@@ -23,18 +23,18 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.logging.Logger;
 
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.RangePoJo;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
+
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/GetStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/GetStatementService.java
@@ -15,13 +15,13 @@
  */
 package io.helidon.tests.integration.dbclient.appl.statement;
 
+import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
@@ -43,12 +43,12 @@ import static io.helidon.tests.integration.tools.service.AppResponse.exceptionSt
  */
 public class GetStatementService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(GetStatementService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(GetStatementService.class.getName());
 
     private interface TestFunction extends BiFunction<Integer, Integer, Single<Optional<DbRow>>> {
     }
 
-    public GetStatementService(final DbClient dbClient, final Map<String, String> statements) {
+    public GetStatementService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -65,13 +65,12 @@ public class GetStatementService extends AbstractService {
     }
 
     // Common test execution code
-    private JsonObject executeTest(
-            final ServerRequest request,
-            final ServerResponse response,
-            final String testName,
-            final TestFunction test
+    private void executeTest(
+            ServerRequest request,
+            ServerResponse response,
+            String testName,
+            TestFunction test
     ) {
-        LOGGER.fine(() -> String.format("Running SimpleGetService.%s on server", testName));
         try {
             String fromIdStr = param(request, QUERY_FROM_ID_PARAM);
             int fromId = Integer.parseInt(fromIdStr);
@@ -89,105 +88,104 @@ public class GetStatementService extends AbstractService {
                         return null;
                     });
         } catch (RemoteTestException | NumberFormatException ex) {
-            LOGGER.fine(() -> String.format("Error in SimpleGetService.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in SimpleGetService.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
-        return null;
     }
 
     // Verify {@code params(Object... parameters)} parameters setting method.
-    private JsonObject testGetArrayParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> exec
-                .createNamedGet("select-pokemons-idrng-order-arg")
-                .params(fromId, toId)
-                .execute()
-        ));
+    private void testGetArrayParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testGetArrayParams",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedGet("select-pokemons-idrng-order-arg")
+                                    .params(fromId, toId)
+                                    .execute()
+                    ));
     }
 
     // Verify {@code params(List<?>)} parameters setting method.
-    private JsonObject testGetListParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> {
-                            List<Integer> params = new ArrayList<>(2);
-                            params.add(fromId);
-                            params.add(toId);
-                            return exec
-                                    .createNamedGet("select-pokemons-idrng-order-arg")
-                                    .params(params)
-                                    .execute();
-                        }
-        ));
+    private void testGetListParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testGetListParams",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> {
+                                List<Integer> params = new ArrayList<>(2);
+                                params.add(fromId);
+                                params.add(toId);
+                                return exec
+                                        .createNamedGet("select-pokemons-idrng-order-arg")
+                                        .params(params)
+                                        .execute();
+                            }
+                    ));
     }
 
     // Verify {@code params(Map<?>)} parameters setting method.
-    private JsonObject testGetMapParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> {
-                            Map<String, Integer> params = new HashMap<>(2);
-                            params.put("idmin", fromId);
-                            params.put("idmax", toId);
-                            return exec
-                                    .createNamedGet("select-pokemons-idrng-named-arg")
-                                    .params(params)
-                                    .execute();
-                        }
-                ));
+    private void testGetMapParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testGetMapParams",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> {
+                                Map<String, Integer> params = new HashMap<>(2);
+                                params.put("idmin", fromId);
+                                params.put("idmax", toId);
+                                return exec
+                                        .createNamedGet("select-pokemons-idrng-named-arg")
+                                        .params(params)
+                                        .execute();
+                            }
+                    ));
     }
 
     // Verify {@code addParam(Object parameter)} parameters setting method.
-    private JsonObject testGetOrderParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedGet("select-pokemons-idrng-order-arg")
-                                .addParam(fromId)
-                                .addParam(toId)
-                                .execute()
-                ));
+    private void testGetOrderParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testGetOrderParam",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedGet("select-pokemons-idrng-order-arg")
+                                    .addParam(fromId)
+                                    .addParam(toId)
+                                    .execute()
+                    ));
     }
 
     // Verify {@code addParam(String name, Object parameter)} parameters setting method.
-    private JsonObject testGetNamedParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedGet("select-pokemons-idrng-named-arg")
-                                .addParam("idmin", fromId)
-                                .addParam("idmax", toId)
-                                .execute()
-                ));
+    private void testGetNamedParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testGetNamedParam",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedGet("select-pokemons-idrng-named-arg")
+                                    .addParam("idmin", fromId)
+                                    .addParam("idmax", toId)
+                                    .execute()
+                    ));
     }
 
     // Verify {@code namedParam(Object parameters)} mapped parameters setting method.
-    private JsonObject testGetMappedNamedParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> {
-                            RangePoJo range = new RangePoJo(fromId, toId);
-                            return exec
-                                    .createNamedGet("select-pokemons-idrng-named-arg")
-                                    .namedParam(range)
-                                    .execute();
-                        }
-                ));
+    private void testGetMappedNamedParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testGetMappedNamedParam",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> {
+                                RangePoJo range = new RangePoJo(fromId, toId);
+                                return exec
+                                        .createNamedGet("select-pokemons-idrng-named-arg")
+                                        .namedParam(range)
+                                        .execute();
+                            }
+                    ));
     }
 
     // Verify {@code indexedParam(Object parameters)} mapped parameters setting method.
-    private JsonObject testGetMappedOrderParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> {
-                            RangePoJo range = new RangePoJo(fromId, toId);
-                            return exec
-                                    .createNamedGet("select-pokemons-idrng-order-arg")
-                                    .indexedParam(range)
-                                    .execute();
-                        }
-                ));
+    private void testGetMappedOrderParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testGetMappedOrderParam",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> {
+                                RangePoJo range = new RangePoJo(fromId, toId);
+                                return exec
+                                        .createNamedGet("select-pokemons-idrng-order-arg")
+                                        .indexedParam(range)
+                                        .execute();
+                            }
+                    ));
     }
 
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/QueryStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/QueryStatementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/QueryStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/QueryStatementService.java
@@ -15,12 +15,12 @@
  */
 package io.helidon.tests.integration.dbclient.appl.statement;
 
+import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbClient;
@@ -44,11 +44,11 @@ import static io.helidon.tests.integration.tools.service.AppResponse.okStatus;
  */
 public class QueryStatementService extends AbstractService {
 
-    private static final Logger LOGGER = Logger.getLogger(GetStatementService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(GetStatementService.class.getName());
 
     private interface TestFunction extends BiFunction<Integer, Integer, Multi<DbRow>> {}
 
-    public QueryStatementService(final DbClient dbClient, final Map<String, String> statements) {
+    public QueryStatementService(DbClient dbClient, Map<String, String> statements) {
         super(dbClient, statements);
     }
 
@@ -65,13 +65,12 @@ public class QueryStatementService extends AbstractService {
     }
 
     // Common test execution code
-    private JsonObject executeTest(
-            final ServerRequest request,
-            final ServerResponse response,
-            final String testName,
-            final TestFunction test
+    private void executeTest(
+            ServerRequest request,
+            ServerResponse response,
+            String testName,
+            TestFunction test
     ) {
-        LOGGER.fine(() -> String.format("Running SimpleQueryService.%s on server", testName));
         try {
             String fromIdStr = param(request, QUERY_FROM_ID_PARAM);
             int fromId = Integer.parseInt(fromIdStr);
@@ -86,105 +85,104 @@ public class QueryStatementService extends AbstractService {
                         return null;
                     });
         } catch (NumberFormatException | RemoteTestException ex) {
-            LOGGER.fine(() -> String.format("Error in SimpleQueryService.%s on server", testName));
+            LOGGER.log(Level.WARNING, String.format("Error in SimpleQueryService.%s on server", testName), ex);
             response.send(exceptionStatus(ex));
         }
-        return null;
     }
 
     // Verify {@code params(Object... parameters)} parameters setting method.
-    private JsonObject testQueryArrayParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedQuery("select-pokemons-idrng-order-arg")
-                                .params(fromId, toId)
-                                .execute()
-                ));
+    private void testQueryArrayParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testQueryArrayParams",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedQuery("select-pokemons-idrng-order-arg")
+                                    .params(fromId, toId)
+                                    .execute()
+                    ));
     }
 
     // Verify {@code params(List<?>)} parameters setting method.
-    private JsonObject testQueryListParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> {
-                            List<Integer> params = new ArrayList<>(2);
-                            params.add(fromId);
-                            params.add(toId);
-                            return exec
-                                    .createNamedQuery("select-pokemons-idrng-order-arg")
-                                    .params(params)
-                                    .execute();
-                        }
-                ));
+    private void testQueryListParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testQueryListParams",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> {
+                                List<Integer> params = new ArrayList<>(2);
+                                params.add(fromId);
+                                params.add(toId);
+                                return exec
+                                        .createNamedQuery("select-pokemons-idrng-order-arg")
+                                        .params(params)
+                                        .execute();
+                            }
+                    ));
     }
 
     // Verify {@code params(Map<?>)} parameters setting method.
-    private JsonObject testQueryMapParams(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> {
-                            Map<String, Integer> params = new HashMap<>(2);
-                            params.put("idmin", fromId);
-                            params.put("idmax", toId);
-                            return exec
-                                    .createNamedQuery("select-pokemons-idrng-named-arg")
-                                    .params(params)
-                                    .execute();
-                        }
-                ));
+    private void testQueryMapParams(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testQueryMapParams",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> {
+                                Map<String, Integer> params = new HashMap<>(2);
+                                params.put("idmin", fromId);
+                                params.put("idmax", toId);
+                                return exec
+                                        .createNamedQuery("select-pokemons-idrng-named-arg")
+                                        .params(params)
+                                        .execute();
+                            }
+                    ));
     }
 
     // Verify {@code addParam(Object parameter)} parameters setting method.
-    private JsonObject testQueryOrderParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedQuery("select-pokemons-idrng-order-arg")
-                                .addParam(fromId)
-                                .addParam(toId)
-                                .execute()
-                ));
+    private void testQueryOrderParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testQueryOrderParam",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedQuery("select-pokemons-idrng-order-arg")
+                                    .addParam(fromId)
+                                    .addParam(toId)
+                                    .execute()
+                    ));
     }
 
     // Verify {@code addParam(String name, Object parameter)} parameters setting method.
-    private JsonObject testQueryNamedParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> exec
-                                .createNamedQuery("select-pokemons-idrng-named-arg")
-                                .addParam("idmin", fromId)
-                                .addParam("idmax", toId)
-                                .execute()
-                ));
+    private void testQueryNamedParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testQueryNamedParam",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> exec
+                                    .createNamedQuery("select-pokemons-idrng-named-arg")
+                                    .addParam("idmin", fromId)
+                                    .addParam("idmax", toId)
+                                    .execute()
+                    ));
     }
 
     // Verify {@code namedParam(Object parameters)} mapped parameters setting method.
-    private JsonObject testQueryMappedNamedParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> {
-                            RangePoJo range = new RangePoJo(fromId, toId);
-                            return exec
-                                    .createNamedQuery("select-pokemons-idrng-named-arg")
-                                    .namedParam(range)
-                                    .execute();
-                        }
-                ));
+    private void testQueryMappedNamedParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testQueryMappedNamedParam",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> {
+                                RangePoJo range = new RangePoJo(fromId, toId);
+                                return exec
+                                        .createNamedQuery("select-pokemons-idrng-named-arg")
+                                        .namedParam(range)
+                                        .execute();
+                            }
+                    ));
     }
 
     // Verify {@code indexedParam(Object parameters)} mapped parameters setting method.
-    private JsonObject testQueryMappedOrderParam(final ServerRequest request, final ServerResponse response) {
-        return executeTest(request, response, "testCreateNamedGetStrStrNamedArgs",
-                (fromId, toId) -> dbClient().execute(
-                        exec -> {
-                            RangePoJo range = new RangePoJo(fromId, toId);
-                            return exec
-                                    .createNamedQuery("select-pokemons-idrng-order-arg")
-                                    .indexedParam(range)
-                                    .execute();
-                        }
-                ));
+    private void testQueryMappedOrderParam(ServerRequest request, ServerResponse response) {
+        executeTest(request, response, "testQueryMappedOrderParam",
+                    (fromId, toId) -> dbClient().execute(
+                            exec -> {
+                                RangePoJo range = new RangePoJo(fromId, toId);
+                                return exec
+                                        .createNamedQuery("select-pokemons-idrng-order-arg")
+                                        .indexedParam(range)
+                                        .execute();
+                            }
+                    ));
     }
 
 }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/QueryStatementService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/statement/QueryStatementService.java
@@ -22,19 +22,19 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
-import io.helidon.tests.integration.dbclient.appl.AbstractService;
-import io.helidon.tests.integration.dbclient.appl.model.RangePoJo;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
+import io.helidon.tests.integration.dbclient.appl.AbstractService;
+import io.helidon.tests.integration.dbclient.appl.model.RangePoJo;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 import static io.helidon.tests.integration.tools.service.AppResponse.okStatus;

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitService.java
@@ -18,12 +18,12 @@ package io.helidon.tests.integration.dbclient.appl.tools;
 import java.util.logging.Logger;
 
 import io.helidon.common.http.HttpMediaType;
-import io.helidon.tests.integration.dbclient.appl.InitService;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.reactive.webserver.Service;
 import io.helidon.reactive.webserver.WebServer;
+import io.helidon.tests.integration.dbclient.appl.InitService;
 
 /**
  * Web resource to terminate web server.
@@ -51,7 +51,7 @@ public class ExitService implements Service {
      * @return {@code null} value
      */
     public String exit(final ServerRequest request, final ServerResponse response) {
-        response.headers().contentType(MediaType.TEXT_PLAIN);
+        response.headers().contentType(HttpMediaType.TEXT_PLAIN);
         response.send("Testing web application shutting down.");
         ExitThread.start(server);
         return null;

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitService.java
@@ -15,22 +15,17 @@
  */
 package io.helidon.tests.integration.dbclient.appl.tools;
 
-import java.util.logging.Logger;
-
 import io.helidon.common.http.HttpMediaType;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.reactive.webserver.Service;
 import io.helidon.reactive.webserver.WebServer;
-import io.helidon.tests.integration.dbclient.appl.InitService;
 
 /**
  * Web resource to terminate web server.
  */
 public class ExitService implements Service {
-
-    private static final Logger LOGGER = Logger.getLogger(InitService.class.getName());
 
     private WebServer server;
 
@@ -40,7 +35,7 @@ public class ExitService implements Service {
                 .get("/", this::exit);
     }
 
-    public void setServer(final WebServer server) {
+    public void setServer(WebServer server) {
         this.server = server;
     }
 
@@ -50,7 +45,7 @@ public class ExitService implements Service {
      * @param response where to send server termination message.
      * @return {@code null} value
      */
-    public String exit(final ServerRequest request, final ServerResponse response) {
+    public String exit(ServerRequest request, ServerResponse response) {
         response.headers().contentType(HttpMediaType.TEXT_PLAIN);
         response.send("Testing web application shutting down.");
         ExitThread.start(server);

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitThread.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitThread.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/ExitThread.java
@@ -15,8 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.tools;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger.Level;
 
 import io.helidon.reactive.webserver.WebServer;
 
@@ -25,20 +24,20 @@ import io.helidon.reactive.webserver.WebServer;
  */
 public class ExitThread implements Runnable {
 
-    private static final Logger LOGGER = Logger.getLogger(ExitThread.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(ExitThread.class.getName());
 
     /**
      * Starts application exit thread.
      *
      * @param server web server instance to shut down
      */
-    public static final void start(final WebServer server) {
+    public static void start(WebServer server) {
         new Thread(new ExitThread(server)).start();
     }
 
     private final WebServer server;
 
-    private ExitThread(final WebServer server) {
+    private ExitThread(WebServer server) {
         this.server = server;
     }
 
@@ -50,7 +49,7 @@ public class ExitThread implements Runnable {
         try {
             Thread.sleep(3000);
         } catch (InterruptedException ie) {
-            LOGGER.log(Level.WARNING, ie, () -> String.format("Thread was interrupted: %s", ie.getMessage()));
+            LOGGER.log(Level.WARNING, String.format("Thread was interrupted: %s", ie.getMessage()), ie);
         } finally {
             server.shutdown();
         }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/QueryParams.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/QueryParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/QueryParams.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/tools/QueryParams.java
@@ -39,7 +39,7 @@ public class QueryParams extends HashMap<String, String> {
      * @param value value of parameter
      * @return query parameters {@code Map} with provided single value
      */
-    public static final QueryParams single(final String name, final String value) {
+    public static QueryParams single(String name, String value) {
         return  QueryParams.builder().add(name, value).build();
     }
 
@@ -48,7 +48,7 @@ public class QueryParams extends HashMap<String, String> {
      *
      * @return new query parameters builder instance
      */
-    public static final Builder builder() {
+    public static Builder builder() {
         return new Builder();
     }
 
@@ -70,7 +70,7 @@ public class QueryParams extends HashMap<String, String> {
          * @param value value of parameter
          * @return updated query parameter builder
          */
-        public Builder add(final String name, final String value) {
+        public Builder add(String name, String value) {
             params.put(name, value);
             return this;
         }

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionDeleteService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionDeleteService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionDeleteService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionDeleteService.java
@@ -19,17 +19,17 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
-import io.helidon.tests.integration.dbclient.appl.AbstractService;
-import io.helidon.tests.integration.tools.service.AppResponse;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
+import io.helidon.tests.integration.dbclient.appl.AbstractService;
+import io.helidon.tests.integration.tools.service.AppResponse;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionGetService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionGetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionGetService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionGetService.java
@@ -20,17 +20,17 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
-import io.helidon.tests.integration.dbclient.appl.AbstractService;
-import io.helidon.tests.integration.tools.service.AppResponse;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
+import io.helidon.tests.integration.dbclient.appl.AbstractService;
+import io.helidon.tests.integration.tools.service.AppResponse;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
+
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionInsertService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionInsertService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionInsertService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionInsertService.java
@@ -20,18 +20,18 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.dbclient.appl.model.Type;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
+
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.dbclient.appl.model.Type.TYPES;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionQueriesService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionQueriesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionQueriesService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionQueriesService.java
@@ -19,19 +19,19 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
-import io.helidon.tests.integration.dbclient.appl.AbstractService;
-import io.helidon.tests.integration.tools.service.AppResponse;
-import io.helidon.tests.integration.tools.service.RemoteTestException;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.ServerRequest;
 import io.helidon.reactive.webserver.ServerResponse;
+import io.helidon.tests.integration.dbclient.appl.AbstractService;
+import io.helidon.tests.integration.tools.service.AppResponse;
+import io.helidon.tests.integration.tools.service.RemoteTestException;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionUpdateService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionUpdateService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionUpdateService.java
+++ b/tests/integration/dbclient/appl/src/main/java/io/helidon/tests/integration/dbclient/appl/transaction/TransactionUpdateService.java
@@ -19,18 +19,18 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.dbclient.DbClient;
+import io.helidon.reactive.webserver.Routing;
+import io.helidon.reactive.webserver.ServerRequest;
+import io.helidon.reactive.webserver.ServerResponse;
 import io.helidon.tests.integration.dbclient.appl.AbstractService;
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.tools.service.AppResponse;
 import io.helidon.tests.integration.tools.service.RemoteTestException;
-import io.helidon.reactive.webserver.Routing;
-import io.helidon.reactive.webserver.ServerRequest;
-import io.helidon.reactive.webserver.ServerResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 
 import static io.helidon.tests.integration.tools.service.AppResponse.exceptionStatus;
 

--- a/tests/integration/dbclient/appl/src/main/resources/h2.yaml
+++ b/tests/integration/dbclient/appl/src/main/resources/h2.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/resources/h2.yaml
+++ b/tests/integration/dbclient/appl/src/main/resources/h2.yaml
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 0
+  host: 0.0.0.0
+
+db:
+  source: jdbc
+  connection:
+    url: ${db.url}
+    username: ${db.user}
+    password: ${db.password}
+  health-check:
+    type: query
+    statement: "SELECT 0"
+  statements:
+    # custom query ping statement
+    ping-query: "SELECT 0"
+    # database schema drop statements
+    drop-types: "DROP TABLE Types"
+    drop-pokemons: "DROP TABLE Pokemons"
+    drop-poketypes: "DROP TABLE PokemonTypes"
+    # database schema initialization statements
+    create-types: "CREATE TABLE Types (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(64) NOT NULL)"
+    create-pokemons: "CREATE TABLE Pokemons (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(64) NOT NULL)"
+    create-poketypes: "CREATE TABLE PokemonTypes (id_pokemon INTEGER NOT NULL, id_type INTEGER NOT NULL REFERENCES Types(id))"
+    # database schema cleanup statements
+    drop-types: "DROP TABLE Types"
+    drop-pokemons: "DROP TABLE Pokemons"
+    drop-poketypes: "DROP TABLE PokemonTypes"
+    # data initialization statements
+    insert-type: "INSERT INTO Types(id, name) VALUES(?, ?)"
+    insert-pokemon: "INSERT INTO Pokemons(id, name) VALUES(?, ?)"
+    insert-poketype: "INSERT INTO PokemonTypes(id_pokemon, id_type) VALUES(?, ?)"
+    # data initialization verification statements
+    select-types: "SELECT id, name FROM Types"
+    select-pokemons: "SELECT id, name FROM Pokemons"
+    select-poketypes: "SELECT id_pokemon, id_type FROM PokemonTypes p WHERE id_pokemon = ?"
+    # data cleanup verification statements
+    select-poketypes-all: "SELECT id_pokemon, id_type FROM PokemonTypes"
+    # retrieve max. Pokemon ID
+    select-max-id: "SELECT MAX(id) FROM Pokemons"
+    # test queries
+    select-pokemon-named-arg: "SELECT id, name FROM Pokemons WHERE name=:name"
+    select-pokemon-order-arg: "SELECT id, name FROM Pokemons WHERE name=?"
+    # test DML insert
+    insert-pokemon-named-arg: "INSERT INTO Pokemons(id, name) VALUES(:id, :name)"
+    insert-pokemon-order-arg: "INSERT INTO Pokemons(id, name) VALUES(?, ?)"
+    # Pokemon mapper uses reverse order of indexed arguments
+    insert-pokemon-order-arg-rev: "INSERT INTO Pokemons(name, id) VALUES(?, ?)"
+    # test DML update
+    select-pokemon-by-id: "SELECT id, name FROM Pokemons WHERE id=?"
+    update-pokemon-named-arg: "UPDATE Pokemons SET name=:name WHERE id=:id"
+    update-pokemon-order-arg: "UPDATE Pokemons SET name=? WHERE id=?"
+    # test DML delete
+    delete-pokemon-named-arg: "DELETE FROM Pokemons WHERE id=:id"
+    delete-pokemon-order-arg: "DELETE FROM Pokemons WHERE id=?"
+    # Pokemon mapper uses full list of attributes
+    delete-pokemon-full-named-arg: "DELETE FROM Pokemons WHERE name=:name AND id=:id"
+    delete-pokemon-full-order-arg: "DELETE FROM Pokemons WHERE name=? AND id=?"
+    # test DbStatementQuery methods
+    select-pokemons-idrng-named-arg: "SELECT id, name FROM Pokemons WHERE id > :idmin AND id < :idmax"
+    select-pokemons-idrng-order-arg: "SELECT id, name FROM Pokemons WHERE id > ? AND id < ?"
+    # Test query with both named and ordered parameters (shall cause an exception)
+    select-pokemons-error-arg: "SELECT id, name FROM Pokemons WHERE id > :id AND name = ?"
+
+# Tests configuration
+test:
+  # Whether database supports ping statement as DML (default value is true)
+  ping-dml: false

--- a/tests/integration/dbclient/appl/src/main/resources/h2.yaml
+++ b/tests/integration/dbclient/appl/src/main/resources/h2.yaml
@@ -50,6 +50,10 @@ db:
     select-types: "SELECT id, name FROM Types"
     select-pokemons: "SELECT id, name FROM Pokemons"
     select-poketypes: "SELECT id_pokemon, id_type FROM PokemonTypes p WHERE id_pokemon = ?"
+    # data verification: get pokemon by ID
+    get-pokemon-by-id: "SELECT id, name FROM Pokemons WHERE id = ?"
+    # data verification: get pokemon's types by pokemon's ID
+    get-pokemon-types: "SELECT t.id AS id, t.name AS name FROM Types t INNER JOIN PokemonTypes pt ON pt.id_type = t.id WHERE pt.id_pokemon = ?"
     # data cleanup verification statements
     select-poketypes-all: "SELECT id_pokemon, id_type FROM PokemonTypes"
     # retrieve max. Pokemon ID

--- a/tests/integration/dbclient/appl/src/main/resources/pgsql.yaml
+++ b/tests/integration/dbclient/appl/src/main/resources/pgsql.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/main/resources/pgsql.yaml
+++ b/tests/integration/dbclient/appl/src/main/resources/pgsql.yaml
@@ -50,6 +50,10 @@ db:
     select-types: "SELECT id, name FROM Types"
     select-pokemons: "SELECT id, name FROM Pokemons"
     select-poketypes: "SELECT id_pokemon, id_type FROM PokemonTypes p WHERE id_pokemon = ?"
+    # data verification: get pokemon by ID
+    get-pokemon-by-id: "SELECT id, name FROM Pokemons WHERE id = ?"
+    # data verification: get pokemon's types by pokemon's ID
+    get-pokemon-types: "SELECT t.id AS id, t.name AS name FROM Types t INNER JOIN PokemonTypes pt ON pt.id_type = t.id WHERE pt.id_pokemon = ?"
     # data cleanup verification statements
     select-poketypes-all: "SELECT id_pokemon, id_type FROM PokemonTypes"
     # retrieve max. Pokemon ID

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/ApplInitIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/ApplInitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/ApplInitIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/ApplInitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.tools.JsonTools;
 import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
@@ -27,6 +23,8 @@ import io.helidon.tests.integration.tools.client.HelidonTestException;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -38,7 +36,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 @TestMethodOrder(OrderAnnotation.class)
 public class ApplInitIT {
 
-    private static final Logger LOGGER = Logger.getLogger(ApplInitIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(ApplInitIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -48,19 +46,19 @@ public class ApplInitIT {
     // Test executor methods
 
     private void executeTest(final String testName) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         JsonObject data = testClient
                 .callServiceAndGetData(testName)
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
     }
 
     private void executeInit(final String testName) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         JsonValue data = testClient
                 .callServiceAndGetData(testName);
         Long count = JsonTools.getLong(data);
-        LOGGER.finer(() -> String.format("Rows modified: %d", count));
+        LOGGER.log(Level.DEBUG, () -> String.format("Rows modified: %d", count));
     }
 
     @Test
@@ -75,37 +73,32 @@ public class ApplInitIT {
         executeTest("testPing");
     }
 
-    @Test
-    @Order(3)
+    // Called from LifeCycleExtension in setup phase
     public void testDropSchema() {
         try {
             executeInit("testDropSchema");
         // This remote call will fail on fresh database without existing tables.
         } catch (HelidonTestException ex){
-            LOGGER.info(() -> "Remote database tables did not exist.");
+            LOGGER.log(Level.INFO, () -> "Remote database tables did not exist.");
         }
     }
 
-    @Test
-    @Order(4)
+    // Called from LifeCycleExtension in setup phase
     public void testInitSchema() {
         executeInit("testInitSchema");
     }
 
-    @Test
-    @Order(5)
+    // Called from LifeCycleExtension in setup phase
     public void testInitTypes() {
         executeInit("testInitTypes");
     }
 
-    @Test
-    @Order(6)
+    // Called from LifeCycleExtension in setup phase
     public void testInitPokemons() {
         executeInit("testInitPokemons");
     }
 
-    @Test
-    @Order(7)
+    // Called from LifeCycleExtension in setup phase
     public void testInitPokemonTypes() {
         executeInit("testInitPokemonTypes");
     }

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/ApplInitIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/ApplInitIT.java
@@ -45,16 +45,14 @@ public class ApplInitIT {
 
     // Test executor methods
 
-    private void executeTest(final String testName) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeTest(String testName) {
         JsonObject data = testClient
                 .callServiceAndGetData(testName)
                 .asJsonObject();
         LogData.logJsonObject(Level.DEBUG, data);
     }
 
-    private void executeInit(final String testName) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeInit(String testName) {
         JsonValue data = testClient
                 .callServiceAndGetData(testName);
         Long count = JsonTools.getLong(data);
@@ -74,32 +72,32 @@ public class ApplInitIT {
     }
 
     // Called from LifeCycleExtension in setup phase
-    public void testDropSchema() {
+    public void dropSchema() {
         try {
             executeInit("testDropSchema");
         // This remote call will fail on fresh database without existing tables.
         } catch (HelidonTestException ex){
-            LOGGER.log(Level.INFO, () -> "Remote database tables did not exist.");
+            LOGGER.log(Level.INFO, "Remote database tables did not exist.");
         }
     }
 
     // Called from LifeCycleExtension in setup phase
-    public void testInitSchema() {
+    public void initSchema() {
         executeInit("testInitSchema");
     }
 
     // Called from LifeCycleExtension in setup phase
-    public void testInitTypes() {
+    public void initTypes() {
         executeInit("testInitTypes");
     }
 
     // Called from LifeCycleExtension in setup phase
-    public void testInitPokemons() {
+    public void initPokemons() {
         executeInit("testInitPokemons");
     }
 
     // Called from LifeCycleExtension in setup phase
-    public void testInitPokemonTypes() {
+    public void initPokemonTypes() {
         executeInit("testInitPokemonTypes");
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/LogData.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/LogData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/LogData.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/LogData.java
@@ -33,7 +33,7 @@ public class LogData {
      * @param level logging level
      * @param data  data to log
      */
-    public static void logJsonObject(final Level level, final JsonObject data) {
+    public static void logJsonObject(Level level, JsonObject data) {
         LOGGER.log(level, () -> "JSON object:");
         if (data == null) {
             LOGGER.log(level, "   is null");
@@ -53,7 +53,7 @@ public class LogData {
      * @param level logging level
      * @param data  data to log
      */
-    public static void logJsonArray(final Level level, final JsonArray data) {
+    public static void logJsonArray(Level level, JsonArray data) {
         LOGGER.log(level, () -> String.format("JSON array: %s", data.toString()));
         data.forEach(row -> {
             switch (row.getValueType()) {

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/LogData.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/LogData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger.Level;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -26,7 +25,7 @@ import jakarta.json.JsonObject;
  */
 public class LogData {
 
-    private static final Logger LOGGER = Logger.getLogger(LogData.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(LogData.class.getName());
 
     /**
      * Log JSON object in human readable form.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/VerifyData.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/VerifyData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/VerifyData.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/VerifyData.java
@@ -15,8 +15,6 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it;
 
-import java.util.logging.Logger;
-
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.dbclient.appl.tools.QueryParams;
 import io.helidon.tests.integration.tools.client.TestClient;
@@ -31,8 +29,6 @@ import static org.hamcrest.Matchers.notNullValue;
  * Test data verification helper methods.
  */
 public class VerifyData {
-
-    private static final Logger LOGGER = Logger.getLogger(VerifyData.class.getName());
 
     private static final String POKEMON_ID_KEY = "id";
     private static final String POKEMON_NAME_KEY = "name";
@@ -73,7 +69,7 @@ public class VerifyData {
      * @param id ID of pokemon to retrieve
      * @return pokemon stored in JSON object
      */
-    public static JsonObject getPokemon(final TestClient testClient, final int id) {
+    public static JsonObject getPokemon(TestClient testClient, int id) {
         return testClient.callServiceAndGetData(
                 "Verify",
                 "getPokemonById",

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/VerifyData.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/VerifyData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@ package io.helidon.tests.integration.dbclient.appl.it;
 
 import java.util.logging.Logger;
 
-import jakarta.json.JsonObject;
-
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.dbclient.appl.tools.QueryParams;
 import io.helidon.tests.integration.tools.client.TestClient;
+
+import jakarta.json.JsonObject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/health/HealthCheckIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/health/HealthCheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/health/HealthCheckIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/health/HealthCheckIT.java
@@ -15,10 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.health;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.tools.QueryParams;
@@ -26,6 +23,7 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -39,7 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class HealthCheckIT {
 
-    private static final Logger LOGGER = Logger.getLogger(HealthCheckIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(HealthCheckIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -51,18 +49,18 @@ public class HealthCheckIT {
 
     @BeforeAll
     public void setup() {
-        LOGGER.info(() -> "Running HealthCheckIT setup");
+        LOGGER.log(Level.INFO, () -> "Running HealthCheckIT setup");
         final JsonObject dbTypeValue = testClient
                 .callServiceAndGetData("Verify", "getDatabaseType", null)
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, dbTypeValue);
+        LogData.logJsonObject(Level.DEBUG, dbTypeValue);
         dbType = dbTypeValue.getString("type");
         final JsonObject pingDmlValue = testClient
                 .callServiceAndGetData(
                         "Verify", "getConfigParam",
                         QueryParams.single(QueryParams.NAME, "test.ping-dml"))
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, pingDmlValue);
+        LogData.logJsonObject(Level.DEBUG, pingDmlValue);
         if (pingDmlValue.containsKey("config")) {
             pingDml = Boolean.parseBoolean(pingDmlValue.getString("config"));
         }
@@ -73,11 +71,11 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheck() {
-        LOGGER.info(() -> "Running test testHealthCheck");
+        LOGGER.log(Level.INFO, () -> "Running test testHealthCheck");
         JsonObject data = testClient
                 .callServiceAndGetData("testHealthCheck")
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         assertThat(data.getString("status"), equalTo(HealthCheckResponse.Status.UP.name()));
     }
 
@@ -86,14 +84,14 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithName() {
-        LOGGER.info(() -> "Running test testHealthCheckWithName");
+        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithName");
         final String hcName = "TestHC";
         JsonObject data = testClient
                 .callServiceAndGetData(
                         "testHealthCheckWithName",
                         QueryParams.single(QueryParams.NAME, hcName))
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         assertThat(data.getString("status"), equalTo(HealthCheckResponse.Status.UP.name()));
         assertThat(data.getString("name"), equalTo(hcName));
     }
@@ -103,15 +101,15 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomNamedDML() {
-        LOGGER.info(() -> "Running test testHealthCheckWithCustomNamedDML");
+        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithCustomNamedDML");
         if (!pingDml) {
-            LOGGER.info(() -> String.format("Database %s does not support DML ping, skipping this test", dbType));
+            LOGGER.log(Level.INFO, () -> String.format("Database %s does not support DML ping, skipping this test", dbType));
             return;
         }
         JsonObject data = testClient
                 .callServiceAndGetData("testHealthCheckWithCustomNamedDML")
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         assertThat(data.getString("status"), equalTo(HealthCheckResponse.Status.UP.name()));
     }
 
@@ -120,15 +118,15 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomDML() {
-        LOGGER.info(() -> "Running test testHealthCheckWithCustomDML");
+        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithCustomDML");
         if (!pingDml) {
-            LOGGER.info(() -> String.format("Database %s does not support DML ping, skipping this test", dbType));
+            LOGGER.log(Level.INFO, () -> String.format("Database %s does not support DML ping, skipping this test", dbType));
             return;
         }
         JsonObject data = testClient
                 .callServiceAndGetData("testHealthCheckWithCustomDML")
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         assertThat(data.getString("status"), equalTo(HealthCheckResponse.Status.UP.name()));
     }
 
@@ -137,11 +135,11 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomNamedQuery() {
-        LOGGER.info(() -> "Running test testHealthCheckWithCustomNamedQuery");
+        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithCustomNamedQuery");
         JsonObject data = testClient
                 .callServiceAndGetData("testHealthCheckWithCustomNamedQuery")
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         assertThat(data.getString("status"), equalTo(HealthCheckResponse.Status.UP.name()));
     }
 
@@ -150,11 +148,11 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomQuery() {
-        LOGGER.info(() -> "Running test testHealthCheckWithCustomQuery");
+        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithCustomQuery");
         JsonObject data = testClient
                 .callServiceAndGetData("testHealthCheckWithCustomQuery")
                 .asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         assertThat(data.getString("status"), equalTo(HealthCheckResponse.Status.UP.name()));
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/health/HealthCheckIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/health/HealthCheckIT.java
@@ -49,13 +49,12 @@ public class HealthCheckIT {
 
     @BeforeAll
     public void setup() {
-        LOGGER.log(Level.INFO, () -> "Running HealthCheckIT setup");
-        final JsonObject dbTypeValue = testClient
+        JsonObject dbTypeValue = testClient
                 .callServiceAndGetData("Verify", "getDatabaseType", null)
                 .asJsonObject();
         LogData.logJsonObject(Level.DEBUG, dbTypeValue);
         dbType = dbTypeValue.getString("type");
-        final JsonObject pingDmlValue = testClient
+        JsonObject pingDmlValue = testClient
                 .callServiceAndGetData(
                         "Verify", "getConfigParam",
                         QueryParams.single(QueryParams.NAME, "test.ping-dml"))
@@ -71,7 +70,6 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheck() {
-        LOGGER.log(Level.INFO, () -> "Running test testHealthCheck");
         JsonObject data = testClient
                 .callServiceAndGetData("testHealthCheck")
                 .asJsonObject();
@@ -84,7 +82,6 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithName() {
-        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithName");
         final String hcName = "TestHC";
         JsonObject data = testClient
                 .callServiceAndGetData(
@@ -101,7 +98,6 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomNamedDML() {
-        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithCustomNamedDML");
         if (!pingDml) {
             LOGGER.log(Level.INFO, () -> String.format("Database %s does not support DML ping, skipping this test", dbType));
             return;
@@ -118,9 +114,8 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomDML() {
-        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithCustomDML");
         if (!pingDml) {
-            LOGGER.log(Level.INFO, () -> String.format("Database %s does not support DML ping, skipping this test", dbType));
+            LOGGER.log(Level.DEBUG, () -> String.format("Database %s does not support DML ping, skipping this test", dbType));
             return;
         }
         JsonObject data = testClient
@@ -135,7 +130,6 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomNamedQuery() {
-        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithCustomNamedQuery");
         JsonObject data = testClient
                 .callServiceAndGetData("testHealthCheckWithCustomNamedQuery")
                 .asJsonObject();
@@ -148,7 +142,6 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomQuery() {
-        LOGGER.log(Level.INFO, () -> "Running test testHealthCheckWithCustomQuery");
         JsonObject data = testClient
                 .callServiceAndGetData("testHealthCheckWithCustomQuery")
                 .asJsonObject();

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/interceptor/InterceptorIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/interceptor/InterceptorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/interceptor/InterceptorIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/interceptor/InterceptorIT.java
@@ -15,8 +15,6 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.interceptor;
 
-import java.util.logging.Logger;
-
 import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
@@ -28,8 +26,6 @@ import org.junit.jupiter.api.Test;
  */
 public class InterceptorIT {
 
-    private static final Logger LOGGER = Logger.getLogger(InterceptorIT.class.getName());
-
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
             .service("Interceptor")
@@ -40,7 +36,6 @@ public class InterceptorIT {
      */
     @Test
     public void testStatementInterceptor() {
-        LOGGER.fine("Running testStatementInterceptor");
         testClient
                 .callServiceAndGetData("testStatementInterceptor");
     }

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/mapping/MapperIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/mapping/MapperIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/mapping/MapperIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/mapping/MapperIT.java
@@ -48,8 +48,7 @@ public class MapperIT {
             .service("Mapper")
             .build();
 
-    private void executeInsertTest(final String testName, final int id) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeInsertTest(String testName, int id) {
         try {
             JsonObject data = testClient.callServiceAndGetData(
                     testName,
@@ -60,12 +59,11 @@ public class MapperIT {
             LogData.logJsonObject(Level.DEBUG, pokemonData);
             VerifyData.verifyPokemon(pokemonData, data);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
+            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 
-    private void executeUpdateTest(final String testName, final int id, final String newName) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeUpdateTest(String testName, int id, String newName) {
         try {
             Pokemon pokemon = Pokemon.POKEMONS.get(id);
             Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
@@ -82,12 +80,11 @@ public class MapperIT {
             assertThat(count, equalTo(1L));
             VerifyData.verifyPokemon(pokemonData, updatedPokemon);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
+            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 
-    private void executeDeleteTest(final String testName, final int id) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeDeleteTest(String testName, int id) {
         try {
             JsonValue data = testClient.callServiceAndGetData(
                     testName,
@@ -100,7 +97,7 @@ public class MapperIT {
             assertThat(count, equalTo(1));
             assertThat(pokemonData.isEmpty(), equalTo(true));
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
+            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 
@@ -159,7 +156,6 @@ public class MapperIT {
      */
     @Test
     public void testQueryWithMapping() {
-        LOGGER.log(Level.INFO, () -> "Running testQueryWithMapping");
         final Pokemon pokemon = Pokemon.POKEMONS.get(1);
         JsonArray data = testClient.callServiceAndGetData(
                 "testQueryWithMapping",
@@ -175,7 +171,6 @@ public class MapperIT {
      */
     @Test
     public void testGetWithMapping() {
-        LOGGER.log(Level.INFO, () -> "Running testGetWithMapping");
         final Pokemon pokemon = Pokemon.POKEMONS.get(2);
         JsonObject data = testClient.callServiceAndGetData(
                 "testGetWithMapping",

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/mapping/MapperIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/mapping/MapperIT.java
@@ -48,59 +48,6 @@ public class MapperIT {
             .service("Mapper")
             .build();
 
-    private void executeInsertTest(String testName, int id) {
-        try {
-            JsonObject data = testClient.callServiceAndGetData(
-                    testName,
-                    QueryParams.single(QueryParams.ID, String.valueOf(id)))
-                    .asJsonObject();
-            LogData.logJsonObject(Level.DEBUG, data);
-            JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
-            LogData.logJsonObject(Level.DEBUG, pokemonData);
-            VerifyData.verifyPokemon(pokemonData, data);
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
-        }
-    }
-
-    private void executeUpdateTest(String testName, int id, String newName) {
-        try {
-            Pokemon pokemon = Pokemon.POKEMONS.get(id);
-            Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
-            JsonValue data = testClient.callServiceAndGetData(
-                    testName,
-                    QueryParams.builder()
-                            .add(QueryParams.NAME, newName)
-                            .add(QueryParams.ID, String.valueOf(id))
-                            .build());
-            Long count = JsonTools.getLong(data);
-            LOGGER.log(Level.DEBUG, () -> String.format("Rows updated: %d", count));
-            JsonObject pokemonData = VerifyData.getPokemon(testClient, pokemon.getId());
-            LogData.logJsonObject(Level.DEBUG, pokemonData);
-            assertThat(count, equalTo(1L));
-            VerifyData.verifyPokemon(pokemonData, updatedPokemon);
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
-        }
-    }
-
-    private void executeDeleteTest(String testName, int id) {
-        try {
-            JsonValue data = testClient.callServiceAndGetData(
-                    testName,
-                    QueryParams.single(QueryParams.ID, String.valueOf(id)))
-                    .asJsonObject();
-            Long count = JsonTools.getLong(data);
-            LOGGER.log(Level.DEBUG, () -> String.format("Rows deleted: %d", count));
-            JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
-            LogData.logJsonObject(Level.DEBUG, pokemonData);
-            assertThat(count, equalTo(1));
-            assertThat(pokemonData.isEmpty(), equalTo(true));
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
-        }
-    }
-
     /**
      * Verify insertion of PoJo instance using indexed mapping.
      */
@@ -178,6 +125,46 @@ public class MapperIT {
         ).asJsonObject();
         LogData.logJsonObject(Level.DEBUG, data);
         VerifyData.verifyPokemon(data, pokemon);
+    }
+
+    private void executeInsertTest(String testName, int id) {
+        JsonObject data = testClient.callServiceAndGetData(
+                        testName,
+                        QueryParams.single(QueryParams.ID, String.valueOf(id)))
+                .asJsonObject();
+        LogData.logJsonObject(Level.DEBUG, data);
+        JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
+        LogData.logJsonObject(Level.DEBUG, pokemonData);
+        VerifyData.verifyPokemon(pokemonData, data);
+    }
+
+    private void executeUpdateTest(String testName, int id, String newName) {
+        Pokemon pokemon = Pokemon.POKEMONS.get(id);
+        Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
+        JsonValue data = testClient.callServiceAndGetData(
+                testName,
+                QueryParams.builder()
+                        .add(QueryParams.NAME, newName)
+                        .add(QueryParams.ID, String.valueOf(id))
+                        .build());
+        Long count = JsonTools.getLong(data);
+        LOGGER.log(Level.DEBUG, () -> String.format("Rows updated: %d", count));
+        JsonObject pokemonData = VerifyData.getPokemon(testClient, pokemon.getId());
+        LogData.logJsonObject(Level.DEBUG, pokemonData);
+        assertThat(count, equalTo(1L));
+        VerifyData.verifyPokemon(pokemonData, updatedPokemon);
+    }
+
+    private void executeDeleteTest(String testName, int id) {
+        JsonValue data = testClient.callServiceAndGetData(
+                        testName,
+                        QueryParams.single(QueryParams.ID, String.valueOf(id)));
+        Long count = JsonTools.getLong(data);
+        LOGGER.log(Level.DEBUG, () -> String.format("Rows deleted: %d", count));
+        JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
+        LogData.logJsonObject(Level.DEBUG, pokemonData);
+        assertThat(count, equalTo(1L));
+        assertThat(pokemonData.isEmpty(), equalTo(true));
     }
 
 }

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/mapping/MapperIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/mapping/MapperIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.mapping;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -31,6 +26,9 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,7 +41,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class MapperIT {
 
-    private static final Logger LOGGER = Logger.getLogger(MapperIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(MapperIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -51,23 +49,23 @@ public class MapperIT {
             .build();
 
     private void executeInsertTest(final String testName, final int id) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             JsonObject data = testClient.callServiceAndGetData(
                     testName,
                     QueryParams.single(QueryParams.ID, String.valueOf(id)))
                     .asJsonObject();
-            LogData.logJsonObject(Level.FINER, data);
+            LogData.logJsonObject(Level.DEBUG, data);
             JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             VerifyData.verifyPokemon(pokemonData, data);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 
     private void executeUpdateTest(final String testName, final int id, final String newName) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             Pokemon pokemon = Pokemon.POKEMONS.get(id);
             Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
@@ -78,31 +76,31 @@ public class MapperIT {
                             .add(QueryParams.ID, String.valueOf(id))
                             .build());
             Long count = JsonTools.getLong(data);
-            LOGGER.fine(() -> String.format("Rows updated: %d", count));
+            LOGGER.log(Level.DEBUG, () -> String.format("Rows updated: %d", count));
             JsonObject pokemonData = VerifyData.getPokemon(testClient, pokemon.getId());
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             assertThat(count, equalTo(1L));
             VerifyData.verifyPokemon(pokemonData, updatedPokemon);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 
     private void executeDeleteTest(final String testName, final int id) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             JsonValue data = testClient.callServiceAndGetData(
                     testName,
                     QueryParams.single(QueryParams.ID, String.valueOf(id)))
                     .asJsonObject();
             Long count = JsonTools.getLong(data);
-            LOGGER.fine(() -> String.format("Rows deleted: %d", count));
+            LOGGER.log(Level.DEBUG, () -> String.format("Rows deleted: %d", count));
             JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             assertThat(count, equalTo(1));
             assertThat(pokemonData.isEmpty(), equalTo(true));
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 
@@ -161,13 +159,13 @@ public class MapperIT {
      */
     @Test
     public void testQueryWithMapping() {
-        LOGGER.fine(() -> "Running testQueryWithMapping");
+        LOGGER.log(Level.INFO, () -> "Running testQueryWithMapping");
         final Pokemon pokemon = Pokemon.POKEMONS.get(1);
         JsonArray data = testClient.callServiceAndGetData(
                 "testQueryWithMapping",
                 QueryParams.single(QueryParams.NAME, pokemon.getName()))
                 .asJsonArray();
-        LogData.logJsonArray(Level.FINER, data);
+        LogData.logJsonArray(Level.DEBUG, data);
         assertThat(data.size(), equalTo(1));
         VerifyData.verifyPokemon(data.getJsonObject(0), pokemon);
     }
@@ -177,13 +175,13 @@ public class MapperIT {
      */
     @Test
     public void testGetWithMapping() {
-        LOGGER.fine(() -> "Running testGetWithMapping");
+        LOGGER.log(Level.INFO, () -> "Running testGetWithMapping");
         final Pokemon pokemon = Pokemon.POKEMONS.get(2);
         JsonObject data = testClient.callServiceAndGetData(
                 "testGetWithMapping",
                 QueryParams.single(QueryParams.NAME, pokemon.getName())
         ).asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         VerifyData.verifyPokemon(data, pokemon);
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/metrics/ServerMetricsCheckIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/metrics/ServerMetricsCheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/metrics/ServerMetricsCheckIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/metrics/ServerMetricsCheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,13 @@ package io.helidon.tests.integration.dbclient.appl.it.metrics;
 import java.io.IOException;
 import java.util.logging.Logger;
 
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
-
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.dbclient.appl.tools.QueryParams;
 import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/metrics/ServerMetricsCheckIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/metrics/ServerMetricsCheckIT.java
@@ -16,7 +16,6 @@
 package io.helidon.tests.integration.dbclient.appl.it.metrics;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import io.helidon.tests.integration.dbclient.appl.model.Pokemon;
 import io.helidon.tests.integration.dbclient.appl.tools.QueryParams;
@@ -31,12 +30,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
+
 /**
  * Verify metrics check in web server environment.
  */
 public class ServerMetricsCheckIT {
-
-    private static final Logger LOGGER = Logger.getLogger(ServerMetricsCheckIT.class.getName());
 
     private final TestClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/result/FlowControlIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/result/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/result/FlowControlIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/result/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,14 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.result;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -36,7 +34,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class FlowControlIT {
 
-    private static final Logger LOGGER = Logger.getLogger(FlowControlIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(FlowControlIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -45,14 +43,14 @@ public class FlowControlIT {
 
     // Test executor method
     private void executeTest(final String testName) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             JsonObject data = testClient
                     .callServiceAndGetData(testName)
                     .asJsonObject();
-            LogData.logJsonObject(Level.FINER, data);
+            LogData.logJsonObject(Level.DEBUG, data);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/result/FlowControlIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/result/FlowControlIT.java
@@ -42,15 +42,14 @@ public class FlowControlIT {
             .build();
 
     // Test executor method
-    private void executeTest(final String testName) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeTest(String testName) {
         try {
             JsonObject data = testClient
                     .callServiceAndGetData(testName)
                     .asJsonObject();
             LogData.logJsonObject(Level.DEBUG, data);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
+            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleDeleteIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleDeleteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleDeleteIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleDeleteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.simple;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -29,6 +25,8 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,7 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class SimpleDeleteIT {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleQueriesIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleQueriesIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -48,19 +46,19 @@ public class SimpleDeleteIT {
 
     // Test executor method
     private void executeTest(final String testName, final int id) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             JsonValue data = testClient.callServiceAndGetData(
                     testName,
                     QueryParams.single(QueryParams.ID, String.valueOf(id)));
             Long count = JsonTools.getLong(data);
-            LOGGER.fine(() -> String.format("Rows deleted: %d", count));
+            LOGGER.log(Level.DEBUG, () -> String.format("Rows deleted: %d", count));
             JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             assertThat(count, equalTo(1L));
             assertThat(pokemonData.isEmpty(), equalTo(true));
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleDeleteIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleDeleteIT.java
@@ -45,8 +45,7 @@ public class SimpleDeleteIT {
             .build();
 
     // Test executor method
-    private void executeTest(final String testName, final int id) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeTest(String testName, int id) {
         try {
             JsonValue data = testClient.callServiceAndGetData(
                     testName,
@@ -58,7 +57,7 @@ public class SimpleDeleteIT {
             assertThat(count, equalTo(1L));
             assertThat(pokemonData.isEmpty(), equalTo(true));
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
+            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleGetIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleGetIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleGetIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleGetIT.java
@@ -33,16 +33,13 @@ import org.junit.jupiter.api.Test;
  */
 public class SimpleGetIT {
 
-    private static final System.Logger LOGGER = System.getLogger(SimpleGetIT.class.getName());
-
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
             .service("SimpleGet")
             .build();
 
     // Test executor method
-    public void executeTest(final String testName, final Pokemon pokemon) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    public void executeTest(String testName, Pokemon pokemon) {
         JsonObject data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.single(QueryParams.NAME, pokemon.getName())

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleGetIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleGetIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.simple;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -28,6 +25,7 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,7 +33,7 @@ import org.junit.jupiter.api.Test;
  */
 public class SimpleGetIT {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleGetIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleGetIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -44,12 +42,12 @@ public class SimpleGetIT {
 
     // Test executor method
     public void executeTest(final String testName, final Pokemon pokemon) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         JsonObject data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.single(QueryParams.NAME, pokemon.getName())
         ).asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         VerifyData.verifyPokemon(data, pokemon);
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleInsertIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleInsertIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleInsertIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleInsertIT.java
@@ -40,8 +40,7 @@ public class SimpleInsertIT {
             .build();
 
     // Test executor method
-    private void executeTest(final String testName, final int id) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeTest(String testName, int id) {
         try {
             JsonObject data = testClient.callServiceAndGetData(
                     testName,
@@ -52,7 +51,7 @@ public class SimpleInsertIT {
             LogData.logJsonObject(Level.DEBUG, pokemonData);
             VerifyData.verifyPokemon(pokemonData, data);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
+            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleInsertIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleInsertIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.simple;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -27,6 +24,7 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,7 +32,7 @@ import org.junit.jupiter.api.Test;
  */
 public class SimpleInsertIT {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleQueriesIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleQueriesIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -43,18 +41,18 @@ public class SimpleInsertIT {
 
     // Test executor method
     private void executeTest(final String testName, final int id) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             JsonObject data = testClient.callServiceAndGetData(
                     testName,
                     QueryParams.single(QueryParams.ID, String.valueOf(id)))
                     .asJsonObject();
-            LogData.logJsonObject(Level.FINER, data);
+            LogData.logJsonObject(Level.DEBUG, data);
             JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             VerifyData.verifyPokemon(pokemonData, data);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleQueriesIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleQueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleQueriesIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleQueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.simple;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonArray;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -28,6 +25,7 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonArray;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class SimpleQueriesIT {
 
     /** Local logger instance. */
-    static final Logger LOGGER = Logger.getLogger(SimpleQueriesIT.class.getName());
+    static final System.Logger LOGGER = System.getLogger(SimpleQueriesIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -48,12 +46,12 @@ public class SimpleQueriesIT {
 
     // Test executor method
     private void executeTest(final String testName, final Pokemon pokemon) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         JsonArray data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.single(QueryParams.NAME, pokemon.getName()))
                 .asJsonArray();
-        LogData.logJsonArray(Level.FINER, data);
+        LogData.logJsonArray(Level.DEBUG, data);
         assertThat(data.size(), Matchers.equalTo(1));
         VerifyData.verifyPokemon(data.getJsonObject(0), pokemon);
     }

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleQueriesIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleQueriesIT.java
@@ -36,17 +36,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class SimpleQueriesIT {
 
-    /** Local logger instance. */
-    static final System.Logger LOGGER = System.getLogger(SimpleQueriesIT.class.getName());
-
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
             .service("SimpleQuery")
             .build();
 
     // Test executor method
-    private void executeTest(final String testName, final Pokemon pokemon) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeTest(String testName, Pokemon pokemon) {
         JsonArray data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.single(QueryParams.NAME, pokemon.getName()))

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleUpdateIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleUpdateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleUpdateIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleUpdateIT.java
@@ -46,8 +46,7 @@ public class SimpleUpdateIT {
             .build();
 
     // Test executor method
-    private void executeTest(final String testName, final int id, final String newName) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeTest(String testName, int id, String newName) {
         try {
             Pokemon pokemon = Pokemon.POKEMONS.get(id);
             Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
@@ -64,7 +63,7 @@ public class SimpleUpdateIT {
             assertThat(count, equalTo(1L));
             VerifyData.verifyPokemon(pokemonData, updatedPokemon);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
+            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleUpdateIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/simple/SimpleUpdateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.simple;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -30,6 +26,8 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,7 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class SimpleUpdateIT {
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleQueriesIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleQueriesIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -49,7 +47,7 @@ public class SimpleUpdateIT {
 
     // Test executor method
     private void executeTest(final String testName, final int id, final String newName) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             Pokemon pokemon = Pokemon.POKEMONS.get(id);
             Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
@@ -60,13 +58,13 @@ public class SimpleUpdateIT {
                             .add(QueryParams.ID, String.valueOf(id))
                             .build());
             Long count = JsonTools.getLong(data);
-            LOGGER.fine(() -> String.format("Rows updated: %d", count));
+            LOGGER.log(Level.DEBUG, () -> String.format("Rows updated: %d", count));
             JsonObject pokemonData = VerifyData.getPokemon(testClient, pokemon.getId());
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             assertThat(count, equalTo(1L));
             VerifyData.verifyPokemon(pokemonData, updatedPokemon);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/DmlStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/DmlStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/DmlStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/DmlStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.statement;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -30,6 +26,8 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,7 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class DmlStatementIT {
 
-    private static final Logger LOGGER = Logger.getLogger(DmlStatementIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(DmlStatementIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -49,7 +47,7 @@ public class DmlStatementIT {
 
     // Test executor method
     private void executeTest(final String testName, final int id, final String newName) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             Pokemon pokemon = Pokemon.POKEMONS.get(id);
             Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
@@ -60,13 +58,13 @@ public class DmlStatementIT {
                             .add(QueryParams.ID, String.valueOf(id))
                             .build());
             Long count = JsonTools.getLong(data);
-            LOGGER.fine(() -> String.format("Rows modified: %d", count));
+            LOGGER.log(Level.DEBUG, () -> String.format("Rows modified: %d", count));
             JsonObject pokemonData = VerifyData.getPokemon(testClient, pokemon.getId());
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             assertThat(count, equalTo(1L));
             VerifyData.verifyPokemon(pokemonData, updatedPokemon);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/DmlStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/DmlStatementIT.java
@@ -46,8 +46,7 @@ public class DmlStatementIT {
             .build();
 
     // Test executor method
-    private void executeTest(final String testName, final int id, final String newName) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeTest(String testName, int id, String newName) {
         try {
             Pokemon pokemon = Pokemon.POKEMONS.get(id);
             Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
@@ -64,7 +63,7 @@ public class DmlStatementIT {
             assertThat(count, equalTo(1L));
             VerifyData.verifyPokemon(pokemonData, updatedPokemon);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
+            LOGGER.log(Level.WARNING, String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/GetStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/GetStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/GetStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/GetStatementIT.java
@@ -36,16 +36,13 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class GetStatementIT {
 
-    private static final System.Logger LOGGER = System.getLogger(GetStatementIT.class.getName());
-
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
             .service("GetStatement")
             .build();
 
     // Test executor method
-    public void executeTest(final String testName, final int fromId, final int toId) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    public void executeTest(String testName, int fromId, int toId) {
         JsonObject data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.builder()
@@ -54,10 +51,10 @@ public class GetStatementIT {
                     .build()
         ).asJsonObject();
         LogData.logJsonObject(Level.DEBUG, data);
-        int counter[] = { 0 };
+        int[] counter = { 0 };
         Pokemon.POKEMONS.keySet().forEach(id -> {
             if (id > fromId && id < toId) {
-                final Pokemon pokemon = Pokemon.POKEMONS.get(id);
+                Pokemon pokemon = Pokemon.POKEMONS.get(id);
                 VerifyData.verifyPokemon(data, pokemon);
                 counter[0]++;
             }

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/GetStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/GetStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.statement;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -28,6 +25,7 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,7 +36,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class GetStatementIT {
 
-    private static final Logger LOGGER = Logger.getLogger(GetStatementIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(GetStatementIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -47,7 +45,7 @@ public class GetStatementIT {
 
     // Test executor method
     public void executeTest(final String testName, final int fromId, final int toId) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         JsonObject data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.builder()
@@ -55,7 +53,7 @@ public class GetStatementIT {
                     .add(QueryParams.TO_ID, String.valueOf(toId))
                     .build()
         ).asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         int counter[] = { 0 };
         Pokemon.POKEMONS.keySet().forEach(id -> {
             if (id > fromId && id < toId) {

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/QueryStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/QueryStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/QueryStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/QueryStatementIT.java
@@ -39,17 +39,13 @@ import static org.hamcrest.Matchers.lessThan;
  */
 public class QueryStatementIT {
 
-   /** Local logger instance. */
-    static final System.Logger LOGGER = System.getLogger(QueryStatementIT.class.getName());
-
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
             .service("QueryStatement")
             .build();
 
     // Test executor method
-    private void executeTest(final String testName, final int fromId, final int toId) {
-        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
+    private void executeTest(String testName, int fromId, int toId) {
         JsonArray data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.builder()
@@ -61,7 +57,7 @@ public class QueryStatementIT {
         assertThat(data.size(), equalTo(toId - fromId - 1));
         data.getValuesAs(JsonObject.class).forEach(dataPokemon -> {
             int id = dataPokemon.getInt("id");
-            final Pokemon pokemon = Pokemon.POKEMONS.get(id);
+            Pokemon pokemon = Pokemon.POKEMONS.get(id);
             assertThat(id, greaterThan(fromId));
             assertThat(id, lessThan(toId));
             VerifyData.verifyPokemon(dataPokemon, pokemon);

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/QueryStatementIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/statement/QueryStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.statement;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -29,6 +25,8 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,7 +40,7 @@ import static org.hamcrest.Matchers.lessThan;
 public class QueryStatementIT {
 
    /** Local logger instance. */
-    static final Logger LOGGER = Logger.getLogger(QueryStatementIT.class.getName());
+    static final System.Logger LOGGER = System.getLogger(QueryStatementIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -51,7 +49,7 @@ public class QueryStatementIT {
 
     // Test executor method
     private void executeTest(final String testName, final int fromId, final int toId) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         JsonArray data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.builder()
@@ -59,7 +57,7 @@ public class QueryStatementIT {
                     .add(QueryParams.TO_ID, String.valueOf(toId))
                     .build()
         ).asJsonArray();
-        LogData.logJsonArray(Level.FINER, data);
+        LogData.logJsonArray(Level.DEBUG, data);
         assertThat(data.size(), equalTo(toId - fromId - 1));
         data.getValuesAs(JsonObject.class).forEach(dataPokemon -> {
             int id = dataPokemon.getInt("id");

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/tools/LifeCycleExtension.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/tools/LifeCycleExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionDeleteIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionDeleteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionDeleteIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionDeleteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.transaction;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -29,6 +25,8 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,7 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class TransactionDeleteIT {
 
-    private static final Logger LOGGER = Logger.getLogger(TransactionDeleteIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(TransactionDeleteIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -48,19 +46,19 @@ public class TransactionDeleteIT {
 
     // Test executor method
     private void executeTest(final String testName, final int id) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             JsonValue data = testClient.callServiceAndGetData(
                     testName,
                     QueryParams.single(QueryParams.ID, String.valueOf(id)));
             Long count = JsonTools.getLong(data);
-            LOGGER.fine(() -> String.format("Rows deleted: %d", count));
+            LOGGER.log(Level.DEBUG, () -> String.format("Rows deleted: %d", count));
             JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             assertThat(count, equalTo(1L));
             assertThat(pokemonData.isEmpty(), equalTo(true));
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionGetIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionGetIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionGetIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionGetIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.transaction;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -28,6 +25,7 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,7 +33,7 @@ import org.junit.jupiter.api.Test;
  */
 public class TransactionGetIT {
 
-    private static final Logger LOGGER = Logger.getLogger(TransactionGetIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(TransactionGetIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -44,12 +42,12 @@ public class TransactionGetIT {
 
     // Test executor method
     public void executeTest(final String testName, final Pokemon pokemon) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         JsonObject data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.single(QueryParams.NAME, pokemon.getName())
         ).asJsonObject();
-        LogData.logJsonObject(Level.FINER, data);
+        LogData.logJsonObject(Level.DEBUG, data);
         VerifyData.verifyPokemon(data, pokemon);
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionInsertIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionInsertIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionInsertIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionInsertIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.transaction;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -27,6 +24,7 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,7 +32,7 @@ import org.junit.jupiter.api.Test;
  */
 public class TransactionInsertIT {
 
-    private static final Logger LOGGER = Logger.getLogger(TransactionInsertIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(TransactionInsertIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -43,18 +41,18 @@ public class TransactionInsertIT {
 
     // Test executor method
     private void executeTest(final String testName, final int id) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             JsonObject data = testClient.callServiceAndGetData(
                     testName,
                     QueryParams.single(QueryParams.ID, String.valueOf(id)))
                     .asJsonObject();
-            LogData.logJsonObject(Level.FINER, data);
+            LogData.logJsonObject(Level.DEBUG, data);
             JsonObject pokemonData = VerifyData.getPokemon(testClient, id);
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             VerifyData.verifyPokemon(pokemonData, data);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionQueriesIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionQueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionQueriesIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionQueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.transaction;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonArray;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -28,6 +25,7 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonArray;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TransactionQueriesIT {
 
     /** Local logger instance. */
-    static final Logger LOGGER = Logger.getLogger(TransactionQueriesIT.class.getName());
+    static final System.Logger LOGGER = System.getLogger(TransactionQueriesIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -48,12 +46,12 @@ public class TransactionQueriesIT {
 
     // Test executor method
     private void executeTest(final String testName, final Pokemon pokemon) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         JsonArray data = testClient.callServiceAndGetData(
                 testName,
                 QueryParams.single(QueryParams.NAME, pokemon.getName()))
                 .asJsonArray();
-        LogData.logJsonArray(Level.FINER, data);
+        LogData.logJsonArray(Level.DEBUG, data);
         assertThat(data.size(), Matchers.equalTo(1));
         VerifyData.verifyPokemon(data.getJsonObject(0), pokemon);
     }

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionUpdateIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionUpdateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionUpdateIT.java
+++ b/tests/integration/dbclient/appl/src/test/java/io/helidon/tests/integration/dbclient/appl/it/transaction/TransactionUpdateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.appl.it.transaction;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
+import java.lang.System.Logger.Level;
 
 import io.helidon.tests.integration.dbclient.appl.it.LogData;
 import io.helidon.tests.integration.dbclient.appl.it.VerifyData;
@@ -30,6 +26,8 @@ import io.helidon.tests.integration.tools.client.HelidonProcessRunner;
 import io.helidon.tests.integration.tools.client.TestClient;
 import io.helidon.tests.integration.tools.client.TestServiceClient;
 
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,7 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class TransactionUpdateIT {
 
-    private static final Logger LOGGER = Logger.getLogger(TransactionUpdateIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(TransactionUpdateIT.class.getName());
 
     private final TestServiceClient testClient = TestClient.builder()
             .port(HelidonProcessRunner.HTTP_PORT)
@@ -49,7 +47,7 @@ public class TransactionUpdateIT {
 
     // Test executor method
     private void executeTest(final String testName, final int id, final String newName) {
-        LOGGER.fine(() -> String.format("Running %s", testName));
+        LOGGER.log(Level.INFO, () -> String.format("Running %s", testName));
         try {
             Pokemon pokemon = Pokemon.POKEMONS.get(id);
             Pokemon updatedPokemon = new Pokemon(pokemon.getId(), newName, pokemon.getTypes());
@@ -61,11 +59,11 @@ public class TransactionUpdateIT {
                             .build());
             Long count = JsonTools.getLong(data);
             JsonObject pokemonData = VerifyData.getPokemon(testClient, pokemon.getId());
-            LogData.logJsonObject(Level.FINER, pokemonData);
+            LogData.logJsonObject(Level.DEBUG, pokemonData);
             assertThat(count, equalTo(1L));
             VerifyData.verifyPokemon(pokemonData, updatedPokemon);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, e, () -> String.format("Exception in %s: %s", testName, e.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("Exception in %s: %s", testName, e.getMessage()), e);
         }
     }
 

--- a/tests/integration/dbclient/appl/src/test/resources/logging.properties
+++ b/tests/integration/dbclient/appl/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/appl/src/test/resources/logging.properties
+++ b/tests/integration/dbclient/appl/src/test/resources/logging.properties
@@ -18,7 +18,7 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 # Send messages to the console
 
-# handlers=io.helidon.logging.jul.HelidonConsoleHandler
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
 # HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 # Global logging level. Can be overridden by specific loggers

--- a/tests/integration/dbclient/appl/src/test/resources/logging.properties
+++ b/tests/integration/dbclient/appl/src/test/resources/logging.properties
@@ -18,7 +18,7 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 # Send messages to the console
 
-handlers=io.helidon.logging.jul.HelidonConsoleHandler
+# handlers=io.helidon.logging.jul.HelidonConsoleHandler
 # HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 # Global logging level. Can be overridden by specific loggers

--- a/tests/integration/dbclient/common/pom.xml
+++ b/tests/integration/dbclient/common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/pom.xml
+++ b/tests/integration/dbclient/common/pom.xml
@@ -41,6 +41,18 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.reactive.metrics</groupId>
+            <artifactId>helidon-reactive-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.reactive.health</groupId>
+            <artifactId>helidon-reactive-health</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.reactive.dbclient</groupId>
             <artifactId>helidon-reactive-dbclient-common</artifactId>
         </dependency>
@@ -51,10 +63,6 @@
         <dependency>
             <groupId>io.helidon.reactive.dbclient</groupId>
             <artifactId>helidon-reactive-dbclient-metrics</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.parsson</groupId>

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/AbstractIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/AbstractIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/AbstractIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/AbstractIT.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.helidon.config.Config;

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/AbstractIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/AbstractIT.java
@@ -16,10 +16,10 @@
 package io.helidon.tests.integration.dbclient.common;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
@@ -31,9 +31,6 @@ import io.helidon.reactive.dbclient.DbRow;
  * Common testing code.
  */
 public abstract class AbstractIT {
-
-    /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(AbstractIT.class.getName());
 
     public static final Config CONFIG = Config.create(ConfigSources.classpath(ConfigIT.configFile()));
 
@@ -120,9 +117,7 @@ public abstract class AbstractIT {
             this.name = name;
             this.types = new ArrayList<>(types != null ? types.length : 0);
             if (types != null) {
-                for (Type type : types) {
-                    this.types.add(type);
-                }
+                this.types.addAll(Arrays.asList(types));
             }
         }
 

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/ConfigIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/ConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/ConfigIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/ConfigIT.java
@@ -15,7 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.common;
 
-import java.util.logging.Logger;
+import java.lang.System.Logger.Level;
 
 /**
  * Configuration utilities.
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
 public class ConfigIT {
     
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(ConfigIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(ConfigIT.class.getName());
 
     private static final String CONFIG_PROPERTY_NAME="io.helidon.tests.integration.dbclient.config";
 
@@ -38,7 +38,7 @@ public class ConfigIT {
      */
     public static String configFile() {
         String configFile = System.getProperty(CONFIG_PROPERTY_NAME, DEFAULT_CONFIG_FILE);
-        LOGGER.info(() -> String.format("Configuration file: %s", configFile));
+        LOGGER.log(Level.DEBUG, () -> String.format("Configuration file: %s", configFile));
         return configFile;
     }
 

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/ConfigIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/ConfigIT.java
@@ -15,7 +15,6 @@
  */
 package io.helidon.tests.integration.dbclient.common;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/dbresult/FlowControlIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/dbresult/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/dbresult/FlowControlIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/dbresult/FlowControlIT.java
@@ -15,11 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.dbresult;
 
+import java.lang.System.Logger.Level;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbRow;
@@ -41,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class FlowControlIT {
 
-    private static final Logger LOGGER = Logger.getLogger(FlowControlIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(FlowControlIT.class.getName());
 
     /**
      * Test subscriber.
@@ -80,27 +79,27 @@ public class FlowControlIT {
             // Initially request 3 DbRows.
             requested = REQUESTS[reqIdx];
             remaining = REQUESTS[reqIdx++];
-            LOGGER.info(() -> String.format("Requesting first rows: %d", requested));
+            LOGGER.log(Level.DEBUG, () -> String.format("Requesting first rows: %d", requested));
             this.subscription.request(requested);
         }
 
         @Override
-        public void onNext(final DbRow dbRow) {
-            final Type type = new Type(dbRow.column(1).as(Integer.class), dbRow.column(2).as(String.class));
+        public void onNext(DbRow dbRow) {
+            Type type = new Type(dbRow.column(1).as(Integer.class), dbRow.column(2).as(String.class));
             total++;
             if (remaining > 0) {
-                LOGGER.info(() -> String.format(
+                LOGGER.log(Level.DEBUG, () -> String.format(
                         "NEXT: tot: %d req: %d rem: %d type: %s", total, requested, remaining, type.toString()));
                 remaining -= 1;
                 if (remaining == 0 && reqIdx < REQUESTS.length) {
-                    LOGGER.info(() -> String.format("Notifying main thread to request more rows"));
+                    LOGGER.log(Level.DEBUG, "Notifying main thread to request more rows");
                     synchronized (this) {
                         this.notify();
                     }
                 }
                 // Shall not recieve dbRow when not requested!
             } else {
-                LOGGER.warning(() -> String.format(
+                LOGGER.log(Level.WARNING, () -> String.format(
                         "NEXT: tot: %d req: %d rem: %d type: %s", total, requested, remaining, type.toString()));
                 throw new IllegalStateException(String.format("Recieved unexpected row: %s", type.toString()));
             }
@@ -109,13 +108,13 @@ public class FlowControlIT {
         @Override
         public void onError(Throwable throwable) {
             error = throwable.getMessage();
-            LOGGER.warning(() -> String.format("EXCEPTION: %s", throwable.getMessage()));
+            LOGGER.log(Level.WARNING, () -> String.format("EXCEPTION: %s", throwable.getMessage()));
             finished = true;
         }
 
         @Override
         public void onComplete() {
-            LOGGER.info(() -> String.format("COMPLETE: tot: %d req: %d rem: %d", total, requested, remaining));
+            LOGGER.log(Level.DEBUG, () -> String.format("COMPLETE: tot: %d req: %d rem: %d", total, requested, remaining));
             finished = true;
             synchronized (this) {
                 this.notify();
@@ -129,7 +128,7 @@ public class FlowControlIT {
         public void requestNext() {
             if (reqIdx < REQUESTS.length) {
                 requested = remaining = REQUESTS[reqIdx++];
-                LOGGER.info(() -> String.format("Requesting more rows: %d", requested));
+                LOGGER.log(Level.DEBUG, () -> String.format("Requesting more rows: %d", requested));
                 this.subscription.request(requested);
             } else {
                 fail("Can't request more rows, processing shall be finished now.");
@@ -153,9 +152,9 @@ public class FlowControlIT {
         for (DbRow row : list) {
             Integer id = row.column(1).as(Integer.class);
             String name = row.column(2).as(String.class);
-            final Type type = new Type(id, name);
+            Type type = new Type(id, name);
             assertThat(name, TYPES.get(id).getName().equals(name));
-            LOGGER.info(() -> String.format("Type: %s", type.toString()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Type: %s", type.toString()));
         }
     }
 
@@ -165,9 +164,8 @@ public class FlowControlIT {
      * @throws InterruptedException if the current thread was interrupted
      */
     @Test
-    @SuppressWarnings("SleepWhileInLoop")
+    @SuppressWarnings({"SleepWhileInLoop", "BusyWait", "SynchronizationOnLocalVariableOrMethodParameter"})
     public void testFlowControl() throws InterruptedException {
-        CompletableFuture<Long> rowsFuture = new CompletableFuture<>();
         TestSubscriber subscriber = new TestSubscriber();
         Multi<DbRow> rows = DB_CLIENT.execute(exec -> exec
                 .namedQuery("select-types"));
@@ -186,7 +184,7 @@ public class FlowControlIT {
                 Thread.sleep(500);
                 subscriber.requestNext();
             } else {
-                LOGGER.info(() -> String.format("All requests were already done."));
+                LOGGER.log(Level.DEBUG, "All requests were already done.");
             }
         }
         if (subscriber.error != null) {

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
@@ -18,13 +18,13 @@ package io.helidon.tests.integration.dbclient.common.tests.health;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import io.helidon.config.Config;
 import io.helidon.health.HealthCheck;
 import io.helidon.health.HealthCheckResponse;
 import io.helidon.reactive.dbclient.health.DbClientHealthCheck;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.CONFIG;
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
@@ -18,17 +18,18 @@ package io.helidon.tests.integration.dbclient.common.tests.health;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import io.helidon.config.Config;
-import io.helidon.reactive.dbclient.health.DbClientHealthCheck;
-
-import org.eclipse.microprofile.health.HealthCheck;
-import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import io.helidon.config.Config;
+import io.helidon.health.HealthCheck;
+import io.helidon.health.HealthCheckResponse;
+import io.helidon.reactive.dbclient.health.DbClientHealthCheck;
+
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.CONFIG;
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -56,8 +57,8 @@ public class HealthCheckIT {
         LOGGER.log(Level.INFO, "Running test testHealthCheck");
         HealthCheck check = DbClientHealthCheck.create(DB_CLIENT, CONFIG.get("db.health-check"));
         HealthCheckResponse response = check.call();
-        HealthCheckResponse.Status state = response.getStatus();
-        assertThat("Healthcheck failed, response: " + response.getData(), state, equalTo(HealthCheckResponse.Status.UP));
+        HealthCheckResponse.Status state = response.status();
+        assertThat("Health check failed, response: " + response.details(), state, equalTo(HealthCheckResponse.Status.UP));
     }
 
     /**
@@ -69,8 +70,8 @@ public class HealthCheckIT {
         final String hcName = "TestHC";
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).config(CONFIG.get("db.health-check")).name(hcName).build();
         HealthCheckResponse response = check.call();
-        String name = response.getName();
-        HealthCheckResponse.Status state = response.getStatus();
+        String name = check.name();
+        HealthCheckResponse.Status state = response.status();
         assertThat(name, equalTo(hcName));
         assertThat(state, equalTo(HealthCheckResponse.Status.UP));
     }
@@ -87,8 +88,8 @@ public class HealthCheckIT {
         }
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).dml().statementName("ping-dml").build();
         HealthCheckResponse response = check.call();
-        HealthCheckResponse.Status state = response.getStatus();
-        assertThat("Healthcheck failed, response: " + response.getData(), state, equalTo(HealthCheckResponse.Status.UP));
+        HealthCheckResponse.Status state = response.status();
+        assertThat("Health check failed, response: " + response.details(), state, equalTo(HealthCheckResponse.Status.UP));
     }
 
     /**
@@ -108,8 +109,8 @@ public class HealthCheckIT {
         LOGGER.log(Level.INFO, () -> String.format("Using db.statements.ping-dml value %s", statement));
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).dml().statement(statement).build();
         HealthCheckResponse response = check.call();
-        HealthCheckResponse.Status state = response.getStatus();
-        assertThat("Healthcheck failed, response: " + response.getData(), state, equalTo(HealthCheckResponse.Status.UP));
+        HealthCheckResponse.Status state = response.status();
+        assertThat("Health check failed, response: " + response.details(), state, equalTo(HealthCheckResponse.Status.UP));
     }
 
     /**
@@ -120,8 +121,8 @@ public class HealthCheckIT {
         LOGGER.log(Level.INFO, "Running test testHealthCheckWithCustomNamedQuery");
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).query().statementName("ping-query").build();
         HealthCheckResponse response = check.call();
-        HealthCheckResponse.Status state = response.getStatus();
-        assertThat("Healthcheck failed, response: " + response.getData(), state, equalTo(HealthCheckResponse.Status.UP));
+        HealthCheckResponse.Status state = response.status();
+        assertThat("Health check failed, response: " + response.details(), state, equalTo(HealthCheckResponse.Status.UP));
     }
 
     /**
@@ -137,8 +138,8 @@ public class HealthCheckIT {
         LOGGER.log(Level.INFO, () -> String.format("Using db.statements.ping-query value %s", statement));
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).query().statement(statement).build();
         HealthCheckResponse response = check.call();
-        HealthCheckResponse.Status state = response.getStatus();
-        assertThat("Healthcheck failed, response: " + response.getData(), state, equalTo(HealthCheckResponse.Status.UP));
+        HealthCheckResponse.Status state = response.status();
+        assertThat("Health check failed, response: " + response.details(), state, equalTo(HealthCheckResponse.Status.UP));
     }
 
 

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
@@ -15,8 +15,7 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.health;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger.Level;
 
 import io.helidon.config.Config;
 import io.helidon.health.HealthCheck;
@@ -39,7 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class HealthCheckIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(HealthCheckIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(HealthCheckIT.class.getName());
 
     private static boolean pingDml = true;
 
@@ -54,7 +53,6 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheck() {
-        LOGGER.log(Level.INFO, "Running test testHealthCheck");
         HealthCheck check = DbClientHealthCheck.create(DB_CLIENT, CONFIG.get("db.health-check"));
         HealthCheckResponse response = check.call();
         HealthCheckResponse.Status state = response.status();
@@ -66,7 +64,6 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithName() {
-        LOGGER.log(Level.INFO, "Running test testHealthCheckWithName");
         final String hcName = "TestHC";
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).config(CONFIG.get("db.health-check")).name(hcName).build();
         HealthCheckResponse response = check.call();
@@ -81,9 +78,8 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomNamedDML() {
-        LOGGER.log(Level.INFO, "Running test testHealthCheckWithCustomNamedDML");
         if (!pingDml) {
-            LOGGER.log(Level.INFO, () -> String.format("Database %s does not support DML ping, skipping this test", DB_CLIENT.dbType()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Database %s does not support DML ping, skipping this test", DB_CLIENT.dbType()));
             return;
         }
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).dml().statementName("ping-dml").build();
@@ -97,16 +93,15 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomDML() {
-        LOGGER.log(Level.INFO, "Running test testHealthCheckWithCustomDML");
         if (!pingDml) {
-            LOGGER.log(Level.INFO, () -> String.format("Database %s does not support DML ping, skipping this test", DB_CLIENT.dbType()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Database %s does not support DML ping, skipping this test", DB_CLIENT.dbType()));
             return;
         }
         Config cfgStatement = CONFIG.get("db.statements.ping-dml");
         assertThat("Missing ping-dml statement in database configuration!", cfgStatement.exists(), equalTo(true));
         String statement = cfgStatement.asString().get();
         assertThat("Missing ping-dml statement String in database configuration!", statement, is(notNullValue()));
-        LOGGER.log(Level.INFO, () -> String.format("Using db.statements.ping-dml value %s", statement));
+        LOGGER.log(Level.DEBUG, () -> String.format("Using db.statements.ping-dml value %s", statement));
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).dml().statement(statement).build();
         HealthCheckResponse response = check.call();
         HealthCheckResponse.Status state = response.status();
@@ -118,7 +113,6 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomNamedQuery() {
-        LOGGER.log(Level.INFO, "Running test testHealthCheckWithCustomNamedQuery");
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).query().statementName("ping-query").build();
         HealthCheckResponse response = check.call();
         HealthCheckResponse.Status state = response.status();
@@ -130,12 +124,11 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithCustomQuery() {
-        LOGGER.log(Level.INFO, "Running test testHealthCheckWithCustomQuery");
         Config cfgStatement = CONFIG.get("db.statements.ping-query");
         assertThat("Missing ping-query statement in database configuration!", cfgStatement.exists(), equalTo(true));
         String statement = cfgStatement.asString().get();
         assertThat("Missing ping-query statement String in database configuration!", statement, is(notNullValue()));
-        LOGGER.log(Level.INFO, () -> String.format("Using db.statements.ping-query value %s", statement));
+        LOGGER.log(Level.DEBUG, () -> String.format("Using db.statements.ping-query value %s", statement));
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).query().statement(statement).build();
         HealthCheckResponse response = check.call();
         HealthCheckResponse.Status state = response.status();

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/HealthCheckIT.java
@@ -64,7 +64,7 @@ public class HealthCheckIT {
      */
     @Test
     public void testHealthCheckWithName() {
-        final String hcName = "TestHC";
+        String hcName = "TestHC";
         HealthCheck check = DbClientHealthCheck.builder(DB_CLIENT).config(CONFIG.get("db.health-check")).name(hcName).build();
         HealthCheckResponse response = check.call();
         String name = check.name();
@@ -134,6 +134,5 @@ public class HealthCheckIT {
         HealthCheckResponse.Status state = response.status();
         assertThat("Health check failed, response: " + response.details(), state, equalTo(HealthCheckResponse.Status.UP));
     }
-
 
 }

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/ServerHealthCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/ServerHealthCheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/ServerHealthCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/ServerHealthCheckIT.java
@@ -30,21 +30,19 @@ import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonStructure;
-import jakarta.json.JsonValue;
 import jakarta.json.stream.JsonParsingException;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import io.helidon.common.reactive.Multi;
-import io.helidon.config.Config;
+import io.helidon.health.HealthCheck;
 import io.helidon.reactive.dbclient.DbRow;
 import io.helidon.reactive.dbclient.health.DbClientHealthCheck;
 import io.helidon.reactive.health.HealthSupport;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.WebServer;
-
-import org.eclipse.microprofile.health.HealthCheck;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.CONFIG;
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
@@ -67,7 +65,7 @@ public class ServerHealthCheckIT {
     private static Routing createRouting() {
         HealthCheck check = DbClientHealthCheck.create(DB_CLIENT, CONFIG.get("db.health-check"));
         final HealthSupport health = HealthSupport.builder()
-                .addLiveness(check)
+                .add(check)
                 .build();
         return Routing.builder()
                 .register(health) // Health at "/health"
@@ -144,13 +142,8 @@ public class ServerHealthCheckIT {
         }
         JsonArray checks = jsonResponse.asJsonObject().getJsonArray("checks");
         assertThat(checks.size(), greaterThan(0));
-        checks.stream().map((check) -> {
-            String name = check.asJsonObject().getString("name");
-            return check;
-        }).forEachOrdered((check) -> {
-            String state = check.asJsonObject().getString("state");
+        checks.stream().forEachOrdered((check) -> {
             String status = check.asJsonObject().getString("status");
-            assertThat(state, equalTo("UP"));
             assertThat(status, equalTo("UP"));
         });
     }

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/ServerHealthCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/health/ServerHealthCheckIT.java
@@ -26,16 +26,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonStructure;
-import jakarta.json.stream.JsonParsingException;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.health.HealthCheck;
 import io.helidon.reactive.dbclient.DbRow;
@@ -43,6 +33,15 @@ import io.helidon.reactive.dbclient.health.DbClientHealthCheck;
 import io.helidon.reactive.health.HealthSupport;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.WebServer;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonStructure;
+import jakarta.json.stream.JsonParsingException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.CONFIG;
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/interceptor/InterceptorIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/interceptor/InterceptorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/interceptor/InterceptorIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/interceptor/InterceptorIT.java
@@ -15,13 +15,11 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.interceptor;
 
-import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbClientService;
 import io.helidon.reactive.dbclient.DbClientServiceContext;
-import io.helidon.reactive.dbclient.DbRow;
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
 import org.junit.jupiter.api.Test;
@@ -38,26 +36,19 @@ public class InterceptorIT {
     private static final class TestClientService implements DbClientService {
 
         private boolean called;
-        private DbClientServiceContext context;
 
         private TestClientService() {
             this.called = false;
-            this.context = null;
         }
 
         @Override
         public Single<DbClientServiceContext> statement(DbClientServiceContext context) {
             this.called = true;
-            this.context = context;
             return Single.just(context);
         }
 
         private boolean called() {
             return called;
-        }
-
-        private DbClientServiceContext getContext() {
-            return context;
         }
 
     }
@@ -75,7 +66,7 @@ public class InterceptorIT {
     public void testStatementInterceptor() {
         TestClientService interceptor = new TestClientService();
         DbClient dbClient = initDbClient(interceptor);
-        Multi<DbRow> rows = dbClient.execute(exec -> exec
+        dbClient.execute(exec -> exec
                 .createNamedQuery("select-pokemon-named-arg")
                 .addParam("name", POKEMONS.get(6).getName())
                 .execute());

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/mapping/MapperIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/mapping/MapperIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/mapping/MapperIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/mapping/MapperIT.java
@@ -15,9 +15,9 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.mapping;
 
+import java.lang.System.Logger.Level;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbRow;
@@ -40,11 +40,11 @@ import static org.hamcrest.Matchers.equalTo;
 public class MapperIT extends AbstractIT  {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(MapperIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(MapperIT.class.getName());
     /** Maximum Pokemon ID. */
     private static final int BASE_ID = LAST_POKEMON_ID + 400;
 
-    private static void addPokemon(Pokemon pokemon) throws ExecutionException, InterruptedException {
+    private static void addPokemon(Pokemon pokemon) {
         POKEMONS.put(pokemon.getId(), pokemon);
         Long result = DB_CLIENT.execute(exec -> exec
                 .namedInsert("insert-pokemon", pokemon.getId(), pokemon.getName())
@@ -68,19 +68,16 @@ public class MapperIT extends AbstractIT  {
             addPokemon(new Pokemon(++curId, "Makuhita", TYPES.get(2)));                 // BASE_ID+5
             addPokemon(new Pokemon(++curId, "Hariyama", TYPES.get(2)));                 // BASE_ID+6
         } catch (Exception ex) {
-            LOGGER.warning(() -> String.format("Exception in setup: %s", ex.getMessage()));
+            LOGGER.log(Level.WARNING, String.format("Exception in setup: %s", ex.getMessage()), ex);
             throw ex;
         }
     }
 
     /**
      * Verify insertion of PoJo instance using indexed mapping.
-     *
-     * @throws InterruptedException if the current thread was interrupted
-     * @throws ExecutionException when database query failed
      */
     @Test
-    public void testInsertWithOrderMapping() throws ExecutionException, InterruptedException {
+    public void testInsertWithOrderMapping() {
         Pokemon pokemon = new Pokemon(BASE_ID+1 , "Articuno", TYPES.get(3), TYPES.get(15));
         Long result = DB_CLIENT.execute(exec -> exec
                 .createNamedInsert("insert-pokemon-order-arg-rev")
@@ -92,12 +89,9 @@ public class MapperIT extends AbstractIT  {
 
     /**
      * Verify insertion of PoJo instance using named mapping.
-     *
-     * @throws InterruptedException if the current thread was interrupted
-     * @throws ExecutionException when database query failed
      */
     @Test
-    public void testInsertWithNamedMapping() throws ExecutionException, InterruptedException {
+    public void testInsertWithNamedMapping() {
         Pokemon pokemon = new Pokemon(BASE_ID+2 , "Zapdos", TYPES.get(3), TYPES.get(13));
         Long result = DB_CLIENT.execute(exec -> exec
                 .createNamedInsert("insert-pokemon-named-arg")
@@ -109,12 +103,9 @@ public class MapperIT extends AbstractIT  {
 
     /**
      * Verify update of PoJo instance using indexed mapping.
-     *
-     * @throws InterruptedException if the current thread was interrupted
-     * @throws ExecutionException when database query failed
      */
     @Test
-    public void testUpdateWithOrderMapping() throws ExecutionException, InterruptedException {
+    public void testUpdateWithOrderMapping() {
         Pokemon pokemon = new Pokemon(BASE_ID+3 , "Masquerain", TYPES.get(3), TYPES.get(15));
         Long result = DB_CLIENT.execute(exec -> exec
                 .createNamedUpdate("update-pokemon-order-arg")
@@ -126,12 +117,9 @@ public class MapperIT extends AbstractIT  {
 
     /**
      * Verify update of PoJo instance using named mapping.
-     *
-     * @throws InterruptedException if the current thread was interrupted
-     * @throws ExecutionException when database query failed
      */
     @Test
-    public void testUpdateWithNamedMapping() throws ExecutionException, InterruptedException {
+    public void testUpdateWithNamedMapping() {
         Pokemon pokemon = new Pokemon(BASE_ID+4 , "Moltres", TYPES.get(3), TYPES.get(13));
         Long result = DB_CLIENT.execute(exec -> exec
                 .createNamedUpdate("update-pokemon-named-arg")
@@ -143,12 +131,9 @@ public class MapperIT extends AbstractIT  {
 
     /**
      * Verify delete of PoJo instance using indexed mapping.
-     *
-     * @throws InterruptedException if the current thread was interrupted
-     * @throws ExecutionException when database query failed
      */
     @Test
-    public void testDeleteWithOrderMapping() throws ExecutionException, InterruptedException {
+    public void testDeleteWithOrderMapping() {
         Pokemon pokemon = POKEMONS.get(BASE_ID+5);
         Long result = DB_CLIENT.execute(exec -> exec
                 .createNamedDelete("delete-pokemon-full-order-arg")
@@ -160,12 +145,9 @@ public class MapperIT extends AbstractIT  {
 
     /**
      * Verify delete of PoJo instance using named mapping.
-     *
-     * @throws InterruptedException if the current thread was interrupted
-     * @throws ExecutionException when database query failed
      */
     @Test
-    public void testDeleteWithNamedMapping() throws ExecutionException, InterruptedException {
+    public void testDeleteWithNamedMapping() {
         Pokemon pokemon = POKEMONS.get(BASE_ID+6);
         Long result = DB_CLIENT.execute(exec -> exec
                 .createNamedDelete("delete-pokemon-full-named-arg")

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/metrics/ServerMetricsCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/metrics/ServerMetricsCheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/metrics/ServerMetricsCheckIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/metrics/ServerMetricsCheckIT.java
@@ -26,24 +26,23 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonValue;
-import jakarta.json.stream.JsonParsingException;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.config.Config;
 import io.helidon.reactive.dbclient.DbClient;
 import io.helidon.reactive.dbclient.DbRow;
 import io.helidon.reactive.dbclient.DbStatementType;
 import io.helidon.reactive.dbclient.metrics.DbClientMetrics;
-import io.helidon.metrics.MetricsSupport;
-import io.helidon.tests.integration.dbclient.common.AbstractIT;
-import io.helidon.tests.integration.dbclient.common.AbstractIT.Pokemon;
+import io.helidon.reactive.metrics.MetricsSupport;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.WebServer;
+import io.helidon.tests.integration.dbclient.common.AbstractIT;
+import io.helidon.tests.integration.dbclient.common.AbstractIT.Pokemon;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonParsingException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/ExceptionalStmtIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/ExceptionalStmtIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/ExceptionalStmtIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/ExceptionalStmtIT.java
@@ -15,8 +15,8 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.concurrent.CompletionException;
-import java.util.logging.Logger;
 
 import io.helidon.reactive.dbclient.DbClientException;
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
@@ -31,58 +31,47 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ExceptionalStmtIT extends AbstractIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(ExceptionalStmtIT.class.getName());
-
-    /** Maximum Pokemon ID. */
-    private static final int BASE_ID = LAST_POKEMON_ID + 40;
+    private static final System.Logger LOGGER = System.getLogger(ExceptionalStmtIT.class.getName());
 
     /**
      * Verify that execution of query with non existing named statement throws an exception.
-     *
      */
     @Test
     public void testCreateNamedQueryNonExistentStmt() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.execute(exec -> exec
                     .createNamedQuery("select-pokemons-not-exists")
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of non existing statement shall cause an exception to be thrown.");
         } catch (DbClientException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 
     /**
      * Verify that execution of query with both named and ordered arguments throws an exception.
-     *
      */
     @Test
     public void testCreateNamedQueryNamedAndOrderArgsWithoutArgs() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.execute(exec -> exec
                     .createNamedQuery("select-pokemons-error-arg")
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of query with both named and ordered parameters without passing any shall fail.");
         } catch (DbClientException | CompletionException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 
     /**
      * Verify that execution of query with both named and ordered arguments throws an exception.
-     *
      */
     @Test
     public void testCreateNamedQueryNamedAndOrderArgsWithArgs() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.execute(exec -> exec
                     .createNamedQuery("select-pokemons-error-arg")
@@ -91,20 +80,17 @@ public class ExceptionalStmtIT extends AbstractIT {
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of query with both named and ordered parameters without passing them shall fail.");
         } catch (DbClientException | CompletionException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 
     /**
      * Verify that execution of query with named arguments throws an exception while trying to set ordered argument.
-     *
      */
     @Test
     public void testCreateNamedQueryNamedArgsSetOrderArg() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.execute(exec -> exec
                     .createNamedQuery("select-pokemon-named-arg")
@@ -112,20 +98,17 @@ public class ExceptionalStmtIT extends AbstractIT {
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of query with named parameter with passing ordered parameter value shall fail.");
         } catch (DbClientException | CompletionException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 
     /**
      * Verify that execution of query with ordered arguments throws an exception while trying to set named argument.
-     *
      */
     @Test
     public void testCreateNamedQueryOrderArgsSetNamedArg() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.execute(exec -> exec
                     .createNamedQuery("select-pokemon-order-arg")
@@ -133,10 +116,9 @@ public class ExceptionalStmtIT extends AbstractIT {
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of query with ordered parameter with passing named parameter value shall fail.");
         } catch (DbClientException | CompletionException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDeleteIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDeleteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDeleteIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDeleteIT.java
@@ -25,8 +25,6 @@ import io.helidon.tests.integration.dbclient.common.AbstractIT;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.TYPES;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyDeletePokemon;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyInsertPokemon;
 

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDeleteIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDeleteIT.java
@@ -15,10 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
@@ -34,7 +34,7 @@ import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyIns
 public class SimpleDeleteIT extends AbstractIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(SimpleDeleteIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleDeleteIT.class.getName());
 
     /** Maximum Pokemon ID. */
     private static final int BASE_ID = LAST_POKEMON_ID + 30;
@@ -68,7 +68,7 @@ public class SimpleDeleteIT extends AbstractIT {
             addPokemon(new Pokemon(++curId, "Regirock", TYPES.get(6)));                // BASE_ID+6
             addPokemon(new Pokemon(++curId, "Kyogre", TYPES.get(11)));                 // BASE_ID+7
         } catch (Exception ex) {
-            LOGGER.warning(() -> String.format("Exception in setup: %s", ex));
+            LOGGER.log(Level.WARNING, String.format("Exception in setup: %s", ex));
             throw ex;
         }
     }

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDmlIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDmlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDmlIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDmlIT.java
@@ -25,9 +25,6 @@ import io.helidon.tests.integration.dbclient.common.AbstractIT;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.LAST_POKEMON_ID;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.TYPES;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyDeletePokemon;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyInsertPokemon;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyUpdatePokemon;

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDmlIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleDmlIT.java
@@ -15,10 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
@@ -35,7 +35,7 @@ import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyUpd
 public class SimpleDmlIT extends AbstractIT {
     
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(SimpleDmlIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleDmlIT.class.getName());
 
     /** Maximum Pokemon ID. */
     private static final int BASE_ID = LAST_POKEMON_ID + 40;
@@ -78,7 +78,7 @@ public class SimpleDmlIT extends AbstractIT {
             addPokemon(new Pokemon(BASE_ID + 25, "Cubchoo", TYPES.get(15)));                 // BASE_ID+25
             addPokemon(new Pokemon(BASE_ID + 26, "Beartic", TYPES.get(15)));                 // BASE_ID+26
         } catch (Exception ex) {
-            LOGGER.warning(() -> String.format("Exception in setup: %s", ex));
+            LOGGER.log(Level.WARNING, String.format("Exception in setup: %s", ex));
             throw ex;
         }
     }

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleGetIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleGetIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleGetIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleGetIT.java
@@ -23,8 +23,6 @@ import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.POKEMONS;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyPokemon;
 
 /**

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleQueriesIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleQueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleQueriesIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleQueriesIT.java
@@ -15,8 +15,6 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.simple;
 
-import java.util.logging.Logger;
-
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbRow;
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
@@ -29,9 +27,6 @@ import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyPok
  * Test set of basic JDBC queries.
  */
 public class SimpleQueriesIT extends AbstractIT {
-
-    /** Local logger instance. */
-    static final Logger LOGGER = Logger.getLogger(SimpleQueriesIT.class.getName());
 
     /**
      * Verify {@code createNamedQuery(String, String)} API method with ordered parameters.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleUpdateIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleUpdateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleUpdateIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/simple/SimpleUpdateIT.java
@@ -15,10 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.simple;
 
+import java.lang.System.Logger.Level;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
@@ -34,7 +34,7 @@ import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyUpd
 public class SimpleUpdateIT extends AbstractIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(SimpleUpdateIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(SimpleUpdateIT.class.getName());
 
     /** Maximum Pokemon ID. */
     private static final int BASE_ID = LAST_POKEMON_ID + 20;
@@ -68,7 +68,7 @@ public class SimpleUpdateIT extends AbstractIT {
             addPokemon(new Pokemon(++curId, "Sandslash", TYPES.get(5)));             // BASE_ID+6
             addPokemon(new Pokemon(++curId, "Diglett", TYPES.get(5)));               // BASE_ID+7
         } catch (Exception ex) {
-            LOGGER.warning(() -> String.format("Exception in setup: %s", ex));
+            LOGGER.log(Level.WARNING, String.format("Exception in setup: %s", ex));
             throw ex;
         }
     }

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/DmlStatementIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/DmlStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/DmlStatementIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/DmlStatementIT.java
@@ -15,12 +15,12 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.statement;
 
+import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
@@ -36,7 +36,7 @@ import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyUpd
 public class DmlStatementIT extends AbstractIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(DmlStatementIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(DmlStatementIT.class.getName());
 
     /** Maximum Pokemon ID. */
     private static final int BASE_ID = LAST_POKEMON_ID + 100;
@@ -54,12 +54,11 @@ public class DmlStatementIT extends AbstractIT {
 
     /**
      * Initialize DbStatementDml methods tests.
-     *
      */
     @BeforeAll
     public static void setup() {
         try {
-            addPokemon(new Pokemon(BASE_ID + 0, "Shinx", TYPES.get(13)));               // BASE_ID+0
+            addPokemon(new Pokemon(BASE_ID, "Shinx", TYPES.get(13)));                      // BASE_ID+0
             addPokemon(new Pokemon(BASE_ID + 1, "Luxio", TYPES.get(13)));               // BASE_ID+1
             addPokemon(new Pokemon(BASE_ID + 2, "Luxray", TYPES.get(13)));              // BASE_ID+2
             addPokemon(new Pokemon(BASE_ID + 3, "Kricketot", TYPES.get(7)));            // BASE_ID+3
@@ -67,7 +66,7 @@ public class DmlStatementIT extends AbstractIT {
             addPokemon(new Pokemon(BASE_ID + 5, "Phione", TYPES.get(11)));              // BASE_ID+5
             addPokemon(new Pokemon(BASE_ID + 6, "Chatot", TYPES.get(1), TYPES.get(3))); // BASE_ID+6
         } catch (Exception ex) {
-            LOGGER.warning(() -> String.format("Exception in setup: %s", ex));
+            LOGGER.log(Level.WARNING, String.format("Exception in setup: %s", ex), ex);
             throw ex;
         }
     }
@@ -80,7 +79,7 @@ public class DmlStatementIT extends AbstractIT {
      */
     @Test
     public void testDmlArrayParams() throws ExecutionException, InterruptedException {
-        Pokemon pokemon = new Pokemon(BASE_ID + 0, "Luxio", TYPES.get(13));
+        Pokemon pokemon = new Pokemon(BASE_ID, "Luxio", TYPES.get(13));
         Long result = DB_CLIENT.execute(exec -> exec
                 .createNamedDmlStatement("update-pokemon-order-arg")
                 .params(pokemon.getName(), pokemon.getId())

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/GetStatementIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/GetStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/GetStatementIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/GetStatementIT.java
@@ -53,7 +53,6 @@ public class GetStatementIT {
 
     /**
      * Verify {@code params(List<?>)} parameters setting method.
-     *
      */
     @Test
     public void testGetListParams() {
@@ -71,7 +70,6 @@ public class GetStatementIT {
 
     /**
      * Verify {@code params(Map<?>)} parameters setting method.
-     *
      */
     @Test
     public void testGetMapParams() {
@@ -89,7 +87,6 @@ public class GetStatementIT {
 
     /**
      * Verify {@code addParam(Object parameter)} parameters setting method.
-     *
      */
     @Test
     public void testGetOrderParam() {

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/QueryStatementIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/QueryStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/QueryStatementIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/statement/QueryStatementIT.java
@@ -36,7 +36,6 @@ public class QueryStatementIT extends AbstractIT {
 
     /**
      * Verify {@code params(Object... parameters)} parameters setting method.
-     *
      */
     @Test
     public void testQueryArrayParams() {
@@ -50,7 +49,6 @@ public class QueryStatementIT extends AbstractIT {
 
     /**
      * Verify {@code params(List<?>)} parameters setting method.
-     *
      */
     @Test
     public void testQueryListParams() {
@@ -67,7 +65,6 @@ public class QueryStatementIT extends AbstractIT {
 
     /**
      * Verify {@code params(Map<?>)} parameters setting method.
-     *
      */
     @Test
     public void testQueryMapParams() {
@@ -84,7 +81,6 @@ public class QueryStatementIT extends AbstractIT {
 
     /**
      * Verify {@code addParam(Object parameter)} parameters setting method.
-     *
      */
     @Test
     public void testQueryOrderParam() {
@@ -99,7 +95,6 @@ public class QueryStatementIT extends AbstractIT {
 
     /**
      * Verify {@code addParam(String name, Object parameter)} parameters setting method.
-     *
      */
     @Test
     public void testQueryNamedParam() {
@@ -114,7 +109,6 @@ public class QueryStatementIT extends AbstractIT {
 
     /**
      * Verify {@code namedParam(Object parameters)} mapped parameters setting method.
-     *
      */
     @Test
     public void testQueryMappedNamedParam() {
@@ -129,7 +123,6 @@ public class QueryStatementIT extends AbstractIT {
 
     /**
      * Verify {@code indexedParam(Object parameters)} mapped parameters setting method.
-     *
      */
     @Test
     public void testQueryMappedOrderParam() {

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionDeleteIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionDeleteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionDeleteIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionDeleteIT.java
@@ -25,10 +25,6 @@ import io.helidon.tests.integration.dbclient.common.AbstractIT;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.DELETE_POKEMON_ORDER_ARG;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.LAST_POKEMON_ID;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.TYPES;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyDeletePokemon;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyInsertPokemon;
 

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionDeleteIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionDeleteIT.java
@@ -15,10 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.transaction;
 
+import java.lang.System.Logger.Level;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
@@ -34,7 +34,7 @@ import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyIns
 public class TransactionDeleteIT extends AbstractIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(TransactionDeleteIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(TransactionDeleteIT.class.getName());
 
     /** Maximum Pokemon ID. */
     private static final int BASE_ID = LAST_POKEMON_ID + 230;
@@ -68,7 +68,7 @@ public class TransactionDeleteIT extends AbstractIT {
             addPokemon(new Pokemon(++curId, "Bayleef", TYPES.get(12)));                // BASE_ID+6
             addPokemon(new Pokemon(++curId, "Meganium", TYPES.get(12)));               // BASE_ID+7
         } catch (Exception ex) {
-            LOGGER.warning(() -> String.format("Exception in setup: %s", ex));
+            LOGGER.log(Level.WARNING, String.format("Exception in setup: %s", ex));
             throw ex;
         }
     }

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionExceptionalStmtIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionExceptionalStmtIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionExceptionalStmtIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionExceptionalStmtIT.java
@@ -15,15 +15,14 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.transaction;
 
+import java.lang.System.Logger.Level;
 import java.util.concurrent.CompletionException;
-import java.util.logging.Logger;
 
 import io.helidon.reactive.dbclient.DbClientException;
 
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.LAST_POKEMON_ID;
 import static io.helidon.tests.integration.dbclient.common.AbstractIT.POKEMONS;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -33,10 +32,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TransactionExceptionalStmtIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(TransactionExceptionalStmtIT.class.getName());
-
-    /** Maximum Pokemon ID. */
-    private static final int BASE_ID = LAST_POKEMON_ID + 40;
+    private static final System.Logger LOGGER = System.getLogger(TransactionExceptionalStmtIT.class.getName());
 
     /**
      * Verify that execution of query with non existing named statement throws an exception.
@@ -44,17 +40,15 @@ public class TransactionExceptionalStmtIT {
      */
     @Test
     public void testCreateNamedQueryNonExistentStmt() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.inTransaction(tx -> tx
                     .createNamedQuery("select-pokemons-not-exists")
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of non existing statement shall cause an exception to be thrown.");
         } catch (DbClientException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 
@@ -64,17 +58,15 @@ public class TransactionExceptionalStmtIT {
      */
     @Test
     public void testCreateNamedQueryNamedAndOrderArgsWithoutArgs() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.inTransaction(tx -> tx
                     .createNamedQuery("select-pokemons-error-arg")
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of query with both named and ordered parameters without passing any shall fail.");
         } catch (DbClientException | CompletionException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 
@@ -84,7 +76,6 @@ public class TransactionExceptionalStmtIT {
      */
     @Test
     public void testCreateNamedQueryNamedAndOrderArgsWithArgs() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.inTransaction(tx -> tx
                     .createNamedQuery("select-pokemons-error-arg")
@@ -93,10 +84,9 @@ public class TransactionExceptionalStmtIT {
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of query with both named and ordered parameters without passing them shall fail.");
         } catch (DbClientException | CompletionException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 
@@ -106,7 +96,6 @@ public class TransactionExceptionalStmtIT {
      */
     @Test
     public void testCreateNamedQueryNamedArgsSetOrderArg() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.inTransaction(tx -> tx
                     .createNamedQuery("select-pokemon-named-arg")
@@ -114,10 +103,9 @@ public class TransactionExceptionalStmtIT {
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of query with named parameter with passing ordered parameter value shall fail.");
         } catch (DbClientException | CompletionException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 
@@ -127,7 +115,6 @@ public class TransactionExceptionalStmtIT {
      */
     @Test
     public void testCreateNamedQueryOrderArgsSetNamedArg() {
-        LOGGER.info(() -> "Starting test");
         try {
             DB_CLIENT.inTransaction(tx -> tx
                     .createNamedQuery("select-pokemon-order-arg")
@@ -135,10 +122,9 @@ public class TransactionExceptionalStmtIT {
                     .execute())
                     .collectList()
                     .await();
-            LOGGER.warning(() -> "Test failed");
             fail("Execution of query with ordered parameter with passing named parameter value shall fail.");
         } catch (DbClientException | CompletionException ex) {
-            LOGGER.info(() -> String.format("Expected exception: %s", ex.getMessage()));
+            LOGGER.log(Level.DEBUG, () -> String.format("Expected exception: %s", ex.getMessage()), ex);
         }
     }
 

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionInsertIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionInsertIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionInsertIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionInsertIT.java
@@ -22,11 +22,6 @@ import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.INSERT_POKEMON_NAMED_ARG;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.INSERT_POKEMON_ORDER_ARG;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.LAST_POKEMON_ID;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.TYPES;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyInsertPokemon;
 
 /**

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionInsertIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionInsertIT.java
@@ -16,7 +16,6 @@
 package io.helidon.tests.integration.dbclient.common.tests.transaction;
 
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
@@ -28,9 +27,6 @@ import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyIns
  * Test set of basic JDBC inserts in transaction.
  */
 public class TransactionInsertIT extends AbstractIT {
-
-    /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(TransactionInsertIT.class.getName());
 
     /** Maximum Pokemon ID. */
     private static final int BASE_ID = LAST_POKEMON_ID + 210;

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionQueriesIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionQueriesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionQueriesIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionQueriesIT.java
@@ -30,7 +30,6 @@ public class TransactionQueriesIT extends AbstractIT {
 
     /**
      * Verify {@code createNamedQuery(String, String)} API method with ordered parameters.
-     *
      */
     @Test
     public void testCreateNamedQueryStrStrOrderArgs() {
@@ -43,7 +42,6 @@ public class TransactionQueriesIT extends AbstractIT {
 
     /**
      * Verify {@code createNamedQuery(String)} API method with named parameters.
-     *
      */
     @Test
     public void testCreateNamedQueryStrNamedArgs() {
@@ -57,7 +55,6 @@ public class TransactionQueriesIT extends AbstractIT {
 
     /**
      * Verify {@code createNamedQuery(String)} API method with ordered parameters.
-     *
      */
     @Test
     public void testCreateNamedQueryStrOrderArgs() {
@@ -71,7 +68,6 @@ public class TransactionQueriesIT extends AbstractIT {
 
     /**
      * Verify {@code createQuery(String)} API method with named parameters.
-     *
      */
     @Test
     public void testCreateQueryNamedArgs() {
@@ -85,7 +81,6 @@ public class TransactionQueriesIT extends AbstractIT {
 
     /**
      * Verify {@code createQuery(String)} API method with ordered parameters.
-     *
      */
     @Test
     public void testCreateQueryOrderArgs() {
@@ -99,7 +94,6 @@ public class TransactionQueriesIT extends AbstractIT {
 
     /**
      * Verify {@code namedQuery(String)} API method with ordered parameters passed directly to the {@code namedQuery} method.
-     *
      */
     @Test
     public void testNamedQueryOrderArgs() {
@@ -111,7 +105,6 @@ public class TransactionQueriesIT extends AbstractIT {
 
     /**
      * Verify {@code query(String)} API method with ordered parameters passed directly to the {@code query} method.
-     *
      */
     @Test
     public void testQueryOrderArgs() {

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionUpdateIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionUpdateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionUpdateIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionUpdateIT.java
@@ -25,11 +25,6 @@ import io.helidon.tests.integration.dbclient.common.AbstractIT;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.DB_CLIENT;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.LAST_POKEMON_ID;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.TYPES;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.UPDATE_POKEMON_NAMED_ARG;
-import static io.helidon.tests.integration.dbclient.common.AbstractIT.UPDATE_POKEMON_ORDER_ARG;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyInsertPokemon;
 import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyUpdatePokemon;
 

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionUpdateIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/transaction/TransactionUpdateIT.java
@@ -15,10 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.common.tests.transaction;
 
+import java.lang.System.Logger.Level;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 import io.helidon.tests.integration.dbclient.common.AbstractIT;
 
@@ -34,7 +34,7 @@ import static io.helidon.tests.integration.dbclient.common.utils.Utils.verifyUpd
 public class TransactionUpdateIT extends AbstractIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(TransactionUpdateIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(TransactionUpdateIT.class.getName());
 
     /** Maximum Pokemon ID. */
     private static final int BASE_ID = LAST_POKEMON_ID + 220;
@@ -68,7 +68,7 @@ public class TransactionUpdateIT extends AbstractIT {
             addPokemon(new Pokemon(++curId, "Lombre", TYPES.get(11), TYPES.get(12)));   // BASE_ID+6
             addPokemon(new Pokemon(++curId, "Ludicolo", TYPES.get(11), TYPES.get(12))); // BASE_ID+7
         } catch (Exception ex) {
-            LOGGER.warning(() -> String.format("Exception in setup: %s", ex));
+            LOGGER.log(Level.WARNING, String.format("Exception in setup: %s", ex));
             throw ex;
         }
     }

--- a/tests/integration/dbclient/jdbc/pom.xml
+++ b/tests/integration/dbclient/jdbc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/jdbc/pom.xml
+++ b/tests/integration/dbclient/jdbc/pom.xml
@@ -182,11 +182,121 @@
     </build>
 
     <profiles>
+
+        <profile>
+            <id>h2</id>
+            <activation>
+                <property>
+                    <name>!db</name>
+                </property>
+            </activation>
+            <properties>
+                <app.config>h2.yaml</app.config>
+                <db.port>9092</db.port>
+                <db.host>localhost</db.host>
+                <db.database>test</db.database>
+                <db.user>sa</db.user>
+                <db.password>password</db.password>
+                <db.url>jdbc:h2:tcp://${db.host}:${db.port}/${db.database};DATABASE_TO_UPPER=FALSE</db.url>
+                <mainClassH2>org.h2.tools.Server</mainClassH2>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>io.helidon.integrations.db</groupId>
+                    <artifactId>h2</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <io.helidon.tests.integration.dbclient.config>h2.yaml</io.helidon.tests.integration.dbclient.config>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-libs</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <includeArtifactIds>h2</includeArtifactIds>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>start-db</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>java</executable>
+                                    <arguments>
+                                        <argument>-classpath</argument>
+                                        <argument>${project.build.directory}/dependency/h2-${version.lib.h2}.jar</argument>
+                                        <argument>${mainClassH2}</argument>
+                                        <argument>-tcp</argument>
+                                        <argument>-tcpPassword</argument>
+                                        <argument>${db.password}</argument>
+                                        <argument>-tcpPort</argument>
+                                        <argument>${db.port}</argument>
+                                        <argument>-baseDir</argument>
+                                        <argument>${project.build.directory}/h2</argument>
+                                        <argument>-ifNotExists</argument>
+                                    </arguments>
+                                    <async>true</async>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-db</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>java</executable>
+                                    <arguments>
+                                        <argument>-classpath</argument>
+                                        <argument>${project.build.directory}/dependency/h2-${version.lib.h2}.jar</argument>
+                                        <argument>${mainClassH2}</argument>
+                                        <argument>-tcpShutdown</argument>
+                                        <argument>tcp://localhost:${db.port}</argument>
+                                        <argument>-tcpPassword</argument>
+                                        <argument>${db.password}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>mysql</id>
             <activation>
                 <property>
-                    <name>mysql</name>
+                    <name>db</name>
+                    <value>mysql</value>
                 </property>
             </activation>
             <properties>
@@ -258,7 +368,8 @@
             <id>mariadb</id>
             <activation>
                 <property>
-                    <name>mariadb</name>
+                    <name>db</name>
+                    <value>mariadb</value>
                 </property>
             </activation>
             <properties>
@@ -330,7 +441,8 @@
             <id>pgsql</id>
             <activation>
                 <property>
-                    <name>pgsql</name>
+                    <name>db</name>
+                    <value>pgsql</value>
                 </property>
             </activation>
             <properties>
@@ -400,7 +512,8 @@
             <id>mssql</id>
             <activation>
                 <property>
-                    <name>mssql</name>
+                    <name>db</name>
+                    <value>mssqk</value>
                 </property>
             </activation>
             <properties>

--- a/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/CheckIT.java
+++ b/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/CheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/CheckIT.java
+++ b/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/CheckIT.java
@@ -15,12 +15,12 @@
  */
 package io.helidon.tests.integration.dbclient.jdbc.init;
 
+import java.lang.System.Logger.Level;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class CheckIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(CheckIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(CheckIT.class.getName());
 
     /** Test configuration. */
     public static final Config CONFIG = Config.create(ConfigSources.classpath(ConfigIT.configFile()));
@@ -71,7 +71,7 @@ public class CheckIT {
                     connected = true;
                     return;
                 } catch (SQLException ex) {
-                    LOGGER.info(() -> String.format("Connection check: %s", ex.getMessage()));
+                    LOGGER.log(Level.DEBUG, () -> String.format("Connection check: %s", ex.getMessage()), ex);
                     if (System.currentTimeMillis() > endTm) {
                         return;
                     }
@@ -147,19 +147,20 @@ public class CheckIT {
         ConnectionBuilder builder = new ConnectionBuilder();
         String ping = CONFIG.get("db.health-check.statement").asString().get();
         String typeStr = CONFIG.get("db.health-check.type").asString().get();
-        boolean pingDml = typeStr != null && "dml".equals(typeStr.toLowerCase());
+        boolean pingDml = "dml".equalsIgnoreCase(typeStr);
         CONFIG.get("db.connection").ifExists(builder);
-        Connection conn = builder.createConnection();
-        if (pingDml) {
-            int result = conn.createStatement().executeUpdate(ping);
-            assertThat(result, equalTo(0));
-            LOGGER.info(() -> String.format("Command ping result: %d", result));
-        } else {
-            ResultSet rs = conn.createStatement().executeQuery(ping);
-            rs.next();
-            int result = rs.getInt(1);
-            assertThat(result, equalTo(0));
-            LOGGER.info(() -> String.format("Command ping result: %d", result));
+        try (Connection conn = builder.createConnection()) {
+            if (pingDml) {
+                int result = conn.createStatement().executeUpdate(ping);
+                assertThat(result, equalTo(0));
+                LOGGER.log(Level.DEBUG, () -> String.format("Command ping result: %d", result));
+            } else {
+                ResultSet rs = conn.createStatement().executeQuery(ping);
+                rs.next();
+                int result = rs.getInt(1);
+                assertThat(result, equalTo(0));
+                LOGGER.log(Level.DEBUG, () -> String.format("Command ping result: %d", result));
+            }
         }
     }
 

--- a/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/CheckMsSqlIT.java
+++ b/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/CheckMsSqlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/InitIT.java
+++ b/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/InitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/InitIT.java
+++ b/tests/integration/dbclient/jdbc/src/test/java/io/helidon/tests/integration/dbclient/jdbc/init/InitIT.java
@@ -15,12 +15,11 @@
  */
 package io.helidon.tests.integration.dbclient.jdbc.init;
 
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
@@ -42,9 +41,6 @@ import static org.hamcrest.Matchers.notNullValue;
  * Initialize database
  */
 public class InitIT extends AbstractIT {
-
-    /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(InitIT.class.getName());
 
     /**
      * Initializes database schema (tables).
@@ -116,8 +112,6 @@ public class InitIT extends AbstractIT {
      */
     @BeforeAll
     public static void setup() {
-        LOGGER.info(() -> "Initializing Integration Tests");
-
         initSchema(DB_CLIENT);
         initData(DB_CLIENT);
     }
@@ -132,7 +126,7 @@ public class InitIT extends AbstractIT {
                 .namedQuery("select-types"));
 
         assertThat(rows, notNullValue());
-        List<DbRow> rowsList = rows.collectList().await(5, TimeUnit.SECONDS);
+        List<DbRow> rowsList = rows.collectList().await(Duration.ofSeconds(5));
         assertThat(rowsList, not(empty()));
         Set<Integer> ids = new HashSet<>(TYPES.keySet());
         for (DbRow row : rowsList) {

--- a/tests/integration/dbclient/jdbc/src/test/resources/h2.yaml
+++ b/tests/integration/dbclient/jdbc/src/test/resources/h2.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/jdbc/src/test/resources/h2.yaml
+++ b/tests/integration/dbclient/jdbc/src/test/resources/h2.yaml
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 0
+  host: 0.0.0.0
+
+db:
+  source: jdbc
+  connection:
+    url: ${db.url}
+    username: ${db.user}
+    password: ${db.password}
+  health-check:
+    type: query
+    statement: "SELECT 0"
+  statements:
+    # custom query ping statement
+    ping-query: "SELECT 0"
+    # database schema initialization statements
+    create-types: "CREATE TABLE Types (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(64) NOT NULL)"
+    create-pokemons: "CREATE TABLE Pokemons (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(64) NOT NULL)"
+    create-poketypes: "CREATE TABLE PokemonTypes (id_pokemon INTEGER NOT NULL REFERENCES Pokemons(id), id_type INTEGER NOT NULL REFERENCES Types(id))"
+    # database schema cleanup statements
+    drop-types: "DROP TABLE Types"
+    drop-pokemons: "DROP TABLE Pokemons"
+    drop-poketypes: "DROP TABLE PokemonTypes"
+    # data initialization statements
+    insert-type: "INSERT INTO Types(id, name) VALUES(?, ?)"
+    insert-pokemon: "INSERT INTO Pokemons(id, name) VALUES(?, ?)"
+    insert-poketype: "INSERT INTO PokemonTypes(id_pokemon, id_type) VALUES(?, ?)"
+    # data initialization verification statements
+    select-types: "SELECT id, name FROM Types"
+    select-pokemons: "SELECT id, name FROM Pokemons"
+    select-poketypes: "SELECT id_pokemon, id_type FROM PokemonTypes p WHERE id_pokemon = ?"
+    # data cleanup verification statements
+    select-poketypes-all: "SELECT id_pokemon, id_type FROM PokemonTypes"
+    # retrieve max. Pokemon ID
+    select-max-id: "SELECT MAX(id) FROM Pokemons"
+    # test queries
+    select-pokemon-named-arg: "SELECT id, name FROM Pokemons WHERE name=:name"
+    select-pokemon-order-arg: "SELECT id, name FROM Pokemons WHERE name=?"
+    # test DML insert
+    insert-pokemon-named-arg: "INSERT INTO Pokemons(id, name) VALUES(:id, :name)"
+    insert-pokemon-order-arg: "INSERT INTO Pokemons(id, name) VALUES(?, ?)"
+    # Pokemon mapper uses reverse order of indexed arguments
+    insert-pokemon-order-arg-rev: "INSERT INTO Pokemons(name, id) VALUES(?, ?)"
+    # test DML update
+    select-pokemon-by-id: "SELECT id, name FROM Pokemons WHERE id=?"
+    update-pokemon-named-arg: "UPDATE Pokemons SET name=:name WHERE id=:id"
+    update-pokemon-order-arg: "UPDATE Pokemons SET name=? WHERE id=?"
+    # test DML delete
+    delete-pokemon-named-arg: "DELETE FROM Pokemons WHERE id=:id"
+    delete-pokemon-order-arg: "DELETE FROM Pokemons WHERE id=?"
+    # Pokemon mapper uses full list of attributes
+    delete-pokemon-full-named-arg: "DELETE FROM Pokemons WHERE name=:name AND id=:id"
+    delete-pokemon-full-order-arg: "DELETE FROM Pokemons WHERE name=? AND id=?"
+    # test DbStatementQuery methods
+    select-pokemons-idrng-named-arg: "SELECT id, name FROM Pokemons WHERE id > :idmin AND id < :idmax"
+    select-pokemons-idrng-order-arg: "SELECT id, name FROM Pokemons WHERE id > ? AND id < ?"
+    # Test query with both named and ordered parameters (shall cause an exception)
+    select-pokemons-error-arg: "SELECT id, name FROM Pokemons WHERE id > :id AND name = ?"
+
+# Tests configuration
+test:
+  # Whether database supports ping statement as DML (default value is true)
+  ping-dml: false

--- a/tests/integration/dbclient/mongodb/pom.xml
+++ b/tests/integration/dbclient/mongodb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/mongodb/pom.xml
+++ b/tests/integration/dbclient/mongodb/pom.xml
@@ -167,6 +167,18 @@
     </build>
 
     <profiles>
+        <!-- Skip Mongo DB integration tests until explicitly enabled by db property. -->
+        <profile>
+            <id>skip</id>
+            <activation>
+                <property>
+                    <name>!db</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>true</skipITs>
+            </properties>
+        </profile>
         <!--
              mvn -pl common,mongodb -Pdebug,docker install \
                  -Dit.jdbc.debug="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8787 -Xnoagent -Djava.compiler=NONE" \

--- a/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/destroy/DestroyIT.java
+++ b/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/destroy/DestroyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/destroy/DestroyIT.java
+++ b/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/destroy/DestroyIT.java
@@ -15,10 +15,9 @@
  */
 package io.helidon.tests.integration.dbclient.mongodb.destroy;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.dbclient.DbClient;
@@ -37,9 +36,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class DestroyIT {
 
-    /** Local logger instance. */
-    static final Logger LOGGER = Logger.getLogger(DestroyIT.class.getName());
-
     /**
      * Delete database content.
      *
@@ -52,7 +48,7 @@ public class DestroyIT {
                 .namedDelete("delete-poketypes")
                 .flatMapSingle(result -> exec.namedDelete("delete-pokemons"))
                 .flatMapSingle(result -> exec.namedDelete("delete-types"))
-        ).await(10, TimeUnit.SECONDS);
+        ).await(Duration.ofSeconds(10));
     }
 
     /**
@@ -71,13 +67,12 @@ public class DestroyIT {
      * Verify that table Types does not exist.
      */
     @Test
-    public void testTypesDeleted() throws InterruptedException {
+    public void testTypesDeleted() {
         Multi<DbRow> rows = DB_CLIENT.execute(exec -> exec
                 .namedQuery("select-types"));
 
         if (rows != null) {
             List<DbRow> rowsList = rows.collectList().await();
-            LOGGER.warning(() -> String.format("Rows count: %d", rowsList.size()));
             assertThat(rowsList, empty());
         }
     }
@@ -86,30 +81,26 @@ public class DestroyIT {
      * Verify that table Pokemons does not exist.
      */
     @Test
-    public void testPokemonsDeleted() throws InterruptedException {
+    public void testPokemonsDeleted() {
         Multi<DbRow> rows = DB_CLIENT.execute(exec -> exec
                 .namedQuery("select-pokemons"));
 
         if (rows != null) {
             List<DbRow> rowsList = rows.collectList().await();
-            LOGGER.warning(() -> String.format("Rows count: %d", rowsList.size()));
             assertThat(rowsList, empty());
         }
     }
 
     /**
      * Verify that table PokemonTypes does not exist.
-     *
-     * @throws ExecutionException when database query failed
      */
     @Test
-    public void testPokemonTypesDeleted() throws InterruptedException {
+    public void testPokemonTypesDeleted() {
         Multi<DbRow> rows = DB_CLIENT.execute(exec -> exec
                 .namedQuery("select-poketypes-all"));
 
         if (rows != null) {
             List<DbRow> rowsList = rows.collectList().await();
-            LOGGER.warning(() -> String.format("Rows count: %d", rowsList.size()));
             assertThat(rowsList, empty());
         }
     }

--- a/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/init/CheckIT.java
+++ b/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/init/CheckIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/init/CheckIT.java
+++ b/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/init/CheckIT.java
@@ -15,11 +15,10 @@
  */
 package io.helidon.tests.integration.dbclient.mongodb.init;
 
+import java.lang.System.Logger.Level;
+import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.config.Config;
@@ -41,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class CheckIT extends AbstractIT {
 
     /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(CheckIT.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(CheckIT.class.getName());
 
     /** Timeout in seconds to wait for database to come up. */
     private static final int TIMEOUT = 60;
@@ -65,14 +64,14 @@ public class CheckIT extends AbstractIT {
         while (retry) {
             try {
                 dbClient.execute(exec -> exec.namedGet("ping"))
-                        .await(1, TimeUnit.SECONDS);
+                        .await(Duration.ofSeconds(1));
                 retry = false;
             } catch (Exception ex) {
                 if (System.currentTimeMillis() > endTm) {
                     fail("Database startup failed!", ex);
                 } else {
-                    LOGGER.info(() -> String.format("Exception: %s", ex.getMessage()));
-                    LOGGER.log(Level.INFO, "Exception details: ", ex);
+                    // Exceptions will be coming until database is up
+                    LOGGER.log(Level.DEBUG, () -> String.format("Exception: %s", ex.getMessage()), ex);
                 }
             }
         }
@@ -90,7 +89,7 @@ public class CheckIT extends AbstractIT {
                     .flatMapSingle(result -> exec.namedGet("create-user"))
             ).await();
         } catch (Exception ex) {
-                LOGGER.warning(() -> String.format("Exception: %s", ex.getMessage()));
+                LOGGER.log(Level.WARNING, () -> String.format("Exception: %s", ex.getMessage()), ex);
                 fail("Database user setup failed!", ex);
         }
     }
@@ -98,12 +97,9 @@ public class CheckIT extends AbstractIT {
     /**
      * Setup database for tests.
      * Wait for database to start. Returns after ping query completed successfully or timeout passed.
-     *
-     * @throws ExecutionException when database query failed
-     * @throws InterruptedException if the current thread was interrupted
      */
     @BeforeAll
-    public static void setup() throws ExecutionException, InterruptedException {
+    public static void setup() {
         waitForStart(DB_ADMIN);
         //initUser(DB_ADMIN);
     }
@@ -111,18 +107,15 @@ public class CheckIT extends AbstractIT {
     /**
      * Simple test to verify that DML query execution works.
      * Used before running database schema initialization.
-     *
-     * @throws ExecutionException when database query failed
-     * @throws InterruptedException if the current thread was interrupted
      */
     @Test
-    public void testDmlStatementExecution() throws ExecutionException, InterruptedException {
+    public void testDmlStatementExecution() {
         Multi<DbRow> result = DB_CLIENT.execute(exec -> exec.namedQuery("ping-query"));
         List<DbRow> rowsList = result.collectList().await(5, TimeUnit.SECONDS);
         DbRow row = rowsList.get(0);
         Double ok = row.column("ok").as(Double.class);
         assertThat(ok, equalTo(1.0));
-        LOGGER.info(() -> String.format("Command ping row: %s", row.toString()));
+        LOGGER.log(Level.DEBUG, () -> String.format("Command ping row: %s", row));
     }
 
 }

--- a/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/init/InitIT.java
+++ b/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/init/InitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/init/InitIT.java
+++ b/tests/integration/dbclient/mongodb/src/test/java/io/helidon/tests/integration/dbclient/mongodb/init/InitIT.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
@@ -42,9 +41,6 @@ import static org.hamcrest.Matchers.notNullValue;
  * Initialize database
  */
 public class InitIT extends AbstractIT {
-
-    /** Local logger instance. */
-    private static final Logger LOGGER = Logger.getLogger(InitIT.class.getName());
 
     /**
      * Initialize database content (rows in tables).
@@ -103,8 +99,6 @@ public class InitIT extends AbstractIT {
      */
     @BeforeAll
     public static void setup() {
-        LOGGER.info(() ->  "Initializing Integration Tests");
-
         initData(DB_CLIENT);
     }
 

--- a/tests/integration/dbclient/test.sh
+++ b/tests/integration/dbclient/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,13 +89,13 @@ fi
 # Run simple JDBC tests
 [ -n "${FLAG_S}" ] && \
     (cd ${WS_DIR}/tests/integration/dbclient && \
-        echo mvn -P${DB_PROFILE} -pl common,jdbc \
+        echo mvn -D${DB_PROPERTY} -pl common,jdbc \
             -Dapp.config=${TEST_CONFIG} \
             -Ddb.user=${DB_USER} \
             -Ddb.password=${DB_PASSWORD} \
             -Ddb.url="${DB_URL}" \
              verify && \
-        mvn -P${DB_PROFILE} -pl common,jdbc \
+        mvn -D${DB_PROPERTY} -pl common,jdbc \
             -Dapp.config=${TEST_CONFIG} \
             -Ddb.user=${DB_USER} \
             -Ddb.password=${DB_PASSWORD} \
@@ -105,13 +105,13 @@ fi
 # Run remote application tests in Java VM mode
 [ -n "${FLAG_J}" ] && \
     (cd ${WS_DIR}/tests/integration/dbclient && \
-        echo mvn -P${DB_PROFILE} \
+        echo mvn -D${DB_PROPERTY} \
             -Dapp.config=${TEST_CONFIG} \
             -Ddb.user=${DB_USER} \
             -Ddb.password=${DB_PASSWORD} \
             -Ddb.url="${DB_URL}" \
             -pl appl verify && \
-        mvn -P${DB_PROFILE} \
+        mvn -D${DB_PROPERTY} \
             -Dapp.config=${TEST_CONFIG} \
             -Ddb.user=${DB_USER} \
             -Ddb.password=${DB_PASSWORD} \
@@ -121,13 +121,13 @@ fi
 # Run remote application tests in native image mode
 [ -n "${FLAG_N}" ] && \
     (cd ${WS_DIR}/tests/integration/dbclient && \
-        echo mvn -P${DB_PROFILE} -Pnative-image \
+        echo mvn -D${DB_PROPERTY} -Pnative-image \
             -Dapp.config=${TEST_CONFIG} \
             -Ddb.user=${DB_USER} \
             -Ddb.password=${DB_PASSWORD} \
             -Ddb.url="${DB_URL}" \
             -pl appl verify && \
-        mvn -P${DB_PROFILE} -Pnative-image \
+        mvn -D${DB_PROPERTY} -Pnative-image \
             -Dapp.config=${TEST_CONFIG} \
             -Ddb.user=${DB_USER} \
             -Ddb.password=${DB_PASSWORD} \

--- a/tests/integration/dbclient/test.sh
+++ b/tests/integration/dbclient/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -62,6 +62,7 @@
         <module>jpa</module>
         <module>jms</module>
         <module>config</module>
+        <module>dbclient</module>
         <module>jep290</module>
         <module>mp-bean-validation</module>
         <module>restclient</module>
@@ -82,12 +83,4 @@
         </dependencies>
     </dependencyManagement>
 
-    <profiles>
-        <profile>
-            <id>dbclient-it</id>
-            <modules>
-                <module>dbclient</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Some changes in `HealthCheck` API caused build issues with integration tests. Also name removal from `HealthCheckResponse` caused test failures.

Fixed build issues mostly with import changes.
`HealthCheck` name was checked as part of response. Changed this to verify name directly from `HealthCheck` instance.