### PR TITLE
Updated intermittently failing CircuitBreakerTest 

### DIFF
--- a/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/CircuitBreakerImpl.java
+++ b/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/CircuitBreakerImpl.java
@@ -172,6 +172,10 @@ class CircuitBreakerImpl implements CircuitBreaker {
                              }, delayMillis, TimeUnit.MILLISECONDS));
     }
 
+    ScheduledFuture<Boolean> schedule() {
+        return schedule.get();
+    }
+
     private void resetCounters() {
         results.reset();
         successCounter.set(0);


### PR DESCRIPTION
Updated intermittently failing test replacing a busy loop with code that waits on an internal future for more robustness. See issue #4977.