### PR TITLE
Remove retries from executor metrics test fix; use the pre-existing countdown latch in `GreetService` instead

### DIFF
--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -103,11 +103,6 @@
             <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.helidon.reactive.fault-tolerance</groupId>
-            <artifactId>helidon-reactive-fault-tolerance</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
@@ -22,7 +22,6 @@ import java.util.logging.Logger;
 
 import io.helidon.common.http.Http;
 import io.helidon.common.media.type.MediaTypes;
-import io.helidon.reactive.faulttolerance.Retry;
 import io.helidon.reactive.media.jsonp.JsonpSupport;
 import io.helidon.reactive.webclient.WebClient;
 import io.helidon.reactive.webclient.WebClientRequestBuilder;
@@ -50,10 +49,7 @@ import static org.hamcrest.Matchers.not;
 public class TestServer {
 
     private static final Logger LOGGER = Logger.getLogger(TestServer.class.getName());
-    private static final int RETRY_COUNT = Integer.getInteger("io.helidon.test.retryCount", 10);
-    private static final Duration RETRY_DELAY = Duration.ofMillis(Integer.getInteger("io.helidon.test.retryDelayMs", 500));
     private static final Duration CLIENT_TIMEOUT = Duration.ofSeconds(Integer.getInteger("io.helidon.test.clientTimeoutSec", 10));
-    private static final Duration RETRY_TIMEOUT = Duration.ofSeconds(Integer.getInteger("io.helidon.test.retryTimeoutSec", 60));
     private static final String[] EXPECTED_NO_CACHE_HEADER_SETTINGS = {"no-cache", "no-store", "must-revalidate", "no-transform"};
 
     private static WebServer webServer;
@@ -61,7 +57,6 @@ public class TestServer {
     private static final MetricsSupport.Builder NORMAL_BUILDER = MetricsSupport.builder();
 
     private static MetricsSupport metricsSupport;
-    private static Retry.Builder retry;
     private static WebClient.Builder webClientBuilder;
 
     @BeforeAll
@@ -71,12 +66,6 @@ public class TestServer {
         webClientBuilder = WebClient.builder()
                 .baseUri("http://localhost:" + webServer.port() + "/")
                 .addMediaSupport(JsonpSupport.create());
-        retry = Retry.builder()
-                .overallTimeout(RETRY_TIMEOUT)
-                .retryPolicy(Retry.JitterRetryPolicy.builder()
-                        .calls(RETRY_COUNT)
-                        .delay(RETRY_DELAY)
-                        .build());
     }
 
     @AfterAll
@@ -164,7 +153,7 @@ public class TestServer {
     }
 
     @Test
-    void checkMetricsForExecutorService() {
+    void checkMetricsForExecutorService() throws InterruptedException {
 
         String jsonKeyForCompleteTaskCountInThreadPool =
                 "executor-service.completed-task-count;poolIndex=0;supplierCategory=my-thread-thread-pool-1;supplierIndex=0";
@@ -190,6 +179,7 @@ public class TestServer {
         int completedTaskCount = metrics.getInt(jsonKeyForCompleteTaskCountInThreadPool);
         assertThat("Completed task count before accessing slow endpoint", completedTaskCount, is(0));
 
+        GreetService.initSlowRequest();
         WebClientResponse slowGreetResponse = webClientBuilder
                 .build()
                 .get()
@@ -200,17 +190,23 @@ public class TestServer {
 
         assertThat("Slow greet access response status", slowGreetResponse.status().code(), is(200));
 
-        retry.build()
-                .invoke(() -> metricsRequestBuilder
-                        .submit()
-                        .peek(res -> assertThat("Second access to metrics", res.status().code(), is(200)))
-                        .flatMapSingle(res -> res.content().as(JsonObject.class))
-                        .peek(json -> assertThat("JSON metrics results after accessing slow endpoint",
-                                json, hasKey(jsonKeyForCompleteTaskCountInThreadPool)))
-                        .map(json -> json.getInt(jsonKeyForCompleteTaskCountInThreadPool))
-                        .forSingle(secCompletedTaskCnt ->
-                                assertThat("Completed task count after accessing slow endpoint", secCompletedTaskCnt, is(1))))
+        GreetService.awaitSlowRequestStarted();
+
+        WebClientResponse secondMetricsResponse = metricsRequestBuilder
+                .submit()
                 .await(CLIENT_TIMEOUT);
+
+        assertThat("Second access to metrics", secondMetricsResponse.status().code(), is(200));
+
+        JsonObject secondMetrics = secondMetricsResponse.content().as(JsonObject.class).await(CLIENT_TIMEOUT);
+
+        assertThat("JSON metrics results after accessing slow endpoint",
+                   secondMetrics,
+                   hasKey(jsonKeyForCompleteTaskCountInThreadPool));
+
+        int secondCompletedTaskCount = secondMetrics.getInt(jsonKeyForCompleteTaskCountInThreadPool);
+
+        assertThat("Completed task count after accessing slow endpoint", secondCompletedTaskCount, is(1));
     }
 
     @ParameterizedTest

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
@@ -24,7 +24,6 @@ import io.helidon.common.http.Http;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.reactive.media.jsonp.JsonpSupport;
 import io.helidon.reactive.webclient.WebClient;
-import io.helidon.reactive.webclient.WebClientRequestBuilder;
 import io.helidon.reactive.webclient.WebClientResponse;
 import io.helidon.reactive.webserver.Routing;
 import io.helidon.reactive.webserver.Service;
@@ -42,7 +41,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
@@ -152,63 +150,6 @@ public class TestServer {
         assertThat("In-flight concurrent gauge metric exists", inflightRequests.isPresent(), is(isKPIEnabled));
     }
 
-    @Test
-    void checkMetricsForExecutorService() throws InterruptedException {
-
-        String jsonKeyForCompleteTaskCountInThreadPool =
-                "executor-service.completed-task-count;poolIndex=0;supplierCategory=my-thread-thread-pool-1;supplierIndex=0";
-
-        WebClientRequestBuilder metricsRequestBuilder = webClientBuilder
-                .build()
-                .get()
-                .accept(MediaTypes.APPLICATION_JSON)
-                .path("metrics/vendor");
-
-        WebClientResponse response = metricsRequestBuilder
-                .submit()
-                .await(CLIENT_TIMEOUT);
-
-        assertThat("Normal metrics/vendor URL HTTP response", response.status().code(), is(200));
-
-        JsonObject metrics = response.content().as(JsonObject.class).await(CLIENT_TIMEOUT);
-
-        assertThat("JSON metrics results before accessing slow endpoint",
-                   metrics,
-                   hasKey(jsonKeyForCompleteTaskCountInThreadPool));
-
-        int completedTaskCount = metrics.getInt(jsonKeyForCompleteTaskCountInThreadPool);
-        assertThat("Completed task count before accessing slow endpoint", completedTaskCount, is(0));
-
-        GreetService.initSlowRequest();
-        WebClientResponse slowGreetResponse = webClientBuilder
-                .build()
-                .get()
-                .accept(MediaTypes.TEXT_PLAIN)
-                .path("greet/slow")
-                .submit()
-                .await(CLIENT_TIMEOUT);
-
-        assertThat("Slow greet access response status", slowGreetResponse.status().code(), is(200));
-
-        GreetService.awaitSlowRequestExecutorCompleted();
-
-        WebClientResponse secondMetricsResponse = metricsRequestBuilder
-                .submit()
-                .await(CLIENT_TIMEOUT);
-
-        assertThat("Second access to metrics", secondMetricsResponse.status().code(), is(200));
-
-        JsonObject secondMetrics = secondMetricsResponse.content().as(JsonObject.class).await(CLIENT_TIMEOUT);
-
-        assertThat("JSON metrics results after accessing slow endpoint",
-                   secondMetrics,
-                   hasKey(jsonKeyForCompleteTaskCountInThreadPool));
-
-        int secondCompletedTaskCount = secondMetrics.getInt(jsonKeyForCompleteTaskCountInThreadPool);
-
-        assertThat("Completed task count after accessing slow endpoint", secondCompletedTaskCount, is(1));
-    }
-
     @ParameterizedTest
     @ValueSource(strings = {"", "/base", "/vendor", "/application"})
     void testCacheSuppression(String pathSuffix) {
@@ -238,5 +179,4 @@ public class TestServer {
                     response.headers().values(Http.Header.CACHE_CONTROL),
                     not(containsInAnyOrder(EXPECTED_NO_CACHE_HEADER_SETTINGS)));
     }
-
 }

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
@@ -190,7 +190,7 @@ public class TestServer {
 
         assertThat("Slow greet access response status", slowGreetResponse.status().code(), is(200));
 
-        GreetService.awaitSlowRequestStarted();
+        GreetService.awaitSlowRequestExecutorCompleted();
 
         WebClientResponse secondMetricsResponse = metricsRequestBuilder
                 .submit()

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
@@ -157,7 +157,7 @@ public class TestServer {
 
         // Because ThreadPoolExecutor methods are documented as reporting approximations of task counts, etc., we should
         // not depend on the values changing in a reasonable time period...or at all. So this test simply makes sure that
-        // an expected metrics is present.
+        // an expected metric is present.
         String jsonKeyForCompleteTaskCountInThreadPool =
                 "executor-service.completed-task-count;poolIndex=0;supplierCategory=my-thread-thread-pool-1;supplierIndex=0";
 


### PR DESCRIPTION
Resolves #4982 

Daniel's recent PR improved on my original one that used retries, but retrying is not the correct approach here.

In fact, we cannot depend on the reported values changing as we would like. 

The executor service metrics we implement rely on `ThreadPoolExecutor` methods which are documented as returning _estimates_ of task counts, etc. Even if retry seems to help, there is no guarantee that the numbers reported by `ThreadPoolExecutor` - and therefore the values reported by our metrics - will change as a result of running one async task in the executor.

We can still check to make sure that the expected metrics are created; we just cannot reliably test that the values increase.