### PR TITLE
[3.x] Register a low-priority exception mapper to log internal errors 

### DIFF
--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -51,11 +51,16 @@ import io.helidon.webserver.Service;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.jersey.HelidonHK2InjectionManagerFactory.InjectionManagerWrapper;
 
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Configurable;
 import jakarta.ws.rs.core.Configuration;
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.ext.ExceptionMapper;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.internal.MapPropertiesDelegate;
 import org.glassfish.jersey.internal.inject.InjectionManager;
@@ -137,6 +142,9 @@ public class JerseySupport implements Service {
         // Prevents reads/writes after Netty event loops are shutdown
         serviceShutdownHook = new Thread(service::shutdownNow);
         Runtime.getRuntime().addShutdownHook(serviceShutdownHook);
+
+        // Register an error mapper to log internal exceptions in Jersey
+        builder.resourceConfig.register(InternalErrorMapper.class);
 
         // make sure we have a wrapped async executor as well
         if (builder.asyncExecutorService == null) {
@@ -505,6 +513,15 @@ public class JerseySupport implements Service {
         }
 
         /**
+         * This method is used for testing only.
+         *
+         * @return underlying resource config.
+         */
+        ResourceConfig resourceConfig() {
+            return resourceConfig;
+        }
+
+        /**
          * Jersey Module builder class for convenient creating {@link JerseySupport}.
          *
          * @return built module
@@ -661,6 +678,21 @@ public class JerseySupport implements Service {
         public void reload(ResourceConfig configuration) {
             // no op
             throw new UnsupportedOperationException("Reloading is not supported in Helidon");
+        }
+    }
+
+    /**
+     * A low priority mapper to catch internal exceptions in Jersey and log them.
+     * Otherwise, these errors can get lost and never reported by Helidon. One example
+     * is a {@code ClassNotFoundException} exception in Jersey's code.
+     */
+    @Priority(Priorities.USER + 1000)
+    static class InternalErrorMapper implements ExceptionMapper<InternalServerErrorException> {
+
+        @Override
+        public Response toResponse(InternalServerErrorException e) {
+            LOGGER.log(Level.FINE, "Internal error thrown by Jersey", e);
+            return Response.status(500).build();
         }
     }
 }

--- a/webserver/jersey/src/main/java/module-info.java
+++ b/webserver/jersey/src/main/java/module-info.java
@@ -38,5 +38,5 @@ module io.helidon.webserver.jersey {
     provides InjectionManagerFactory with io.helidon.webserver.jersey.HelidonHK2InjectionManagerFactory;
 
     // reflection access from jersey injection
-    opens io.helidon.webserver.jersey to org.glassfish.hk2.utilities, org.glassfish.hk2.locator;
+    opens io.helidon.webserver.jersey to org.glassfish.hk2.utilities, org.glassfish.hk2.locator,weld.core.impl;
 }

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 
 import io.helidon.common.http.HttpRequest;
-
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
@@ -39,7 +38,9 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.webserver.jersey.JerseySupport.IGNORE_EXCEPTION_RESPONSE;
 import static io.helidon.webserver.jersey.JerseySupport.basePath;
 import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -336,6 +337,14 @@ public class JerseySupportTest {
     public void testJerseyProperties() {
         assertThat(System.getProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER), is("true"));
         assertThat(System.getProperty(IGNORE_EXCEPTION_RESPONSE), is("true"));
+    }
+
+    @Test
+    public void testInternalErrorMapper() {
+        JerseySupport.Builder builder = JerseySupport.builder();
+        JerseySupport jerseySupport = builder.build();
+        assertThat(jerseySupport, is(notNullValue()));
+        assertThat(builder.resourceConfig().getClasses(), contains(JerseySupport.InternalErrorMapper.class));
     }
 
     static class PathMockup implements HttpRequest.Path {


### PR DESCRIPTION
Register a low-priority exception mapper to log internal errors in Jersey that are otherwise lost.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>