### PR TITLE
Use Hamcrest assertions instead of JUnit in   microprofile/reactive-streams (#1749)

### DIFF
--- a/microprofile/reactive-streams/pom.xml
+++ b/microprofile/reactive-streams/pom.xml
@@ -62,5 +62,10 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/microprofile/reactive-streams/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngineTckTest.java
+++ b/microprofile/reactive-streams/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngineTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@ import org.reactivestreams.tck.TestEnvironment;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @Test
 public class HelidonReactiveStreamsEngineTckTest extends ReactiveStreamsTck<HelidonReactiveStreamsEngine> {
@@ -64,6 +67,6 @@ public class HelidonReactiveStreamsEngineTckTest extends ReactiveStreamsTck<Heli
 
     @Test
     public void hasExecutor() {
-        org.testng.Assert.assertNotNull(executor);
+        assertThat(executor, notNullValue());
     }
 }


### PR DESCRIPTION
Part of #1749

I've already signed OCA. It's an automation problem.

There was no hamcrest-dependency in pom.xml. I've added.

[Backport 2.x](https://github.com/helidon-io/helidon/pull/5042)