### PR TITLE
Use Hamcrest assertions instead of JUnit in common/common - backport helidon-2.x (#1749)

### DIFF
--- a/common/common/src/test/java/io/helidon/common/ErrorsTest.java
+++ b/common/common/src/test/java/io/helidon/common/ErrorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ class ErrorsTest {
     private static final Logger LOGGER = Logger.getLogger(ErrorsTest.class.getName());
 
     private static void assertErrorMessage(Optional<Errors.ErrorMessage> actual, String expected, String message) {
-        assertThat(actual, not(Optional.empty()));
+        assertThat(message, actual, not(Optional.empty()));
         assertThat(actual.get().getMessage(), is(expected));
     }
 

--- a/common/common/src/test/java/io/helidon/common/GenericTypeUtilTest.java
+++ b/common/common/src/test/java/io/helidon/common/GenericTypeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package io.helidon.common;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit tests for class {@link GenericTypeUtil}.
@@ -34,14 +34,14 @@ public class GenericTypeUtilTest{
   public void testRawClass() {
       Class<?> claszResult = GenericTypeUtil.rawClass(Object.class);
 
-      assertFalse(claszResult.isInterface());
-      assertFalse(claszResult.isArray());
-      assertEquals("class java.lang.Object", claszResult.toString());
-      assertEquals(1, claszResult.getModifiers());
-      assertFalse(claszResult.isEnum());
-      assertFalse(claszResult.isSynthetic());
-      assertFalse(claszResult.isAnnotation());
-      assertFalse(claszResult.isPrimitive());
+      assertThat(claszResult.isInterface(), is(false));
+      assertThat(claszResult.isArray(), is(false));
+      assertThat(claszResult.toString(), is("class java.lang.Object"));
+      assertThat(claszResult.getModifiers(), is(1));
+      assertThat(claszResult.isEnum(), is(false));
+      assertThat(claszResult.isSynthetic(), is(false));
+      assertThat(claszResult.isAnnotation(), is(false));
+      assertThat(claszResult.isPrimitive(), is(false));
   }
 
   @Test


### PR DESCRIPTION
Part of #1749 . 

Backport helidon-2.x, details can be found [here](https://github.com/oracle/helidon/issues/1749#issuecomment-1248512970) .

I've already signed OCA.