### PR TITLE
Use Hamcrest assertions instead of JUnit in  microprofile/messaging/core (#1749)

### DIFF
--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/EmitterTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/EmitterTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
 
 import jakarta.inject.Inject;
 
@@ -69,7 +69,7 @@ class EmitterTest {
         emitter.send("Test2");
         emitter.send(Message.of("Test3"));
         emitter.complete();
-        assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+        assertThat(countDownLatch.await(10, TimeUnit.SECONDS), is(true));
         assertThat(payloads, contains("Test1", "Test2", "Test3"));
     }
 }

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/connector/Processor2ConnectorTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/connector/Processor2ConnectorTest.java
@@ -54,7 +54,7 @@ import org.reactivestreams.FlowAdapters;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @HelidonTest
@@ -89,7 +89,7 @@ public class Processor2ConnectorTest {
         emitter.emit(Message.of("test2"));
         emitter.complete();
         connector.awaitComplete("to-connector-" + channelPostfix);
-        assertEquals(4, resultList.size());
+        assertThat(resultList, hasSize(4));
         assertThat(resultList.stream()
                         .map(Message::getPayload)
                         .collect(Collectors.toList()),


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

- [ ] Create backport 2.x