### PR TITLE
Register a low-priority exception mapper to log internal errors

### DIFF
--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -17,8 +17,6 @@
 package io.helidon.webserver.jersey;
 
 import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -694,9 +692,7 @@ public class JerseySupport implements Service {
 
         @Override
         public Response toResponse(InternalServerErrorException e) {
-            StringWriter sw = new StringWriter();
-            e.printStackTrace(new PrintWriter(sw));
-            LOGGER.fine(sw.toString());
+            LOGGER.log(Level.FINE, "Internal error thrown by Jersey", e);
             return Response.status(500).build();
         }
     }

--- a/webserver/jersey/src/main/java/module-info.java
+++ b/webserver/jersey/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/jersey/src/main/java/module-info.java
+++ b/webserver/jersey/src/main/java/module-info.java
@@ -43,5 +43,5 @@ module io.helidon.webserver.jersey {
     provides InjectionManagerFactory with io.helidon.webserver.jersey.HelidonHK2InjectionManagerFactory;
 
     // reflection access from jersey injection
-    opens io.helidon.webserver.jersey to hk2.locator,hk2.utils;
+    opens io.helidon.webserver.jersey to hk2.locator,hk2.utils,weld.core.impl;
 }

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.helidon.common.http.HttpRequest;
-
 import org.glassfish.jersey.CommonProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,7 +39,9 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.webserver.jersey.JerseySupport.IGNORE_EXCEPTION_RESPONSE;
 import static io.helidon.webserver.jersey.JerseySupport.basePath;
 import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -338,6 +339,14 @@ public class JerseySupportTest {
     public void testJerseyProperties() {
         assertThat(System.getProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER), is("true"));
         assertThat(System.getProperty(IGNORE_EXCEPTION_RESPONSE), is("true"));
+    }
+
+    @Test
+    public void testInternalErrorMapper() {
+        JerseySupport.Builder builder = JerseySupport.builder();
+        JerseySupport jerseySupport = builder.build();
+        assertThat(jerseySupport, is(notNullValue()));
+        assertThat(builder.resourceConfig().getClasses(), contains(JerseySupport.InternalErrorMapper.class));
     }
 
     static class PathMockup implements HttpRequest.Path {


### PR DESCRIPTION
Register a low-priority exception mapper to log internal errors in Jersey that are otherwise lost.