### PR TITLE
Use Hamcrest assertions instead of JUnit in  examples/employee-app - backport 2.x (#1749)

### DIFF
--- a/examples/employee-app/pom.xml
+++ b/examples/employee-app/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/employee-app/src/test/java/io/helidon/service/employee/MainTest.java
+++ b/examples/employee-app/src/test/java/io/helidon/service/employee/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,11 @@ import io.helidon.webclient.WebClient;
 import io.helidon.webserver.WebServer;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MainTest {
 
@@ -58,7 +60,7 @@ public class MainTest {
                 .request()
                 .thenAccept(response -> {
                     response.close();
-                    Assertions.assertEquals(Http.Status.OK_200, response.status(), "HTTP response2");
+                    assertThat("HTTP response2", response.status(), is(Http.Status.OK_200));
                 })
                 .await();
 
@@ -67,7 +69,7 @@ public class MainTest {
                 .request()
                 .thenAccept(response -> {
                     response.close();
-                    Assertions.assertEquals(Http.Status.OK_200, response.status(), "HTTP response2");
+                    assertThat("HTTP response2", response.status(), is(Http.Status.OK_200));
                 })
                 .await();
 
@@ -76,7 +78,7 @@ public class MainTest {
                 .request()
                 .thenAccept(response -> {
                     response.close();
-                    Assertions.assertEquals(Http.Status.OK_200, response.status(), "HTTP response2");
+                    assertThat("HTTP response2", response.status(), is(Http.Status.OK_200));
                 })
                 .await();
     }


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/5128)