### PR TITLE
fix builder build for mvn -T 4, forcing test-builder to depend on bui…

### DIFF
--- a/pico/builder/test-builder/pom.xml
+++ b/pico/builder/test-builder/pom.xml
@@ -43,6 +43,11 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.pico.builder</groupId>
+            <artifactId>helidon-pico-builder-processor</artifactId>
+            <scope>provided</scope> <!-- force reactor to build processor 1st -->
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.pico.builder</groupId>
             <artifactId>helidon-pico-builder-api</artifactId>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
This addresses an issue found when mvnd or mvn -T 4 is used to build. FIx adds a dep from test-builder to builder-processor to cause the reactor to build processor before it is used.