### PR TITLE
Use Hamcrest assertions instead of JUnit in  tests/integration/kafka - backport 2.x (#1749)

### DIFF
--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/AbstractKafkaTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/AbstractKafkaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 
 package io.helidon.messaging.connectors.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
@@ -101,13 +102,13 @@ public abstract class AbstractKafkaTest {
         if (requested > 0) {
             // Wait till records are delivered
             boolean done = kafkaConsumingBean.await();
-            assertTrue(done, String.format("Timeout waiting for results.\nExpected: %s \nBut was: %s",
-                    expected.toString(), kafkaConsumingBean.consumed().toString()));
+            assertThat(String.format("Timeout waiting for results.\nExpected: %s \nBut was: %s",
+                    expected.toString(), kafkaConsumingBean.consumed().toString()), done, is(true));
         }
         Collections.sort(kafkaConsumingBean.consumed());
         Collections.sort(expected);
         if (!expected.isEmpty()) {
-            assertEquals(expected, kafkaConsumingBean.consumed());
+            assertThat(kafkaConsumingBean.consumed(), contains(expected.toArray()));
         }
     }
 

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/EmittingPublisherTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/EmittingPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,11 @@ import java.util.logging.Logger;
 import io.helidon.common.reactive.EmittingPublisher;
 import io.helidon.microprofile.reactive.HelidonReactiveStreamsEngine;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.spi.ReactiveStreamsEngine;
@@ -58,14 +59,14 @@ public class EmittingPublisherTest {
 
         TEST_DATA.forEach(emitter::emit);
 
-        assertEquals(TEST_DATA, result);
+        assertThat(result, contains(TEST_DATA.toArray()));
     }
 
     @Test
     void notReady() {
         EmittingPublisher<String> emitter = EmittingPublisher.create();
         emitter.onRequest((n, d) -> LOGGER.fine(() -> Long.toString(n)));
-        assertFalse(emitter.emit(""));
+        assertThat(emitter.emit(""), is(false));
     }
 
     @Test
@@ -99,9 +100,9 @@ public class EmittingPublisherTest {
             }
         });
 
-        assertTrue(emitter.isCancelled());
-        assertFalse(emitter.emit("should false"));
-        assertEquals(List.of(), forbiddenSigns);
+        assertThat(emitter.isCancelled(), is(true));
+        assertThat(emitter.emit("should false"), is(false));
+        assertThat(forbiddenSigns, empty());
     }
 
     @Test
@@ -132,9 +133,9 @@ public class EmittingPublisherTest {
             }
         });
         emitter.complete();
-        assertTrue(onCompleteCalled.get());
-        assertTrue(emitter.isCompleted());
+        assertThat(onCompleteCalled.get(), is(true));
+        assertThat(emitter.isCompleted(), is(true));
         assertThrows(IllegalStateException.class, () -> emitter.emit("should false"));
-        assertEquals(List.of(), forbiddenSigs);
+        assertThat(forbiddenSigs, empty());
     }
 }

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaMpTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaMpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 
 package io.helidon.messaging.connectors.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
@@ -227,9 +229,9 @@ class KafkaMpTest extends AbstractKafkaTest{
     static void cdiContainerDown() {
         KafkaConnector factory = getInstance(KafkaConnector.class, KAFKA_CONNECTOR_LITERAL).get();
         Collection<KafkaPublisher<?, ?>> resources = factory.resources();
-        assertFalse(resources.isEmpty());
+        assertThat(resources, not(empty()));
         cdiContainer.close();
-        assertTrue(resources.isEmpty());
+        assertThat(resources, empty());
         LOGGER.info("Container destroyed");
     }
 
@@ -247,7 +249,7 @@ class KafkaMpTest extends AbstractKafkaTest{
 
         Map<String, String> p = new HashMap<>(cdiConfig());
         cdiContainer = startCdiContainer(p, classes);
-        assertTrue(cdiContainer.isRunning());
+        assertThat(cdiContainer.isRunning(), is(true));
         List<String> topicsInKafka = new ArrayList<>(kafkaResource.getKafkaTestUtils().getTopicNames());
         //Wait till consumers are ready
         getInstance(KafkaConnector.class, KAFKA_CONNECTOR_LITERAL).stream()
@@ -260,7 +262,7 @@ class KafkaMpTest extends AbstractKafkaTest{
             }
             topicsInKafka.removeAll(c.topics());
         });
