### PR TITLE
Use Hamcrest assertions instead of JUnit in   microprofile/fault-tolerance (#1749)

### DIFF
--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/BulkheadTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/BulkheadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,8 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for beans whose methods are protected by bulkheads.
@@ -86,10 +85,10 @@ class BulkheadTest extends FaultToleranceTest {
         CompletableFuture<String> f1 = bean.executeCancelInQueue(1000);
         CompletableFuture<String> f2 = bean.executeCancelInQueue(2000);    // should never run
         boolean b = f2.cancel(true);
-        assertTrue(b);
-        assertTrue(f2.isCancelled());
+        assertThat(b, is(true));
+        assertThat(f2.isCancelled(), is(true));
         assertThrows(CancellationException.class, f2::get);
-        assertNotNull(f1.get());
+        assertThat(f1.get(), notNullValue());
     }
 
     @Test

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/CircuitBreakerTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/CircuitBreakerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -128,11 +127,11 @@ class CircuitBreakerTest extends FaultToleranceTest {
     void testWithBulkhead() throws Exception {
         CountDownLatch started = new CountDownLatch(1);
         bean.withBulkhead(started);             // enters bulkhead
-        assertTrue(started.await(1000, TimeUnit.MILLISECONDS));
+        assertThat(started.await(1000, TimeUnit.MILLISECONDS), is(true));
 
         started = new CountDownLatch(1);
         bean.withBulkhead(started);             // gets queued
-        assertFalse(started.await(1000, TimeUnit.MILLISECONDS));
+        assertThat(started.await(1000, TimeUnit.MILLISECONDS), is(false));
 
         assertThrows(ExecutionException.class, () -> {
             CompletableFuture<?> future = bean.withBulkhead(new CountDownLatch(1));
@@ -144,11 +143,11 @@ class CircuitBreakerTest extends FaultToleranceTest {
     void testWithBulkheadStage() throws Exception {
         CountDownLatch started = new CountDownLatch(1);
         bean.withBulkheadStage(started);             // enters bulkhead
-        assertTrue(started.await(1000, TimeUnit.MILLISECONDS));
+        assertThat(started.await(1000, TimeUnit.MILLISECONDS), is(true));
 
         started = new CountDownLatch(1);
         bean.withBulkheadStage(started);             // gets queued
-        assertFalse(started.await(1000, TimeUnit.MILLISECONDS));
+        assertThat(started.await(1000, TimeUnit.MILLISECONDS), is(false));
 
         CompletionStage<?> stage = bean.withBulkheadStage(new CountDownLatch(1));
         final CountDownLatch called = new CountDownLatch(1);
@@ -156,7 +155,7 @@ class CircuitBreakerTest extends FaultToleranceTest {
             called.countDown();
             assertThat(throwable, instanceOf(BulkheadException.class));
         });
-        assertTrue(called.await(1000, TimeUnit.MILLISECONDS));
+        assertThat(called.await(1000, TimeUnit.MILLISECONDS), is(true));
     }
 
     // -- Private methods -----------------------------------------------------


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Backport 2.x](https://github.com/helidon-io/helidon/pull/5058)