### PR TITLE
Use Hamcrest assertions instead of JUnit in common/reactive - backport 2.x (#1749)

### DIFF
--- a/common/reactive/src/test/java/io/helidon/common/reactive/IgnoreElementsTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/IgnoreElementsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -40,7 +40,7 @@ public class IgnoreElementsTest {
                 .peek(i -> latch.countDown())
                 .ignoreElements(); // should trigger subscription on its own
 
-        assertTrue(latch.await(200, TimeUnit.MILLISECONDS));
+        assertThat(latch.await(200, TimeUnit.MILLISECONDS), is(true));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class IgnoreElementsTest {
                 .peek(i -> latch.countDown())
                 .ignoreElement(); // should trigger subscription on its own
 
-        assertTrue(latch.await(200, TimeUnit.MILLISECONDS));
+        assertThat(latch.await(200, TimeUnit.MILLISECONDS), is(true));
     }
 
     @Test

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiDefaultIfEmptyTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiDefaultIfEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ package io.helidon.common.reactive;
 import java.io.IOException;
 import java.util.concurrent.SubmissionPublisher;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 public class MultiDefaultIfEmptyTest {
 
@@ -129,13 +129,13 @@ public class MultiDefaultIfEmptyTest {
                 .defaultIfEmpty(2)
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
     @Test
@@ -147,13 +147,13 @@ public class MultiDefaultIfEmptyTest {
                 .defaultIfEmpty(() -> 2)
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,11 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.RepeatedTest;
@@ -154,7 +155,7 @@ public class MultiFlatMapPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Arrays.asList(6));
+        assertThat(ts.getItems(), contains(6));
         assertThat(ts.getLastError(), instanceOf(ArithmeticException.class));
         assertThat(ts.isComplete(), is(false));
     }
@@ -170,7 +171,7 @@ public class MultiFlatMapPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Arrays.asList(6, -6));
+        assertThat(ts.getItems(), contains(6, -6));
         assertThat(ts.getLastError(), instanceOf(ArithmeticException.class));
         assertThat(ts.isComplete(), is(false));
     }
@@ -257,7 +258,7 @@ public class MultiFlatMapPublisherTest {
 
         ts.request1();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
     }
@@ -275,7 +276,7 @@ public class MultiFlatMapPublisherTest {
                 .flatMap(Single::just)
                 .subscribe(ts);
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
     }
@@ -307,12 +308,11 @@ public class MultiFlatMapPublisherTest {
 
     @RepeatedTest(500)
     public void multi() throws ExecutionException, InterruptedException {
-        assertEquals(EXPECTED_EMISSION_COUNT, Multi.create(TEST_DATA)
+        assertThat(Multi.create(TEST_DATA)
                 .flatMap(MultiFlatMapPublisherTest::asyncFlowPublisher, MAX_CONCURRENCY, false, PREFETCH)
                 .distinct()
                 .collectList()
-                .await(800, TimeUnit.MILLISECONDS)
-                .size());
+                .await(800, TimeUnit.MILLISECONDS), hasSize(EXPECTED_EMISSION_COUNT));
     }
 
     private static Flow.Publisher<? extends String> asyncFlowPublisher(Integer i) {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiRetryTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.emptyArray;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultiRetryTest {
 
@@ -47,7 +49,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(count.get(), 5);
+        assertThat(count.get(), is(5));
     }
 
     @Test
@@ -59,7 +61,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(NullPointerException.class);
-        assertTrue(ts.getLastError().getSuppressed()[0] instanceof IOException, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
     }
 
     @Test
@@ -73,7 +75,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertTrue(ts.getLastError().getSuppressed()[0] instanceof IOException, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
     }
 
     @Test
@@ -87,7 +89,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -121,7 +123,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -146,7 +148,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -166,7 +168,7 @@ public class MultiRetryTest {
             ts.awaitDone(5, TimeUnit.SECONDS)
                     .assertResult(1);
 
-            assertEquals(count.get(), 5);
+            assertThat(count.get(), is(5));
         } finally {
             executor.shutdown();
         }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiSkipPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiSkipPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,14 @@
 
 package io.helidon.common.reactive;
 
+import java.util.Iterator;
+
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
-
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiSkipPublisherTest {
 
@@ -67,7 +67,7 @@ public class MultiSkipPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(3));
+        assertThat(ts.getItems(), contains(3));
         assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
         assertThat(ts.isComplete(), is(false));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiSwitchIfEmptyTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiSwitchIfEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ package io.helidon.common.reactive;
 import java.io.IOException;
 import java.util.concurrent.SubmissionPublisher;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultiSwitchIfEmptyTest {
 
@@ -93,13 +93,13 @@ public class MultiSwitchIfEmptyTest {
                 .switchIfEmpty(Multi.singleton(2))
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
     @Test
@@ -111,13 +111,13 @@ public class MultiSwitchIfEmptyTest {
                 .switchIfEmpty(Multi.create(sp))
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTakeWhilePublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTakeWhilePublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,12 @@ package io.helidon.common.reactive;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiTakeWhilePublisherTest {
 
@@ -54,7 +53,7 @@ public class MultiTakeWhilePublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Arrays.asList(1, 2, 3));
+        assertThat(ts.getItems(), contains(1, 2, 3));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTappedPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTappedPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,15 @@
 package io.helidon.common.reactive;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiTappedPublisherTest {
 
@@ -162,7 +161,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -183,7 +182,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -207,7 +206,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -234,7 +233,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -327,7 +326,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -346,7 +345,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -365,7 +364,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -384,7 +383,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -448,7 +447,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -474,7 +473,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTimeoutTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultiTimeoutTest {
 
@@ -128,11 +128,11 @@ public class MultiTimeoutTest {
             Thread.sleep(10);
         }
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
 
         ts.assertValuesOnly(1L);
 
-        assertTrue(sp2.hasSubscribers());
+        assertThat(sp2.hasSubscribers(), is(true));
 
         sp2.submit(2L);
         sp2.close();

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SequentialSubscriberTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SequentialSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SequentialSubscriberTest {
     int counter = 0;
@@ -99,7 +100,7 @@ public class SequentialSubscriberTest {
         } catch (InterruptedException e) {
             executorService.shutdownNow();
         }
-        assertFalse(errorFound.isPresent(), () -> errorFound.get());
+        assertThat(errorFound.orElse(""), errorFound.isPresent(), is(false));
     }
 
     private void sleep(long millis) {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleDefaultIfEmptyTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleDefaultIfEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,10 @@ package io.helidon.common.reactive;
 import java.io.IOException;
 import java.util.concurrent.SubmissionPublisher;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SingleDefaultIfEmptyTest {
 
@@ -130,13 +129,13 @@ public class SingleDefaultIfEmptyTest {
                 .defaultIfEmpty(2)
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
     @Test
@@ -148,13 +147,13 @@ public class SingleDefaultIfEmptyTest {
                 .defaultIfEmpty(() -> 2)
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleRetryTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SingleRetryTest {
 
@@ -47,7 +49,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(count.get(), 5);
+        assertThat(count.get(), is(5));
     }
 
     @Test
@@ -59,7 +61,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(NullPointerException.class);
-        assertTrue(ts.getLastError().getSuppressed()[0] instanceof IOException, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
     }
 
     @Test
@@ -73,7 +75,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertTrue(ts.getLastError().getSuppressed()[0] instanceof IOException, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
     }
 
     @Test
@@ -87,7 +89,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -121,7 +123,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -146,7 +148,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -166,7 +168,7 @@ public class SingleRetryTest {
             ts.awaitDone(5, TimeUnit.SECONDS)
                     .assertResult(1);
 
-            assertEquals(count.get(), 5);
+            assertThat(count.get(), is(5));
         } finally {
             executor.shutdown();
         }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleSwitchIfEmptyTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleSwitchIfEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import java.io.IOException;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SingleSwitchIfEmptyTest {
 
@@ -107,13 +107,13 @@ public class SingleSwitchIfEmptyTest {
                 .switchIfEmpty(Single.just(2))
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
     @Test
@@ -125,13 +125,13 @@ public class SingleSwitchIfEmptyTest {
                 .switchIfEmpty(Single.create(sp))
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTappedPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTappedPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,15 @@
 package io.helidon.common.reactive;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SingleTappedPublisherTest {
 
@@ -171,7 +170,7 @@ public class SingleTappedPublisherTest {
                 .subscribe(ts);
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -193,7 +192,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -218,7 +217,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -246,7 +245,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -342,7 +341,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -361,7 +360,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -380,7 +379,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -399,7 +398,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -463,7 +462,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -489,7 +488,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/TerminatedFutureTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/TerminatedFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class TerminatedFutureTest {
@@ -39,11 +37,11 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.cancel(ref);
 
-        assertSame(ref.get(), TerminatedFuture.CANCELED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.CANCELED));
 
         TerminatedFuture.cancel(ref);
 
-        assertSame(ref.get(), TerminatedFuture.CANCELED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.CANCELED));
     }
 
     @Test
@@ -55,9 +53,9 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.cancel(ref);
 
-        assertSame(ref.get(), TerminatedFuture.CANCELED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.CANCELED));
 
-        assertTrue(cf.isCancelled());
+        assertThat(cf.isCancelled(), is(true));
     }
 
     @Test
@@ -68,7 +66,7 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.setFuture(ref, cf);
 
-        assertSame(ref.get(), cf);
+        assertThat(ref.get(), sameInstance(cf));
     }
 
     @Test
@@ -78,7 +76,7 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.cancel(ref);
 
-        assertSame(ref.get(), TerminatedFuture.FINISHED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.FINISHED));
     }
 
     @Test
@@ -90,11 +88,11 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.setFuture(ref, cf);
 
-        assertSame(ref.get(), cf);
+        assertThat(ref.get(), sameInstance(cf));
 
         TerminatedFuture.setFuture(ref, cf1);
 
-        assertSame(ref.get(), cf);
+        assertThat(ref.get(), sameInstance(cf));
     }
 
     @Test
@@ -106,7 +104,7 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.setFuture(ref, cf);
 
-        assertSame(ref.get(), TerminatedFuture.FINISHED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.FINISHED));
     }
 
 
@@ -119,31 +117,31 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.setFuture(ref, cf);
 
-        assertSame(ref.get(), TerminatedFuture.CANCELED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.CANCELED));
 
-        assertTrue(cf.isCancelled());
+        assertThat(cf.isCancelled(), is(true));
     }
 
     @Test
     public void finishedMethods() {
-        assertFalse(TerminatedFuture.FINISHED.cancel(true));
+        assertThat(TerminatedFuture.FINISHED.cancel(true), is(false));
 
-        assertFalse(TerminatedFuture.FINISHED.isCancelled());
+        assertThat(TerminatedFuture.FINISHED.isCancelled(), is(false));
 
-        assertTrue(TerminatedFuture.FINISHED.isDone());
+        assertThat(TerminatedFuture.FINISHED.isDone(), is(true));
 
-        assertNull(TerminatedFuture.FINISHED.get());
+        assertThat(TerminatedFuture.FINISHED.get(), nullValue());
 
-        assertNull(TerminatedFuture.FINISHED.get(1, TimeUnit.MINUTES));
+        assertThat(TerminatedFuture.FINISHED.get(1, TimeUnit.MINUTES), nullValue());
     }
 
     @Test
     public void canceledMethods() {
-        assertFalse(TerminatedFuture.CANCELED.cancel(true));
+        assertThat(TerminatedFuture.CANCELED.cancel(true), is(false));
 
-        assertTrue(TerminatedFuture.CANCELED.isCancelled());
+        assertThat(TerminatedFuture.CANCELED.isCancelled(), is(true));
 
-        assertTrue(TerminatedFuture.CANCELED.isDone());
+        assertThat(TerminatedFuture.CANCELED.isDone(), is(true));
     }
 
     @Test


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/4908)