### PR TITLE
Use Hamcrest assertions instead of JUnit in integrations/cdi/datasource-hikaricp - backport 2.x (#1749)

### DIFF
--- a/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
+++ b/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 class TestConfiguration {
@@ -58,14 +59,14 @@ class TestConfiguration {
     void startServer() {
         this.stopServer();
         final Server.Builder builder = Server.builder();
-        assertNotNull(builder);
+        assertThat(builder, notNullValue());
         // The Helidon MicroProfile server implementation uses
         // ConfigProviderResolver#getConfig(ClassLoader) directly
         // instead of ConfigProvider#getConfig() so we follow suit
         // here for fidelity.
         builder.config(ConfigProviderResolver.instance().getConfig(Thread.currentThread().getContextClassLoader()));
         this.server = builder.build();
-        assertNotNull(this.server);
+        assertThat(this.server, notNullValue());
         this.server.start();
     }
 
@@ -78,11 +79,11 @@ class TestConfiguration {
     }
 
     private void onStartup(@Observes @Initialized(ApplicationScoped.class) final Object event) throws SQLException {
-        assertNotNull(this.test);
-        assertNotNull(this.hikariTest);
-        assertNotNull(this.test.toString());
-        assertNotNull(this.hikariTest.toString());
-        assertTrue(this.hikariTest.getMetricsTrackerFactory() instanceof MicroProfileMetricsTrackerFactory);
+        assertThat(this.test, notNullValue());
+        assertThat(this.hikariTest, notNullValue());
+        assertThat(this.test.toString(), notNullValue());
+        assertThat(this.hikariTest.toString(), notNullValue());
+        assertThat(this.hikariTest.getMetricsTrackerFactory(), instanceOf(MicroProfileMetricsTrackerFactory.class));
         Connection connection = null;
         try {
             connection = this.test.getConnection();


### PR DESCRIPTION
Part of #1749

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/4948)