### PR TITLE
Fix OpenMetrics formatting error (3.x)

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/MediaType.java
+++ b/common/http/src/main/java/io/helidon/common/http/MediaType.java
@@ -152,6 +152,11 @@ public final class MediaType implements AcceptPredicate<MediaType> {
      */
     public static final MediaType APPLICATION_X_NDJSON;
 
+    /**
+     * A {@link MediaType} constant representing the {@code application/openmetrics-text} media type.
+     */
+    public static final MediaType APPLICATION_OPENMETRICS;
+
     static {
         Map<String, MediaType> knownTypes = new HashMap<>();
 
@@ -220,6 +225,9 @@ public final class MediaType implements AcceptPredicate<MediaType> {
 
         APPLICATION_X_NDJSON = new MediaType("application", "x-ndjson");
         knownTypes.put("application/x-ndjson", APPLICATION_X_NDJSON);
+
+        APPLICATION_OPENMETRICS = new MediaType("application", "openmetrics-text");
+        knownTypes.put("application/openmetrics-text", APPLICATION_OPENMETRICS);
 
         KNOWN_TYPES = Collections.unmodifiableMap(knownTypes);
     }

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonSimpleTimer.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonSimpleTimer.java
@@ -111,7 +111,7 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
         SimpleTimerImpl simpleTimerImpl = (delegate instanceof SimpleTimerImpl) ? ((SimpleTimerImpl) delegate) : null;
         Sample.Labeled sample = simpleTimerImpl != null ? simpleTimerImpl.sample : null;
         if (sample != null) {
-            sb.append(prometheusExemplar(elapsedTimeInSeconds(sample.value()), simpleTimerImpl.sample));
+            sb.append(prometheusExemplar(1, sample)); // exemplar always contributes 1 to the count
         }
         sb.append("\n");
 
@@ -124,6 +124,7 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
                 .append(tags)
                 .append(" ")
                 .append(elapsedTimeInSeconds())
+                .append(exemplarForElapsedTime(sample))
                 .append("\n");
 
         promName = prometheusNameWithUnits(name + "_maxTimeDuration", Optional.of(MetricUnits.SECONDS));
@@ -134,6 +135,8 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
                 .append(tags)
                 .append(" ")
                 .append(durationPrometheusOutput(getMaxTimeDuration()))
+                .append(exemplarForElapsedTime(getMaxTimeDuration(),
+                                               simpleTimerImpl == null ? null : simpleTimerImpl.lastMaxSample))
                 .append("\n");
 
         promName = prometheusNameWithUnits(name + "_minTimeDuration", Optional.of(MetricUnits.SECONDS));
@@ -144,13 +147,9 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
                 .append(tags)
                 .append(" ")
                 .append(durationPrometheusOutput(getMinTimeDuration()))
+                .append(exemplarForElapsedTime(getMinTimeDuration(),
+                                               simpleTimerImpl == null ? null : simpleTimerImpl.lastMinSample))
                 .append("\n");
-
-
-        if (sample != null) {
-            sb.append(prometheusExemplar(elapsedTimeInSeconds(sample.value()), sample));
-        }
-        sb.append("\n");
     }
 
     @Override
@@ -166,6 +165,15 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
                 .add(jsonFullKey("maxTimeDuration", metricID), jsonDuration(getMaxTimeDuration()))
                 .add(jsonFullKey("minTimeDuration", metricID), jsonDuration(getMinTimeDuration()));
         builder.add(metricID.getName(), myBuilder);
+    }
+
+    private String exemplarForElapsedTime(Duration duration, Sample.Labeled sample) {
+        // If the duration is null, then there is no value to which a sample might have contributed. So there's no exemplar.
+        return duration == null ? "" : exemplarForElapsedTime(sample);
+    }
+
+    private String exemplarForElapsedTime(Sample.Labeled sample) {
+        return sample == null ? "" : prometheusExemplar(sample.value(), sample);
     }
 
     private static String durationPrometheusOutput(Duration duration) {
@@ -221,6 +229,10 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
         private long lastMinute;
 
         private Sample.Labeled sample = null;
+        private Sample.Labeled currentMaxSample = null;
+        private Sample.Labeled currentMinSample = null;
+        private Sample.Labeled lastMaxSample = null;
+        private Sample.Labeled lastMinSample = null;
 
         private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -300,9 +312,11 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
                     updateStateLocked();
                     if (currentMin == null || currentMin.toNanos() > nanos) {
                         currentMin = Duration.ofNanos(nanos);
+                        currentMinSample = sample;
                     }
                     if (currentMax == null || currentMax.toNanos() < nanos) {
                         currentMax = Duration.ofNanos(nanos);
+                        currentMaxSample = sample;
                     }
                 }
                 return null;
