### PR TITLE
Use Hamcrest assertions instead of JUnit in  dbclient/mongodb (#1749)

### DIFF
--- a/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/StatementParsersTest.java
+++ b/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/StatementParsersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import io.helidon.dbclient.mongodb.StatementParsers.NamedParser;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit test for {@link StatementParsers}.
@@ -43,7 +44,7 @@ public class StatementParsersTest {
                 .replace("$idmax", String.valueOf(mapping.get("idmax")));
         NamedParser parser = new NamedParser(stmtIn, mapping);
         String stmtOut = parser.convert();
-        assertEquals(stmtExp, stmtOut);
+        assertThat(stmtOut, is(stmtExp));
     }
 
 }


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Backport 2.x](https://github.com/helidon-io/helidon/pull/5125)