-        assertEquals(Collections.emptyList(), topicsInKafka);
+        assertThat(topicsInKafka, empty());
         LOGGER.info("Container setup");
     }
 
@@ -271,8 +273,7 @@ class KafkaMpTest extends AbstractKafkaTest{
         Config config = Config.builder().sources(ConfigSources.create(p)).build();
         KafkaConfig kafkaConfig = KafkaConfig.create(config);
         List<String> topics = kafkaConfig.topics();
-        assertEquals(2, topics.size());
-        assertTrue(topics.containsAll(Arrays.asList("topic1", "topic2")));
+        assertThat(topics, contains("topic1", "topic2"));
     }
 
     @Test
@@ -281,10 +282,10 @@ class KafkaMpTest extends AbstractKafkaTest{
         Map<String, String> p = Map.of("topic.pattern", "topic[1-2]");
         Config config = Config.builder().sources(ConfigSources.create(p)).build();
         KafkaConfig kafkaConfig = KafkaConfig.create(config);
-        assertTrue(kafkaConfig.topicPattern().isPresent());
-        assertTrue(kafkaConfig.topicPattern().get().matcher("topic1").matches());
-        assertTrue(kafkaConfig.topicPattern().get().matcher("topic2").matches());
-        assertFalse(kafkaConfig.topicPattern().get().matcher("topic3").matches());
+        assertThat(kafkaConfig.topicPattern().isPresent(), is(true));
+        assertThat(kafkaConfig.topicPattern().get().matcher("topic1").matches(), is(true));
+        assertThat(kafkaConfig.topicPattern().get().matcher("topic2").matches(), is(true));
+        assertThat(kafkaConfig.topicPattern().get().matcher("topic3").matches(), is(false));
     }
 
     @Test
@@ -362,7 +363,7 @@ class KafkaMpTest extends AbstractKafkaTest{
         produceAndCheck(kafkaConsumingBean, testData, TEST_TOPIC_10, Collections.emptyList(), 0);
         // As the channel is cancelled, we cannot wait till something happens. We need to explicitly wait some time.
         Thread.sleep(1000);
-        assertEquals(Collections.emptyList(), kafkaConsumingBean.consumed());
+        assertThat(kafkaConsumingBean.consumed(), empty());
         kafkaResource.getKafkaTestUtils().consumeAllRecordsFromTopic(TEST_TOPIC_10);
     }
 
@@ -378,7 +379,7 @@ class KafkaMpTest extends AbstractKafkaTest{
         produceAndCheck(kafkaConsumingBean, testData, TEST_TOPIC_13, Collections.emptyList(), 0);
         // As the channel is cancelled, we cannot wait till something happens. We need to explicitly wait some time.
         Thread.sleep(1000);
-        assertEquals(Collections.emptyList(), kafkaConsumingBean.consumed());
+        assertThat(kafkaConsumingBean.consumed(), empty());
         kafkaResource.getKafkaTestUtils().consumeAllRecordsFromTopic(TEST_TOPIC_13);
     }
 
@@ -397,7 +398,7 @@ class KafkaMpTest extends AbstractKafkaTest{
                 .registerConfig(config,
                         Thread.currentThread().getContextClassLoader());
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance();
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         initializer.addBeanClasses(beanClasses.toArray(new Class<?>[0]));
         return initializer.initialize();
     }

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@
 package io.helidon.messaging.connectors.kafka;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -450,7 +451,7 @@ public class KafkaSeTest extends AbstractKafkaTest {
         List<String> events = readTopic(TOPIC, uncommit.size(), GROUP);
         Collections.sort(events);
         Collections.sort(uncommit);
-        assertEquals(uncommit, events);
+        assertThat(events, contains(uncommit.toArray()));
     }
 
     @Test
@@ -493,9 +494,9 @@ public class KafkaSeTest extends AbstractKafkaTest {
         }
         int uncommited = kafkaConsumingBean.uncommitted();
         // At least one message was not committed
-        assertTrue(uncommited > 0);
+        assertThat(uncommited, greaterThan(0));
         LOGGER.fine(() -> "Uncommitted messages : " + uncommited);
         List<String> messages = readTopic(TOPIC, uncommited, GROUP);
-        assertEquals(uncommited, messages.size(), "Received messages are " + messages);
+        assertThat("Received messages are " + messages, messages, hasSize(uncommited));
     }
 }


### PR DESCRIPTION
Part of #1749 

[Original PR](https://github.com/helidon-io/helidon/pull/5235)