### PR TITLE
Use Hamcrest assertions instead of JUnit in  media/common - backport 2.x (#1749)

### DIFF
--- a/media/common/src/test/java/io/helidon/media/common/DataChunkInputStreamTest.java
+++ b/media/common/src/test/java/io/helidon/media/common/DataChunkInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ import io.helidon.common.reactive.Single;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -121,7 +121,7 @@ public class DataChunkInputStreamTest {
 
         submitFuture.get(500, TimeUnit.MILLISECONDS);
         receiveFuture.get(500, TimeUnit.MILLISECONDS);
-        assertEquals(test_data, result);
+        assertThat(result, contains("test0", "test1", "test2", "test3"));
     }
 
     @Test


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/4999)