### PR TITLE
Replace deprecated ServerConfiguration.builder() on WebServer.builder() in docs (#5023)

### DIFF
--- a/docs/se/health.adoc
+++ b/docs/se/health.adoc
@@ -432,7 +432,7 @@ Routing defaultRouting = Routing.builder()
         .build();
 
 WebServer server = WebServer.builder(defaultRouting)
-        .config(ServerConfiguration.builder()
+        .config(WebServer.builder()
                 .port(8080) // <6>
                 .addSocket("health", SocketConfiguration.builder() // <7>
                         .port(8081)

--- a/docs/se/tracing.adoc
+++ b/docs/se/tracing.adoc
@@ -85,11 +85,11 @@ Helidon provides such an implementation for:
 [source,java]
 .Configuring OpenTracing `Tracer`
 ----
-ServerConfiguration.builder()
-                   .tracer(TracerBuilder.create("my-application")                    // <1>
-                                 .collectorUri(URI.create("http://10.0.0.18:9411"))  // <2>
-                                 .build())
-                   .build()
+WebServer.builder()
+         .tracer(TracerBuilder.create("my-application")                    // <1>
+                       .collectorUri(URI.create("http://10.0.0.18:9411"))  // <2>
+                       .build())
+         .build()
 ----
 <1> The name of the application (service) to associate with the tracing events
 <2> The endpoint for tracing events, specific to the tracer used, usually loaded from Config

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -59,7 +59,7 @@ pom.xml:
 
 code using config:
 ```java
-return ServerConfiguration.builder()
+return WebServer.builder()
                 .config(config.get("webserver"))
                 .tracer(TracerBuilder.create(config.get("tracing"))
                                         .buildAndRegister())


### PR DESCRIPTION
Fixes #5023 

I've already signed OCA. It's an automation problem.

I didn't find any more:
<img width="1214" alt="Screenshot 2022-10-07 at 22 54 28" src="https://user-images.githubusercontent.com/4740207/194644095-dee185a2-0bd4-4cae-b2a0-94a5732c9433.png">
