### PR TITLE
Replace deprecated ServerConfiguration.builder() on WebServer.builder() in docs - backport 2.x (#5024)

### DIFF
--- a/docs/se/health/02_health_in_k8s.adoc
+++ b/docs/se/health/02_health_in_k8s.adoc
@@ -144,7 +144,7 @@ Routing defaultRouting = Routing.builder()
         .build();
 
 WebServer server = WebServer.builder(defaultRouting)
-        .config(ServerConfiguration.builder()
+        .config(WebServer.builder()
                 .port(8080) // <6>
                 .addSocket("health", SocketConfiguration.builder() // <7>
                         .port(8081)

--- a/docs/se/tracing/01_tracing.adoc
+++ b/docs/se/tracing/01_tracing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -50,11 +50,11 @@ To configure tracer with WebServer:
 [source,java]
 .Configuring OpenTracing `Tracer`
 ----
-ServerConfiguration.builder()
-                   .tracer(TracerBuilder.create("my-application")                    // <1>
-                                 .collectorUri(URI.create("http://10.0.0.18:9411"))  // <2>
-                                 .build())
-                   .build()
+WebServer.builder()
+         .tracer(TracerBuilder.create("my-application")                    // <1>
+                       .collectorUri(URI.create("http://10.0.0.18:9411"))  // <2>
+                       .build())
+         .build()
 ----
 <1> The name of the application (service) to associate with the tracing events
 <2> The endpoint for tracing events, specific to the tracer used, usually loaded from Config

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -57,7 +57,7 @@ pom.xml:
 
 code using config:
 ```java
-return ServerConfiguration.builder()
+return WebServer.builder()
                 .config(config.get("webserver"))
                 .tracer(TracerBuilder.create(config.get("tracing"))
                                         .buildAndRegister())


### PR DESCRIPTION
Fixes #5024 

I've already signed OCA. It's an automation problem.

I didn't find any more:
<img width="1211" alt="Screenshot 2022-10-07 at 22 42 48" src="https://user-images.githubusercontent.com/4740207/194641482-810242de-ce3b-40ff-85e4-41597667d128.png">