@@ -324,6 +338,10 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
                 lastMin = currentMin;
                 currentMax = null;
                 currentMin = null;
+                lastMaxSample = currentMaxSample;
+                lastMinSample = currentMinSample;
+                currentMaxSample = null;
+                currentMinSample = null;
                 lastMinute = currentMinute;
             }
         }
@@ -341,12 +359,19 @@ final class HelidonSimpleTimer extends MetricImpl implements SimpleTimer {
                     && elapsed.equals(that.elapsed)
                     && Objects.equals(lastMin, that.lastMin)
                     && Objects.equals(lastMax, that.lastMax)
-                    && Objects.equals(sample, that.sample);
+                    && Objects.equals(sample, that.sample)
+                    && Objects.equals(currentMin, that.currentMin)
+                    && Objects.equals(currentMax, that.currentMax)
+                    && Objects.equals(currentMinSample, that.currentMinSample)
+                    && Objects.equals(currentMaxSample, that.currentMaxSample)
+                    && Objects.equals(lastMinSample, that.lastMinSample)
+                    && Objects.equals(lastMaxSample, that.lastMaxSample);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(counter, elapsed, lastMin, lastMax, sample);
+            return Objects.hash(counter, elapsed, lastMin, lastMax, sample, currentMin, currentMax,
+                                currentMinSample, currentMaxSample, lastMinSample, lastMaxSample);
         }
 
         private <T> T writeAccess(Callable<T> action) {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -593,7 +593,7 @@ public final class MetricsSupport extends HelidonRestServiceSupport
 
     private static boolean matches(MediaType candidateMediaType, MediaType... standardTypes) {
         for (MediaType mt : standardTypes) {
-            if (candidateMediaType.test(mt)) {
+            if (mt.test(candidateMediaType)) {
                 return true;
             }
         }

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -196,7 +196,9 @@ public final class MetricsSupport extends HelidonRestServiceSupport
     }
 
     private static MediaType findBestAccepted(RequestHeaders headers) {
-        Optional<MediaType> mediaType = headers.bestAccepted(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON);
+        Optional<MediaType> mediaType = headers.bestAccepted(MediaType.TEXT_PLAIN,
+                                                             MediaType.APPLICATION_JSON,
+                                                             MediaType.APPLICATION_OPENMETRICS);
         return mediaType.orElse(null);
     }
 
@@ -221,8 +223,8 @@ public final class MetricsSupport extends HelidonRestServiceSupport
         MediaType mediaType = findBestAccepted(req.headers());
         if (mediaType == MediaType.APPLICATION_JSON) {
             sendJson(res, toJsonData(registry));
-        } else if (mediaType == MediaType.TEXT_PLAIN) {
-            res.send(toPrometheusData(registry));
+        } else if (mediaType == MediaType.TEXT_PLAIN || mediaType == MediaType.APPLICATION_OPENMETRICS) {
+            sendPrometheus(res, toPrometheusData(registry), mediaType);
         } else {
             res.status(Http.Status.NOT_ACCEPTABLE_406);
             res.send();
@@ -526,8 +528,8 @@ public final class MetricsSupport extends HelidonRestServiceSupport
                     MediaType mediaType = findBestAccepted(req.headers());
                     if (mediaType == MediaType.APPLICATION_JSON) {
                         sendJson(res, jsonDataByName(registry, metricName));
-                    } else if (mediaType == MediaType.TEXT_PLAIN) {
-                        res.send(prometheusDataByName(registry, metricName));
+                    } else if (mediaType == MediaType.TEXT_PLAIN || mediaType == MediaType.APPLICATION_OPENMETRICS) {
+                        sendPrometheus(res, prometheusDataByName(registry, metricName), mediaType);
                     } else {
                         res.status(Http.Status.NOT_ACCEPTABLE_406);
                         res.send();
@@ -571,8 +573,8 @@ public final class MetricsSupport extends HelidonRestServiceSupport
         res.cachingStrategy(ServerResponse.CachingStrategy.NO_CACHING);
         if (mediaType == MediaType.APPLICATION_JSON) {
             sendJson(res, toJsonData(registries));
-        } else if (mediaType == MediaType.TEXT_PLAIN) {
-            res.send(toPrometheusData(registries));
+        } else if (mediaType == MediaType.TEXT_PLAIN || mediaType == MediaType.APPLICATION_OPENMETRICS) {
+            sendPrometheus(res, toPrometheusData(registries), mediaType);
         } else {
             res.status(Http.Status.NOT_ACCEPTABLE_406);
             res.send();
@@ -609,6 +611,19 @@ public final class MetricsSupport extends HelidonRestServiceSupport
                     res.status(Http.Status.NO_CONTENT_204);
                     res.send();
                 });
+    }
+
+    private static void sendPrometheus(ServerResponse res, String formattedOutput, MediaType requestedMediaType) {
+        MediaType.Builder responseMediaTypeBuilder = MediaType.builder()
+                .type(requestedMediaType.type())
+                .subtype(requestedMediaType.subtype());
+
+        if (requestedMediaType == MediaType.APPLICATION_OPENMETRICS) {
+            responseMediaTypeBuilder.charset("UTF-8")
+                    .addParameter("version", "1.0.0");
+        }
+        res.addHeader("Content-Type", responseMediaTypeBuilder.build().toString());
+        res.send(formattedOutput + "# EOF\n");
     }
 
     /**

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
@@ -80,6 +80,8 @@ public class TestServer {
     private static final MediaType EXPECTED_PROMETHEUS_CONTENT_TYPE = MediaType.builder()
             .type(MediaType.TEXT_PLAIN.type())
             .subtype(MediaType.TEXT_PLAIN.subtype())
+            .addParameter("version", "0.0.4")
+            .charset("UTF-8")
             .build();
 
     private WebClient.Builder webClientBuilder;

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
@@ -15,6 +15,9 @@
  */
 package io.helidon.metrics;
 
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.StringReader;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -37,6 +40,7 @@ import jakarta.json.JsonObject;
 import org.eclipse.microprofile.metrics.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +49,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -64,6 +69,18 @@ public class TestServer {
     private static MetricsSupport metricsSupport;
 
     private static final Duration CLIENT_TIMEOUT = Duration.ofSeconds(5);
+
+    private static final MediaType EXPECTED_OPENMETRICS_CONTENT_TYPE = MediaType.builder()
+            .type(MediaType.APPLICATION_OPENMETRICS.type())
+            .subtype(MediaType.APPLICATION_OPENMETRICS.subtype())
+            .addParameter("version", "1.0.0")
+            .charset("UTF-8")
+            .build();
+
+    private static final MediaType EXPECTED_PROMETHEUS_CONTENT_TYPE = MediaType.builder()
+            .type(MediaType.TEXT_PLAIN.type())
+            .subtype(MediaType.TEXT_PLAIN.subtype())
+            .build();
 
     private WebClient.Builder webClientBuilder;
 
@@ -250,6 +267,47 @@ public class TestServer {
         assertThat ("Headers suppressing caching in OPTIONS request",
                     response.headers().values(Http.Header.CACHE_CONTROL),
                     not(containsInAnyOrder(EXPECTED_NO_CACHE_HEADER_SETTINGS)));
+    }
+
+    @Test
+    void testOpenMetricsFormatting() throws IOException {
+        WebClientResponse response = webClientBuilder
+                .build()
+                .get()
+                .accept(MediaType.APPLICATION_OPENMETRICS)
+                .path("/metrics")
+                .submit()
+                .await();
+
+        assertThat("Content-Type",
+                   response.headers().values(Http.Header.CONTENT_TYPE),
+                   containsInAnyOrder(EXPECTED_OPENMETRICS_CONTENT_TYPE.toString()));
+
+        String content = response.content().as(String.class).await(10, TimeUnit.SECONDS);
+        assertThat("Terminated content", content, endsWith("EOF\n"));
+
+        LineNumberReader reader = new LineNumberReader(new StringReader(content));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            if (line.isBlank()) {
+                Assertions.fail("Found blank line where none is allowed in response: \n" + content);
+            }
+        }
+    }
+
+    @Test
+    void testPrometheusFormatting() {
+        WebClientResponse response = webClientBuilder
+                .build()
+                .get()
+                .accept(MediaType.TEXT_PLAIN)
+                .path("/metrics")
+                .submit()
+                .await();
+
+        assertThat("Content-Type",
+                   response.headers().values(Http.Header.CONTENT_TYPE),
+                   containsInAnyOrder(EXPECTED_PROMETHEUS_CONTENT_TYPE.toString()));
     }
 
 }


### PR DESCRIPTION
The initial problem was that the OpenMetrics output format was not quite right. It lacked a trailing `# EOF`, it sometimes included a stray blank line, and we did not correctly deal with `Accept` and `Content-Type` for the `application/openmetrics-text` media type. (The issue was reported by a user who was having trouble with a Prometheus server that was set up to record exemplars complaining when it scraped a Helidon service's `/metrics` endpoint.)

Along the way I discovered that exemplars for `SimpleTimer` were incorrect so that fix is part of this PR also.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>