### PR TITLE
Make Github pipeline more robust by increasing HTTP ttl and adding a retry

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -103,7 +103,7 @@ jobs:
           cache: maven
       - name: Maven build
         run: |
-          mvn -B -e "-Dmaven.test.skip=true" ${MAVEN_HTTP_ARGS} -DskipTests -Ppipeline install 
+          mvn -B -e "-Dmaven.test.skip=true" $MAVEN_HTTP_ARGS -DskipTests -Ppipeline install 
           cd examples
           mvn -B verify
   mp-tck:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,7 @@ env:
   JAVA_VERSION: '19'
   JAVA_DISTRO: 'temurin'
   HELIDON_PIPELINES: 'true'
+  MAVEN_HTTP_ARGS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -102,7 +103,7 @@ jobs:
           cache: maven
       - name: Maven build
         run: |
-          mvn -B -e "-Dmaven.test.skip=true" -DskipTests -Ppipeline install 
+          mvn -B -e "-Dmaven.test.skip=true" ${MAVEN_HTTP_ARGS} -DskipTests -Ppipeline install 
           cd examples
           mvn -B verify
   mp-tck:

--- a/etc/scripts/includes/pipeline-env.sh
+++ b/etc/scripts/includes/pipeline-env.sh
@@ -67,7 +67,7 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
 
     if [ -n "${HELIDON_PIPELINES}" ] ; then
       export PIPELINE="true"
-      MAVEN_ARGS="${MAVEN_ARGS} -B"
+      MAVEN_ARGS="${MAVEN_ARGS} -B -Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3"
       export MAVEN_ARGS
       # temporary fix for copyright plugin (currently fails on big renaming action for Nima)
       git config diff.renameLimit 32768

--- a/etc/scripts/includes/pipeline-env.sh
+++ b/etc/scripts/includes/pipeline-env.sh
@@ -67,7 +67,7 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
 
     if [ -n "${HELIDON_PIPELINES}" ] ; then
       export PIPELINE="true"
-      MAVEN_ARGS="${MAVEN_ARGS} -B -Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3"
+      MAVEN_ARGS="${MAVEN_ARGS} -B ${MAVEN_HTTP_ARGS}"
       export MAVEN_ARGS
       # temporary fix for copyright plugin (currently fails on big renaming action for Nima)
       git config diff.renameLimit 32768


### PR DESCRIPTION
Make Github pipeline more robust by increasing HTTP ttl and adding a retry.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>