### PR TITLE
Fix broken links for ServerThreadPoolSupplier and ScheduledThreadPoolSupplier in mp/fault-tolerance.adoc (#4899)

### DIFF
--- a/docs/includes/attributes.adoc
+++ b/docs/includes/attributes.adoc
@@ -187,7 +187,7 @@ endif::[]
 
 // Helidon component javadoc base URLs
 :config-javadoc-base-url: {javadoc-base-url}/io.helidon.config
-:configurable-javadoc-base-url: {javadoc-base-url}/apidocs/io.helidon.common.configurable
+:configurable-javadoc-base-url: {javadoc-base-url}/io.helidon.common.configurable
 :faulttolerance-javadoc-base-url: {javadoc-base-url}/io.helidon.faulttolerance
 :grpc-server-javadoc-base-url: {javadoc-base-url}/io.helidon.grpc.server
 :health-javadoc-base-url: {javadoc-base-url}/io.helidon.health.checks

--- a/docs/mp/fault-tolerance.adoc
+++ b/docs/mp/fault-tolerance.adoc
@@ -171,8 +171,8 @@ NOTE: There is currently _no support_ to configure these executor properties via
 `microprofile-config.properties` file.
 
 For a complete set of properties available to configure these executors, see
-link:{configurable-javadoc-base-url}/io.helidon.common.configurable/ThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)[ServerThreadPoolSupplier] and
-link:{configurable-javadoc-base-url}/io.helidon.common.configurable/ScheduledThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)[ScheduledThreadPoolSupplier].
+link:{configurable-javadoc-base-url}/io/helidon/common/configurable/ThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)[ServerThreadPoolSupplier] and
+link:{configurable-javadoc-base-url}/io/helidon/common/configurable/ScheduledThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)[ScheduledThreadPoolSupplier].
 
 == Examples
 


### PR DESCRIPTION
Resolves #4899 

I've already signed OCA. It's an automation problem.