### PR TITLE
3.x: Add back helidon-licensing dependency to application pom

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -154,6 +154,13 @@
                     <groupId>io.helidon.build-tools</groupId>
                     <artifactId>helidon-maven-plugin</artifactId>
                     <version>${version.plugin.helidon}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.helidon.licensing</groupId>
+                            <artifactId>helidon-licensing</artifactId>
+                            <version>${helidon.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>io.helidon.build-tools</groupId>


### PR DESCRIPTION
Fix over-aggressive cleanup.