### PR TITLE
Use Hamcrest assertions instead of JUnit in  examples/quickstarts/helidon-quickstart-se - backport-2.x (#1749)

### DIFF
--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -72,6 +72,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
             <scope>test</scope>

--- a/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
@@ -32,7 +32,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 class MainTest {
 
@@ -74,37 +75,37 @@ class MainTest {
                 .path("/greet")
                 .request(JsonObject.class)
                 .await();
-        assertEquals("Hello World!", jsonObject.getString("message"));
+        assertThat(jsonObject.getString("message"), is("Hello World!"));
 
         jsonObject = webClient.get()
                 .path("/greet/Joe")
                 .request(JsonObject.class)
                 .await();
-        assertEquals("Hello Joe!", jsonObject.getString("message"));
+        assertThat(jsonObject.getString("message"), is("Hello Joe!"));
 
         response = webClient.put()
                 .path("/greet/greeting")
                 .submit(TEST_JSON_OBJECT)
                 .await();
-        assertEquals(204, response.status().code());
+        assertThat(response.status().code(), is(204));
 
         jsonObject = webClient.get()
                 .path("/greet/Joe")
                 .request(JsonObject.class)
                 .await();
-        assertEquals("Hola Joe!", jsonObject.getString("message"));
+        assertThat(jsonObject.getString("message"), is("Hola Joe!"));
 
         response = webClient.get()
                 .path("/health")
                 .request()
                 .await();
-        assertEquals(200, response.status().code());
+        assertThat(response.status().code(), is(200));
 
         response = webClient.get()
                 .path("/metrics")
                 .request()
                 .await();
-        assertEquals(200, response.status().code());
+        assertThat(response.status().code(), is(200));
     }
 
 }


### PR DESCRIPTION
Part of #1749 

I've already signed OCA. It's an automation problem.

[Original PR](https://github.com/helidon-io/helidon/pull/5205)