### PR TITLE
(3.x)  Document config.require-encryption

### DIFF
--- a/docs/includes/security/providers/http-basic-auth.adoc
+++ b/docs/includes/security/providers/http-basic-auth.adoc
@@ -48,6 +48,8 @@ See the link:{helidon-github-tree-url}/master/examples/security/outbound-overrid
 .Configuration example
 ----
 security:
+  config.require-encryption: false
+security:
   providers:
   - http-basic-auth:
       realm: "helidon"

--- a/docs/includes/security/providers/http-digest-auth.adoc
+++ b/docs/includes/security/providers/http-digest-auth.adoc
@@ -46,6 +46,8 @@ include::{rootdir}/config/io_helidon_security_providers_httpauth_HttpDigestAuthP
 .Configuration example
 ----
 security:
+  config.require-encryption: false
+security:
   providers:
   - http-digest-auth:
       realm: "helidon"

--- a/docs/includes/security/providers/http-signatures.adoc
+++ b/docs/includes/security/providers/http-signatures.adoc
@@ -49,6 +49,8 @@ See the link:{helidon-github-tree-url}/master/examples/security/webserver-signat
 .Configuration example
 ----
 security:
+  config.require-encryption: false
+security:
   providers:
     - http-signatures:
         inbound:

--- a/docs/includes/security/providers/oidc.adoc
+++ b/docs/includes/security/providers/oidc.adoc
@@ -32,6 +32,8 @@ See the link:{helidon-github-tree-url}/examples/security/idcs-login[example] on 
 .Configuration example
 ----
 security:
+  config.require-encryption: false
+security:
   providers:
   - oidc:
       client-id: "client-id-of-this-service"

--- a/docs/mp/security/providers.adoc
+++ b/docs/mp/security/providers.adoc
@@ -49,6 +49,16 @@ The following providers are no longer evolved:
 |<<JWT Provider,JWT Provider>> |Authentication |✅ |JWT tokens passed from frontend
 |===
 
+**Note**: If the example code uses clear-text passwords in configuration, ensure that you add the following to the code snippet:
+
+[source,]
+----
+security:
+  config.require-encryption: false
+----
+If set to `true`, an exception is thrown. However, in a production environment, you would set this value to `true` so that any attempt to pass a clear-text password throws an exception.
+
+
 === OIDC Provider [[OIDC-Provider]]
 Open ID Connect security provider.
 


### PR DESCRIPTION
Fixes #4810 

Update security providers docs to document `config.require-encryption`.