### PR TITLE
4975 ThreadPoolTest RC 2.x backport

### DIFF
--- a/common/configurable/src/test/java/io/helidon/common/configurable/ThreadPoolTest.java
+++ b/common/configurable/src/test/java/io/helidon/common/configurable/ThreadPoolTest.java
@@ -561,6 +561,7 @@ class ThreadPoolTest {
         };
         pool.submit(task4);
         pool.shutdown();
+        assertThat(pool.awaitTermination(20, SECONDS), is(true));
         assertThat(pool.getCompletedTasks(), is(2));
         assertThat(pool.getFailedTasks(), is(2));
         assertThat(pool.getTotalTasks(), is(pool.getCompletedTasks() + pool.getFailedTasks()));


### PR DESCRIPTION
Fixes #4975

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>
(cherry picked from commit ab8d9e22038c4c23619587fdb35652fb002dbdd6)