### PR TITLE
3.x: Upgrade Hibernate to 6.1.4.Final, EclipseLink to 3.0.3

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -72,14 +72,6 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate.enhance}</version>
-                    <dependencies>
-                        <dependency>
-                            <!-- used by hibernate plugin - requires update for Java 17 -->
-                            <groupId>net.bytebuddy</groupId>
-                            <artifactId>byte-buddy</artifactId>
-                            <version>${version.lib.byte-buddy}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -40,12 +40,11 @@
         <version.lib.animal-sniffer>1.18</version.lib.animal-sniffer>
         <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
-        <version.lib.byte-buddy>1.11.20</version.lib.byte-buddy>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
-        <version.lib.eclipselink>3.0.2</version.lib.eclipselink>
+        <version.lib.eclipselink>3.0.3</version.lib.eclipselink>
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>
@@ -61,7 +60,7 @@
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>2.1.212</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
-        <version.lib.hibernate>6.1.1.Final</version.lib.hibernate>
+        <version.lib.hibernate>6.1.4.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>7.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
@@ -188,12 +187,6 @@
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>2.1.1</version>
-            </dependency>
-            <dependency>
-                <!-- used by hibernate plugin -->
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>${version.lib.byte-buddy}</version>
             </dependency>
 
             <!-- Section 1: direct third party dependencies -->

--- a/examples/integrations/cdi/pokemons/pom.xml
+++ b/examples/integrations/cdi/pokemons/pom.xml
@@ -174,17 +174,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <!--
-                         3.0.0-JAKARTA
-                         used by hibernate plugin
-                         -->
-                        <groupId>net.bytebuddy</groupId>
-                        <artifactId>byte-buddy</artifactId>
-                        <version>${version.lib.byte-buddy}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -621,14 +621,6 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate-enhance}</version>
-                    <dependencies>
-                        <dependency>
-                            <!-- used by hibernate plugin - requires update for Java 17 -->
-                            <groupId>net.bytebuddy</groupId>
-                            <artifactId>byte-buddy</artifactId>
-                            <version>${version.lib.byte-buddy}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Fixes #5085

With this version of Hibernate we no longer need to manage the version of byte-buddy.

