### PR TITLE
Use Hamcrest assertions instead of JUnit in  dbclient/jdbc - 2.x (#1749)

### DIFF
--- a/webserver/tyrus/src/test/java/io/helidon/webserver/tyrus/EchoClient.java
+++ b/webserver/tyrus/src/test/java/io/helidon/webserver/tyrus/EchoClient.java
@@ -33,7 +33,8 @@ import javax.websocket.Session;
 
 import org.glassfish.tyrus.client.ClientManager;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -82,7 +83,7 @@ public class EchoClient {
                             LOGGER.info("Client OnMessage called '" + message + "'");
 
                             int index = messages.length - (int) messageLatch.getCount();
-                            assertTrue(equals.apply(messages[index], message));
+                            assertThat(equals.apply(messages[index], message), is(true));
 
                             messageLatch.countDown();
                             if (messageLatch.getCount() == 0) {


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

There is no tyrus module in 3.x . I wasn't sure about this PR. There is only line line so :) 