### PR TITLE
Use Hamcrest assertions instead of JUnit in webserver/jersey - backport 2.x (#1749)

### DIFF
--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ import io.helidon.webserver.ServerResponse;
 
 import io.opentracing.SpanContext;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * The JerseyExampleResource.
@@ -150,7 +151,7 @@ public class JerseyExampleResource {
         String content = new String(inputStream.readAllBytes());
 
         try {
-            assertEquals(JerseySupportTest.longData(length).toString(), content);
+            assertThat(content, is(JerseySupportTest.longData(length).toString()));
         } catch (Throwable e) {
             streamException = e;
             throw new IllegalStateException("NOT EQUALS");

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -43,8 +43,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * The JerseySupportTest.
@@ -224,7 +222,7 @@ public class JerseySupportTest {
             // in this case the test is a no-op.
             return;
         }
-        assertNotNull(response);
+        assertThat(response, notNullValue());
         doAssert(response, null, Response.Status.NOT_FOUND);
     }
 
@@ -309,8 +307,9 @@ public class JerseySupportTest {
         Response response = webTarget.path("jersey/first/streamingOutput")
                 .request()
                 .get();
-        assertEquals(Response.Status.Family.SUCCESSFUL, response.getStatusInfo().getFamily(),
-                "Unexpected error: " + response.getStatus());
+
+        assertThat(response.getStatusInfo().getFamily(), is(Response.Status.Family.SUCCESSFUL));
+
         try (InputStream is = response.readEntity(InputStream.class)) {
             byte[] buffer = new byte[32];
             int n = is.read(buffer);        // should read only first chunk
@@ -407,12 +406,9 @@ public class JerseySupportTest {
     }
 
     private void doAssert(Response response, String expected) {
-        try {
-            assertEquals(Response.Status.Family.SUCCESSFUL, response.getStatusInfo().getFamily(),
-                    "Unexpected error: " + response.getStatus());
-            assertEquals(expected, response.readEntity(String.class));
-        } finally {
-            response.close();
+        try (response) {
+            assertThat(response.getStatusInfo().getFamily(), is(Response.Status.Family.SUCCESSFUL));
+            assertThat(response.readEntity(String.class), is(expected));
         }
     }
 
@@ -421,14 +417,11 @@ public class JerseySupportTest {
     }
 
     private void doAssert(Response response, String expectedContent, int expectedStatusCode) {
-        try {
-            assertEquals(expectedStatusCode, response.getStatus(),
-                    "Unexpected error: " + response.getStatus());
+        try (response) {
+            assertThat(response.getStatus(), is(expectedStatusCode));
             if (expectedContent != null) {
-                assertEquals(expectedContent, response.readEntity(String.class));
+                assertThat(response.readEntity(String.class), is(expectedContent));
             }
-        } finally {
-            response.close();
         }
     }
 }


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/5113)