### PR TITLE
[3.x] - Tracing header case

### DIFF
--- a/tracing/tracing/src/main/java/io/helidon/tracing/HeaderProvider.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/HeaderProvider.java
@@ -15,7 +15,10 @@
  */
 package io.helidon.tracing;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,7 +43,10 @@ public interface HeaderProvider {
      */
 
     static HeaderProvider create(Map<String, List<String>> inboundHeaders) {
-        return new MapHeaderConsumer(Map.copyOf(inboundHeaders));
+        Map<String, List<String>> result = new HashMap<>();
+        // Normalize to lower-case keys, particularly so B3 headers match correctly.
+        inboundHeaders.forEach((key, value) -> result.put(key.toLowerCase(Locale.ROOT), value));
+        return new MapHeaderConsumer(Collections.unmodifiableMap(result));
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
@@ -15,8 +15,10 @@
  */
 package io.helidon.webserver;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -339,12 +341,13 @@ public abstract class WebTracingConfig {
                     });
         }
 
-        private static class TracingHeaderProvider implements HeaderProvider {
+        static class TracingHeaderProvider implements HeaderProvider {
 
-            private final Map<String, List<String>> headers;
+            private final Map<String, List<String>> headers = new HashMap<>();
 
             TracingHeaderProvider(Map<String, List<String>> headers) {
-                this.headers = headers;
+                // Normalize to lower-case keys, particularly so B3 headers match correctly.
+                headers.forEach((key, values) -> this.headers.put(key.toLowerCase(Locale.ROOT), values));
             }
 
             @Override

--- a/webserver/webserver/src/test/java/io/helidon/webserver/WebTracingConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/WebTracingConfigTest.java
@@ -86,7 +86,6 @@ class WebTracingConfigTest {
     }
 
     @Test
-    @Disabled
     void testHeaderCaseInsensitivity() {
         String hLower = "x-lower";
         String hMixed = "x-Mixed";


### PR DESCRIPTION
Resolves #4956 

In two places related to `HeaderProvider`, instead of storing the input headers `Map` and returning a copy of it from `headers()` the code now builds a new `Map` using the lower-cased keys (and unchanged values) from the input `Map`.

The changes are in `HeaderProvider.create` and `WebTracingConfig.TracingHeaderProvider`.

Two questions for reviewers:

1. There are other implementations of `HeaderProvider` listed below. It is not clear (to me) whether they should also change. I have left them alone so far so as to perturb as little code as possible. Do they need to change also to address this issue?
2. I looked at creating an integration test that would create a server with two endpoints:
   * `/hello`
   * `/spans`
      * `POST` would act as a tracing server, accepting tracing data and storing it internally
  
The test would ping `/hello` with preset B3 headers (but with varying case). That `GET` would trigger a tracing `POST` to `/spans`.
Then (after the tracing data had been collected as indicated by a countdown latch) the test would check the gathered tracing data to make sure the headers had propagated correctly despite the intentionally odd case of the header keys.

This could get complicated because the `POST` requests to `/spans` could themselves trigger traces, there could be threading issues with the server sending trace updates to itself, etc. which could mean we'd need two separate servers running.

I can pursue this if the unit tests included here do not seem sufficient.

----

helidon-grpc-client
  io.helidon.grpc.client
    ClientTracingInterceptor.ClientTracingListener
        private class MetadataHeaderConsumer implements HeaderConsumer {

helidon-grpc-server
  io.helidon.grpc.server
    GrpcTracing
      private static class MapHeaderProvider implements HeaderProvider {

helidon-tracing
  io.helidon.tracing
    HeaderConsumer.java
    MapHeaderConsumer.java

helidon-webclient-tracing
  io.helidon.webclient.tracing
    WebClientTracing
      private static class ClientHeaderConsumer implements HeaderConsumer {
