### PR TITLE
[4.x] Add some retries because post-request metrics updates occur after the response is sent

### DIFF
--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseTest.java
@@ -123,9 +123,9 @@ public class HelloWorldAsyncResponseTest {
         long explicitDiffNanos = explicitSimpleTimer.getElapsedTime().toNanos() - explicitSimpleTimerDurationBefore.toNanos();
         assertThat("Change in elapsed time for explicit SimpleTimer", explicitDiffNanos, is(greaterThan(minDuration.toNanos())));
 
-        long syntheticDiffNanos = simpleTimer.getElapsedTime().toNanos() - syntheticaSimpleTimerDurationBefore.toNanos();
-        assertThat("Change in synthetic SimpleTimer elapsed time", syntheticDiffNanos,
-                is(greaterThan(minDuration.toNanos())));
+        assertThatWithRetry("Change in synthetic SimpleTimer elapsed time",
+                            () -> simpleTimer.getElapsedTime().toNanos() - syntheticaSimpleTimerDurationBefore.toNanos(),
+                            is(greaterThan(minDuration.toNanos())));
 
         assertThat("Change in timer count", timer.getCount() - slowMessageTimerCountBefore, is(1L));
         assertThat("Timer mean rate", timer.getMeanRate(), is(greaterThan(0.0)));


### PR DESCRIPTION
Resolves #5030 

Two tests in this class involve asynchronous activity. 

Helidon updates some KPI metrics (such as the current number of in-flight requests) _after_ it sends the response. As a result, thread scheduling could allow the test to get the response and check the metrics _before_ the server has updated those metrics. There is no way to synchronize the test with the server's processing, so use retries in key places rather than optimistic fixed-length sleeps.

