### PR TITLE
[4.x] Register a low-priority exception mapper to log internal errors

### DIFF
--- a/reactive/webserver/jersey/src/main/java/module-info.java
+++ b/reactive/webserver/jersey/src/main/java/module-info.java
@@ -40,5 +40,5 @@ module io.helidon.reactive.webserver.jersey {
     provides InjectionManagerFactory with HelidonHK2InjectionManagerFactory;
 
     // reflection access from jersey injection
-    opens io.helidon.reactive.webserver.jersey to org.glassfish.hk2.utilities, org.glassfish.hk2.locator;
+    opens io.helidon.reactive.webserver.jersey to org.glassfish.hk2.utilities, org.glassfish.hk2.locator, weld.core.impl;
 }

--- a/reactive/webserver/jersey/src/test/java/io/helidon/reactive/webserver/jersey/JerseySupportTest.java
+++ b/reactive/webserver/jersey/src/test/java/io/helidon/reactive/webserver/jersey/JerseySupportTest.java
@@ -40,7 +40,9 @@ import static io.helidon.reactive.webserver.jersey.JerseySupport.IGNORE_EXCEPTIO
 import static io.helidon.reactive.webserver.jersey.JerseySupport.basePath;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -336,6 +338,14 @@ public class JerseySupportTest {
     public void testJerseyProperties() {
         assertThat(System.getProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER), is("true"));
         assertThat(System.getProperty(IGNORE_EXCEPTION_RESPONSE), is("true"));
+    }
+
+    @Test
+    public void testInternalErrorMapper() {
+        JerseySupport.Builder builder = JerseySupport.builder();
+        JerseySupport jerseySupport = builder.build();
+        assertThat(jerseySupport, is(notNullValue()));
+        assertThat(builder.resourceConfig().getClasses(), contains(JerseySupport.InternalErrorMapper.class));
     }
 
     static class PathMockup implements ServerRequest.Path {


### PR DESCRIPTION
Register a low-priority exception mapper to log internal errors in Jersey that are otherwise lost.
