### PR TITLE
[2.x] Remove value check of executor metrics; just check for existence

### DIFF
--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestServer.java
@@ -186,6 +186,9 @@ public class TestServer {
     @Test
     void checkMetricsForExecutorService() {
 
+        // Because ThreadPoolExecutor methods are documented as reporting approximations of task counts, etc., we should
+        // not depend on the values changing in a reasonable time period...or at all. So this test simply makes sure that
+        // an expected metric is present.
         String jsonKeyForCompleteTaskCountInThreadPool =
                 "executor-service.completed-task-count;poolIndex=0;supplierCategory=helidon-thread-pool-1;supplierIndex=0";
 
@@ -206,28 +209,6 @@ public class TestServer {
         int completedTaskCount =
                 metrics.getInt(jsonKeyForCompleteTaskCountInThreadPool);
         assertThat("Completed task count before accessing slow endpoint", completedTaskCount, is(0));
-
-        WebClientResponse slowGreetResponse = webClientBuilder
-                .build()
-                .get()
-                .accept(MediaType.TEXT_PLAIN)
-                .path("greet/slow")
-                .submit()
-                .await();
-
-        assertThat("Slow greet access response status", slowGreetResponse.status().code(), is(200));
-
-        WebClientResponse secondMetricsResponse = metricsRequestBuilder
-                .submit()
-                .await();
-
-        assertThat("Second access to metrics", secondMetricsResponse.status().code(), is(200));
-
-        JsonObject secondMetrics = secondMetricsResponse.content().as(JsonObject.class).await();
-
-        int secondCompletedTaskCount = secondMetrics.getInt(jsonKeyForCompleteTaskCountInThreadPool);
-
-        assertThat("Completed task count after accessing slow endpoint", secondCompletedTaskCount, is(1));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Resolves #5110 

`ThreadPoolExecutor` methods reporting statistics are documented as returning approximate values. Even if we were to retry, there is no guarantee that the values from `ThreadPoolExecutor`--and therefore in our thread pool metrics``would change during a test. 

This PR removes the value check portion of the test, leaving only the existence check to make sure the metrics are created correctly.