### PR TITLE
Fix invalid example in se/config/advanced-configuration.adoc (#4775)

### DIFF
--- a/docs/se/config/advanced-configuration.adoc
+++ b/docs/se/config/advanced-configuration.adoc
@@ -103,7 +103,7 @@ your application can load this as configuration as follows:
 [source,java]
 .Using `directory` config source
 ----
-Config secrets = Config.withSources(
+Config secrets = Config.builder(
         ConfigSources.directory("conf/secrets")) // <1>
         .disableEnvironmentVariablesSource()     // <2>
         .disableSystemPropertiesSource()         // <2>


### PR DESCRIPTION
Part of #4775 

I can backport it into 2.x and 4.x after merging if necessary. 

I've already signed OCA. It's an automation problem.

- [ ] Backport to 2.x
- [ ] Backport to 4.x