### PR TITLE
Use Hamcrest assertions instead of JUnit in  examples/webserver/tutorial - backport 2.x (#1749)

### DIFF
--- a/examples/webserver/tutorial/src/test/java/io/helidon/webserver/examples/tutorial/CommentServiceTest.java
+++ b/examples/webserver/tutorial/src/test/java/io/helidon/webserver/examples/tutorial/CommentServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,10 @@ import io.helidon.webserver.testsupport.TestResponse;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 
 /**
@@ -38,17 +41,17 @@ public class CommentServiceTest {
     @Test
     public void addAndGetComments() throws Exception {
         CommentService service = new CommentService();
-        assertEquals(0, service.getComments("one").size());
-        assertEquals(0, service.getComments("two").size());
+        assertThat(service.getComments("one"), empty());
+        assertThat(service.getComments("two"), empty());
         service.addComment("one", null, "aaa");
-        assertEquals(1, service.getComments("one").size());
-        assertEquals(0, service.getComments("two").size());
+        assertThat(service.getComments("one"), hasSize(1));
+        assertThat(service.getComments("two"), empty());
         service.addComment("one", null, "bbb");
-        assertEquals(2, service.getComments("one").size());
-        assertEquals(0, service.getComments("two").size());
+        assertThat(service.getComments("one"), hasSize(2));
+        assertThat(service.getComments("two"), empty());
         service.addComment("two", null, "bbb");
-        assertEquals(2, service.getComments("one").size());
-        assertEquals(1, service.getComments("two").size());
+        assertThat(service.getComments("one"), hasSize(2));
+        assertThat(service.getComments("two"), hasSize(1));
     }
 
     @Test
@@ -59,30 +62,30 @@ public class CommentServiceTest {
         TestResponse response = TestClient.create(routing)
                                         .path("one")
                                         .get();
-        assertEquals(Http.Status.OK_200, response.status());
+        assertThat(response.status(), is(Http.Status.OK_200));
 
         // Add first comment
         response = TestClient.create(routing)
                 .path("one")
                 .post(MediaPublisher.create(MediaType.TEXT_PLAIN, "aaa"));
-        assertEquals(Http.Status.OK_200, response.status());
+        assertThat(response.status(), is(Http.Status.OK_200));
         response = TestClient.create(routing)
                 .path("one")
                 .get();
-        assertEquals(Http.Status.OK_200, response.status());
+        assertThat(response.status(), is(Http.Status.OK_200));
         byte[] data = response.asBytes().toCompletableFuture().get();
-        assertEquals("anonymous: aaa\n", new String(data, StandardCharsets.UTF_8));
+        assertThat(new String(data, StandardCharsets.UTF_8), is("anonymous: aaa\n"));
 
         // Add second comment
         response = TestClient.create(routing)
                 .path("one")
                 .post(MediaPublisher.create(MediaType.TEXT_PLAIN, "bbb"));
-        assertEquals(Http.Status.OK_200, response.status());
+        assertThat(response.status(), is(Http.Status.OK_200));
         response = TestClient.create(routing)
                 .path("one")
                 .get();
-        assertEquals(Http.Status.OK_200, response.status());
+        assertThat(response.status(), is(Http.Status.OK_200));
         data = response.asBytes().toCompletableFuture().get();
-        assertEquals("anonymous: aaa\nanonymous: bbb\n", new String(data, StandardCharsets.UTF_8));
+        assertThat(new String(data, StandardCharsets.UTF_8), is("anonymous: aaa\nanonymous: bbb\n"));
     }
 }

--- a/examples/webserver/tutorial/src/test/java/io/helidon/webserver/examples/tutorial/MainTest.java
+++ b/examples/webserver/tutorial/src/test/java/io/helidon/webserver/examples/tutorial/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import io.helidon.webserver.testsupport.TestResponse;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests {@link Main}.
@@ -39,12 +39,12 @@ public class MainTest {
         TestResponse response = TestClient.create(Main.createRouting())
                 .path("/mgmt/shutdown")
                 .post();
-        assertEquals(Http.Status.OK_200, response.status());
+        assertThat(response.status(), is(Http.Status.OK_200));
         CountDownLatch latch = new CountDownLatch(1);
         WebServer webServer = response.webServer();
                 webServer
                         .whenShutdown()
                         .thenRun(latch::countDown);
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertThat(latch.await(10, TimeUnit.SECONDS), is(true));
     }
 }

--- a/examples/webserver/tutorial/src/test/java/io/helidon/webserver/examples/tutorial/user/UserFilterTest.java
+++ b/examples/webserver/tutorial/src/test/java/io/helidon/webserver/examples/tutorial/user/UserFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import io.helidon.webserver.testsupport.TestResponse;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests {@link UserFilter}.
@@ -46,11 +47,11 @@ public class UserFilterTest {
         TestResponse response = TestClient.create(routing)
                 .path("/")
                 .get();
-        assertEquals(User.ANONYMOUS, userReference.get());
+        assertThat(userReference.get(), is(User.ANONYMOUS));
         response = TestClient.create(routing)
                 .path("/")
                 .header("Cookie", "Unauthenticated-User-Alias=Foo")
                 .get();
-        assertEquals("Foo", userReference.get().getAlias());
+        assertThat(userReference.get().getAlias(), is("Foo"));
     }
 }


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/5139)