### PR TITLE
Use Hamcrest assertions instead of JUnit in  integrations/cdi/jpa-cdi (#1749)

### DIFF
--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAnnotationRewriting.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAnnotationRewriting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ApplicationScoped
@@ -78,7 +79,7 @@ class TestAnnotationRewriting {
         System.setProperty("jpaAnnotationRewritingEnabled", "true");
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
   
@@ -109,24 +110,24 @@ class TestAnnotationRewriting {
     @PersistenceContext(unitName = "test")
     private void observerMethod(@Observes final TestIsRunning event,
                                 final EntityManager emParameter) {
-        assertNotNull(event);
+        assertThat(event, notNullValue());
 
-        assertNotNull(emParameter);
-        assertTrue(emParameter.isOpen());
-        assertFalse(emParameter.isJoinedToTransaction());
+        assertThat(emParameter, notNullValue());
+        assertThat(emParameter.isOpen(), is(true));
+        assertThat(emParameter.isJoinedToTransaction(), is(false));
 
-        assertNotNull(this.em);
-        assertTrue(this.em.isOpen());
-        assertFalse(this.em.isJoinedToTransaction());
+        assertThat(this.em, notNullValue());
+        assertThat(this.em.isOpen(), is(true));
+        assertThat(this.em.isJoinedToTransaction(), is(false));
 
-        assertNotNull(this.emf);
-        assertTrue(this.emf.isOpen());
+        assertThat(this.emf, notNullValue());
+        assertThat(this.emf.isOpen(), is(true));
         EntityManager em = null;
         try {
           em = this.emf.createEntityManager();
-          assertNotNull(em);
-          assertTrue(em.isOpen());
-          assertFalse(em.isJoinedToTransaction());
+          assertThat(em, notNullValue());
+          assertThat(em.isOpen(), is(true));
+          assertThat(em.isJoinedToTransaction(), is(false));
         } finally {
           if (em != null && !em.isOpen()) {
             em.close();
@@ -162,9 +163,9 @@ class TestAnnotationRewriting {
         qualifiers.add(ContainerManaged.Literal.INSTANCE);
         qualifiers.add(JpaTransactionScoped.Literal.INSTANCE);
         final EntityManager entityManager = this.cdiContainer.select(EntityManager.class, qualifiers.toArray(new Annotation[qualifiers.size()])).get();
-        assertTrue(entityManager instanceof DelegatingEntityManager);
-        assertTrue(entityManager.isOpen());
-        assertFalse(entityManager.isJoinedToTransaction());
+        assertThat(entityManager, instanceOf(DelegatingEntityManager.class));
+        assertThat(entityManager.isOpen(), is(true));
+        assertThat(entityManager.isJoinedToTransaction(), is(false));
         try {
             entityManager.persist(new Object());
             fail("A TransactionRequiredException should have been thrown");
@@ -187,14 +188,14 @@ class TestAnnotationRewriting {
             .fire(new TestIsRunning("testTransactionalEntityManager"));
         final Instance<TestAnnotationRewriting> instance = this.cdiContainer.select(TestAnnotationRewriting.class);
         final TestAnnotationRewriting test = instance.get();
-        assertNotNull(test);
+        assertThat(test, notNullValue());
         test.testEntityManagerIsJoinedToTransactionInTransactionalAnnotatedMethod();
     }
     
     @Transactional
     void testEntityManagerIsJoinedToTransactionInTransactionalAnnotatedMethod() {
-        assertNotNull(this.em);
-        assertTrue(this.em.isJoinedToTransaction());
+        assertThat(this.em, notNullValue());
+        assertThat(this.em.isJoinedToTransaction(), is(true));
         try {
             this.em.close();
             fail("Closed EntityManager; should not have been able to");

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestMessages.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,17 @@ package io.helidon.integrations.cdi.jpa;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 final class TestMessages {
 
     @Test
     final void testMessages() {
         final String message = Messages.format("resourceLocalPersistenceUnitWarning");
-        assertNotNull(message);
-        assertTrue(message.startsWith("The persistence unit "));
+        assertThat(message, notNullValue());
+        assertThat(message, startsWith("The persistence unit "));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestMultiplePersistenceUnits.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestMultiplePersistenceUnits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 @DataSourceDefinition(
@@ -70,7 +71,7 @@ class TestMultiplePersistenceUnits {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -109,15 +110,15 @@ class TestMultiplePersistenceUnits {
     @Test
     void testMultiplePersistenceUnits() {
         TestMultiplePersistenceUnits self = this.cdiContainer.select(TestMultiplePersistenceUnits.class).get();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         EntityManager testEm = self.getTestEntityManager();
-        assertNotNull(testEm);
-        assertTrue(testEm.isOpen());
+        assertThat(testEm, notNullValue());
+        assertThat(testEm.isOpen(), is(true));
 
         EntityManager test2Em = self.getTest2EntityManager();
-        assertNotNull(test2Em);
-        assertTrue(test2Em.isOpen());
+        assertThat(test2Em, notNullValue());
+        assertThat(test2Em.isOpen(), is(true));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedSynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedSynchronizedEntityManager.java
@@ -37,9 +37,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 @DataSourceDefinition(
@@ -89,7 +89,7 @@ class TestExtendedSynchronizedEntityManager {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -157,20 +157,20 @@ class TestExtendedSynchronizedEntityManager {
         // is important to use "self" in this test instead of "this".
         final TestExtendedSynchronizedEntityManager self =
             this.cdiContainer.select(TestExtendedSynchronizedEntityManager.class).get();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         // Get the EntityManager that is synchronized with but whose
         // persistence context extends past a single JTA transaction.
         final EntityManager em = self.getExtendedSynchronizedEntityManager();
-        assertNotNull(em);
-        assertTrue(em.isOpen());
+        assertThat(em, notNullValue());
+        assertThat(em.isOpen(), is(true));
 
         // We haven't started any kind of transaction yet and we
         // aren't testing anything using
         // the @jakarta.transaction.Transactional annotation so there is
         // no transaction in effect so the EntityManager cannot be
         // joined to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Create a JPA entity and try to insert it.  Should be just
         // fine.
@@ -183,30 +183,30 @@ class TestExtendedSynchronizedEntityManager {
         // Get the TransactionManager that normally is behind the
         // scenes and use it to start a Transaction.
         final TransactionManager tm = self.getTransactionManager();
-        assertNotNull(tm);
+        assertThat(tm, notNullValue());
         tm.begin();
 
         // Now magically our EntityManager should be joined to it.
-        assertTrue(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(true));
 
         // Roll the transaction back and note that our EntityManager
         // is no longer joined to it.
         tm.rollback();
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Start another transaction and persist our Author.
         tm.begin();
         em.persist(author);
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
         tm.commit();
 
         // The transaction is over, so our EntityManager is not joined
         // to one anymore.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Our PersistenceContextType is EXTENDED, not TRANSACTION, so
         // the underlying persistence context spans transactions.
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedUnsynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedUnsynchronizedEntityManager.java
@@ -37,9 +37,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 @DataSourceDefinition(
@@ -89,7 +89,7 @@ class TestExtendedUnsynchronizedEntityManager {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -156,21 +156,21 @@ class TestExtendedUnsynchronizedEntityManager {
         // is important to use "self" in this test instead of "this".
         final TestExtendedUnsynchronizedEntityManager self =
             this.cdiContainer.select(TestExtendedUnsynchronizedEntityManager.class).get();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         // Get the EntityManager that is not synchronized with and
         // whose persistence context extends past a single JTA
         // transaction.
         final EntityManager em = self.getExtendedUnsynchronizedEntityManager();
-        assertNotNull(em);
-        assertTrue(em.isOpen());
+        assertThat(em, notNullValue());
+        assertThat(em.isOpen(), is(true));
 
         // We haven't started any kind of transaction yet and we
         // aren't testing anything using
         // the @jakarta.transaction.Transactional annotation so there is
         // no transaction in effect so the EntityManager cannot be
         // joined to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Create a JPA entity and try to insert it.  Should be just
         // fine.
@@ -183,41 +183,41 @@ class TestExtendedUnsynchronizedEntityManager {
         // Get the TransactionManager that normally is behind the
         // scenes and use it to start a Transaction.
         final TransactionManager tm = self.getTransactionManager();
-        assertNotNull(tm);
+        assertThat(tm, notNullValue());
         tm.begin();
 
         // Because we're UNSYNCHRONIZED, no automatic joining takes place.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // We can join manually.
         em.joinTransaction();
 
         // Now we should be joined to it.
-        assertTrue(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(true));
 
         // Roll the transaction back and note that our EntityManager
         // is no longer joined to it.
         tm.rollback();
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Start another transaction and persist our Author.  But note
         // that joining the transaction must be manual.
         tm.begin();
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
         em.persist(author);
-        assertFalse(em.isJoinedToTransaction());
-        assertTrue(em.contains(author));
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(em.contains(author), is(true));
 
         // (Remember, we weren't ever joined to this transaction.)
         tm.commit();
 
         // The transaction is over, and our EntityManager is STILL not joined
         // to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Our PersistenceContextType is EXTENDED, not TRANSACTION, so
         // the underlying persistence context spans transactions.
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestWithTransactionalInterceptors.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestWithTransactionalInterceptors.java
@@ -42,11 +42,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 @DataSourceDefinition(
@@ -98,28 +97,28 @@ class TestWithTransactionalInterceptors {
 
     @BeforeEach
     void startCdiContainer() throws SQLException, SystemException {
-        assertNull(this.dataSource);
-        assertNull(this.em);
-        assertNull(this.tm);
-        assertNull(this.self);
+        assertThat(this.dataSource, nullValue());
+        assertThat(this.em, nullValue());
+        assertThat(this.tm, nullValue());
+        assertThat(this.self, nullValue());
 
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
-        assertNotNull(this.cdiContainer);
+        assertThat(this.cdiContainer, notNullValue());
 
         this.self = this.cdiContainer.select(this.getClass()).get();
-        assertNotNull(this.self);
+        assertThat(this.self, notNullValue());
 
         this.em = this.self.getEntityManager();
-        assertNotNull(this.em);
+        assertThat(this.em, notNullValue());
 
         this.tm = this.self.getTransactionManager();
-        assertNotNull(this.tm);
+        assertThat(this.tm, notNullValue());
 
         this.dataSource = this.self.getDataSource();
-        assertNotNull(this.dataSource);
+        assertThat(this.dataSource, notNullValue());
 
         assertAuthorTableIsEmpty();
         assertNoTransaction();
@@ -189,10 +188,10 @@ class TestWithTransactionalInterceptors {
         try (final Connection connection = this.dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT ID FROM AUTHOR");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(1, resultSet.getInt(1));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(1));
+            assertThat(resultSet.next(), is(false));
         }
 
     }
@@ -217,11 +216,11 @@ class TestWithTransactionalInterceptors {
         try (final Connection connection = this.dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT ID, NAME FROM AUTHOR");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(1, resultSet.getInt(1));
-            assertEquals("Abe Lincoln", resultSet.getString(2));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(1));
+            assertThat(resultSet.getString(2), is("Abe Lincoln"));
+            assertThat(resultSet.next(), is(false));
         }
     }
 
@@ -241,17 +240,17 @@ class TestWithTransactionalInterceptors {
         // Persist an Author.
         final Author author = new Author("Abraham Lincoln");
         em.persist(author);
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
     }
 
     @Transactional
     public void testFindAndUpdate() throws Exception {
         assertActiveTransaction();
         final Author author = this.em.find(Author.class, Integer.valueOf(1));
-        assertNotNull(author);
-        assertEquals(Integer.valueOf(1), author.getId());
-        assertEquals("Abraham Lincoln", author.getName());
-        assertTrue(this.em.contains(author));
+        assertThat(author, notNullValue());
+        assertThat(author.getId(), is(1));
+        assertThat(author.getName(), is("Abraham Lincoln"));
+        assertThat(this.em.contains(author), is(true));
         author.setName("Abe Lincoln");
     }
 
@@ -262,29 +261,29 @@ class TestWithTransactionalInterceptors {
 
 
     private void assertAuthorTableIsEmpty() throws SQLException {
-        assertNotNull(this.dataSource);
+        assertThat(this.dataSource, notNullValue());
         try (final Connection connection = this.dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM AUTHOR");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(0, resultSet.getInt(1));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(0));
+            assertThat(resultSet.next(), is(false));
         }
     }
 
     private void assertActiveTransaction() throws SystemException {
-        assertNotNull(this.tm);
-        assertEquals(Status.STATUS_ACTIVE, this.tm.getStatus());
-        assertNotNull(this.em);
-        assertTrue(this.em.isJoinedToTransaction());
+        assertThat(this.tm, notNullValue());
+        assertThat(this.tm.getStatus(), is(Status.STATUS_ACTIVE));
+        assertThat(this.em, notNullValue());
+        assertThat(this.em.isJoinedToTransaction(), is(true));
     }
 
     private void assertNoTransaction() throws SystemException {
-        assertNotNull(this.tm);
-        assertNotNull(this.em);
-        assertEquals(Status.STATUS_NO_TRANSACTION, this.tm.getStatus());
-        assertFalse(this.em.isJoinedToTransaction());
+        assertThat(this.tm, notNullValue());
+        assertThat(this.em, notNullValue());
+        assertThat(this.tm.getStatus(), is(Status.STATUS_NO_TRANSACTION));
+        assertThat(this.em.isJoinedToTransaction(), is(false));
     }
 
 }


### PR DESCRIPTION
Part of #1749 

[Backport 2.x](https://github.com/helidon-io/helidon/pull/5252)