### PR TITLE
Add some retries because post-request metrics updates occur after the response is sent

### DIFF
--- a/config/testing/src/main/java/io/helidon/config/testing/MatcherWithRetry.java
+++ b/config/testing/src/main/java/io/helidon/config/testing/MatcherWithRetry.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.config.testing;
+
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+
+/**
+ * Hamcrest matcher capable of configured retries before failing the assertion, plus more generic retry processing.
+ */
+public class MatcherWithRetry {
+
+    private static final int RETRY_COUNT = Integer.getInteger("io.helidon.test.retryCount", 10);
+    private static final int RETRY_DELAY_MS = Integer.getInteger("io.helidon.test.retryDelayMs", 500);
+
+    private MatcherWithRetry() {
+    }
+
+    /**
+     * Checks the matcher, possibly multiple times after configured delays, invoking the supplier of the matched value each time,
+     * until either the matcher passes or the maximum retry expires.
+     * @param reason explanation of the assertion
+     * @param actualSupplier {@code Supplier} that furnishes the value to submit to the matcher
+     * @param matcher Hamcrest matcher which evaluates the supplied value
+     * @return the supplied value
+     * @param <T> type of the supplied value
+     * @throws InterruptedException if the sleep is interrupted
+     */
+    public static <T> T assertThatWithRetry(String reason, Supplier<T> actualSupplier, Matcher<? super T> matcher)
+            throws InterruptedException {
+
+        T actual = null;
+        for (int i = 0; i < RETRY_COUNT; i++) {
+            actual = actualSupplier.get();
+            if (matcher.matches(actual)) {
+                return actual;
+            }
+            Thread.sleep(RETRY_DELAY_MS);
+        }
+
+        Description description = new StringDescription();
+        description.appendText(reason)
+                .appendText("\nExpected: ")
+                .appendDescriptionOf(matcher)
+                .appendText("\n     but: ");
+        matcher.describeMismatch(actual, description);
+
+        throw new AssertionError(description.toString());
+    }
+
+    /**
+     * Retries the specified work until successful or retry limit is exceeded.
+     *
+     * @param work the work to perform; returned boolean indicates if the work was successful
+     * @throws Exception exception from the work or from the sleep being interrupted
+     */
+    public static void retry(Callable<Boolean> work) throws Exception {
+        for (int i = 0; i < RETRY_COUNT; i++) {
+            if (work.call()) {
+                return;
+            }
+            Thread.sleep(RETRY_DELAY_MS);
+        }
+    }
+}

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>helidon-microprofile-tests-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Resolves #4984 

See PR #5122 for explanation.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>