### PR TITLE
Broad changes to rework headers and parameters

### DIFF
--- a/common/http/pom.xml
+++ b/common/http/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>helidon-common-context</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/http/src/main/java/io/helidon/common/http/HashHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/HashHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.helidon.common.http;
 
 import java.util.ArrayList;
@@ -31,11 +30,10 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Function;
 
 /**
- * A {@link ConcurrentSkipListMap} based {@link Parameters} implementation with
- * case-insensitive keys and immutable {@link List} of values that needs to be copied on each write.
+ * A {@link java.util.concurrent.ConcurrentSkipListMap} based {@link Headers} implementation with
+ * case-insensitive keys and immutable {@link java.util.List} of values that needs to be copied on each write.
  */
-public class HashParameters implements Parameters {
-
+public class HashHeaders implements Headers {
     private static final List<String> EMPTY_STRING_LIST = Collections.emptyList();
 
     private final ConcurrentMap<String, List<String>> content;
@@ -43,8 +41,8 @@ public class HashParameters implements Parameters {
     /**
      * Creates a new instance.
      */
-    protected HashParameters() {
-        this((Parameters) null);
+    protected HashHeaders() {
+        this((Headers) null);
     }
 
     /**
@@ -53,11 +51,11 @@ public class HashParameters implements Parameters {
      *
      * @param initialContent initial content.
      */
-    protected HashParameters(Map<String, List<String>> initialContent) {
+    protected HashHeaders(Map<String, List<String>> initialContent) {
         if (initialContent == null) {
-            content = new ConcurrentSkipListMap<>();
+            content = new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER);
         } else {
-            content = new ConcurrentSkipListMap<>();
+            content = new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER);
             for (Map.Entry<String, List<String>> entry : initialContent.entrySet()) {
                 content.compute(
                         entry.getKey(),
@@ -81,94 +79,94 @@ public class HashParameters implements Parameters {
      *
      * @param initialContent initial content.
      */
-    protected HashParameters(Parameters initialContent) {
+    protected HashHeaders(Headers initialContent) {
         this(initialContent == null ? null : initialContent.toMap());
     }
 
     /**
-     * Creates a new empty instance {@link HashParameters}.
+     * Creates a new empty instance {@link HashHeaders}.
      *
-     * @return a new instance of {@link HashParameters}.
+     * @return a new instance of {@link HashHeaders}.
      */
-    public static HashParameters create() {
-        return new HashParameters();
+    public static HashHeaders create() {
+        return new HashHeaders();
     }
 
     /**
-     * Creates a new instance {@link HashParameters} from provided data. Initial data is copied.
+     * Creates a new instance {@link HashHeaders} from provided data. Initial data is copied.
      *
      * @param initialContent initial content.
-     * @return a new instance of {@link HashParameters} initialized with the given content.
+     * @return a new instance of {@link HashHeaders} initialized with the given content.
      */
-    public static HashParameters create(Map<String, List<String>> initialContent) {
-        return new HashParameters(initialContent);
+    public static HashHeaders create(Map<String, List<String>> initialContent) {
+        return new HashHeaders(initialContent);
     }
 
     /**
-     * Creates a new instance {@link HashParameters} from provided data. Initial data is copied.
+     * Creates a new instance {@link HashHeaders} from provided data. Initial data is copied.
      *
      * @param initialContent initial content.
-     * @return a new instance of {@link HashParameters} initialized with the given content.
+     * @return a new instance of {@link HashHeaders} initialized with the given content.
      */
-    public static HashParameters create(Parameters initialContent) {
-        return new HashParameters(initialContent);
+    public static HashHeaders create(Headers initialContent) {
+        return new HashHeaders(initialContent);
     }
 
     /**
-     * Creates new instance of {@link HashParameters} as a concatenation of provided parameters.
-     * Values for keys found across the provided parameters are "concatenated" into a {@link List} entry for their respective key
-     * in the created {@link HashParameters} instance.
+     * Creates new instance of {@link HashHeaders} as a concatenation of provided headers.
+     * Values for keys found across the provided headers are "concatenated" into a {@link List} entry for their respective key
+     * in the created {@link HashHeaders} instance.
      *
-     * @param parameters parameters to concatenate.
-     * @return a new instance of {@link HashParameters} that represents the concatenation of the provided parameters.
+     * @param headers headers to concatenate.
+     * @return a new instance of {@link HashHeaders} that represents the concatenation of the provided headers.
      */
-    public static HashParameters concat(Parameters... parameters) {
-        if (parameters == null || parameters.length == 0) {
-            return new HashParameters();
+    public static HashHeaders concat(Headers... headers) {
+        if (headers == null || headers.length == 0) {
+            return new HashHeaders();
         }
-        List<Map<String, List<String>>> prms = new ArrayList<>(parameters.length);
-        for (Parameters p : parameters) {
-            if (p != null) {
-                prms.add(p.toMap());
+        List<Map<String, List<String>>> hdrs = new ArrayList<>(headers.length);
+        for (Headers h : headers) {
+            if (h != null) {
+                hdrs.add(h.toMap());
             }
         }
-        return concat(prms);
+        return concat(hdrs);
     }
 
     /**
-     * Creates new instance of {@link HashParameters} as a concatenation of provided parameters.
-     * Values for keys found across the provided parameters are "concatenated" into a {@link List} entry for their respective key
-     * in the created {@link HashParameters} instance.
+     * Creates new instance of {@link HashHeaders} as a concatenation of provided headers.
+     * Values for keys found across the provided headers are "concatenated" into a {@link List} entry for their respective key
+     * in the created {@link HashHeaders} instance.
      *
-     * @param parameters parameters to concatenate.
-     * @return a new instance of {@link HashParameters} that represents the concatenation of the provided parameters.
+     * @param headers headers to concatenate.
+     * @return a new instance of {@link HashHeaders} that represents the concatenation of the provided headers.
      */
-    public static HashParameters concat(Iterable<Parameters> parameters) {
-        ArrayList<Map<String, List<String>>> prms = new ArrayList<>();
-        for (Parameters p : parameters) {
-            if (p != null) {
-                prms.add(p.toMap());
+    public static HashHeaders concat(Iterable<Headers> headers) {
+        ArrayList<Map<String, List<String>>> hdrs = new ArrayList<>();
+        for (Headers h : headers) {
+            if (h != null) {
+                hdrs.add(h.toMap());
             }
         }
-        return concat(prms);
+        return concat(hdrs);
     }
 
-    private static HashParameters concat(List<Map<String, List<String>>> prms) {
-        if (prms.isEmpty()) {
-            return new HashParameters();
+    private static HashHeaders concat(List<Map<String, List<String>>> hdrs) {
+        if (hdrs.isEmpty()) {
+            return new HashHeaders();
         }
-        if (prms.size() == 1) {
-            return new HashParameters(prms.get(0));
+        if (hdrs.size() == 1) {
+            return new HashHeaders(hdrs.get(0));
         }
 
         Map<String, List<String>> composer = new HashMap<>();
-        for (Map<String, List<String>> prm : prms) {
-            for (Map.Entry<String, List<String>> entry : prm.entrySet()) {
+        for (Map<String, List<String>> hdr : hdrs) {
+            for (Map.Entry<String, List<String>> entry : hdr.entrySet()) {
                 List<String> strings = composer.computeIfAbsent(entry.getKey(), k -> new ArrayList<>(entry.getValue().size()));
                 strings.addAll(entry.getValue());
             }
         }
-        return new HashParameters(composer);
+        return new HashHeaders(composer);
     }
 
     private List<String> internalListCopy(String... values) {
@@ -202,13 +200,13 @@ public class HashParameters implements Parameters {
 
     @Override
     public Optional<String> first(String name) {
-        Objects.requireNonNull(name, "Parameter 'name' is null!");
+        Objects.requireNonNull(name, "Header 'name' is null!");
         return content.getOrDefault(name, EMPTY_STRING_LIST).stream().findFirst();
     }
 
     @Override
     public List<String> all(String name) {
-        Objects.requireNonNull(name, "Parameter 'name' is null!");
+        Objects.requireNonNull(name, "Header 'name' is null!");
         return content.getOrDefault(name, EMPTY_STRING_LIST);
     }
 
@@ -280,12 +278,12 @@ public class HashParameters implements Parameters {
     }
 
     @Override
-    public HashParameters putAll(Parameters parameters) {
-        if (parameters == null) {
+    public HashHeaders putAll(Headers headers) {
+        if (headers == null) {
             return this;
         }
 
-        for (Map.Entry<String, List<String>> entry : parameters.toMap().entrySet()) {
+        for (Map.Entry<String, List<String>> entry : headers.toMap().entrySet()) {
             List<String> values = entry.getValue();
             if (values != null && !values.isEmpty()) {
                 content.put(entry.getKey(), Collections.unmodifiableList(values));
@@ -295,8 +293,23 @@ public class HashParameters implements Parameters {
     }
 
     @Override
-    public HashParameters add(String key, String... values) {
-        Objects.requireNonNull(key, "Parameter 'key' is null!");
+    public Headers putAll(Parameters parameters) {
+        if (parameters == null) {
+            return this;
+        }
+
+        for (Map.Entry<String, List<String>> entry : parameters.toMap().entrySet()) {
+            List<String> values  = entry.getValue();
+            if (values != null && !values.isEmpty()) {
+                content.put(entry.getKey(), Collections.unmodifiableList(values));
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public HashHeaders add(String key, String... values) {
+        Objects.requireNonNull(key, "Header 'key' is null!");
         if (values == null || values.length == 0) {
             // do not necessarily create an entry in the map, simply immediately return
             return this;
@@ -316,7 +329,7 @@ public class HashParameters implements Parameters {
     }
 
     @Override
-    public HashParameters add(String key, Iterable<String> values) {
+    public HashHeaders add(String key, Iterable<String> values) {
         Objects.requireNonNull(key, "Parameter 'key' is null!");
         List<String> vls = internalListCopy(values);
         if (vls == null) {
@@ -338,7 +351,18 @@ public class HashParameters implements Parameters {
     }
 
     @Override
-    public HashParameters addAll(Parameters parameters) {
+    public Headers addAll(Headers headers) {
+        if (headers == null) {
+            return this;
+        }
+        for (Map.Entry<String, List<String>> entry : headers.toMap().entrySet()) {
+            add(entry.getKey(), entry.getValue());
+        }
+        return this;
+    }
+
+    @Override
+    public HashHeaders addAll(Parameters parameters) {
         if (parameters == null) {
             return this;
         }
@@ -375,10 +399,10 @@ public class HashParameters implements Parameters {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof HashParameters)) {
+        if (!(o instanceof HashHeaders)) {
             return false;
         }
-        HashParameters that = (HashParameters) o;
+        HashHeaders that = (HashHeaders) o;
         return content.equals(that.content);
     }
 

--- a/common/http/src/main/java/io/helidon/common/http/Headers.java
+++ b/common/http/src/main/java/io/helidon/common/http/Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,76 @@
 package io.helidon.common.http;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Extends {@link Parameters} interface by adding methods convenient for HTTP headers.
+ * {@code Headers} represents {@code key : value} pairs where {@code key} is a {@code String} with potentially multiple values.
+ * Look-ups use case-insensitive matching.
+ * <p>
+ * This structure represents headers in e.g. {@link HttpRequest}.
+ * <p>
+ * Interface focus on most convenient use cases in HTTP Request and Response processing, like
+ * <pre>
+ * {@code
+ * // Get and map with default
+ * .first("count").map(Integer::new).orElse(0);
+ * // Find max in multiple values
+ * .all("counts").stream().mapToInt(Integer::valueOf).max().orElse(0);
+ * }
+ * </pre>
+ * <p>
+ * Mutable operations are defined in two forms:
+ * <ul>
+ * <li>{@code put...} create or replace association.</li>
+ * <li>{@code add...} create association or add values to existing association.</li>
+ * </ul>
+ * <p>
+ * It is possible to use {@link #toMap()} method to get immutable map view of data.
+ * <p>
+ * Various static factory methods can be used to create common implementations.
  */
-public interface Headers extends Parameters {
+public interface Headers {
+
+    /**
+     * Returns an unmodifiable view.
+     *
+     * @param headers a {@code Headers} instance to be accessed in a read-only way
+     * @return An unmodifiable view.
+     * @throws NullPointerException if parameter {@code headers} is null
+     */
+    static Headers toUnmodifiableHeaders(Headers headers) {
+        Objects.requireNonNull(headers, "Parameter 'headers' is null!");
+        return new ReadOnlyHeaders(headers);
+    }
+
+    /**
+     * Returns an unmodifiable view.
+     *
+     * @param parameters a parameters for unmodifiable view.
+     * @return An unmodifiable view.
+     * @throws NullPointerException if parameter {@code parameters} is null.
+     * @deprecated Use {@link #toUnmodifiableHeaders(Headers)} instead
+     */
+    @Deprecated(since = "3.0.2", forRemoval = true)
+    static Parameters toUnmodifiableParameters(Parameters parameters) {
+        Objects.requireNonNull(parameters, "Parameter 'parameters' is null!");
+        return new UnmodifiableParameters(parameters);
+    }
+
+    /**
+     * Returns an {@link Optional} containing the first value of the given
+     * header (and possibly multi-valued) parameter. If the header is
+     * not present, then the returned Optional is empty.
+     *
+     * @param name the header name
+     * @return an {@code Optional<V>} for the first named value
+     * @throws NullPointerException if name is {@code null}
+     */
+    Optional<String> first(String name);
 
     /**
      * Returns an unmodifiable {@link List} of all header fields - each element represents a value of a single header field
@@ -37,8 +100,154 @@ public interface Headers extends Parameters {
      * @see #value(String)
      * @see #values(String)
      */
-    @Override
     List<String> all(String headerName);
+
+    /**
+     * Associates specified values with the specified key (optional operation).
+     * If the {@code Headers} previously contained a mapping for the key, the old values fully replaced.
+     *
+     * @param key    key with which the specified value is to be associated
+     * @param values value to be associated with the specified key
+     * @return the previous values associated with key, or empty {@code List} if there was no mapping for key.
+     * @throws NullPointerException          if the specified key is null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     */
+    List<String> put(String key, String... values);
+
+    /**
+     * Associates specified values with the specified key (optional operation).
+     * If the {@code Headers} previously contained a mapping for the key, the old values fully replaced.
+     *
+     * @param key    key with which the specified value is to be associated
+     * @param values value to be associated with the specified key. If {@code null} then association will be removed.
+     * @return the previous values associated with key, or empty {@code List} if there was no mapping for key.
+     * @throws NullPointerException          if the specified key is null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     */
+    List<String> put(String key, Iterable<String> values);
+
+    /**
+     * If the specified key is not already associated with a value associates it with the given value and returns empty
+     * {@code List}, else returns the current value  (optional operation).
+     *
+     * @param key    key with which the specified value is to be associated
+     * @param values value to be associated with the specified key
+     * @return the previous values associated with key, or empty {@code List} if there was no mapping for key.
+     * @throws NullPointerException          if the specified key is null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     */
+    List<String> putIfAbsent(String key, String... values);
+
+    /**
+     * If the specified key is not already associated with a value associates it with the given value and returns empty
+     * {@code List}, else returns the current value  (optional operation).
+     *
+     * @param key    key with which the specified value is to be associated
+     * @param values value to be associated with the specified key
+     * @return the previous values associated with key, or empty {@code List} if there was no mapping for key.
+     * @throws NullPointerException          if the specified key is null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     */
+    List<String> putIfAbsent(String key, Iterable<String> values);
+
+    /**
+     * If the specified key is not already associated with a value computes new association using the given function and returns
+     * empty {@code List}, else returns the current value  (optional operation).
+     *
+     * @param key    key with which the specified value is to be associated
+     * @param values value to be associated with the specified key
+     * @return the current (potentially computed) values associated with key,
+     * or empty {@code List} if function returns {@code null}
+     * @throws NullPointerException          if the specified key is null
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers)
+     * @throws IllegalStateException         if the computation detectably
+     *                                       attempts a recursive update to this map that would
+     *                                       otherwise never complete
+     * @throws RuntimeException              or Error if the mappingFunction does so,
+     *                                       in which case the mapping is left unestablished
+     */
+    List<String> computeIfAbsent(String key, Function<String, Iterable<String>> values);
+
+    /**
+     * If the specified key is not already associated with a value computes new association using the given function and returns
+     * empty {@code List}, else returns the current value  (optional operation).
+     *
+     * @param key   a key with which the specified value is to be associated
+     * @param value a single value to be associated with the specified key
+     * @return the current (potentially computed) values associated with key,
+     * or empty {@code List} if function returns {@code null}
+     * @throws NullPointerException          if the specified key is null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     * @throws IllegalStateException         if the computation detectably
+     *                                       attempts a recursive update to this map that would
+     *                                       otherwise never complete
+     * @throws RuntimeException              or Error if the mappingFunction does so,
+     *                                       in which case the mapping is left unestablished
+     */
+    List<String> computeSingleIfAbsent(String key, Function<String, String> value);
+
+    /**
+     * Copies all of the mappings from the specified {@code headers} to this instance replacing values of existing associations
+     * (optional operation).
+     *
+     * @param headers to copy.
+     * @return this instance of {@link Headers}
+     * @throws NullPointerException          if the specified {@code parameters} are null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     */
+    Headers putAll(Headers headers);
+
+    /**
+     * Adds specified values to association with the specified key (optional operation).
+     * If headers doesn't contains mapping, new mapping is created.
+     *
+     * @param key    key with which the specified value is to be associated
+     * @param values value to be add to association with the specified key
+     * @return this instance of {@link Headers}
+     * @throws NullPointerException          if the specified key is null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable headers).
+     */
+    Headers add(String key, String... values);
+
+    /**
+     * Adds specified values to association with the specified key (optional operation).
+     * If headers doesn't contains mapping, new mapping is created.
+     *
+     * @param key    key with which the specified value is to be associated
+     * @param values value to be add to association with the specified key. If {@code null} then noting will be add.
+     * @return this instance of {@link Headers}
+     * @throws NullPointerException          if the specified key is null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     */
+    Headers add(String key, Iterable<String> values);
+
+    /**
+     * Copies all of the mappings from the specified {@code headers} to this instance adding values to existing associations
+     * (optional operation).
+     *
+     * @param headers to copy.
+     * @return this instance of {@link Headers}
+     * @throws NullPointerException          if the specified {@code parameters} are null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     */
+    Headers addAll(Headers headers);
+
+    /**
+     * Removes the mapping for a key if it is present (optional operation).
+     *
+     * @param key key whose mapping is to be removed.
+     * @return the previous value associated with key, or empty {@code List}.
+     */
+    List<String> remove(String key);
+
+    /**
+     * Returns a copy of headers as a Map. This
+     * interface should only be used when it is required to iterate over the
+     * entire set of headers.
+     *
+     * @return the {@code Map}
+     */
+    Map<String, List<String>> toMap();
 
     /**
      * Returns a header value as a single {@link String} potentially concatenated using comma character
@@ -90,4 +299,29 @@ public interface Headers extends Parameters {
                 .flatMap(val -> Utils.tokenize(',', "\"", true, val).stream())
                 .collect(Collectors.toList());
     }
+
+    /**
+     * Copies all the parameters into the current {@code Headers} instance.
+     *
+     * @param parameters to copy.
+     * @return this instance of {@link Headers}
+     * @throws NullPointerException if the specified {@code parameters} are null
+     * @throws UnsupportedOperationException if the {@code putAll} operation is not supported (unmodifiable Headers).
+     * @deprecated Use {@link #putAll(Headers)} instead.
+     */
+    @Deprecated(since = "3.0.2", forRemoval = true)
+    Headers putAll(Parameters parameters);
+
+    /**
+     * Copies all of the mappings from the specified {@code parameters} to this instance adding values to existing associations
+     * (optional operation).
+     *
+     * @param parameters to copy.
+     * @return this instance of {@link Headers}
+     * @throws NullPointerException          if the specified {@code parameters} are null.
+     * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Headers).
+     * @deprecated Use {@link #addAll(Headers)} instead.
+     */
+    @Deprecated(since = "3.0.2", forRemoval = true)
+    Headers addAll(Parameters parameters);
 }

--- a/common/http/src/main/java/io/helidon/common/http/Parameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/Parameters.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 /**
  * Parameters represents {@code key : value} pairs where {@code key} is a {@code String} with potentially multiple values.
  * <p>
- * This structure represents query parameters, headers and path parameters in e.g. {@link HttpRequest}.
+ * This structure represents query parameters and path parameters in e.g. {@link HttpRequest}.
  * <p>
  * Interface focus on most convenient use cases in HTTP Request and Response processing, like
  * <pre>

--- a/common/http/src/main/java/io/helidon/common/http/ReadOnlyHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/ReadOnlyHeaders.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.http;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static io.helidon.common.http.ReadOnlyParameters.copyMultimapAsImmutable;
+
+/**
+ * An immutable implementation of {@link Headers}.
+ *
+ * @see Headers
+ */
+public class ReadOnlyHeaders extends HashHeaders {
+
+    private static final ReadOnlyHeaders EMPTY = new ReadOnlyHeaders((Headers) null);
+
+    /**
+     * Creates an instance from provided multi-map.
+     *
+     * @param data multi-map data to copy.
+     */
+    public ReadOnlyHeaders(Map<String, List<String>> data) {
+        super(copyMultimapAsImmutable(data));
+    }
+
+    /**
+     * Creates an instance from provided {@code Headers}.
+     *
+     * @param headers headers to copy.
+     */
+    public ReadOnlyHeaders(Headers headers) {
+        this(headers == null ? null : headers.toMap());
+    }
+
+    /**
+     * Returns empty and immutable singleton.
+     *
+     * @return the headers singleton instance which is empty and immutable.
+     */
+    public static ReadOnlyHeaders empty() {
+        return EMPTY;
+    }
+
+    @Override
+    public List<String> put(String key, String... values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> put(String key, Iterable<String> values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> putIfAbsent(String key, String... values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> putIfAbsent(String key, Iterable<String> values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> computeIfAbsent(String key, Function<String, Iterable<String>> values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReadOnlyHeaders putAll(Parameters parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReadOnlyHeaders add(String key, String... values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReadOnlyHeaders add(String key, Iterable<String> values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> computeSingleIfAbsent(String key, Function<String, String> value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReadOnlyHeaders addAll(Parameters parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> remove(String key) {
+        throw new UnsupportedOperationException();
+    }
+
+
+}

--- a/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.Function;
 
 /**
@@ -45,7 +44,7 @@ public class ReadOnlyParameters implements Parameters {
      * @param data multi-map data to copy.
      */
     public ReadOnlyParameters(Map<String, List<String>> data) {
-        this.data = copyMultimapAsImutable(data);
+        this.data = copyMultimapAsImmutable(data);
     }
 
     /**
@@ -71,13 +70,25 @@ public class ReadOnlyParameters implements Parameters {
      *
      * @param data data to copy, if {@code null} then returns empty map.
      * @return unmodifiable map, never {@code null}.
+     * @deprecated Use {@link #copyMultimapAsImmutable(java.util.Map)} instead
      */
+    @Deprecated(since = "3.0.2", forRemoval = true)
     static Map<String, List<String>> copyMultimapAsImutable(Map<String, List<String>> data) {
+        return copyMultimapAsImmutable(data);
+    }
+
+    /**
+     * Returns a deep copy of provided multi-map which is completely unmodifiable.
+     *
+     * @param data data to copy, if {@code null} then returns empty map.
+     * @return unmodifiable map, never {@code null}.
+     */
+    static Map<String, List<String>> copyMultimapAsImmutable(Map<String, List<String>> data) {
         if (data == null || data.isEmpty()) {
             return Collections.emptyMap();
         } else {
             // Deep copy
-            Map<String, List<String>> h = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            Map<String, List<String>> h = new HashMap<>();
             data.forEach((k, v) -> h.put(k, Collections.unmodifiableList(new ArrayList<>(v))));
             return Collections.unmodifiableMap(h);
         }

--- a/common/http/src/test/java/io/helidon/common/http/CaseSensitivityTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/CaseSensitivityTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.http;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.testing.CaseSensitivityTester.testMap;
+import static io.helidon.config.testing.CaseSensitivityTester.testStrict;
+
+class CaseSensitivityTest  {
+
+    @Test
+    void testFormParamsImpl() {
+        FormParams.Builder builder = FormParams.builder();
+        testMap().forEach((k, v) -> builder.add(k, v.toArray(new String[0])));
+        testStrict(builder.build(), FormParams::all);
+    }
+
+    @Test
+    void testHashParameters() {
+        testStrict(HashParameters.create(testMap()), HashParameters::all);
+    }
+
+    @Test
+    void testReadOnlyParameters() {
+        testStrict(new ReadOnlyParameters(testMap()), ReadOnlyParameters::all);
+    }
+
+    @Test
+    void testUnmodifiableParameters() {
+        testStrict(new UnmodifiableParameters(new ReadOnlyParameters(testMap())), UnmodifiableParameters::all);
+    }
+}

--- a/config/testing/src/main/java/io/helidon/config/testing/CaseSensitivityTester.java
+++ b/config/testing/src/main/java/io/helidon/config/testing/CaseSensitivityTester.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.config.testing;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+
+/**
+ * Simple framework for checking case-sensitive or case-insensitive behavior of containers such as headers and parameters.
+ */
+public class CaseSensitivityTester {
+    private static final String VLOWER = "lower";
+    private static final String VMIXED = "Mixed";
+    private static final String VUPPER = "UPPER";
+    private static final String VLIST = "LiSt";
+    private static final List<String> LIST_VALUES = List.of("v1", "v2");
+
+
+    private static final Map<String, List<String>> TEST_MAP = Map.of(
+            VLOWER, List.of("lower-value"),
+            VMIXED, List.of("Mixed-value"),
+            VUPPER, List.of("UPPER_value"),
+            VLIST, LIST_VALUES);
+
+    // Maps each key to its changed values we use to expect matches in headers and no matches elsewhere.
+    private static final Map<String, List<String>> CHANGED_KEYS = Map.of(
+            VLOWER, List.of(VLOWER.toUpperCase(Locale.ROOT), "Lower"),
+            VMIXED, List.of(VMIXED.toLowerCase(Locale.ROOT), VMIXED.toUpperCase(Locale.ROOT), "mIxEd"),
+            VUPPER, List.of(VUPPER.toLowerCase(Locale.ROOT), "Upper", "upper"),
+            VLIST, List.of(VLIST.toLowerCase(Locale.ROOT), VLIST.toUpperCase(Locale.ROOT), "lIsT"));
+
+    private CaseSensitivityTester() {
+    }
+
+    /**
+     *
+     * @return test map containing data to populate containers under test
+     */
+    public static Map<String, List<String>> testMap() {
+        return TEST_MAP;
+    }
+
+    /**
+     * Performs case-sensitive and case-insensitive testing of the supplied data,
+     * using strict case matching: changing the case of a valid key should return no results.
+     *
+     * @param dataStructure data structure to be tested
+     * @param valueGetter function which accepts a key and returns an {@code Iterable<String>}
+     * @param <T> type of the data structure
+     */
+    public static <T> void testStrict(T dataStructure,
+                                      BiFunction<T, String, Iterable<String>> valueGetter) {
+        // With strict treatment, using case-altered keys should return an empty iterable.
+        test(dataStructure, valueGetter, true);
+    }
+
+    /**
+     * Performs case-sensitive and case-insensitive testing of the supplied data,
+     * using lenient case matching: changing the case of a valid key should return the same results as
+     * when using the valid key.
+     *
+     * @param dataStructure data structure to be tested
+     * @param valueGetter function which accepts a key and returns an {@code Iterable<String>}
+     * @param <T> type of the data structure
+     */
+    public static <T> void testLenient(T dataStructure,
+                                       BiFunction<T, String, Iterable<String>> valueGetter) {
+        // With lenient treatment, using case-altered keys should return the same values as the unaltered key would.
+        test(dataStructure, valueGetter, false);
+    }
+
+    /**
+     * Makes sure that the data structure (headers, parameters, etc.) responds with the correct values when using the exact
+     * keys and also responds with either values or nothing when using case-altered keys, whichever is correct for the data
+     * structure. (The test data is set up so that case-altered keys are not actually present in the data structure.)
+     *
+     * @param dataStructure the data structure containing key/list-of-values pairs
+     * @param valueGetter function which accepts a key and returns the corresponding list of values
+     * @param isStrict whether the check should be strict (vs. lenient)
+     * @param <T> type of the data structure being queried (inferred from the arguments)
+     */
+    private static <T> void test(T dataStructure,
+                                 BiFunction<T, String, Iterable<String>> valueGetter,
+                                 boolean isStrict) {
+        // Use the correct keys which should always return the expected value from the data structure.
+        for (Map.Entry<String, List<String>> entry : TEST_MAP.entrySet()) {
+            String key = entry.getKey();
+            String[] expectedValue = TEST_MAP.get(key).toArray(new String[0]);
+            assertThat("Values found with key as-is '" + key + "'",
+                       valueGetter.apply(dataStructure, key),
+                       containsInAnyOrder(expectedValue));
+        }
+
+        // Use case-altered keys and check the returned values against the provided matcher, because that varies depending
+        // on which data structure we query.
+        for (Map.Entry<String, List<String>> changedKeyEntry : CHANGED_KEYS.entrySet()) {
+            String validKey = changedKeyEntry.getKey();
+            for (String changedKey : changedKeyEntry.getValue()) {
+                assertThat("Values found with key '" + validKey + "' altered to '" + changedKey + "'",
+                           valueGetter.apply(dataStructure, changedKey),
+                           isStrict ? emptyIterable() : containsInAnyOrder(TEST_MAP.get(validKey).toArray(new String[0])));
+            }
+        }
+    }
+
+
+}

--- a/jersey/connector/pom.xml
+++ b/jersey/connector/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonStructures.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonStructures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import javax.net.ssl.SSLContext;
 
 import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http;
-import io.helidon.common.http.ReadOnlyParameters;
+import io.helidon.common.http.ReadOnlyHeaders;
 import io.helidon.config.Config;
 import io.helidon.media.common.DefaultMediaSupport;
 import io.helidon.media.common.MessageBodyReader;
@@ -87,18 +87,12 @@ class HelidonStructures {
     }
 
     static boolean hasEntity(WebClientResponse webClientResponse) {
-        final ReadOnlyParameters headers = webClientResponse.content().readerContext().headers();
+        final ReadOnlyHeaders headers = webClientResponse.content().readerContext().hdrs();
         final Optional<String> contentLenth = headers.first(Http.Header.CONTENT_LENGTH);
         final Optional<String> encoding = headers.first(Http.Header.TRANSFER_ENCODING);
 
         return ((contentLenth.isPresent() && !contentLenth.get().equals("0"))
                 || (encoding.isPresent() && encoding.get().equals(HttpHeaderValues.CHUNKED.toString())));
-    }
-
-    private static class ReadOnlyHeaders extends ReadOnlyParameters implements Headers {
-        ReadOnlyHeaders(Map<String, List<String>> data) {
-            super(data);
-        }
     }
 
     private static class ProxyBuilder {

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/CaseSensitivityTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/CaseSensitivityTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.jersey.connector;
+
+import io.helidon.common.http.Headers;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.testing.CaseSensitivityTester.testLenient;
+import static io.helidon.config.testing.CaseSensitivityTester.testMap;
+
+class CaseSensitivityTest {
+
+    @Test
+    void testHelidonStructuresHeaders() {
+        Headers headers = HelidonStructures.createHeaders(testMap());
+        testLenient(headers, Headers::all);
+    }
+}

--- a/media/common/src/main/java/io/helidon/media/common/MessageBodyContext.java
+++ b/media/common/src/main/java/io/helidon/media/common/MessageBodyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,6 +204,20 @@ public abstract class MessageBodyContext implements MessageBodyFilters {
      */
     protected MessageBodyContext(MessageBodyContext parent) {
         this(parent, parent.eventListener);
+    }
+
+    /**
+     * Create a new content support instance.
+     *
+     * (This is a convenience "super" constructor so the various  {@link MessageBodyReaderContext} ctors
+     * can delegate to a common ctor.)
+     *
+     * @param parent content filters parent
+     * @param eventListener the event lister
+     * @param useExplicitEventListener whether to use the explicit event listener or not
+     */
+    protected MessageBodyContext(MessageBodyContext parent, EventListener eventListener, boolean useExplicitEventListener) {
+        this(parent, useExplicitEventListener ? eventListener : parent == null ? null : parent.eventListener);
     }
 
     /**

--- a/media/common/src/test/java/io/helidon/media/common/ContentCharsetTest.java
+++ b/media/common/src/test/java/io/helidon/media/common/ContentCharsetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.util.Optional;
 
 import io.helidon.common.http.MediaType;
-import io.helidon.common.http.ReadOnlyParameters;
+import io.helidon.common.http.ReadOnlyHeaders;
 
 import org.junit.jupiter.api.Test;
 
@@ -79,6 +79,6 @@ public class ContentCharsetTest {
             contentType = Optional.of(MediaType.parse(contentTypeValue));
         }
         return MessageBodyReaderContext.create((MediaContext) null, null,
-                                               ReadOnlyParameters.empty(), contentType);
+                                               ReadOnlyHeaders.empty(), contentType);
     }
 }

--- a/media/multipart/pom.xml
+++ b/media/multipart/pom.xml
@@ -93,5 +93,10 @@
             <artifactId>reactive-streams-tck-flow</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/media/multipart/src/main/java/io/helidon/media/multipart/MultiPartBodyWriter.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/MultiPartBodyWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public final class MultiPartBodyWriter implements MessageBodyWriter<WriteableMul
                 .subtype(mediaType.subtype())
                 .addParameter("boundary", "\"" + boundary + "\"")
                 .build();
-        context.headers().put(Http.Header.CONTENT_TYPE, mediaWithBoundary.toString());
+        context.hdrs().put(Http.Header.CONTENT_TYPE, mediaWithBoundary.toString());
         return content.flatMap(new MultiPartToChunks(boundary, context));
     }
 

--- a/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPartHeaders.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPartHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,17 @@ package io.helidon.media.multipart;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
-import io.helidon.common.http.ReadOnlyParameters;
+import io.helidon.common.http.ReadOnlyHeaders;
 
 /**
  * Readable body part headers.
  */
-public final class ReadableBodyPartHeaders extends ReadOnlyParameters implements BodyPartHeaders {
+public final class ReadableBodyPartHeaders extends ReadOnlyHeaders implements BodyPartHeaders {
 
     private final Object internalLock = new Object();
     private ContentDisposition contentDisposition;
@@ -53,6 +54,26 @@ public final class ReadableBodyPartHeaders extends ReadOnlyParameters implements
             }
         }
         return contentDisposition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ReadableBodyPartHeaders that = (ReadableBodyPartHeaders) o;
+        return Objects.equals(contentDisposition, that.contentDisposition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), contentDisposition);
     }
 
     /**

--- a/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.concurrent.Flow.Publisher;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
-import io.helidon.common.http.Parameters;
+import io.helidon.common.http.Headers;
 import io.helidon.common.reactive.Single;
 import io.helidon.common.reactive.SubscriptionHelper;
 import io.helidon.media.common.MessageBodyWriterContext;
@@ -188,10 +188,10 @@ public final class WriteableBodyPart implements BodyPart {
 
         private final Object entity;
         private final GenericType<Object> type;
-        private final Parameters headers;
+        private final Headers headers;
         private Publisher<DataChunk> publisher;
 
-        EntityBodyPartContent(Object entity, Parameters headers) {
+        EntityBodyPartContent(Object entity, Headers headers) {
             this.entity = Objects.requireNonNull(entity, "entity cannot be null!");
             this.headers = Objects.requireNonNull(headers, "headers cannot be null");
             type = GenericType.<Object>create(entity.getClass());
@@ -218,10 +218,10 @@ public final class WriteableBodyPart implements BodyPart {
 
         private final Publisher<T> stream;
         private final GenericType<T> type;
-        private final Parameters headers;
+        private final Headers headers;
         private Publisher<DataChunk> publisher;
 
-        EntityStreamBodyPartContent(Publisher<T> stream, GenericType<T> type, Parameters headers) {
+        EntityStreamBodyPartContent(Publisher<T> stream, GenericType<T> type, Headers headers) {
             this.stream = Objects.requireNonNull(stream, "entity cannot be null!");
             this.type = Objects.requireNonNull(type, "type cannot be null!");
             this.headers = Objects.requireNonNull(headers, "headers cannot be null");

--- a/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPartHeaders.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPartHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import io.helidon.common.http.HashParameters;
+import io.helidon.common.http.HashHeaders;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 
 /**
  * Writeable body part headers.
  */
-public final class WriteableBodyPartHeaders extends HashParameters implements BodyPartHeaders {
+public final class WriteableBodyPartHeaders extends HashHeaders implements BodyPartHeaders {
 
     private WriteableBodyPartHeaders(Map<String, List<String>> params) {
         super(params);

--- a/media/multipart/src/test/java/io/helidon/media/multipart/CaseSensitivityTest.java
+++ b/media/multipart/src/test/java/io/helidon/media/multipart/CaseSensitivityTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.media.multipart;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.testing.CaseSensitivityTester.testLenient;
+import static io.helidon.config.testing.CaseSensitivityTester.testMap;
+
+class CaseSensitivityTest {
+
+    @Test
+    void testReadableBodyPartHeaders() {
+        ReadableBodyPartHeaders.Builder headersBuilder = ReadableBodyPartHeaders.builder();
+        testMap().forEach((k, vs) -> vs.forEach(v -> headersBuilder.header(k, v)));
+        testLenient(headersBuilder.build(), ReadableBodyPartHeaders::all);
+    }
+
+    @Test
+    void testWriteableBodyPartHeaders() {
+        WriteableBodyPartHeaders.Builder headersBuilder = WriteableBodyPartHeaders.builder();
+        testMap().forEach((k, vs) -> vs.forEach(v -> headersBuilder.header(k, v)));
+        testLenient(headersBuilder.build(), WriteableBodyPartHeaders::all);
+    }
+
+
+}

--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -105,5 +105,61 @@
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-http</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-tracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.bedrock</groupId>
+            <artifactId>bedrock-testing-support</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/B3HeadersPropagationCaseTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Run this test in a separate JVM so we don't init GlobalOpenTelemetry multiple times. -->
+                        <id>headers-propagation-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/B3HeadersPropagationCaseTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/B3HeadersPropagationCaseTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/B3HeadersPropagationCaseTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.jaeger;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.common.http.Http;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.Tracer;
+import io.helidon.tracing.TracerBuilder;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientRequestBuilder;
+import io.helidon.webclient.WebClientRequestHeaders;
+import io.helidon.webclient.WebClientResponse;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.WebServer;
+
+import com.oracle.bedrock.runtime.LocalPlatform;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Makes sure that variation in the case of incoming headers does not affect B3 header propagation.
+ */
+class B3HeadersPropagationCaseTest {
+
+    private static final LocalPlatform localPlatform = LocalPlatform.get();
+
+    private static final String PARENT_SPAN_ID = "51b3b1a413dce011";
+    private static final String SPAN_ID = "521c61ede905945f";
+    private static final String TRACE_ID = "0000816c055dc421";
+
+    private WebServer webServer;
+    private WebClient selfClient;
+
+    @BeforeEach
+    void init() {
+        webServer = startServerWithTracing();
+        selfClient = WebClient.builder()
+                .baseUri("http://localhost:" + webServer.port())
+                .build();
+    }
+
+    @AfterEach
+    void cleanup() {
+        webServer.shutdown().await(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testB3HeaderCase() throws ExecutionException, InterruptedException, TimeoutException {
+        WebClientRequestBuilder requestBuilder = selfClient.get()
+                .path("/hello");
+
+        // Convince tracing that a span is already in progress using oddly-cased header names.
+        addB3HeadersWithNamesInOddCases(requestBuilder.headers());
+
+        WebClientResponse response = requestBuilder
+                .submit()
+                .await(15, TimeUnit.SECONDS);
+
+        try {
+            String traceIdSeenByEndpoint = response.content().as(String.class).get(5, TimeUnit.SECONDS);
+            assertThat("Hello request status (with msg " + traceIdSeenByEndpoint + ")",
+                       response.status().code(),
+                       is(200));
+            assertThat("Trace ID",
+                       traceIdSeenByEndpoint,
+                       endsWith(TRACE_ID)); // endsWith because of leading zeros
+            // The span ID seen by the service endpoint is the newly-created child span of the original span we seeded in the
+            // headers. The SpanContext does not expose its parent (primarily because underlying implementations such as OTel do
+            // not currently xpose the parent), so the endpoint cannot discover the parent span ID to send
+            // that back to the test for checking. But if the trace ID sent back matches, the oddly-cased trace ID header
+            // was correctly recognized as a B3 header.
+        } finally {
+            response.close();
+        }
+    }
+
+    private WebServer startServerWithTracing() {
+        int serverPort = localPlatform.getAvailablePorts().next();
+
+        TracerBuilder<?> tracerBuilder = TracerBuilder.create("case-test-service");
+
+        tracerBuilder.serviceName("test-service")
+                .collectorPort(serverPort);
+        tracerBuilder.unwrap(JaegerTracerBuilder.class)
+                .samplerParam(1)
+                .samplerType(JaegerTracerBuilder.SamplerType.CONSTANT);
+
+        Tracer tracer = tracerBuilder.build();
+
+        WebServer server = WebServer.builder()
+                .port(serverPort)
+                .tracer(tracer)
+                .addRouting(prepareRouting())
+                .build();
+
+        return server.start().await(15, TimeUnit.SECONDS);
+    }
+
+    private Routing.Builder prepareRouting() {
+        return Routing.builder()
+                .get("/hello", this::replyWithB3);
+    }
+
+    private void replyWithB3(ServerRequest req, ServerResponse res) {
+
+        Optional<SpanContext> spanContext = req.context().get(SpanContext.class);
+        if (spanContext.isEmpty()) {
+            res.status(Http.Status.EXPECTATION_FAILED_417)
+                    .send("No span found in endpoint");
+            return;
+        }
+
+        res.send(spanContext.get().traceId());
+    }
+
+    private void addB3HeadersWithNamesInOddCases(WebClientRequestHeaders headers) {
+        String mixedB3ParentSpanIdKey = "x-B3-ParentSpanId";
+        String upperB3SpanIdKey = "X-B3-SPANID";
+        String wildB3TraceIdKey = "X-b3-tRaCeiD";
+
+        headers.add(mixedB3ParentSpanIdKey, PARENT_SPAN_ID);
+        headers.add(upperB3SpanIdKey, SPAN_ID);
+        headers.add(wildB3TraceIdKey, TRACE_ID);
+    }
+}

--- a/tracing/tracing/src/main/java/io/helidon/tracing/MapHeaderConsumer.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/MapHeaderConsumer.java
@@ -18,13 +18,14 @@ package io.helidon.tracing;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Stream;
 
 class MapHeaderConsumer implements HeaderConsumer {
-    private final Map<String, List<String>> headers;
+    private final Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     MapHeaderConsumer(Map<String, List<String>> headers) {
-        this.headers = headers;
+        this.headers.putAll(headers);
     }
 
     @Override

--- a/tracing/zipkin/pom.xml
+++ b/tracing/zipkin/pom.xml
@@ -89,6 +89,31 @@
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-http</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.bedrock</groupId>
+            <artifactId>bedrock-testing-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.media</groupId>
+            <artifactId>helidon-media-jsonp</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tracing/zipkin/src/test/java/io/helidon/tracing/zipkin/ZipkinTracerProviderTest.java
+++ b/tracing/zipkin/src/test/java/io/helidon/tracing/zipkin/ZipkinTracerProviderTest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.helidon.config.testing.OptionalMatcher;
 import io.helidon.tracing.HeaderConsumer;
 import io.helidon.tracing.HeaderProvider;
 import io.helidon.tracing.TracerBuilder;
@@ -64,23 +65,28 @@ class ZipkinTracerProviderTest {
                 ZipkinTracerProvider.X_B3_TRACE_ID, List.of(traceId)
         );
         Map<String, List<String>> outboundHeaders = new HashMap<>();
+        HeaderConsumer headerConsumer = HeaderConsumer.create(outboundHeaders);
         provider.updateOutboundHeaders(mt,
                                        span.context(),
                                        HeaderProvider.create(inboundHeaders),
-                                       HeaderConsumer.create(outboundHeaders));
+                                       headerConsumer);
 
         // all should be propagated, X_OT should be fixed
-        List<String> values = outboundHeaders.get(ZipkinTracerProvider.X_OT_SPAN_CONTEXT);
-        assertThat(values, is(List.of("0000816c055dc421;521c61ede905945f;51b3b1a413dce011;sr")));
+        assertThat("Fixed-up X_OT header",
+                   headerConsumer.get(ZipkinTracerProvider.X_OT_SPAN_CONTEXT),
+                   OptionalMatcher.value(is("0000816c055dc421;521c61ede905945f;51b3b1a413dce011;sr")));
 
-        values = outboundHeaders.get(ZipkinTracerProvider.X_B3_PARENT_SPAN_ID);
-        assertThat(values, is(List.of(parentSpanId)));
+        assertThat("Parent span ID header",
+                   headerConsumer.get(ZipkinTracerProvider.X_B3_PARENT_SPAN_ID),
+                   OptionalMatcher.value(is(parentSpanId)));
 
-        values = outboundHeaders.get(ZipkinTracerProvider.X_B3_SPAN_ID);
-        assertThat(values, is(List.of(spanId)));
+        assertThat("Span ID header",
+                   headerConsumer.get(ZipkinTracerProvider.X_B3_SPAN_ID),
+                   OptionalMatcher.value(is(spanId)));
 
-        values = outboundHeaders.get(ZipkinTracerProvider.X_B3_TRACE_ID);
-        assertThat(values, is(List.of(traceId)));
+        assertThat("Trace ID header",
+                   headerConsumer.get(ZipkinTracerProvider.X_B3_TRACE_ID),
+        OptionalMatcher.value(is(traceId)));
     }
 
     @Test
@@ -110,22 +116,27 @@ class ZipkinTracerProviderTest {
                 ZipkinTracerProvider.X_B3_TRACE_ID, List.of("17")
         );
 
+        HeaderConsumer headerConsumer = HeaderConsumer.create(outboundHeaders);
         provider.updateOutboundHeaders(mt,
                                        span.context(),
                                        HeaderProvider.create(inboundHeaders),
-                                       HeaderConsumer.create(outboundHeaders));
+                                       headerConsumer);
 
         // all should be propagated, X_OT should be fixed
-        List<String> values = outboundHeaders.get(ZipkinTracerProvider.X_OT_SPAN_CONTEXT);
-        assertThat(values, is(List.of("0000816c055dc421;521c61ede905945f;51b3b1a413dce011;sr")));
+        assertThat("Fixed-up X_OT header",
+                   headerConsumer.get(ZipkinTracerProvider.X_OT_SPAN_CONTEXT),
+                OptionalMatcher.value(is("0000816c055dc421;521c61ede905945f;51b3b1a413dce011;sr")));
 
-        values = outboundHeaders.get(ZipkinTracerProvider.X_B3_PARENT_SPAN_ID);
-        assertThat(values, is(List.of(parentSpanId)));
+        assertThat("Parent span ID header",
+                   headerConsumer.get(ZipkinTracerProvider.X_B3_PARENT_SPAN_ID),
+                   OptionalMatcher.value(is(parentSpanId)));
 
-        values = outboundHeaders.get(ZipkinTracerProvider.X_B3_SPAN_ID);
-        assertThat(values, is(List.of(spanId)));
+        assertThat("Span ID header",
+                   headerConsumer.get(ZipkinTracerProvider.X_B3_SPAN_ID),
+                   OptionalMatcher.value(is(spanId)));
 
-        values = outboundHeaders.get(ZipkinTracerProvider.X_B3_TRACE_ID);
-        assertThat(values, is(List.of(traceId)));
+        assertThat("Trace ID header",
+                   headerConsumer.get(ZipkinTracerProvider.X_B3_TRACE_ID),
+                   OptionalMatcher.value(is(traceId)));
     }
 }

--- a/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracing.java
+++ b/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracing.java
@@ -18,6 +18,7 @@ package io.helidon.webclient.tracing;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.reactive.Single;
@@ -109,7 +110,13 @@ public final class WebClientTracing implements WebClientService {
 
         private ClientHeaderConsumer(WebClientRequestHeaders headers) {
             this.headers = headers;
-            this.headerMap = LazyValue.create(headers::toMap);
+            this.headerMap = LazyValue.create(this::headerMap);
+        }
+
+        private Map<String, List<String>> headerMap() {
+            Map<String, List<String>> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            result.putAll(headers.toMap());
+            return result;
         }
 
         @Override

--- a/webclient/webclient/pom.xml
+++ b/webclient/webclient/pom.xml
@@ -112,6 +112,11 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeaders.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,7 +200,14 @@ public interface WebClientRequestHeaders extends Headers {
     void clear();
 
     @Override
+    WebClientRequestHeaders addAll(Headers headers);
+
+    @Deprecated(since = "3.0.2", forRemoval = true)
+    @Override
     WebClientRequestHeaders putAll(Parameters parameters);
+
+    @Override
+    WebClientRequestHeaders putAll(Headers headers);
 
     @Override
     WebClientRequestHeaders add(String key, String... values);
@@ -208,6 +215,7 @@ public interface WebClientRequestHeaders extends Headers {
     @Override
     WebClientRequestHeaders add(String key, Iterable<String> values);
 
+    @Deprecated(since = "3.0.2", forRemoval = true)
     @Override
     WebClientRequestHeaders addAll(Parameters parameters);
 }

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeadersImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeadersImpl.java
@@ -27,11 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.common.http.Parameters;
@@ -233,9 +235,16 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
         return Collections.unmodifiableList(associatedHeaders);
     }
 
+    @Deprecated(since = "3.0.2", forRemoval = true)
     @Override
     public WebClientRequestHeaders putAll(Parameters parameters) {
         headers.putAll(parameters.toMap());
+        return this;
+    }
+
+    @Override
+    public WebClientRequestHeaders putAll(Headers headers) {
+        this.headers.putAll(headers.toMap());
         return this;
     }
 
@@ -251,9 +260,16 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
         return this;
     }
 
+    @Deprecated(since = "3.0.2", forRemoval = true)
     @Override
     public WebClientRequestHeaders addAll(Parameters parameters) {
         parameters.toMap().forEach(this::add);
+        return this;
+    }
+
+    @Override
+    public WebClientRequestHeaders addAll(Headers headers) {
+        headers.toMap().forEach(this::add);
         return this;
     }
 
@@ -265,7 +281,9 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
 
     @Override
     public Map<String, List<String>> toMap() {
-        return Collections.unmodifiableMap(new HashMap<>(headers));
+        Map<String, List<String>> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        result.putAll(headers);
+        return Collections.unmodifiableMap(result);
     }
 
     private List<String> iterableToList(Iterable<String> iterable) {

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientResponseHeadersImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientResponseHeadersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,13 +25,13 @@ import java.util.stream.Collectors;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.common.http.Parameters;
-import io.helidon.common.http.ReadOnlyParameters;
+import io.helidon.common.http.ReadOnlyHeaders;
 import io.helidon.common.http.SetCookie;
 
 /**
  * Implementation of {@link WebClientResponseHeaders}.
  */
-class WebClientResponseHeadersImpl extends ReadOnlyParameters implements WebClientResponseHeaders {
+class WebClientResponseHeadersImpl extends ReadOnlyHeaders implements WebClientResponseHeaders {
 
     private WebClientResponseHeadersImpl(Map<String, List<String>> headers) {
         super(headers);
@@ -53,7 +53,7 @@ class WebClientResponseHeadersImpl extends ReadOnlyParameters implements WebClie
      * @param headers response headers in map
      * @return response headers instance
      */
-    static WebClientResponseHeadersImpl create(Map<String, List<String>> headers) {
+    public static WebClientResponseHeadersImpl create(Map<String, List<String>> headers) {
         return new WebClientResponseHeadersImpl(headers);
     }
 

--- a/webclient/webclient/src/test/java/io/helidon/webclient/CaseSensitivityTest.java
+++ b/webclient/webclient/src/test/java/io/helidon/webclient/CaseSensitivityTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.testing.CaseSensitivityTester.testLenient;
+import static io.helidon.config.testing.CaseSensitivityTester.testMap;
+import static io.helidon.config.testing.CaseSensitivityTester.testStrict;
+
+class CaseSensitivityTest {
+    
+    @Test
+    void testWebClientQueryParams() {
+        WebClientQueryParams params = new WebClientQueryParams();
+        testMap().forEach(params::put);
+        testStrict(params, WebClientQueryParams::all);
+    }
+
+    @Test
+    void testWebClientRequestHeaders() {
+        WebClientRequestHeaders headers = new WebClientRequestHeadersImpl();
+        testMap().forEach(headers::put);
+        testLenient(headers, WebClientRequestHeaders::all);
+    }
+
+    @Test
+    void testWebClientResponseHeaders() {
+        WebClientResponseHeaders headers = WebClientResponseHeadersImpl.create(testMap());
+        testLenient(headers, WebClientResponseHeaders::all);
+    }
+}

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -243,5 +243,9 @@
             <artifactId>reactive-streams-tck-flow</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HashRequestHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HashRequestHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,13 +32,14 @@ import io.helidon.common.http.HashParameters;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.common.http.Parameters;
+import io.helidon.common.http.ReadOnlyHeaders;
 import io.helidon.common.http.ReadOnlyParameters;
 import io.helidon.common.http.Utils;
 
 /**
- * A {@link RequestHeaders} implementation on top of {@link ReadOnlyParameters}.
+ * A {@link RequestHeaders} implementation on top of {@link ReadOnlyHeaders}.
  */
-class HashRequestHeaders extends ReadOnlyParameters implements RequestHeaders {
+class HashRequestHeaders extends ReadOnlyHeaders implements RequestHeaders {
 
     /**
      * Header value of the non compliant {@code Accept} header sent by
@@ -195,6 +196,27 @@ class HashRequestHeaders extends ReadOnlyParameters implements RequestHeaders {
         return first(Http.Header.REFERER).map(URI::create);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        HashRequestHeaders that = (HashRequestHeaders) o;
+        return Objects.equals(cookies, that.cookies) && Objects.equals(acceptedtypesCache,
+                                                                       that.acceptedtypesCache);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), cookies, acceptedtypesCache);
+    }
+
     /**
      * Parse cookies based on RFC6265 but it can accepts also older formats including RFC2965 but skips parameters.
      */
@@ -219,11 +241,11 @@ class HashRequestHeaders extends ReadOnlyParameters implements RequestHeaders {
          */
         public static Parameters parse(String cookieHeaderValue) {
             if (cookieHeaderValue == null) {
-                return empty();
+                return ReadOnlyParameters.empty();
             }
             cookieHeaderValue = cookieHeaderValue.trim();
             if (cookieHeaderValue.isEmpty()) {
-                return empty();
+                return ReadOnlyParameters.empty();
             }
 
             // Beware RFC2965
@@ -232,7 +254,7 @@ class HashRequestHeaders extends ReadOnlyParameters implements RequestHeaders {
                 isRfc2965 = true;
                 int ind = cookieHeaderValue.indexOf(';');
                 if (ind < 0) {
-                    return empty();
+                    return ReadOnlyParameters.empty();
                 } else {
                     cookieHeaderValue = cookieHeaderValue.substring(ind + 1);
                 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HashResponseHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HashResponseHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,9 @@ import java.util.stream.Collectors;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.http.AlreadyCompletedException;
+import io.helidon.common.http.HashHeaders;
 import io.helidon.common.http.HashParameters;
+import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.common.http.Parameters;
@@ -49,7 +51,7 @@ import io.helidon.common.reactive.Single;
 /**
  * A {@link ResponseHeaders} implementation on top of {@link HashParameters}.
  */
-class HashResponseHeaders extends HashParameters implements ResponseHeaders {
+class HashResponseHeaders extends HashHeaders implements ResponseHeaders {
 
     private static final String COMPLETED_EXCEPTION_MESSAGE = "Response headers are already completed (sent to the client)!";
 
@@ -311,6 +313,12 @@ class HashResponseHeaders extends HashParameters implements ResponseHeaders {
     @Override
     public HashResponseHeaders putAll(Parameters parameters) {
         completable.runIfNotCompleted(() -> super.putAll(parameters), COMPLETED_EXCEPTION_MESSAGE);
+        return this;
+    }
+
+    @Override
+    public HashResponseHeaders putAll(Headers headers) {
+        completable.runIfNotCompleted(() -> super.putAll(headers), COMPLETED_EXCEPTION_MESSAGE);
         return this;
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
@@ -19,6 +19,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -344,7 +345,8 @@ public abstract class WebTracingConfig {
             private final Map<String, List<String>> headers;
 
             TracingHeaderProvider(Map<String, List<String>> headers) {
-                this.headers = headers;
+                this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                this.headers.putAll(headers);
             }
 
             @Override

--- a/webserver/webserver/src/test/java/io/helidon/webserver/CaseSensitivityTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/CaseSensitivityTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.testing.CaseSensitivityTester.testLenient;
+import static io.helidon.config.testing.CaseSensitivityTester.testMap;
+
+class CaseSensitivityTest {
+
+    @Test
+    void testHashRequestHeaderCase() {
+        testLenient(new HashRequestHeaders(testMap()),
+             HashRequestHeaders::values);
+    }
+
+    @Test
+    void testHashResponseHeaderCase() {
+        HashResponseHeaders headers = new HashResponseHeaders(null);
+        testMap().forEach(headers::add);
+        testLenient(headers, HashResponseHeaders::values);
+    }
+}


### PR DESCRIPTION
Resolves #5149

HTTP header names should be case-insensitive; HTTP parameters (query parameter, path params) should be case-sensitive.

This PR fixes problems in both areas.

I tried to be as minimally-invasive as possible while still addressing the problems. Still, there are quite a few changes needed to fix this situation.

## Some highlights:

Key changes are in `helidon-common-http` but other components are affected as well.

* The new class `HashHeaders` extends `HashParameters`. Each now creates the correct type of `Map` (case-sensitive or -insensitive) in separate protected factory methods. Various writeable headers-related classes now extend `HashHeaders` (instead of extending `HashParameters` as they did before) and so now inherit the correct case-insensitive behavior.
* The new class `ReadOnlyHeaders` extends `ReadOnlyParameters`. Each now creates the correct type of `Map` in protected factory methods for various purposes. Various read-only headers-related classes now extend `ReadOnlyHeaders` to inherit the correct case-insensitive behavior.
* Several other classes are changed to use `Headers` or the various implementations rather than `Parameters` so the data is handled in a case-insensitive manner.
* Tests:
   *Lots of new tests check for the appropriate behavior in many classes related to headers and parameters.
   * A new tracing-specific test checks for proper B3 propagation from client to server.

## Some lower-level details:

`Parameters` now extends `Iterable<Map.Entry<String, List<String>>>` and provides a default implementation of `iterator`. This reduces creation of temporary data structures in other code. Our classes which implement `Parameters` override iterator with more efficient code than the default.

There is opportunity to refactor significantly to reduce some code duplication. But it would be quite a bit more far-reaching than the proposed changes here. Plus, header handling is much different in 3.x so any refactoring work in 3.x would not carry forward and is likely not worth the investment.
