### PR TITLE
WebClient dependency in generated Helidon SE Quickstart should be in test scope (backport)

### DIFF
--- a/archetypes/helidon/src/main/archetype/se/common/common-se.xml
+++ b/archetypes/helidon/src/main/archetype/se/common/common-se.xml
@@ -45,7 +45,12 @@
                     <value key="artifactId">hamcrest-all</value>
                     <value key="scope">test</value>
                 </map>
-                <map order="0">
+                <map if="!(${extra} contains 'webclient')" order="0">
+                    <value key="groupId">io.helidon.webclient</value>
+                    <value key="artifactId">helidon-webclient</value>
+                    <value key="scope">test</value>
+                </map>
+                <map if="${extra} contains 'webclient'" order="0">
                     <value key="groupId">io.helidon.webclient</value>
                     <value key="artifactId">helidon-webclient</value>
                 </map>


### PR DESCRIPTION
See #4996

Signed-off-by: tvallin <thibault.vallin@oracle.com>