### PR TITLE
Use Hamcrest assertions instead of JUnit in  config/encryption (#1749)

### DIFF
--- a/config/encryption/src/test/java/io/helidon/config/encryption/EncryptionUtilTest.java
+++ b/config/encryption/src/test/java/io/helidon/config/encryption/EncryptionUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,10 +33,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -76,8 +74,8 @@ public class EncryptionUtilTest {
         } catch (ConfigEncryptionException e) {
             Throwable cause = e.getCause();
             //our message
-            assertEquals("Failed to encrypt using RSA key", e.getMessage());
-            assertSame(CryptoException.class, cause.getClass());
+            assertThat(e.getMessage(), is("Failed to encrypt using RSA key"));
+            assertThat(cause.getClass(), sameInstance(CryptoException.class));
         }
     }
 
@@ -92,17 +90,17 @@ public class EncryptionUtilTest {
         String encryptedBase64 = EncryptionUtil.encryptRsa(encryptionKey, TEST_SECRET);
         String decrypted = EncryptionUtil.decryptRsa(decryptionKey, encryptedBase64);
 
-        assertEquals(TEST_SECRET, decrypted);
+        assertThat(decrypted, is(TEST_SECRET));
 
         String encryptedAgain = EncryptionUtil.encryptRsa(encryptionKey, TEST_SECRET);
 
         if (mustBeSeeded) {
-            assertNotEquals(encryptedBase64, encryptedAgain);
+            assertThat(encryptedAgain, is(not((encryptedBase64))));
         }
 
         decrypted = EncryptionUtil.decryptRsa(decryptionKey, encryptedAgain);
 
-        assertEquals(TEST_SECRET, decrypted);
+        assertThat(decrypted, is(TEST_SECRET));
     }
 
     @Test
@@ -110,13 +108,13 @@ public class EncryptionUtilTest {
         String encryptedBase64 = EncryptionUtil.encryptAes(MASTER_PASSWORD, TEST_SECRET);
         String decrypted = EncryptionUtil.decryptAes(MASTER_PASSWORD, encryptedBase64);
 
-        assertEquals(TEST_SECRET, decrypted);
+        assertThat(decrypted, is(TEST_SECRET));
 
         String encryptedAgain = EncryptionUtil.encryptAes(MASTER_PASSWORD, TEST_SECRET);
-        assertNotEquals(encryptedBase64, encryptedAgain);
+        assertThat(encryptedAgain, is(not(encryptedBase64)));
         decrypted = EncryptionUtil.decryptAes(MASTER_PASSWORD, encryptedAgain);
 
-        assertEquals(TEST_SECRET, decrypted);
+        assertThat(decrypted, is(TEST_SECRET));
     }
 
     @Test
@@ -125,7 +123,7 @@ public class EncryptionUtilTest {
 
         String encryptedString = new String(Base64.getDecoder().decode(encryptedBase64), StandardCharsets.UTF_8);
         //must not be just base64 encoded
-        assertNotEquals(TEST_SECRET, encryptedString);
+        assertThat(encryptedString, is(not(TEST_SECRET)));
 
         try {
             String decrypted = EncryptionUtil.decryptAes("anotherPassword".toCharArray(), encryptedBase64);

--- a/config/encryption/src/test/java/io/helidon/config/encryption/MainTest.java
+++ b/config/encryption/src/test/java/io/helidon/config/encryption/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ import io.helidon.common.pki.KeyConfig;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test Main class (cli).
@@ -42,9 +42,9 @@ public class MainTest {
 
         Main.EncryptionCliProcessor ecp = new Main.EncryptionCliProcessor();
         ecp.parse(args);
-        assertEquals(Main.Algorithm.aes, ecp.getAlgorithm());
-        assertEquals(masterPassword, ecp.getMasterPassword());
-        assertEquals(secret, ecp.getSecret());
+        assertThat(ecp.getAlgorithm(), is(Main.Algorithm.aes));
+        assertThat(ecp.getMasterPassword(), is(masterPassword));
+        assertThat(ecp.getSecret(), is(secret));
 
         String encrypted = ecp.encrypt();
 
@@ -57,7 +57,7 @@ public class MainTest {
         String orig = EncryptionUtil.decryptAes(ecp.getMasterPassword().toCharArray(),
                                                 encrypted.substring(EncryptionFilter.PREFIX_GCM.length(), encrypted.length() - 1));
 
-        assertEquals(secret, orig);
+        assertThat(orig, is(secret));
 
         Main.main(args);
     }
@@ -79,9 +79,9 @@ public class MainTest {
 
         Main.EncryptionCliProcessor ecp = new Main.EncryptionCliProcessor();
         ecp.parse(args);
-        assertEquals(Main.Algorithm.rsa, ecp.getAlgorithm());
-        assertNotNull(ecp.getPublicKey());
-        assertEquals(secret, ecp.getSecret());
+        assertThat(ecp.getAlgorithm(), is(Main.Algorithm.rsa));
+        assertThat(ecp.getPublicKey(), notNullValue());
+        assertThat(ecp.getSecret(), is(secret));
 
         String encrypted = ecp.encrypt();
         assertAll(() -> assertThat("Encrypted string should start with rsa prefix: " + encrypted,
@@ -93,7 +93,7 @@ public class MainTest {
 
         String orig = EncryptionUtil.decryptRsa(pk, base64);
 
-        assertEquals(secret, orig);
+        assertThat(orig, is(secret));
         Main.main(args);
     }
 }


### PR DESCRIPTION
Part of #1749 

[Backport 2.x](https://github.com/helidon-io/helidon/pull/5275)