### PR TITLE
2.x: Remove license-report from maven lifecycle

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -154,21 +154,6 @@
                     <groupId>io.helidon.build-tools</groupId>
                     <artifactId>helidon-maven-plugin</artifactId>
                     <version>${version.plugin.helidon}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.helidon.licensing</groupId>
-                            <artifactId>helidon-licensing</artifactId>
-                            <version>${helidon.version}</version>
-                        </dependency>
-                    </dependencies>
-                    <executions>
-                        <execution>
-                            <id>third-party-license-report</id>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>io.helidon.build-tools</groupId>

--- a/archetypes/bare-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/bare-mp/src/main/resources/pom.xml.mustache
@@ -69,15 +69,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/bare-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/bare-se/src/main/resources/pom.xml.mustache
@@ -66,15 +66,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/database-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-mp/src/main/resources/pom.xml.mustache
@@ -181,15 +181,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/database-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-se/src/main/resources/pom.xml.mustache
@@ -132,15 +132,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/quickstart-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/pom.xml.mustache
@@ -75,15 +75,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/quickstart-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/quickstart-se/src/main/resources/pom.xml.mustache
@@ -66,15 +66,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/examples/grpc/microprofile/basic-client/pom.xml
+++ b/examples/grpc/microprofile/basic-client/pom.xml
@@ -78,15 +78,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/examples/grpc/microprofile/basic-server-implicit/pom.xml
+++ b/examples/grpc/microprofile/basic-server-implicit/pom.xml
@@ -82,15 +82,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/examples/grpc/microprofile/metrics/pom.xml
+++ b/examples/grpc/microprofile/metrics/pom.xml
@@ -86,15 +86,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/examples/istio/helidon-jpa/pom.xml
+++ b/examples/istio/helidon-jpa/pom.xml
@@ -117,15 +117,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/examples/jbatch/pom.xml
+++ b/examples/jbatch/pom.xml
@@ -125,15 +125,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/examples/metrics/http-status-count-se/pom.xml
+++ b/examples/metrics/http-status-count-se/pom.xml
@@ -89,15 +89,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/examples/microprofile/http-status-count-mp/pom.xml
+++ b/examples/microprofile/http-status-count-mp/pom.xml
@@ -114,15 +114,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
                 <executions>

--- a/tests/functional/config-profiles/pom.xml
+++ b/tests/functional/config-profiles/pom.xml
@@ -73,15 +73,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>io.helidon.build-tools</groupId>
-                <artifactId>helidon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>third-party-license-report</id>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.plugin.surefire}</version>


### PR DESCRIPTION
Removes the generation of the license report from the default maven lifecycle. You now need to run it explcitily: `mvn io.helidon.build-tools:helidon-maven-plugin:report`