### PR TITLE
Use Hamcrest assertions instead of JUnit in  tests/integration/webclient (#1749)

### DIFF
--- a/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/RequestTest.java
+++ b/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/RequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import io.helidon.webclient.WebClientResponse;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -59,7 +58,7 @@ public class RequestTest extends TestParent {
     public void testHelloWorld() throws ExecutionException, InterruptedException {
         webClient.get()
                 .request(JsonObject.class)
-                .thenAccept(jsonObject -> Assertions.assertEquals("Hello World!", jsonObject.getString("message")))
+                .thenAccept(jsonObject -> assertThat(jsonObject.getString("message"), is("Hello World!")))
                 .toCompletableFuture()
                 .get();
     }
@@ -84,7 +83,7 @@ public class RequestTest extends TestParent {
         webClient.get()
                 .path("/redirect")
                 .request(JsonObject.class)
-                .thenAccept(jsonObject -> Assertions.assertEquals("Hello World!", jsonObject.getString("message")))
+                .thenAccept(jsonObject -> assertThat(jsonObject.getString("message"), is("Hello World!")))
                 .toCompletableFuture()
                 .get();
 
@@ -103,7 +102,7 @@ public class RequestTest extends TestParent {
                 .path("/redirectPath")
                 .request(JsonObject.class)
                 .await();
-        Assertions.assertEquals("Hello World!", jsonObject.getString("message"));
+        assertThat(jsonObject.getString("message"), is("Hello World!"));
     }
 
     @Test
@@ -132,10 +131,10 @@ public class RequestTest extends TestParent {
         webClient.put()
                 .path("/greeting")
                 .submit(JSON_NEW_GREETING)
-                .thenAccept(response -> Assertions.assertEquals(204, response.status().code()))
+                .thenAccept(response -> assertThat(response.status().code(), is(204)))
                 .thenCompose(nothing -> webClient.get()
                         .request(JsonObject.class))
-                .thenAccept(jsonObject -> Assertions.assertEquals("Hola World!", jsonObject.getString("message")))
+                .thenAccept(jsonObject -> assertThat(jsonObject.getString("message"), is("Hola World!")))
                 .thenCompose(nothing -> webClient.put()
                         .path("/greeting")
                         .submit(JSON_OLD_GREETING))


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Backport 2.x](https://github.com/helidon-io/helidon/pull/5197)