### PR TITLE
3.x: Suppress false positive on  helidon-webserver-access-log

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -370,5 +370,13 @@
    <cve>CVE-2022-34917</cve>
 </suppress>
 
+<!-- False Postive. This CVE is against accesslog_project:accesslog not helidon-webserver-access-log -->
+<suppress>
+   <notes><![CDATA[
+   file name: helidon-webserver-access-log-3.0.2.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.helidon\.webserver/helidon\-webserver\-access\-log@.*$</packageUrl>
+   <cve>CVE-2022-25760</cve>
+</suppress>
 
 </suppressions>


### PR DESCRIPTION
Showed up in a scan of Helidon 3.0.2 release.