### PR TITLE
Use lazy values to initialized HealthSupport FT handlers

### DIFF
--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -58,6 +59,7 @@ public final class FaultTolerance {
             new AtomicReference<>();
     private static final AtomicReference<LazyValue<ExecutorService>> EXECUTOR = new AtomicReference<>();
     private static final AtomicReference<Config> CONFIG = new AtomicReference<>(Config.empty());
+    private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
 
     static {
         SCHEDULED_EXECUTOR.set(LazyValue.create(ScheduledThreadPoolSupplier.builder()
@@ -106,11 +108,23 @@ public final class FaultTolerance {
     }
 
     static LazyValue<? extends ExecutorService> executor() {
+        INITIALIZED.set(true);
         return EXECUTOR.get();
     }
 
     static LazyValue<? extends ScheduledExecutorService> scheduledExecutor() {
+        INITIALIZED.set(true);
         return SCHEDULED_EXECUTOR.get();
+    }
+
+    /**
+     * Mostly used for testing. This class is considered to be initialized if any of its
+     * (lazy valued) executors were returned.
+     *
+     * @return boolean indicating whether init took place
+     */
+    public static boolean initialized() {
+        return INITIALIZED.get();
     }
 
     /**

--- a/health/health/pom.xml
+++ b/health/health/pom.xml
@@ -16,8 +16,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>helidon-health-project</artifactId>
         <groupId>io.helidon.health</groupId>
@@ -101,4 +101,39 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/HealthSupportInitTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>health-support-init-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <includes>
+                                <include>**/HealthSupportInitTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/health/health/src/test/java/io/helidon/health/HealthSupportInitTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportInitTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.health;
+
+import io.helidon.faulttolerance.FaultTolerance;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class HealthSupportInitTest {
+
+    /**
+     * Must be executed at startup, preferably in its own VM. Verifies that fault tolerance
+     * is not initialized too early due to execution of health extension.
+     */
+    @Test
+    void checkLazyFaultToleranceInitialization() {
+        HealthSupport support = HealthSupport.create();
+        assertThat(support, notNullValue());
+        assertThat(FaultTolerance.initialized(), is(false));
+    }
+}

--- a/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
@@ -31,8 +31,6 @@ import io.helidon.common.http.Http;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 
-import io.helidon.faulttolerance.FaultTolerance;
-
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -220,13 +218,6 @@ class HealthSupportTest {
         final JsonObject json = response.json();
         assertThat(json.getJsonArray("checks"), notNullValue());
         assertThat(json.getJsonArray("checks"), hasSize(brokenChecks.size()));
-    }
-
-    @Test
-    void checkLazyFaultToleranceInitialization() {
-        HealthSupport support = HealthSupport.create();
-        assertThat(support, notNullValue());
-        assertThat(FaultTolerance.initialized(), is(false));
     }
 
     private static final class GoodHealthCheck implements HealthCheck {

--- a/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
@@ -1,9 +1,5 @@
 /*
-<<<<<<< HEAD
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
-=======
  * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
->>>>>>> 8496afdea... Use lazy values to initialized HealthSupport FT handlers (#5106)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
@@ -1,5 +1,9 @@
 /*
+<<<<<<< HEAD
  * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+=======
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+>>>>>>> 8496afdea... Use lazy values to initialized HealthSupport FT handlers (#5106)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +30,9 @@ import io.helidon.common.http.Http;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+
+import io.helidon.faulttolerance.FaultTolerance;
+
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -213,6 +220,13 @@ class HealthSupportTest {
         final JsonObject json = response.json();
         assertThat(json.getJsonArray("checks"), notNullValue());
         assertThat(json.getJsonArray("checks"), hasSize(brokenChecks.size()));
+    }
+
+    @Test
+    void checkLazyFaultToleranceInitialization() {
+        HealthSupport support = HealthSupport.create();
+        assertThat(support, notNullValue());
+        assertThat(FaultTolerance.initialized(), is(false));
     }
 
     private static final class GoodHealthCheck implements HealthCheck {


### PR DESCRIPTION
Use lazy values to initialized HealthSupport FT handlers. Early initialization of these handlers may result in improperly configured FT thread pools. Thread pool sizes may be overridden by the FT CDI extension which isn't guaranteed to run before the Health CDI extension. New test.
