### PR TITLE
3.x: using jdk JDK 17.0.3 or newer in Dockerfile.jlink

### DIFF
--- a/archetypes/helidon/src/main/archetype/common/files/Dockerfile.jlink.mustache
+++ b/archetypes/helidon/src/main/archetype/common/files/Dockerfile.jlink.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM maven:3.8.4-openjdk-17-slim as build
+FROM maven:3.8.6-eclipse-temurin-17 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.8.4-openjdk-17-slim as build
+FROM maven:3.8.6-eclipse-temurin-17 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.8.4-openjdk-17-slim as build
+FROM maven:3.8.6-eclipse-temurin-17 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.8.4-openjdk-17-slim as build
+FROM maven:3.8.6-eclipse-temurin-17 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.8.4-openjdk-17-slim as build
+FROM maven:3.8.6-eclipse-temurin-17 as build
 
 WORKDIR /helidon
 


### PR DESCRIPTION
In JDK 17.0.2 and earlier there was a bug where the JVM would crash when generating the CDS archive (see [helidon-io/helidon-build-tools#537](https://github.com/helidon-io/helidon-build-tools/issues/537)). So you need to use JDK 17.0.3 or newer. The Dockerfile-jlink in Helidon 3.0.1 uses maven:3.8.4-openjdk-17-slim as the base image. That uses JDK 17.0.2, so you get the failure.

