### PR TITLE
Updated supported version of MicroProfile to 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Project Helidon is a set of Java Libraries for writing microservices.
 Helidon supports two programming models:
 
-* Helidon MP: [MicroProfile](https://microprofile.io/) 3.3
+* Helidon MP: [MicroProfile](https://microprofile.io/) 5.0
 * Helidon SE: a small, functional style API
 
 In either case your application is just a Java SE program.


### PR DESCRIPTION
According to https://helidon.io/docs/v3/#/mp/introduction
 
> Helidon MP includes a compatible implementation of Eclipse MicroProfile 5.

(and not 3.3).