### PR TITLE
4.x: various fixes for validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,5 @@
 # Notes
-# - cannot run on windows, as we use shell scripts
+# - cannot run on Windows, as we use shell scripts
 # - removed macos-latest from most jobs to speed up the process
 
 name: "Validate"
@@ -19,13 +19,13 @@ concurrency:
 jobs:
   copyright:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0
      - name: Set up JDK 19
-       uses: actions/setup-java@v3
+       uses: actions/setup-java@v3.6.0
        with:
          distribution: ${{ env.JAVA_DISTRO }}
          java-version: ${{ env.JAVA_VERSION }}
@@ -34,11 +34,11 @@ jobs:
        run: etc/scripts/copyright.sh
   checkstyle:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -47,11 +47,11 @@ jobs:
         run: etc/scripts/checkstyle.sh
   spotbugs:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -60,11 +60,11 @@ jobs:
         run: etc/scripts/spotbugs.sh
   docs:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -75,12 +75,12 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -91,12 +91,12 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-20.04, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -111,12 +111,12 @@ jobs:
     name: "MicroProfile TCKs"
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -127,12 +127,12 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -143,12 +143,12 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest]
+        os: [ ubuntu-20.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}

--- a/etc/scripts/copyright.sh
+++ b/etc/scripts/copyright.sh
@@ -30,6 +30,8 @@ readonly RESULT_FILE=$(mktemp -t XXXcopyright-result)
 
 die() { echo "${1}" ; exit 1 ;}
 
+which mvn
+
 mvn ${MAVEN_ARGS} \
         -f ${WS_DIR}/pom.xml \
         -Dhelidon.enforcer.output.file="${RESULT_FILE}" \

--- a/etc/scripts/copyright.sh
+++ b/etc/scripts/copyright.sh
@@ -30,8 +30,6 @@ readonly RESULT_FILE=$(mktemp -t XXXcopyright-result)
 
 die() { echo "${1}" ; exit 1 ;}
 
-which mvn
-
 mvn ${MAVEN_ARGS} \
         -f ${WS_DIR}/pom.xml \
         -Dhelidon.enforcer.output.file="${RESULT_FILE}" \

--- a/pom.xml
+++ b/pom.xml
@@ -1423,11 +1423,6 @@ helidon-parent,helidon-dependencies,helidon-bom,helidon-se,helidon-mp,io.grpc,he
         </profile>
         <profile>
             <id>toolchain</id>
-            <activation>
-                <file>
-                    <exists>${user.home}/.m2/toolchains.xml</exists>
-                </file>
-            </activation>
             <properties>
                 <jdkToolchainVersion>${java.vm.specification.version}</jdkToolchainVersion>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.arquillian>1.7.0.Alpha10</version.lib.arquillian>
-        <version.lib.asm>6.0</version.lib.asm>
+        <version.lib.asm>9.4</version.lib.asm>
         <version.lib.checkstyle>9.1</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <!-- Silence javadoc error org.jboss.logging.annotations.Message$Format not found -->
@@ -219,14 +219,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.plugin.compiler}</version>
-                    <dependencies>
-                        <!-- Force upgrade asm to handle Java 19 -->
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>9.4</version>
-                        </dependency>
-                    </dependencies>
                     <configuration>
                         <source>${version.java}</source>
                         <target>${version.java}</target>
@@ -240,6 +232,13 @@
                             <arg>-Xpkginfo:always</arg>
                         </compilerArgs>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>${version.lib.asm}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -403,10 +402,15 @@
                             <sourceFileExclude>**/target/**/*.java</sourceFileExclude>
                             <sourceFileExclude>**/*_.java</sourceFileExclude>
                         </sourceFileExcludes>
-                        <dependencySourceExcludes>
-
-                        </dependencySourceExcludes>
+                        <dependencySourceExcludes></dependencySourceExcludes>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>${version.lib.asm}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -439,6 +443,13 @@
                         <argLine>${surefire.argLine} ${surefire.coverage.argline}</argLine>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>${version.lib.asm}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -680,12 +691,12 @@
                         <dependency>
                             <groupId>org.ow2.asm</groupId>
                             <artifactId>asm</artifactId>
-                            <version>${version.lib.asm}</version>
+                            <version>6.0</version>
                         </dependency>
                         <dependency>
                             <groupId>org.ow2.asm</groupId>
                             <artifactId>asm-commons</artifactId>
-                            <version>${version.lib.asm}</version>
+                            <version>6.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,7 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.arquillian>1.7.0.Alpha10</version.lib.arquillian>
-        <!-- Force upgrade asm to handle Java 19 -->
-        <version.lib.asm>9.3</version.lib.asm>
+        <version.lib.asm>6.0</version.lib.asm>
         <version.lib.checkstyle>9.1</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <!-- Silence javadoc error org.jboss.logging.annotations.Message$Format not found -->
@@ -221,10 +220,11 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.plugin.compiler}</version>
                     <dependencies>
+                        <!-- Force upgrade asm to handle Java 19 -->
                         <dependency>
                             <groupId>org.ow2.asm</groupId>
                             <artifactId>asm</artifactId>
-                            <version>${version.lib.asm}</version>
+                            <version>9.3</version>
                         </dependency>
                     </dependencies>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
                         <dependency>
                             <groupId>org.ow2.asm</groupId>
                             <artifactId>asm</artifactId>
-                            <version>9.3</version>
+                            <version>9.4</version>
                         </dependency>
                     </dependencies>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,8 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.arquillian>1.7.0.Alpha10</version.lib.arquillian>
-        <version.lib.asm>6.0</version.lib.asm>
+        <!-- Force upgrade asm to handle Java 19 -->
+        <version.lib.asm>9.3</version.lib.asm>
         <version.lib.checkstyle>9.1</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <!-- Silence javadoc error org.jboss.logging.annotations.Message$Format not found -->
@@ -219,6 +220,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.plugin.compiler}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>${version.lib.asm}</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <source>${version.java}</source>
                         <target>${version.java}</target>


### PR DESCRIPTION
When GitHub released https://github.com/actions/setup-java/releases/tag/v3.6.0 our build broke (because that release added support for toolchains, and our toolchain profile autoactivated which triggered an obscure issue with Java 19 generate module files because of on old version of ASM).

This PR addresses the asm issue and makes a few changes so that our validation builds are reproducible. Specifically:

1. Locks runner version to ubuntu-20.04 (instead of latest)
2. Locks `setup-java` action to 3.6.0 instead of latest v3
3. Upgrades asm to 9.4 in compile, javadoc and surefire plugins
4. Turns off activation of `toolchain` profile on existence of `${user.home}/.m2/toolchains.xml`

Thanks to @romain-grecourt for these changes.