### PR TITLE
Move checkLazyFaultToleranceInitialization() test to its own class 

### DIFF
--- a/health/health/pom.xml
+++ b/health/health/pom.xml
@@ -16,8 +16,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>helidon-health-project</artifactId>
         <groupId>io.helidon.health</groupId>
@@ -89,4 +89,39 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/HealthSupportInitTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>health-support-init-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <includes>
+                                <include>**/HealthSupportInitTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/health/health/src/test/java/io/helidon/health/HealthSupportInitTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportInitTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.health;
+
+import io.helidon.faulttolerance.FaultTolerance;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class HealthSupportInitTest {
+
+    /**
+     * Must be executed at startup, preferably in its own VM. Verifies that fault tolerance
+     * is not initialized too early due to execution of health extension.
+     */
+    @Test
+    void checkLazyFaultToleranceInitialization() {
+        HealthSupport support = HealthSupport.create();
+        assertThat(support, notNullValue());
+        assertThat(FaultTolerance.initialized(), is(false));
+    }
+}

--- a/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
@@ -27,7 +27,6 @@ import javax.json.JsonObject;
 
 import io.helidon.common.http.Http;
 
-import io.helidon.faulttolerance.FaultTolerance;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -219,13 +218,6 @@ class HealthSupportTest {
         assertThat(json.getString("outcome"), is("DOWN"));
         assertThat(json.getJsonArray("checks"), notNullValue());
         assertThat(json.getJsonArray("checks"), hasSize(brokenChecks.size()));
-    }
-
-    @Test
-    void checkLazyFaultToleranceInitialization() {
-        HealthSupport support = HealthSupport.create();
-        assertThat(support, notNullValue());
-        assertThat(FaultTolerance.initialized(), is(false));
     }
 
     private static final class GoodHealthCheck implements HealthCheck {


### PR DESCRIPTION
Move checkLazyFaultToleranceInitialization() test to its own class and execute it in its own VM. This test can otherwise fail due to execution ordering in some cases.