### PR TITLE
Use Hamcrest assertions instead of JUnit in  messaging/messaging - backport 2.x (#1749)

### DIFF
--- a/messaging/messaging/src/test/java/io/helidon/messaging/MessagingTest.java
+++ b/messaging/messaging/src/test/java/io/helidon/messaging/MessagingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MessagingTest {
 
@@ -489,6 +488,6 @@ public class MessagingTest {
                 .start();
 
         testData.assertEquals();
-        assertTrue(TestConnector.latch.await(500, TimeUnit.MILLISECONDS));
+        assertThat(TestConnector.latch.await(500, TimeUnit.MILLISECONDS), is(true));
     }
 }


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/5008)