### PR TITLE
Use Hamcrest assertions instead of JUnit in  microprofile/messaging/core - backport 2.x (#1749)

### DIFF
--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/connector/Processor2ConnectorTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/connector/Processor2ConnectorTest.java
@@ -56,7 +56,7 @@ import org.reactivestreams.FlowAdapters;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @HelidonTest
@@ -91,7 +91,7 @@ public class Processor2ConnectorTest {
         emitter.emit(Message.of("test2"));
         emitter.complete();
         connector.awaitComplete("to-connector-" + channelPostfix);
-        assertEquals(4, resultList.size());
+        assertThat(resultList, hasSize(4));
         assertThat(resultList.stream()
                         .map(Message::getPayload)
                         .collect(Collectors.toList()),


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/5043)

There is no file `EmmiterTest.java` in this module.