### PR TITLE
[2.x] Fix CORS annotation handling error in certain cases

### DIFF
--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/TestWithAdjustedCorsType.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/TestWithAdjustedCorsType.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cors;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Inject;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddExtension;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@AddBean(CrossOriginTest.CorsResource0.class)
+@AddExtension(TestWithAdjustedCorsType.AugmentingExtension.class)
+class TestWithAdjustedCorsType extends BaseCrossOriginTest {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void checkAdjustedResource() {
+        // The extension below will have augmented the AnnotatedType (adding a synthetic annotation).
+        // Weld delivers a different concrete subtype of AnnotatedType to the CORS extension as a result.
+        // Make sure the CORS request still works correctly.
+
+        Response response = webTarget.path("/cors0")
+                .request()
+                .header("Origin", "http://foo.com")
+                .header("Host", "here.com")
+                .buildGet()
+                .invoke();
+
+        assertThat("Status from simple CORS request", response.getStatus(), is(200));
+    }
+
+    public static class AugmentingExtension implements Extension {
+
+        void processAnnotatedType(@Observes ProcessAnnotatedType<?> pat) {
+            // Single out the CORS-controlled resource.
+            if (pat.getAnnotatedType().getJavaClass().getName().equals(CrossOriginTest.CorsResource0.class.getName())) {
+                pat.configureAnnotatedType()
+                        .add(AugmentingAnnotation.Literal.getInstance());
+            }
+        }
+    }
+
+    @Target(ElementType.TYPE)
+    static @interface AugmentingAnnotation {
+            class Literal extends AnnotationLiteral<AugmentingAnnotation>implements AugmentingAnnotation {
+
+            private static final long serialVersionUID = 1L;
+
+            private static final Literal INSTANCE=new Literal();
+
+            static Literal getInstance(){
+            return INSTANCE;
+            }
+
+            private Literal(){
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #5094 

Previously the CORS extension used a `ProcessAnnotatedType` observer tuned to `@CrossOrigin` to record the `AnnotatedType` instances with that annotation.

Then, later, a `ProcessManagedBean` observer would check to see if the `AnnotatedType` associated with the bean had been recorded earlier. If not, that observer would skip processing the bean.

But, if some extension had altered the `AnnotatedType` then the specific `AnnotatedType` instance passed to the PMB observer would not match the instance passed to the PAT observer (and recorded in the CORS extension's data structure). So the PMB logic would incorrectly skip the altered bean.

This PR removes the data structure and the PAT observer entirely. The extension now simply traverses each method of each managed bean, checking for the `@CrossOrigin` annotation and, if present, processing it.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>