### PR TITLE
3.x: Do not generate CDS archive when using Dockerfile.jlink 

### DIFF
--- a/archetypes/helidon/src/main/archetype/common/files/Dockerfile.jlink.mustache
+++ b/archetypes/helidon/src/main/archetype/common/files/Dockerfile.jlink.mustache
@@ -13,7 +13,8 @@ RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests
+# Don't generate CDS archive to work around JVM bug https://bugs.openjdk.org/browse/JDK-8274944
+RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests -Djlink.image.addClassDataSharingArchive=false
 RUN echo "done!"
 
 # 2nd stage, build the final image with the JRI built in the 1st stage

--- a/examples/integrations/neo4j/neo4j-mp/Dockerfile.jlink
+++ b/examples/integrations/neo4j/neo4j-mp/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/integrations/neo4j/neo4j-mp/Dockerfile.jlink
+++ b/examples/integrations/neo4j/neo4j-mp/Dockerfile.jlink
@@ -28,7 +28,8 @@ RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests
+# Don't generate CDS archive to work around JVM bug https://bugs.openjdk.org/browse/JDK-8274944
+RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests -Djlink.image.addClassDataSharingArchive=false
 RUN echo "done!"
 
 # 2nd stage, build the final image with the JRI built in the 1st stage

--- a/examples/integrations/neo4j/neo4j-se/Dockerfile.jlink
+++ b/examples/integrations/neo4j/neo4j-se/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/integrations/neo4j/neo4j-se/Dockerfile.jlink
+++ b/examples/integrations/neo4j/neo4j-se/Dockerfile.jlink
@@ -28,7 +28,8 @@ RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests
+# Don't generate CDS archive to work around JVM bug https://bugs.openjdk.org/browse/JDK-8274944
+RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests -Djlink.image.addClassDataSharingArchive=false
 RUN echo "done!"
 
 # 2nd stage, build the final image with the JRI built in the 1st stage

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
@@ -28,7 +28,8 @@ RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests
+# Don't generate CDS archive to work around JVM bug https://bugs.openjdk.org/browse/JDK-8274944
+RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests -Djlink.image.addClassDataSharingArchive=false
 RUN echo "done!"
 
 # 2nd stage, build the final image with the JRI built in the 1st stage

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
@@ -28,7 +28,8 @@ RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests
+# Don't generate CDS archive to work around JVM bug https://bugs.openjdk.org/browse/JDK-8274944
+RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests -Djlink.image.addClassDataSharingArchive=false
 RUN echo "done!"
 
 # 2nd stage, build the final image with the JRI built in the 1st stage

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
@@ -28,7 +28,8 @@ RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests
+# Don't generate CDS archive to work around JVM bug https://bugs.openjdk.org/browse/JDK-8274944
+RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests -Djlink.image.addClassDataSharingArchive=false
 RUN echo "done!"
 
 # 2nd stage, build the final image with the JRI built in the 1st stage

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
@@ -28,7 +28,8 @@ RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests
+# Don't generate CDS archive to work around JVM bug https://bugs.openjdk.org/browse/JDK-8274944
+RUN mvn -Ddocker.build=true package -Pjlink-image -DskipTests -Djlink.image.addClassDataSharingArchive=false
 RUN echo "done!"
 
 # 2nd stage, build the final image with the JRI built in the 1st stage


### PR DESCRIPTION

This is to workaround https://bugs.openjdk.org/browse/JDK-8274944 until we upgrade docker images to Java 17.0.3 or newer.