### PR TITLE
Fix error in OpenAPI handling of `default` values' types

### DIFF
--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -213,5 +213,10 @@
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/openapi/src/main/java/io/helidon/openapi/ExpandedTypeDescription.java
+++ b/openapi/src/main/java/io/helidon/openapi/ExpandedTypeDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -196,8 +196,12 @@ class ExpandedTypeDescription extends TypeDescription {
         return impl;
     }
 
-    boolean hasDefaultProperty() {
-        return getPropertyNoEx("defaultValue") != null;
+    /**
+     *
+     * @return the 'default' property for this type; null if none
+     */
+    Property defaultProperty() {
+        return getPropertyNoEx("defaultValue");
     }
 
     private static boolean setupExtensionType(String key, Node valueNode) {

--- a/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
@@ -84,6 +84,7 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
 import org.jboss.jandex.IndexView;
 import org.yaml.snakeyaml.TypeDescription;
+import org.yaml.snakeyaml.introspector.Property;
 
 import static io.helidon.webserver.cors.CorsEnabledServiceHelper.CORS_CONFIG_KEY;
 
@@ -273,8 +274,9 @@ public abstract class OpenAPISupport implements Service {
             if (Extensible.class.isAssignableFrom(td.getType())) {
                 td.addExtensions();
             }
-            if (td.hasDefaultProperty()) {
-                td.substituteProperty("default", Object.class, "getDefaultValue", "setDefaultValue");
+            Property defaultProperty = td.defaultProperty();
+            if (defaultProperty != null) {
+                td.substituteProperty("default", defaultProperty.getType(), "getDefaultValue", "setDefaultValue");
                 td.addExcludes("defaultValue");
             }
             if (isRef(td)) {

--- a/openapi/src/test/resources/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/openapi/src/test/resources/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1,0 +1,1956 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Inspired by the corresponding file in the OpenAPITools generator.
+openapi: 3.0.0
+info:
+  description: >-
+    This spec is mainly for testing Petstore server and contains fake endpoints,
+    models. Please do not use this for any other purpose. Special characters: "
+    \
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+paths:
+  /foo:
+    get:
+      responses:
+        default:
+          description: response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  string:
+                    $ref: '#/components/schemas/Foo'
+  /pet:
+    servers:
+    - url: 'http://petstore.swagger.io/v2'
+    - url: 'http://path-server-test.petstore.local/v2'
+    - url: 'http://{server}.swagger.io:{port}/v2'
+      description: test server with variables
+      variables:
+        server:
+          description: target server
+          enum:
+            - 'petstore'
+            - 'qa-petstore'
+            - 'dev-petstore'
+          default: 'petstore'
+        port:
+          enum:
+            - 80
+            - 8080
+          default: 80
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '200':
+          description: Successful operation
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      x-webclient-blocking: true
+      responses:
+        '200':
+          description: Successful operation
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      x-webclient-blocking: true
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          style: form
+          explode: false
+          deprecated: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: >-
+        Multiple tags can be provided with comma separated strings. Use tag1,
+        tag2, tag3 for testing.
+      operationId: findPetsByTags
+      x-webclient-blocking: true
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+            uniqueItems: true
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+                uniqueItems: true
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+                uniqueItems: true
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      deprecated: true
+  '/pet/{petId}':
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      x-webclient-blocking: true
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Successful operation
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Successful operation
+        '400':
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+  '/pet/{petId}/uploadImage':
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+                file:
+                  description: file to upload
+                  type: string
+                  format: binary
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ''
+      operationId: placeOrder
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+        description: order placed for purchasing the pet
+        required: true
+  '/store/order/{order_id}':
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: >-
+        For valid response try integer IDs with value <= 5 or > 10. Other values
+        will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: order_id
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 5
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: >-
+        For valid response try integer IDs with value < 1000. Anything above
+        1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: order_id
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Created user object
+        required: true
+  /user/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithArrayInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithListInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+  '/user/{username}':
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid user supplied
+        '404':
+          description: User not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+  /fake_classname_test:
+    patch:
+      tags:
+        - 'fake_classname_tags 123#$%^'
+      summary: To test class name in snake case
+      description: To test class name in snake case
+      operationId: testClassname
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client'
+      security:
+        - api_key_query: []
+      requestBody:
+        $ref: '#/components/requestBodies/Client'
+  /fake:
+    patch:
+      tags:
+        - fake
+      summary: To test "client" model
+      description: To test "client" model
+      operationId: testClientModel
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client'
+      requestBody:
+        $ref: '#/components/requestBodies/Client'
+    get:
+      tags:
+        - fake
+      summary: To test enum parameters
+      description: To test enum parameters
+      operationId: testEnumParameters
+      parameters:
+        - name: enum_header_string_array
+          in: header
+          description: Header parameter enum test (string array)
+          schema:
+            type: array
+            items:
+              type: string
+              default: $
+              enum:
+                - '>'
+                - $
+        - name: enum_header_string
+          in: header
+          description: Header parameter enum test (string)
+          schema:
+            type: string
+            enum:
+              - _abc
+              - '-efg'
+              - (xyz)
+            default: '-efg'
+        - name: enum_query_string_array
+          in: query
+          description: Query parameter enum test (string array)
+          schema:
+            type: array
+            items:
+              type: string
+              default: $
+              enum:
+                - '>'
+                - $
+        - name: enum_query_string
+          in: query
+          description: Query parameter enum test (string)
+          schema:
+            type: string
+            enum:
+              - _abc
+              - '-efg'
+              - (xyz)
+            default: '-efg'
+        - name: enum_query_integer
+          in: query
+          description: Query parameter enum test (double)
+          schema:
+            type: integer
+            format: int32
+            enum:
+              - 1
+              - -2
+        - name: enum_query_double
+          in: query
+          description: Query parameter enum test (double)
+          schema:
+            type: number
+            format: double
+            enum:
+              - 1.1
+              - -1.2
+        - name: enum_query_model_array
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/EnumClass'
+      responses:
+        '400':
+          description: Invalid request
+        '404':
+          description: Not found
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                enum_form_string_array:
+                  description: Form parameter enum test (string array)
+                  type: array
+                  items:
+                    type: string
+                    default: $
+                    enum:
+                      - '>'
+                      - $
+                enum_form_string:
+                  description: Form parameter enum test (string)
+                  type: string
+                  enum:
+                    - _abc
+                    - '-efg'
+                    - (xyz)
+                  default: '-efg'
+    post:
+      tags:
+        - fake
+      summary: |
+        Fake endpoint for testing various parameters
+        假端點
+        偽のエンドポイント
+        가짜 엔드 포인트
+      description: |
+        Fake endpoint for testing various parameters
+        假端點
+        偽のエンドポイント
+        가짜 엔드 포인트
+      operationId: testEndpointParameters
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+      security:
+        - http_basic_test: []
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                integer:
+                  description: None
+                  type: integer
+                  minimum: 10
+                  maximum: 100
+                int32:
+                  description: None
+                  type: integer
+                  format: int32
+                  minimum: 20
+                  maximum: 200
+                int64:
+                  description: None
+                  type: integer
+                  format: int64
+                number:
+                  description: None
+                  type: number
+                  minimum: 32.1
+                  maximum: 543.2
+                float:
+                  description: None
+                  type: number
+                  format: float
+                  maximum: 987.6
+                double:
+                  description: None
+                  type: number
+                  format: double
+                  minimum: 67.8
+                  maximum: 123.4
+                string:
+                  description: None
+                  type: string
+                  pattern: '/[a-z]/i'
+                pattern_without_delimiter:
+                  description: None
+                  type: string
+                  pattern: '^[A-Z].*'
+                byte:
+                  description: None
+                  type: string
+                  format: byte
+                binary:
+                  description: None
+                  type: string
+                  format: binary
+                date:
+                  description: None
+                  type: string
+                  format: date
+                dateTime:
+                  description: None
+                  type: string
+                  format: date-time
+                password:
+                  description: None
+                  type: string
+                  format: password
+                  minLength: 10
+                  maxLength: 64
+                callback:
+                  description: None
+                  type: string
+              required:
+                - number
+                - double
+                - pattern_without_delimiter
+                - byte
+    delete:
+      tags:
+        - fake
+      security:
+        - bearer_test: []
+      summary: Fake endpoint to test group parameters (optional)
+      description: Fake endpoint to test group parameters (optional)
+      operationId: testGroupParameters
+      x-group-parameters: true
+      parameters:
+        - name: required_string_group
+          in: query
+          description: Required String in group parameters
+          required: true
+          schema:
+            type: integer
+        - name: required_boolean_group
+          in: header
+          description: Required Boolean in group parameters
+          required: true
+          schema:
+            type: boolean
+        - name: required_int64_group
+          in: query
+          description: Required Integer in group parameters
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: string_group
+          in: query
+          description: String in group parameters
+          schema:
+            type: integer
+        - name: boolean_group
+          in: header
+          description: Boolean in group parameters
+          schema:
+            type: boolean
+        - name: int64_group
+          in: query
+          description: Integer in group parameters
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Someting wrong
+  /fake/outer/number:
+    post:
+      tags:
+        - fake
+      description: Test serialization of outer number types
+      operationId: fakeOuterNumberSerialize
+      responses:
+        '200':
+          description: Output number
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/OuterNumber'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OuterNumber'
+        description: Input number as post body
+  /fake/property/enum-int:
+    post:
+      tags:
+        - fake
+      description: Test serialization of enum (int) properties with examples
+      operationId: fakePropertyEnumIntegerSerialize
+      responses:
+        '200':
+          description: Output enum (int)
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/OuterObjectWithEnumProperty'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OuterObjectWithEnumProperty'
+        description: Input enum (int) as post body
+  /fake/outer/string:
+    post:
+      tags:
+        - fake
+      description: Test serialization of outer string types
+      operationId: fakeOuterStringSerialize
+      responses:
+        '200':
+          description: Output string
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/OuterString'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OuterString'
+        description: Input string as post body
+  /fake/outer/boolean:
+    post:
+      tags:
+        - fake
+      description: Test serialization of outer boolean types
+      operationId: fakeOuterBooleanSerialize
+      responses:
+        '200':
+          description: Output boolean
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/OuterBoolean'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OuterBoolean'
+        description: Input boolean as post body
+  /fake/outer/composite:
+    post:
+      tags:
+        - fake
+      description: Test serialization of object with outer number type
+      operationId: fakeOuterCompositeSerialize
+      responses:
+        '200':
+          description: Output composite
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/OuterComposite'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OuterComposite'
+        description: Input composite as post body
+  /fake/jsonFormData:
+    get:
+      tags:
+        - fake
+      summary: test json serialization of form data
+      description: ''
+      operationId: testJsonFormData
+      responses:
+        '200':
+          description: successful operation
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                param:
+                  description: field1
+                  type: string
+                param2:
+                  description: field2
+                  type: string
+              required:
+                - param
+                - param2
+  /fake/inline-additionalProperties:
+    post:
+      tags:
+        - fake
+      summary: test inline additionalProperties
+      description: ''
+      operationId: testInlineAdditionalProperties
+      responses:
+        '200':
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+        description: request body
+        required: true
+  /fake/body-with-query-params:
+    put:
+      tags:
+        - fake
+      operationId: testBodyWithQueryParams
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        required: true
+  /another-fake/dummy:
+    patch:
+      tags:
+        - $another-fake?
+      summary: To test special tags
+      description: To test special tags and operation ID starting with number
+      operationId: '123_test_@#$%_special_tags'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client'
+      requestBody:
+        $ref: '#/components/requestBodies/Client'
+  /fake/body-with-file-schema:
+    put:
+      tags:
+        - fake
+      description: >-
+        For this test, the body for this request must reference a schema named
+        `File`.
+      operationId: testBodyWithFileSchema
+      responses:
+        '200':
+          description: Success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileSchemaTestClass'
+        required: true
+  /fake/body-with-binary:
+    put:
+      tags:
+        - fake
+      description: >-
+        For this test, the body has to be a binary file.
+      operationId: testBodyWithBinary
+      responses:
+        '200':
+          description: Success
+      requestBody:
+        content:
+          image/png:
+            schema:
+              type: string
+              nullable: true
+              format: binary
+        description: image to upload
+        required: true
+  /fake/test-query-parameters:
+    put:
+      tags:
+        - fake
+      description: To test the collection format in query parameters
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+        - name: pipe
+          in: query
+          required: true
+          style: pipeDelimited
+          schema:
+            type: array
+            items:
+              type: string
+        - name: ioutil
+          in: query
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: http
+          in: query
+          required: true
+          style: spaceDelimited
+          schema:
+            type: array
+            items:
+              type: string
+        - name: url
+          in: query
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: context
+          in: query
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: language
+          in: query
+          required: false
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+              format: string
+        - name: allowEmpty
+          in: query
+          required: true
+          allowEmptyValue: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+  '/fake/{petId}/uploadImageWithRequiredFile':
+    post:
+      tags:
+        - pet
+      summary: uploads an image (required)
+      description: ''
+      operationId: uploadFileWithRequiredFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+                requiredFile:
+                  description: file to upload
+                  type: string
+                  format: binary
+              required:
+                - requiredFile
+  /fake/health:
+    get:
+      tags:
+        - fake
+      summary: Health check endpoint
+      responses:
+        200:
+          description: The instance started successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthCheckResult'
+  /fake/http-signature-test:
+    get:
+      tags:
+        - fake
+      summary: test http signature authentication
+      operationId: fake-http-signature-test
+      parameters:
+        - name: query_1
+          in: query
+          description: query parameter
+          required: optional
+          schema:
+            type: string
+        - name: header_1
+          in: header
+          description: header parameter
+          required: optional
+          schema:
+            type: string
+      security:
+        - http_signature_test: []
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+      responses:
+        200:
+          description: The instance started successfully
+servers:
+  - url: 'http://{server}.swagger.io:{port}/v2'
+    description: petstore server
+    variables:
+      server:
+        enum:
+          - 'petstore'
+          - 'qa-petstore'
+          - 'dev-petstore'
+        default: 'petstore'
+      port:
+        enum:
+          - 80
+          - 8080
+        default: 80
+  - url: https://localhost:8080/{version}
+    description: The local server
+    variables:
+      version:
+        enum:
+          - 'v1'
+          - 'v2'
+        default: 'v2'
+  - url: https://127.0.0.1/no_varaible
+    description: The local server without variables
+components:
+  requestBodies:
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+      description: List of user object
+      required: true
+    Client:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Client'
+      description: client model
+      required: true
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: 'http://petstore.swagger.io/api/oauth/dialog'
+          scopes:
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    api_key_query:
+      type: apiKey
+      name: api_key_query
+      in: query
+    http_basic_test:
+      type: http
+      scheme: basic
+    bearer_test:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    http_signature_test:
+      type: http
+      scheme: signature
+  schemas:
+    Foo:
+      type: object
+      properties:
+        bar:
+          $ref: '#/components/schemas/Bar'
+    Bar:
+      type: string
+      default: bar
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          default: default-name
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          x-is-unique: true
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+          x-is-unique: true
+        category:
+          $ref: '#/components/schemas/Category'
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+          uniqueItems: true
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+    Return:
+      description: Model for testing reserved words
+      properties:
+        return:
+          type: integer
+          format: int32
+      xml:
+        name: Return
+    Name:
+      description: Model for testing model name same as property name
+      required:
+        - name
+      properties:
+        name:
+          type: integer
+          format: int32
+        snake_case:
+          readOnly: true
+          type: integer
+          format: int32
+        property:
+          type: string
+        123Number:
+          type: integer
+          readOnly: true
+      xml:
+        name: Name
+    200_response:
+      description: Model for testing model name starting with number
+      properties:
+        name:
+          type: integer
+          format: int32
+        class:
+          type: string
+      xml:
+        name: Name
+    ClassModel:
+      description: Model for testing model with "_class" property
+      properties:
+        _class:
+          type: string
+    Dog:
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+        - type: object
+          properties:
+            breed:
+              type: string
+    Cat:
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+        - type: object
+          properties:
+            declawed:
+              type: boolean
+    Animal:
+      type: object
+      discriminator:
+        propertyName: className
+      required:
+        - className
+      properties:
+        className:
+          type: string
+        color:
+          type: string
+          default: red
+    AnimalFarm:
+      type: array
+      items:
+        $ref: '#/components/schemas/Animal'
+    format_test:
+      type: object
+      required:
+        - number
+        - byte
+        - date
+        - password
+      properties:
+        integer:
+          type: integer
+          maximum: 100
+          minimum: 10
+        int32:
+          type: integer
+          format: int32
+          maximum: 200
+          minimum: 20
+        int64:
+          type: integer
+          format: int64
+        number:
+          maximum: 543.2
+          minimum: 32.1
+          type: number
+        float:
+          type: number
+          format: float
+          maximum: 987.6
+          minimum: 54.3
+        double:
+          type: number
+          format: double
+          maximum: 123.4
+          minimum: 67.8
+        decimal:
+          type: string
+          format: number
+        string:
+          type: string
+          pattern: '/[a-z]/i'
+        byte:
+          type: string
+          format: byte
+        binary:
+          type: string
+          format: binary
+        date:
+          type: string
+          format: date
+        dateTime:
+          type: string
+          format: date-time
+        uuid:
+          type: string
+          format: uuid
+          example: 72f98069-206d-4f12-9f12-3d1e525a8e84
+        password:
+          type: string
+          format: password
+          maxLength: 64
+          minLength: 10
+        pattern_with_digits:
+          description: A string that is a 10 digit number. Can have leading zeros.
+          type: string
+          pattern: '^\d{10}$'
+        pattern_with_digits_and_delimiter:
+          description: A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.
+          type: string
+          pattern: '/^image_\d{1,3}$/i'
+    EnumClass:
+      type: string
+      default: '-efg'
+      enum:
+        - _abc
+        - '-efg'
+        - (xyz)
+    Enum_Test:
+      type: object
+      required:
+        - enum_string_required
+      properties:
+        enum_string:
+          type: string
+          enum:
+            - UPPER
+            - lower
+            - ''
+        enum_string_required:
+          type: string
+          enum:
+            - UPPER
+            - lower
+            - ''
+        enum_integer:
+          type: integer
+          format: int32
+          enum:
+            - 1
+            - -1
+        enum_number:
+          type: number
+          format: double
+          enum:
+            - 1.1
+            - -1.2
+        outerEnum:
+          $ref: '#/components/schemas/OuterEnum'
+        outerEnumInteger:
+          $ref: '#/components/schemas/OuterEnumInteger'
+        outerEnumDefaultValue:
+          $ref: '#/components/schemas/OuterEnumDefaultValue'
+        outerEnumIntegerDefaultValue:
+          $ref: '#/components/schemas/OuterEnumIntegerDefaultValue'
+    AdditionalPropertiesClass:
+      type: object
+      properties:
+        map_property:
+          type: object
+          additionalProperties:
+            type: string
+        map_of_map_property:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+    MixedPropertiesAndAdditionalPropertiesClass:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        dateTime:
+          type: string
+          format: date-time
+        map:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Animal'
+    List:
+      type: object
+      properties:
+        123-list:
+          type: string
+    Client:
+      type: object
+      properties:
+        client:
+          type: string
+    ReadOnlyFirst:
+      type: object
+      properties:
+        bar:
+          type: string
+          readOnly: true
+        baz:
+          type: string
+    hasOnlyReadOnly:
+      type: object
+      properties:
+        bar:
+          type: string
+          readOnly: true
+        foo:
+          type: string
+          readOnly: true
+    Capitalization:
+      type: object
+      properties:
+        smallCamel:
+          type: string
+        CapitalCamel:
+          type: string
+        small_Snake:
+          type: string
+        Capital_Snake:
+          type: string
+        SCA_ETH_Flow_Points:
+          type: string
+        ATT_NAME:
+          description: |
+            Name of the pet
+          type: string
+    MapTest:
+      type: object
+      properties:
+        map_map_of_string:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+        map_of_enum_string:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - UPPER
+              - lower
+        direct_map:
+          type: object
+          additionalProperties:
+            type: boolean
+        indirect_map:
+          $ref: '#/components/schemas/StringBooleanMap'
+    ArrayTest:
+      type: object
+      properties:
+        array_of_string:
+          type: array
+          items:
+            type: string
+          minItems: 0
+          maxItems: 3
+        array_array_of_integer:
+          type: array
+          items:
+            type: array
+            items:
+              type: integer
+              format: int64
+        array_array_of_model:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: '#/components/schemas/ReadOnlyFirst'
+    NumberOnly:
+      type: object
+      properties:
+        JustNumber:
+          type: number
+    ArrayOfNumberOnly:
+      type: object
+      properties:
+        ArrayNumber:
+          type: array
+          items:
+            type: number
+    ArrayOfArrayOfNumberOnly:
+      type: object
+      properties:
+        ArrayArrayNumber:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+    EnumArrays:
+      type: object
+      properties:
+        just_symbol:
+          type: string
+          enum:
+            - '>='
+            - $
+        array_enum:
+          type: array
+          items:
+            type: string
+            enum:
+              - fish
+              - crab
+    OuterEnum:
+      nullable: true
+      type: string
+      enum:
+        - placed
+        - approved
+        - delivered
+    OuterEnumInteger:
+      type: integer
+      enum:
+      - 0
+      - 1
+      - 2
+      example: 2
+    OuterEnumDefaultValue:
+      type: string
+      enum:
+      - placed
+      - approved
+      - delivered
+      default: placed
+    OuterEnumIntegerDefaultValue:
+      type: integer
+      enum:
+      - 0
+      - 1
+      - 2
+      default: 0
+    OuterComposite:
+      type: object
+      properties:
+        my_number:
+          $ref: '#/components/schemas/OuterNumber'
+        my_string:
+          $ref: '#/components/schemas/OuterString'
+        my_boolean:
+          $ref: '#/components/schemas/OuterBoolean'
+    OuterNumber:
+      type: number
+    OuterString:
+      type: string
+    OuterBoolean:
+      type: boolean
+      x-codegen-body-parameter-name: boolean_post_body
+    StringBooleanMap:
+      additionalProperties:
+        type: boolean
+    FileSchemaTestClass:
+      type: object
+      properties:
+        file:
+          $ref: '#/components/schemas/File'
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/File'
+    File:
+      type: object
+      description: Must be named `File` for test.
+      properties:
+        sourceURI:
+          description: Test capitalization
+          type: string
+    _special_model.name_:
+      properties:
+        '$special[property.name]':
+          type: integer
+          format: int64
+      xml:
+        name: '$special[model.name]'
+    HealthCheckResult:
+      type: object
+      properties:
+        NullableMessage:
+          nullable: true
+          type: string
+      description: Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
+    NullableClass:
+      type: object
+      properties:
+        integer_prop:
+          type: integer
+          nullable: true
+        number_prop:
+          type: number
+          nullable: true
+        boolean_prop:
+          type: boolean
+          nullable: true
+        string_prop:
+          type: string
+          nullable: true
+        date_prop:
+          type: string
+          format: date
+          nullable: true
+        datetime_prop:
+          type: string
+          format: date-time
+          nullable: true
+        array_nullable_prop:
+          type: array
+          nullable: true
+          items:
+            type: object
+        array_and_items_nullable_prop:
+          type: array
+          nullable: true
+          items:
+            type: object
+            nullable: true
+        array_items_nullable:
+          type: array
+          items:
+            type: object
+            nullable: true
+        object_nullable_prop:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: object
+        object_and_items_nullable_prop:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: object
+            nullable: true
+        object_items_nullable:
+          type: object
+          additionalProperties:
+            type: object
+            nullable: true
+      additionalProperties:
+        type: object
+        nullable: true
+    OuterObjectWithEnumProperty:
+      type: object
+      example:
+        value: 2
+      required:
+        - value
+      properties:
+        value:
+          $ref: '#/components/schemas/OuterEnumInteger'
+    DeprecatedObject:
+      type: object
+      deprecated: true
+      properties:
+        name:
+          type: string
+    ObjectWithDeprecatedFields:
+      type: object
+      properties:
+        uuid:
+          type: string
+        id:
+          type: number
+          deprecated: true
+        deprecatedRef:
+          $ref: '#/components/schemas/DeprecatedObject'
+        bars:
+          type: array
+          deprecated: true
+          items:
+            $ref: '#/components/schemas/Bar'
+    AllOfWithSingleRef:
+      type: object
+      properties:
+        username:
+          type: string
+        SingleRefType:
+          allOf:
+            - $ref: '#/components/schemas/SingleRefType'
+    SingleRefType:
+      type: string
+      title: SingleRefType
+      enum:
+        - admin
+        - user


### PR DESCRIPTION
Resolves #5288 

The code initially treated all default values as type `Object`. Instead, it should be the declared type of the value which might be `Object` but might be something else.

