### PR TITLE
Use Hamcrest assertions instead of JUnit in metrics/metrics (#1749)

### DIFF
--- a/metrics/metrics/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Unit test for {@link RegistryFactory}.
@@ -89,11 +89,11 @@ public class RegistryFactoryTest {
 
         assertThat(c1, notNullValue());
         assertThat(c2, notNullValue());
-        assertNotSame(c1, c2);
+        assertThat(c1, not(sameInstance(c2)));
 
         //replace c2 with a counter from the same registry
         c2 = vendor.counter("new.counter");
-        assertSame(c1, c2);
+        assertThat(c1, sameInstance(c2));
     }
 
     @Test
@@ -103,11 +103,11 @@ public class RegistryFactoryTest {
 
         assertThat(c1, notNullValue());
         assertThat(c2, notNullValue());
-        assertNotSame(c1, c2);
+        assertThat(c1, not(sameInstance(c2)));
 
         //replace c2 with a counter from the same registry
         c2 = app.counter("new.counter");
-        assertSame(c1, c2);
+        assertThat(c1, sameInstance(c2));
     }
 
     @Test


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Backport 2.x](https://github.com/helidon-io/helidon/pull/5108)