### PR TITLE
Use Hamcrest assertions instead of JUnit in webserver/jersey (#1749)

### DIFF
--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
@@ -41,7 +41,8 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriInfo;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * The JerseyExampleResource.
@@ -149,7 +150,7 @@ public class JerseyExampleResource {
         String content = new String(inputStream.readAllBytes());
 
         try {
-            assertEquals(JerseySupportTest.longData(length).toString(), content);
+            assertThat(content, is(JerseySupportTest.longData(length).toString()));
         } catch (Throwable e) {
             streamException = e;
             throw new IllegalStateException("NOT EQUALS");

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -42,7 +42,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * The JerseySupportTest.
@@ -222,7 +221,7 @@ public class JerseySupportTest {
             // in this case the test is a no-op.
             return;
         }
-        assertNotNull(response);
+        assertThat(response, notNullValue());
         doAssert(response, null, Response.Status.NOT_FOUND);
     }
 


### PR DESCRIPTION
Part of #1749

I've already signed OCA. It's an automation problem.

[Backport 2.x](https://github.com/helidon-io/helidon/pull/5116)