### PR TITLE
Use lazy values to initialized HealthSupport FT handlers

### DIFF
--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -58,6 +59,7 @@ public final class FaultTolerance {
             new AtomicReference<>();
     private static final AtomicReference<LazyValue<ExecutorService>> EXECUTOR = new AtomicReference<>();
     private static final AtomicReference<Config> CONFIG = new AtomicReference<>(Config.empty());
+    private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
 
     static {
         SCHEDULED_EXECUTOR.set(LazyValue.create(ScheduledThreadPoolSupplier.builder()
@@ -106,11 +108,23 @@ public final class FaultTolerance {
     }
 
     static LazyValue<? extends ExecutorService> executor() {
+        INITIALIZED.set(true);
         return EXECUTOR.get();
     }
 
     static LazyValue<? extends ScheduledExecutorService> scheduledExecutor() {
+        INITIALIZED.set(true);
         return SCHEDULED_EXECUTOR.get();
+    }
+
+    /**
+     * Mostly used for testing. This class is considered to be initialized if any of its
+     * (lazy valued) executors were returned.
+     *
+     * @return boolean indicating whether init took place
+     */
+    public static boolean initialized() {
+        return INITIALIZED.get();
     }
 
     /**

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -39,6 +39,7 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonStructure;
 
+import io.helidon.common.LazyValue;
 import io.helidon.common.http.Http;
 import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
@@ -85,8 +86,8 @@ public final class HealthSupport implements Service {
     private final boolean backwardCompatible;
     private final CorsEnabledServiceHelper corsEnabledServiceHelper;
     private final MessageBodyWriter<JsonStructure> jsonpWriter = JsonpSupport.writer();
-    private final Timeout timeout;
-    private final Async async;
+    private final LazyValue<? extends Timeout> timeout;
+    private final LazyValue<? extends Async> async;
 
     private HealthSupport(Builder builder) {
         this.enabled = builder.enabled;
@@ -120,9 +121,9 @@ public final class HealthSupport implements Service {
             this.excludedHealthChecks = Collections.emptySet();
         }
 
-
-        this.timeout = Timeout.create(Duration.ofMillis(builder.timeoutMillis));
-        this.async = Async.create();
+        // Lazy values to prevent early init of maybe-not-yet-configured FT thread pools
+        this.timeout = LazyValue.create(() -> Timeout.create(Duration.ofMillis(builder.timeoutMillis)));
+        this.async = LazyValue.create(Async::create);
     }
 
     @Override
@@ -174,7 +175,8 @@ public final class HealthSupport implements Service {
 
     void invoke(ServerResponse res, List<HealthCheck> healthChecks, boolean sendDetails) {
         // timeout on the asynchronous execution
-        Single<HealthResponse> result = timeout.invoke(() -> async.invoke(() -> callHealthChecks(healthChecks)));
+        Single<HealthResponse> result = timeout.get().invoke(
+                () -> async.get().invoke(() -> callHealthChecks(healthChecks)));
 
         // handle timeouts and failures in execution
         result = result.onErrorResume(throwable -> {

--- a/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022hhhh Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022hhhh Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import javax.json.JsonObject;
 
 import io.helidon.common.http.Http;
 
+import io.helidon.faulttolerance.FaultTolerance;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -218,6 +219,13 @@ class HealthSupportTest {
         assertThat(json.getString("outcome"), is("DOWN"));
         assertThat(json.getJsonArray("checks"), notNullValue());
         assertThat(json.getJsonArray("checks"), hasSize(brokenChecks.size()));
+    }
+
+    @Test
+    void checkLazyFaultToleranceInitialization() {
+        HealthSupport support = HealthSupport.create();
+        assertThat(support, notNullValue());
+        assertThat(FaultTolerance.initialized(), is(false));
     }
 
     private static final class GoodHealthCheck implements HealthCheck {


### PR DESCRIPTION
Use lazy values to initialized HealthSupport FT handlers. Early initialization of these handlers may result in improperly configured FT thread pools. Thread pool sizes may be overridden by the FT CDI extension which isn't guaranteed to run before the Health CDI extension (that creates the HealthSupport instance). New test.