### PR TITLE
Use Hamcrest assertions instead of JUnit in integrations/cdi/eclipselink-cdi - backport 2.x (#1749)

### DIFF
--- a/integrations/cdi/eclipselink-cdi/src/test/java/io/helidon/integrations/cdi/eclipselink/TestManualEntityManagerAcquisition.java
+++ b/integrations/cdi/eclipselink-cdi/src/test/java/io/helidon/integrations/cdi/eclipselink/TestManualEntityManagerAcquisition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 class TestManualEntityManagerAcquisition {
@@ -43,7 +44,7 @@ class TestManualEntityManagerAcquisition {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass())
             .addExtensions(new HikariCPBackedDataSourceExtension());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
   
@@ -57,7 +58,7 @@ class TestManualEntityManagerAcquisition {
     @Test
     void testIt() {
         final EntityManagerFactory emf = Persistence.createEntityManagerFactory("test");
-        assertNotNull(emf);
+        assertThat(emf, notNullValue());
     }
   
 }


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/4972)