### PR TITLE
Updated test to use in-memory logging handler to avoid problems with flushing

### DIFF
--- a/nima/tests/integration/webserver/access-log/src/test/resources/logging-test.properties
+++ b/nima/tests/integration/webserver/access-log/src/test/resources/logging-test.properties
@@ -20,9 +20,8 @@ java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS %4$s %3$s %5$s%6$s%n
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
 io.helidon.nima.level=FINEST
-io.helidon.nima.webserver.accesslog.AccessLogHandler.level=FINEST
-io.helidon.nima.webserver.accesslog.AccessLogHandler.pattern=access.log
-io.helidon.nima.webserver.accesslog.AccessLogHandler.append=false
+io.helidon.nima.webserver.accesslog.MemoryLogHandler.level=FINEST
+io.helidon.nima.webserver.accesslog.MemoryLogHandler.append=false
 io.helidon.nima.webserver.AccessLog.level=INFO
 io.helidon.nima.webserver.AccessLog.useParentHandlers=false
-io.helidon.nima.webserver.AccessLog.handlers=io.helidon.nima.webserver.accesslog.AccessLogHandler
+io.helidon.nima.webserver.AccessLog.handlers=io.helidon.nima.tests.integration.server.accesslog.AccessLogTest$MemoryLogHandler

--- a/nima/webserver/access-log/src/main/java/io/helidon/nima/webserver/accesslog/AccessLogFilter.java
+++ b/nima/webserver/access-log/src/main/java/io/helidon/nima/webserver/accesslog/AccessLogFilter.java
@@ -93,7 +93,9 @@ public final class AccessLogFilter implements Filter {
         try {
             chain.proceed();
         } finally {
-            log(req, res, now, nanoNow);
+            if (enabled) {
+                log(req, res, now, nanoNow);
+            }
         }
     }
 


### PR DESCRIPTION
Updated test to use in-memory logging handler to avoid problems with flushing data to disk. This PR also fixes a bug in AccessLogFilter where the enable flag was ignored.