### PR TITLE
4.x: Support for optional entity in Níma.

### DIFF
--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
@@ -17,9 +17,11 @@
 package io.helidon.nima.webserver.http;
 
 import java.io.OutputStream;
+import java.util.Optional;
 
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.HeaderName;
+import io.helidon.common.http.NotFoundException;
 import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.uri.UriQuery;
 
@@ -96,6 +98,15 @@ public interface ServerResponse {
      * @param entity entity object
      */
     void send(Object entity);
+
+    /**
+     * Send an entity if present, throw {@link io.helidon.common.http.NotFoundException} if empty.
+     *
+     * @param entity entity as an optional
+     */
+    default void send(Optional<?> entity) {
+        send(entity.orElseThrow(() -> new NotFoundException("")));
+    }
 
     /**
      * Whether this response has been sent.


### PR DESCRIPTION
This is useful when integrating with databases, where a repository API returns an Optional, and we can simply send it to response.
If this method does not exist on `ServerRespose`, developer must unpack each `Optional` returned from any API and handle the `404` manually.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>