### PR TITLE
Issue 4567 - Grpc component Does not handle "package" directive in proto files.

### DIFF
--- a/grpc/server/src/main/java/io/helidon/grpc/server/BindableServiceImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/BindableServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,8 @@ class BindableServiceImpl implements BindableService {
     @SuppressWarnings("unchecked")
     @Override
     public ServerServiceDefinition bindService() {
-        io.grpc.ServiceDescriptor.Builder serviceDescriptorBuilder = io.grpc.ServiceDescriptor.newBuilder(descriptor.name());
+        io.grpc.ServiceDescriptor.Builder serviceDescriptorBuilder =
+                io.grpc.ServiceDescriptor.newBuilder(descriptor.fullName());
         if (descriptor.proto() != null) {
             serviceDescriptorBuilder.setSchemaDescriptor((ProtoFileDescriptorSupplier) descriptor::proto);
         }

--- a/grpc/server/src/test/java/io/helidon/grpc/server/GrpcProtoPackageNoJavaPackageTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/GrpcProtoPackageNoJavaPackageTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.grpc.server;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.google.protobuf.Descriptors;
+import io.grpc.BindableService;
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.stub.StreamObserver;
+import io.grpc.util.MutableHandlerRegistry;
+import io.helidon.grpc.core.PriorityBag;
+import helidon.test.Echopackagenojavapackage;
+import helidon.test.EchoPackageNoJavaPackageServiceGrpc;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.grpc.core.ResponseHelper.complete;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for gRPC server support for package directive in proto file
+ */
+@SuppressWarnings("unchecked")
+public class GrpcProtoPackageNoJavaPackageTest {
+    final static String PACKAGE_NAME = "helidon.test";
+
+    @Test
+    public void shouldContainPackage() {
+        Descriptors.FileDescriptor protoDescriptor = Echopackagenojavapackage.getDescriptor();
+        String packageName = protoDescriptor.getPackage();
+        assertThat(packageName.isBlank(), is(false));
+        assertThat(protoDescriptor.getPackage(), is(PACKAGE_NAME));
+
+        BindableService service = new EchoPackageStub();
+        ServiceDescriptor descriptor = ServiceDescriptor.builder(service)
+                .name("Foo")
+                .build();
+        assertThat(protoDescriptor.getPackage(), is(descriptor.packageName()));
+    }
+
+    @Test
+    public void shouldHaveNoJavaPackage() {
+        Descriptors.FileDescriptor protoDescriptor = Echopackagenojavapackage.getDescriptor();
+        String javaPackageName = protoDescriptor.getOptions().getJavaPackage();
+        assertThat(javaPackageName.isBlank(), is(true));
+    }
+
+    @Test
+    public void shouldCreateMethodDescriptor() {
+        ServerCallHandler handler = mock(ServerCallHandler.class);
+        String fullServiceName = getServiceFullName(PACKAGE_NAME, "EchoPackageNoJavaPackageService");
+        String fullMethodName = io.grpc.MethodDescriptor.generateFullMethodName(fullServiceName, "Echo");
+        io.grpc.MethodDescriptor grpcDescriptor = EchoPackageNoJavaPackageServiceGrpc.getServiceDescriptor()
+                .getMethods()
+                .stream()
+                .filter(md -> md.getFullMethodName().equals(fullMethodName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Could not find echo method"));
+
+        MethodDescriptor<?, ?> descriptor =
+                MethodDescriptor.create(fullServiceName,"foo", grpcDescriptor.toBuilder(), handler);
+
+        assertThat(descriptor, is(notNullValue()));
+        assertThat(descriptor.name(), is("foo"));
+        assertThat(descriptor.callHandler(), is(sameInstance(handler)));
+        assertThat(descriptor.context(), is(notNullValue()));
+        assertThat(descriptor.context().size(), is(0));
+
+        io.grpc.MethodDescriptor methodDescriptor = descriptor.descriptor();
+        assertThat(methodDescriptor.getFullMethodName(), is(io.grpc.MethodDescriptor.generateFullMethodName(fullServiceName, "foo")));
+    }
+
+    @Test
+    public void shouldBuildFromBindableService() {
+        BindableService service = new EchoPackageStub();
+        ServerServiceDefinition definition = service.bindService();
+        io.grpc.ServiceDescriptor grpcDescriptor = definition.getServiceDescriptor();
+
+        ServiceDescriptor descriptor = ServiceDescriptor.builder(service).build();
+
+        assertThat(descriptor.fullName(), is(grpcDescriptor.getName()));
+
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        assertThat(bindableService, is(notNullValue()));
+
+        ServerServiceDefinition ssd = bindableService.bindService();
+        assertThat(ssd, is(notNullValue()));
+
+        io.grpc.ServiceDescriptor actualDescriptor = ssd.getServiceDescriptor();
+        assertThat(actualDescriptor, is(notNullValue()));
+        assertThat(actualDescriptor.getName(), is(grpcDescriptor.getName()));
+
+        Map<String, io.grpc.MethodDescriptor<?, ?>> methods = grpcDescriptor.getMethods()
+                .stream()
+                .collect(Collectors.toMap(io.grpc.MethodDescriptor::getFullMethodName, m -> m));
+
+        Collection<io.grpc.MethodDescriptor<?, ?>> methodsActual = actualDescriptor.getMethods();
+
+        for (io.grpc.MethodDescriptor<?, ?> method : methodsActual) {
+            assertThat(method.toString(), is(methods.get(method.getFullMethodName()).toString()));
+        }
+    }
+
+    @Test
+    public void shouldOverrideServiceName() {
+        BindableService service = new EchoPackageStub();
+
+        Descriptors.FileDescriptor protoDescriptor = Echopackagenojavapackage.getDescriptor();
+        ServiceDescriptor descriptor = ServiceDescriptor.builder(service)
+                .name("Foo")
+                .proto(protoDescriptor)
+                .build();
+
+        assertThat(descriptor.name(), is("Foo"));
+
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        assertThat(bindableService, is(notNullValue()));
+
+        ServerServiceDefinition ssd = bindableService.bindService();
+        assertThat(ssd, is(notNullValue()));
+
+        io.grpc.ServiceDescriptor actualDescriptor = ssd.getServiceDescriptor();
+        assertThat(actualDescriptor, is(notNullValue()));
+        String fullServiceName = getServiceFullName(PACKAGE_NAME, "Foo");
+        assertThat(actualDescriptor.getName(), is(fullServiceName));
+
+        Collection<io.grpc.MethodDescriptor<?, ?>> methods = actualDescriptor.getMethods();
+
+        for (io.grpc.MethodDescriptor<?, ?> method : methods) {
+            assertThat(method.getFullMethodName().startsWith(fullServiceName + "/"), is(true));
+        }
+    }
+
+    @Test
+    public void shouldBeTheSameServiceDescriptors() {
+        BindableService service = new EchoPackageStub();
+
+        ServiceDescriptor descriptor1 = ServiceDescriptor.builder(service)
+                .name("Foo")
+                .build();
+
+        ServiceDescriptor descriptor2 = ServiceDescriptor.builder(service)
+                .name("Foo")
+                .build();
+        assertThat(descriptor1.equals(descriptor2), is(true));
+        assertThat(descriptor1.hashCode(), is(descriptor2.hashCode()));
+        assertThat(descriptor1.toString().contains(descriptor2.fullName()), is(true));
+        assertThat(descriptor1.toString(), is(descriptor2.toString()));
+    }
+
+    @Test
+    public void shouldBuildFromProtoFile() {
+        ServiceDescriptor descriptor = createServiceDescriptor();
+
+        assertThat(descriptor.name(), is("EchoPackageNoJavaPackageService"));
+
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        assertThat(bindableService, is(notNullValue()));
+
+        ServerServiceDefinition ssd = bindableService.bindService();
+        assertThat(ssd, is(notNullValue()));
+
+        io.grpc.ServiceDescriptor serviceDescriptor = ssd.getServiceDescriptor();
+        assertThat(serviceDescriptor, is(notNullValue()));
+        String fullServiceName = getServiceFullName(PACKAGE_NAME, "EchoPackageNoJavaPackageService");
+        assertThat(serviceDescriptor.getName(), is(fullServiceName));
+    }
+
+    /**
+     * Ensure that io.grpc.MethodDescriptor service name is same as io.grpc.ServiceDescriptor service name as this
+     * is being validated by the grpc-java library.
+     */
+    @Test
+    public void shouldHaveSimilarServiceNamesForServiceAndMethodDescriptors() {
+        ServiceDescriptor descriptor = createServiceDescriptor();
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        ServerServiceDefinition ssd = bindableService.bindService();
+        io.grpc.ServiceDescriptor serviceDescriptor = ssd.getServiceDescriptor();
+
+        io.grpc.MethodDescriptor methodDescriptor = serviceDescriptor.getMethods().stream().findFirst().get();
+        assertThat(methodDescriptor.getServiceName(), is(serviceDescriptor.getName()));
+    }
+
+    @Test
+    public void shouldLookupFromHandlerRegistry() {
+        ServiceDescriptor descriptor = createServiceDescriptor();
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        ServerServiceDefinition ssd = bindableService.bindService();
+
+        MutableHandlerRegistry handlerRegistry = new MutableHandlerRegistry();
+        handlerRegistry.addService(ssd);
+        String fullMethodName = io.grpc.MethodDescriptor.generateFullMethodName(
+                getServiceFullName(PACKAGE_NAME, "EchoPackageNoJavaPackageService"), "Echo");
+        System.out.println("Full Method Name=" + fullMethodName);
+        assertThat(handlerRegistry.lookupMethod(fullMethodName).getMethodDescriptor().getFullMethodName(), is(fullMethodName));
+    }
+
+    @Test
+    public void shouldCompleteGrpcRequest() throws Exception {
+        // Add the EchoService
+        GrpcRouting routing = GrpcRouting.builder()
+                .register(new EchoPackageService())
+                .build();
+
+        // Run the server on port 0 so that it picks a free ephemeral port
+        GrpcServerConfiguration serverConfig = GrpcServerConfiguration.builder()
+                .port(0)
+                .build();
+
+        GrpcServer grpcServer = GrpcServer.create(serverConfig, routing)
+                .start()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+
+        Channel channel = ManagedChannelBuilder.forAddress("localhost", grpcServer.port())
+                .usePlaintext()
+                .build();
+
+        Echopackagenojavapackage.EchoPackageNoJavaPackageResponse response = EchoPackageNoJavaPackageServiceGrpc.newBlockingStub(channel)
+                .echo(Echopackagenojavapackage.EchoPackageNoJavaPackageRequest.newBuilder().setMessage("foo").build());
+
+        assertThat(response.getMessage(), is("foo"));
+        grpcServer.shutdown();
+    }
+
+    private String getServiceFullName(String packageName, String serviceName) {
+        return  packageName + "." + serviceName;
+    }
+
+    private ServiceDescriptor createServiceDescriptor() {
+        GrpcService service = mock(GrpcService.class);
+
+        when(service.name()).thenReturn("EchoPackageNoJavaPackageService");
+
+        Descriptors.FileDescriptor protoDescriptor = Echopackagenojavapackage.getDescriptor();
+
+        ServiceDescriptor descriptor = ServiceDescriptor.builder(service)
+                .proto(protoDescriptor)
+                .unary("Echo", this::dummyUnary)
+                .build();
+        return descriptor;
+    }
+
+    private void dummyUnary(String request, StreamObserver<String> observer) {
+    }
+
+    private class EchoPackageStub
+            extends EchoPackageNoJavaPackageServiceGrpc.EchoPackageNoJavaPackageServiceImplBase {
+    }
+
+    public static class EchoPackageService
+            implements GrpcService {
+
+        @Override
+        public void update(ServiceDescriptor.Rules rules) {
+            rules.proto(Echopackagenojavapackage.getDescriptor())
+                 .name("EchoPackageNoJavaPackageService")
+                 .unary("Echo", this::echo);
+        }
+
+        public void echo(Echopackagenojavapackage.EchoPackageNoJavaPackageRequest request, StreamObserver<Echopackagenojavapackage.EchoPackageNoJavaPackageResponse> observer)  {
+            String message = request.getMessage();
+            Echopackagenojavapackage.EchoPackageNoJavaPackageResponse response = Echopackagenojavapackage.EchoPackageNoJavaPackageResponse.newBuilder().setMessage(message).build();
+            complete(observer, response);
+        }
+    }
+}

--- a/grpc/server/src/test/java/io/helidon/grpc/server/GrpcProtoPackageTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/GrpcProtoPackageTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.grpc.server;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.google.protobuf.Descriptors;
+import io.grpc.BindableService;
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.stub.StreamObserver;
+import io.grpc.util.MutableHandlerRegistry;
+import io.helidon.grpc.core.PriorityBag;
+import io.helidon.grpc.server.test.Echopackage;
+import io.helidon.grpc.server.test.EchoPackageServiceGrpc;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.grpc.core.ResponseHelper.complete;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for gRPC server support for package directive in proto file
+ */
+@SuppressWarnings("unchecked")
+public class GrpcProtoPackageTest {
+    final static String PACKAGE_NAME = "helidon.test";
+
+    @Test
+    public void shouldContainPackage() {
+        Descriptors.FileDescriptor protoDescriptor = Echopackage.getDescriptor();
+        String packageName = protoDescriptor.getPackage();
+        assertThat(packageName.isBlank(), is(false));
+        assertThat(protoDescriptor.getPackage(), is(PACKAGE_NAME));
+
+        BindableService service = new EchoPackageStub();
+        ServiceDescriptor descriptor = ServiceDescriptor.builder(service)
+                .name("Foo")
+                .build();
+        assertThat(protoDescriptor.getPackage(), is(descriptor.packageName()));
+    }
+
+    @Test
+    public void shouldHaveJavaPackage() {
+        Descriptors.FileDescriptor protoDescriptor = Echopackage.getDescriptor();
+        String javaPackageName = protoDescriptor.getOptions().getJavaPackage();
+        assertThat(javaPackageName.isBlank(), is(false));
+    }
+
+    @Test
+    public void shouldCreateMethodDescriptor() {
+        ServerCallHandler handler = mock(ServerCallHandler.class);
+        String fullServiceName = getServiceFullName(PACKAGE_NAME, "EchoPackageService");
+        String fullMethodName = io.grpc.MethodDescriptor.generateFullMethodName(fullServiceName, "Echo");
+        io.grpc.MethodDescriptor grpcDescriptor = EchoPackageServiceGrpc.getServiceDescriptor()
+                .getMethods()
+                .stream()
+                .filter(md -> md.getFullMethodName().equals(fullMethodName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Could not find echo method"));
+
+        MethodDescriptor<?, ?> descriptor =
+                MethodDescriptor.create(fullServiceName,"foo", grpcDescriptor.toBuilder(), handler);
+
+        assertThat(descriptor, is(notNullValue()));
+        assertThat(descriptor.name(), is("foo"));
+        assertThat(descriptor.callHandler(), is(sameInstance(handler)));
+        assertThat(descriptor.context(), is(notNullValue()));
+        assertThat(descriptor.context().size(), is(0));
+
+        io.grpc.MethodDescriptor methodDescriptor = descriptor.descriptor();
+        assertThat(methodDescriptor.getFullMethodName(), is(io.grpc.MethodDescriptor.generateFullMethodName(fullServiceName, "foo")));
+    }
+
+    @Test
+    public void shouldBuildFromBindableService() {
+        BindableService service = new EchoPackageStub();
+        ServerServiceDefinition definition = service.bindService();
+        io.grpc.ServiceDescriptor grpcDescriptor = definition.getServiceDescriptor();
+
+        ServiceDescriptor descriptor = ServiceDescriptor.builder(service).build();
+
+        assertThat(descriptor.fullName(), is(grpcDescriptor.getName()));
+
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        assertThat(bindableService, is(notNullValue()));
+
+        ServerServiceDefinition ssd = bindableService.bindService();
+        assertThat(ssd, is(notNullValue()));
+
+        io.grpc.ServiceDescriptor actualDescriptor = ssd.getServiceDescriptor();
+        assertThat(actualDescriptor, is(notNullValue()));
+        assertThat(actualDescriptor.getName(), is(grpcDescriptor.getName()));
+
+        Map<String, io.grpc.MethodDescriptor<?, ?>> methods = grpcDescriptor.getMethods()
+                .stream()
+                .collect(Collectors.toMap(io.grpc.MethodDescriptor::getFullMethodName, m -> m));
+
+        Collection<io.grpc.MethodDescriptor<?, ?>> methodsActual = actualDescriptor.getMethods();
+
+        for (io.grpc.MethodDescriptor<?, ?> method : methodsActual) {
+            assertThat(method.toString(), is(methods.get(method.getFullMethodName()).toString()));
+        }
+    }
+
+    @Test
+    public void shouldOverrideServiceName() {
+        BindableService service = new EchoPackageStub();
+
+        Descriptors.FileDescriptor protoDescriptor = Echopackage.getDescriptor();
+        ServiceDescriptor descriptor = ServiceDescriptor.builder(service)
+                .name("Foo")
+                .proto(protoDescriptor)
+                .build();
+
+        assertThat(descriptor.name(), is("Foo"));
+
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        assertThat(bindableService, is(notNullValue()));
+
+        ServerServiceDefinition ssd = bindableService.bindService();
+        assertThat(ssd, is(notNullValue()));
+
+        io.grpc.ServiceDescriptor actualDescriptor = ssd.getServiceDescriptor();
+        assertThat(actualDescriptor, is(notNullValue()));
+        String fullServiceName = getServiceFullName(PACKAGE_NAME, "Foo");
+        assertThat(actualDescriptor.getName(), is(fullServiceName));
+
+        Collection<io.grpc.MethodDescriptor<?, ?>> methods = actualDescriptor.getMethods();
+
+        for (io.grpc.MethodDescriptor<?, ?> method : methods) {
+            assertThat(method.getFullMethodName().startsWith(fullServiceName + "/"), is(true));
+        }
+    }
+
+    @Test
+    public void shouldBeTheSameServiceDescriptors() {
+        BindableService service = new EchoPackageStub();
+
+        ServiceDescriptor descriptor1 = ServiceDescriptor.builder(service)
+                .name("Foo")
+                .build();
+
+        ServiceDescriptor descriptor2 = ServiceDescriptor.builder(service)
+                .name("Foo")
+                .build();
+        assertThat(descriptor1.equals(descriptor2), is(true));
+        assertThat(descriptor1.hashCode(), is(descriptor2.hashCode()));
+        assertThat(descriptor1.toString().contains(descriptor2.fullName()), is(true));
+        assertThat(descriptor1.toString(), is(descriptor2.toString()));
+    }
+
+    @Test
+    public void shouldBuildFromProtoFile() {
+        ServiceDescriptor descriptor = createServiceDescriptor();
+
+        assertThat(descriptor.name(), is("EchoPackageService"));
+
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        assertThat(bindableService, is(notNullValue()));
+
+        ServerServiceDefinition ssd = bindableService.bindService();
+        assertThat(ssd, is(notNullValue()));
+
+        io.grpc.ServiceDescriptor serviceDescriptor = ssd.getServiceDescriptor();
+        assertThat(serviceDescriptor, is(notNullValue()));
+        String fullServiceName = getServiceFullName(PACKAGE_NAME, "EchoPackageService");
+        assertThat(serviceDescriptor.getName(), is(fullServiceName));
+    }
+
+    /**
+     * Ensure that io.grpc.MethodDescriptor service name is same as io.grpc.ServiceDescriptor service name as this
+     * is being validated by the grpc-java library.
+     */
+    @Test
+    public void shouldHaveSimilarServiceNamesForServiceAndMethodDescriptors() {
+        ServiceDescriptor descriptor = createServiceDescriptor();
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        ServerServiceDefinition ssd = bindableService.bindService();
+        io.grpc.ServiceDescriptor serviceDescriptor = ssd.getServiceDescriptor();
+
+        io.grpc.MethodDescriptor methodDescriptor = serviceDescriptor.getMethods().stream().findFirst().get();
+        assertThat(methodDescriptor.getServiceName(), is(serviceDescriptor.getName()));
+    }
+
+    @Test
+    public void shouldLookupFromHandlerRegistry() {
+        ServiceDescriptor descriptor = createServiceDescriptor();
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
+        ServerServiceDefinition ssd = bindableService.bindService();
+
+        MutableHandlerRegistry handlerRegistry = new MutableHandlerRegistry();
+        handlerRegistry.addService(ssd);
+        String fullMethodName = io.grpc.MethodDescriptor.generateFullMethodName(
+                getServiceFullName(PACKAGE_NAME, "EchoPackageService"), "Echo");
+        System.out.println("Full Method Name=" + fullMethodName);
+        assertThat(handlerRegistry.lookupMethod(fullMethodName).getMethodDescriptor().getFullMethodName(), is(fullMethodName));
+    }
+
+    @Test
+    public void shouldCompleteGrpcRequest() throws Exception {
+        // Add the EchoService
+        GrpcRouting routing = GrpcRouting.builder()
+                .register(new EchoPackageService())
+                .build();
+
+        // Run the server on port 0 so that it picks a free ephemeral port
+        GrpcServerConfiguration serverConfig = GrpcServerConfiguration.builder()
+                .port(0)
+                .build();
+
+        GrpcServer grpcServer = GrpcServer.create(serverConfig, routing)
+                .start()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+
+        Channel channel = ManagedChannelBuilder.forAddress("localhost", grpcServer.port())
+                .usePlaintext()
+                .build();
+
+        Echopackage.EchoPackageResponse response = EchoPackageServiceGrpc.newBlockingStub(channel)
+                .echo(Echopackage.EchoPackageRequest.newBuilder().setMessage("foo").build());
+
+        assertThat(response.getMessage(), is("foo"));
+        grpcServer.shutdown();
+    }
+
+    private String getServiceFullName(String packageName, String serviceName) {
+        return  packageName + "." + serviceName;
+    }
+
+    private ServiceDescriptor createServiceDescriptor() {
+        GrpcService service = mock(GrpcService.class);
+
+        when(service.name()).thenReturn("EchoPackageService");
+
+        Descriptors.FileDescriptor protoDescriptor = Echopackage.getDescriptor();
+
+        ServiceDescriptor descriptor = ServiceDescriptor.builder(service)
+                .proto(protoDescriptor)
+                .unary("Echo", this::dummyUnary)
+                .build();
+        return descriptor;
+    }
+
+    private void dummyUnary(String request, StreamObserver<String> observer) {
+    }
+
+    private class EchoPackageStub
+            extends EchoPackageServiceGrpc.EchoPackageServiceImplBase {
+    }
+
+    public static class EchoPackageService
+            implements GrpcService {
+
+        @Override
+        public void update(ServiceDescriptor.Rules rules) {
+            rules.proto(Echopackage.getDescriptor())
+                 .name("EchoPackageService")
+                 .unary("Echo", this::echo);
+        }
+
+        public void echo(Echopackage.EchoPackageRequest request, StreamObserver<Echopackage.EchoPackageResponse> observer)  {
+            String message = request.getMessage();
+            Echopackage.EchoPackageResponse response = Echopackage.EchoPackageResponse.newBuilder().setMessage(message).build();
+            complete(observer, response);
+        }
+    }
+}

--- a/grpc/server/src/test/java/io/helidon/grpc/server/ServiceDescriptorTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/ServiceDescriptorTest.java
@@ -61,6 +61,22 @@ public class ServiceDescriptorTest {
                 .build();
 
         assertThat(descriptor.name(), is(service.name()));
+        // Name and FullName should be the same as there is no proto package directive
+        assertThat(descriptor.name(), is(descriptor.fullName()));
+    }
+
+    @Test
+    public void shouldBeTheSameObjects() {
+        GrpcService service = createMockService();
+        ServiceDescriptor descriptor1 = ServiceDescriptor.builder(service)
+                .build();
+        ServiceDescriptor descriptor2 = ServiceDescriptor.builder(service)
+                .build();
+
+        assertThat(descriptor1.equals(descriptor2), is(true));
+        assertThat(descriptor1.hashCode(), is(descriptor2.hashCode()));
+        assertThat(descriptor1.toString().contains(descriptor2.fullName()), is(true));
+        assertThat(descriptor1.toString(), is(descriptor2.toString()));
     }
 
     @Test

--- a/grpc/server/src/test/proto/echopackage.proto
+++ b/grpc/server/src/test/proto/echopackage.proto
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package helidon.test;
+
+option java_package = "io.helidon.grpc.server.test";
+
+service EchoPackageService {
+  rpc Echo (EchoPackageRequest) returns (EchoPackageResponse) {}
+}
+
+message EchoPackageRequest {
+  string message = 1;
+}
+
+message EchoPackageResponse {
+  string message = 1;
+}

--- a/grpc/server/src/test/proto/echopackagenojavapackage.proto
+++ b/grpc/server/src/test/proto/echopackagenojavapackage.proto
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package helidon.test;
+
+service EchoPackageNoJavaPackageService {
+  rpc Echo (EchoPackageNoJavaPackageRequest) returns (EchoPackageNoJavaPackageResponse) {}
+}
+
+message EchoPackageNoJavaPackageRequest {
+  string message = 1;
+}
+
+message EchoPackageNoJavaPackageResponse {
+  string message = 1;
+}


### PR DESCRIPTION
Problems:
1. ServiceDescriptor$Builder.getTypeFromMethodDescriptor throws ClassNotFoundException. This is the original issue reported by the filer. example java.lang.RuntimeException: java.lang.ClassNotFoundException: io.helidon.grpc.server.test.Echo$helidon$tests$EchoRequest
2. Request throws this exception: "io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found". This issue was only exposed when "mvn verify" was used which triggered 3 additional integration tests, ContextIT, TracingIT and SslIT that all encountered the same problem. example: [ERROR] io.helidon.grpc.server.ContextIT.shouldObtainValueFromContextForRequest  Time elapsed: 0.192 s  <<< ERROR!
         io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found: helidon.test.EchoService/Echo
                 at io.helidon.grpc.server.ContextIT.shouldObtainValueFromContextForRequest(ContextIT.java:90)

Solutions:
1. For the 1st Problem, change className generation in ServiceDescriptor$Builder.getTypeFromMethodDescriptor of using "type.getFullName().replace('.', '$')" to instead use "type.getName()".
2. For 2nd Problem, There are 2 fixes that needs to be done: a. io.grpc.MethodDescriptor() needs to have the service part of the fullMethodName to be prefixed with the package directive name, example it should be "helidon.test.EchoService/Echo" instead of "EchoService/Echo" if the package directive name is "helidon.test". Not doing this will cause "registry.lookupMethod(methodName)" call in ServerImpl.runInternal() on gprc-java-core library to throw "UNIMPLEMENTED: Method not found" as it won't be able to find it without the service name prefixed with the package name. This is fixed in ServiceDescriptor$Builder.build() and ServiceDescriptor$Builder.createMethodDescriptor() by passing in the fullMethodName (that prefixes it with the package name) though the fullName() method in io.helidon.grpc.server.MethodDescriptor$Builder which in turn sets the io.grpc.MethodDescriptor() that it encapsulates. b. Even if above is fixed, io.grpc.ServiceDescriptor() also needs to have its name be prefixed with the package directive name. This is because when io.grpc.ServiceDescriptor() is instantiated, it validates its name against the service Name of all io.grpc.MethodDescriptor() objects that it holds and will throw an error like this: "java.lang.IllegalArgumentException: service names helidon.test.EchoService != EchoService". To fix this issue, BindableServiceImpl.bindService() needs to use the fullServiceName (i.e. the name of the service prefixed with the package name) when creating a new Builder for io.grpc.ServiceDescriptor.
3. getFullName logic is moved inside ServiceDescriptor builder and will set ServiceDescriptor fullName field when build is triggered to create a new instance.
4. More refactoring and additional unit test to cover no java package in proto file scenario
5. Rename methods for retrieving fullName and packageNane in ServiceDescriptor and add shouldBuildFromBindableService test in GrpcProtoPackageTest and GrpcProtoPackageNoJavaPackageTest to test scenario where name is already prefixed with package.