### PR TITLE
Log an entry in warning level for a 400 or 413 response 

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -564,7 +564,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
      * @param request Netty HTTP request
      * @param t associated throwable
      */
-    private void  send400BadRequest(ChannelHandlerContext ctx, HttpRequest request, Throwable t, String message) {
+    private void send400BadRequest(ChannelHandlerContext ctx, HttpRequest request, Throwable t, String message) {
         TransportResponse handlerResponse = directHandlers.handler(DirectHandler.EventType.BAD_REQUEST)
                 .handle(new DirectHandlerRequest(request),
                         DirectHandler.EventType.BAD_REQUEST,

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -582,7 +582,9 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         ctx.writeAndFlush(response)
                 .addListener(future -> ctx.close());
 
-        failPublisher(new Error("400: Bad request"));
+        Error error = new Error("400: Bad request");
+        LOGGER.log(Level.WARNING, error, error::getMessage);
+        failPublisher(error);
     }
 
     /**
@@ -604,7 +606,9 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         ctx.writeAndFlush(response)
                 .addListener(future -> ctx.close());
 
-        failPublisher(new Error("413: Payload is too large"));
+        Error error = new Error("413: Payload is too large");
+        LOGGER.log(Level.WARNING, error, error::getMessage);
+        failPublisher(error);
     }
 
     private FullHttpResponse toNettyResponse(TransportResponse handlerResponse) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -388,7 +388,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                 try {
                     long value = Long.parseLong(contentLength);
                     if (value > maxPayloadSize) {
-                        LOGGER.fine(() -> formatMsg("Payload length over max %d > %d", ctx, value, maxPayloadSize));
                         ignorePayload = true;
                         send413PayloadTooLarge(ctx, request);
                         return true;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -139,16 +139,16 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             if (lastContent) {
                 // if the last thing that went through channelRead0 was LastHttpContent, then
                 // there is no request handler that should be enforcing backpressure
-                LOGGER.fine(() -> log("Read complete lastContent", ctx));
+                LOGGER.fine(() -> formatMsg("Read complete lastContent", ctx));
                 ctx.channel().config().setAutoRead(true);
             } else {
-                LOGGER.fine(() -> log("Read complete not lastContent", ctx));
+                LOGGER.fine(() -> formatMsg("Read complete not lastContent", ctx));
             }
             return;
         }
 
         if (requestContext.hasRequests()) {
-            LOGGER.fine(() -> log("Read complete has requests: %s", ctx, requestContext));
+            LOGGER.fine(() -> formatMsg("Read complete has requests: %s", ctx, requestContext));
             ctx.channel().read();
         }
     }
@@ -177,7 +177,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
         if (msg instanceof HttpContent) {
             if (requestContext == null) {
-                LOGGER.fine(() -> log("Received HttpContent: %s", ctx, System.identityHashCode(msg)));
+                LOGGER.fine(() -> formatMsg("Received HttpContent: %s", ctx, System.identityHashCode(msg)));
                 HelidonMdc.remove(MDC_SCOPE_ID);
                 throw new IllegalStateException("There is no request context associated with this http content. "
                                                 + "This is never expected to happen!");
@@ -195,7 +195,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             requestContext.runInScope(() -> {
                 // Simply forward raw bytebuf to Tyrus for processing
                 if (LOGGER.isLoggable(Level.FINEST)) {
-                    LOGGER.finest(log("Received ByteBuf of WebSockets connection: %s", ctx, msg));
+                    LOGGER.finest(formatMsg("Received ByteBuf of WebSockets connection: %s", ctx, msg));
                 }
                 requestContext.emit((ByteBuf) msg);
             });
@@ -205,7 +205,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
     private void channelReadHttpContent(ChannelHandlerContext ctx, Object msg) {
         if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.fine(log("Received HttpContent: %s", ctx, System.identityHashCode(msg)));
+            LOGGER.fine(formatMsg("Received HttpContent: %s", ctx, System.identityHashCode(msg)));
         }
         lastContent = false;
 
@@ -221,7 +221,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                 // consumed; if not, the request might proceed when payload is small enough
                 requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
                 if (LOGGER.isLoggable(Level.FINER)) {
-                    LOGGER.finer(log("Closing connection illegal payload; method: ", ctx, method));
+                    LOGGER.finer(formatMsg("Closing connection illegal payload; method: ", ctx, method));
                 }
                 throw new BadRequestException("It is illegal to send a payload with http method: " + method);
             }
@@ -229,15 +229,13 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             // compliance with RFC 7231
             if (requestContext.responseCompleted() && !(msg instanceof LastHttpContent)) {
                 // payload is not consumed and the response is already sent; we must close the connection
-                LOGGER.finer(() -> log("Closing connection unconsumed payload; method: ", ctx, method));
+                LOGGER.finer(() -> formatMsg("Closing connection unconsumed payload; method: ", ctx, method));
                 ctx.close();
             } else if (!ignorePayload) {
                 // Check payload size if a maximum has been set
                 if (maxPayloadSize >= 0) {
                     actualPayloadSize += content.readableBytes();
                     if (actualPayloadSize > maxPayloadSize) {
-                        LOGGER.finer(() -> log("Chunked Payload over max %d > %d", ctx,
-                                               actualPayloadSize, maxPayloadSize));
                         ignorePayload = true;
                         send413PayloadTooLarge(ctx, requestContext.request());
                     } else {
@@ -251,7 +249,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
         if (msg instanceof LastHttpContent) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine(log("Received LastHttpContent: %s", ctx, System.identityHashCode(msg)));
+                LOGGER.fine(formatMsg("Received LastHttpContent: %s", ctx, System.identityHashCode(msg)));
             }
 
             if (!isWebSocketUpgrade) {
@@ -279,7 +277,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
     @SuppressWarnings("checkstyle:methodlength")
     private boolean channelReadHttpRequest(ChannelHandlerContext ctx, Context requestScope, Object msg) {
         if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.fine(log("Received HttpRequest: %s. Remote address: %s. Scope id: %s",
+            LOGGER.fine(formatMsg("Received HttpRequest: %s. Remote address: %s. Scope id: %s",
                                   ctx,
                                   System.identityHashCode(msg),
                                   ctx.channel().remoteAddress(),
@@ -300,13 +298,12 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         try {
             checkDecoderResult(request);
         } catch (Throwable e) {
-            LOGGER.finest(() -> log("Invalid HTTP request. %s", ctx, e.getMessage()));
-            send400BadRequest(ctx, request, e);
+            send400BadRequest(ctx, request, e, formatMsg("Invalid HTTP request. %s", ctx, e.getMessage()));
             return true;
         }
 
         if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.finest(log("Requested URI: %s %s", ctx, request.method(), request.uri()));
+            LOGGER.finest(formatMsg("Requested URI: %s %s", ctx, request.method(), request.uri()));
         }
 
         // Certificate management
@@ -336,18 +333,18 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         // Set up read strategy for channel based on consumer demand
         publisher.onRequest((n, demand) -> {
             if (publisher.isUnbounded()) {
-                LOGGER.finest(() -> log("Netty autoread: true", ctx));
+                LOGGER.finest(() -> formatMsg("Netty autoread: true", ctx));
                 ctx.channel().config().setAutoRead(true);
             } else {
-                LOGGER.finest(() -> log("Netty autoread: false", ctx));
+                LOGGER.finest(() -> formatMsg("Netty autoread: false", ctx));
                 ctx.channel().config().setAutoRead(false);
             }
 
             if (publisher.hasRequests()) {
-                LOGGER.finest(() -> log("Requesting next (%d, %d) chunks from Netty", ctx, n, demand));
+                LOGGER.finest(() -> formatMsg("Requesting next (%d, %d) chunks from Netty", ctx, n, demand));
                 ctx.channel().read();
             } else {
-                LOGGER.finest(() -> log("No hook action required", ctx));
+                LOGGER.finest(() -> formatMsg("No hook action required", ctx));
             }
         });
 
@@ -364,12 +361,12 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                                               sslEngine,
                                               requestId);
         } catch (IllegalArgumentException e) {
-            send400BadRequest(ctx, request, e);
+            send400BadRequest(ctx, request, e, "Malformed URI in request");
             return true;
         }
 
         if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.finest(log("Request id: %s", ctx, bareRequest.requestId()));
+            LOGGER.finest(formatMsg("Request id: %s", ctx, bareRequest.requestId()));
         }
 
         String contentLength = request.headers().get(HttpHeaderNames.CONTENT_LENGTH);
@@ -391,14 +388,14 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                 try {
                     long value = Long.parseLong(contentLength);
                     if (value > maxPayloadSize) {
-                        LOGGER.fine(() -> log("Payload length over max %d > %d", ctx, value, maxPayloadSize));
+                        LOGGER.fine(() -> formatMsg("Payload length over max %d > %d", ctx, value, maxPayloadSize));
                         ignorePayload = true;
                         send413PayloadTooLarge(ctx, request);
                         return true;
                     }
                 } catch (NumberFormatException e) {
                     // this cannot happen, content length is validated in decoder
-                    send400BadRequest(ctx, request, e);
+                    send400BadRequest(ctx, request, e, "Invalid Content-Length header value");
                     return true;
                 }
             }
@@ -446,7 +443,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                     thisResp.complete(null);
 
                     if (LOGGER.isLoggable(Level.FINE)) {
-                        LOGGER.fine(log("Response complete: %s", ctx, System.identityHashCode(msg)));
+                        LOGGER.fine(formatMsg("Response complete: %s", ctx, System.identityHashCode(msg)));
                     }
                 });
         /*
@@ -462,14 +459,14 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             requestContext.runInScope(() -> routing.route(bareRequest, bareResponse));
         } catch (IllegalArgumentException e) {
             // this probably cannot happen
-            send400BadRequest(ctx, request, e);
+            send400BadRequest(ctx, request, e, "Exception encountered while routing request");
             return true;
         }
 
         // If WebSockets upgrade, re-arrange pipeline and drop HTTP decoder
         if (bareResponse.isWebSocketUpgrade()) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine(log("Replacing HttpRequestDecoder by WebSocketServerProtocolHandler", ctx));
+                LOGGER.fine(formatMsg("Replacing HttpRequestDecoder by WebSocketServerProtocolHandler", ctx));
             }
             ctx.pipeline().replace(httpRequestDecoder, "webSocketsHandler",
                                    new WebSocketServerProtocolHandler(bareRequest.uri().getPath(), null, true));
@@ -490,7 +487,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         // Log just cause as string
-        LOGGER.fine(() -> log("Exception caught: %s", ctx, cause.toString()));
+        LOGGER.fine(() -> formatMsg("Exception caught: %s", ctx, cause.toString()));
 
         // We ignore stream resets (RST_STREAM) from HTTP/2
         if (cause instanceof Http2Exception.StreamException
@@ -516,7 +513,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
     private void checkDecoderResult(HttpRequest request) {
         DecoderResult decoderResult = request.decoderResult();
         if (decoderResult.isFailure()) {
-            LOGGER.info(() -> log("Request %s to %s rejected: %s", null,
+            LOGGER.info(() -> formatMsg("Request %s to %s rejected: %s", null,
                     request.method().asciiName(), request.uri(), decoderResult.cause().getMessage()));
             throw new BadRequestException(String.format("Request was rejected: %s", decoderResult.cause().getMessage()),
                     decoderResult.cause());
@@ -542,7 +539,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         if (handshakeHandler != null) {
             ctx.pipeline().remove(handshakeHandler);
         } else {
-            LOGGER.warning(() -> log("Unable to remove WebSockets handshake handler from pipeline", ctx));
+            LOGGER.warning(() -> formatMsg("Unable to remove WebSockets handshake handler from pipeline", ctx));
         }
     }
 
@@ -568,7 +565,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
      * @param request Netty HTTP request
      * @param t associated throwable
      */
-    private void send400BadRequest(ChannelHandlerContext ctx, HttpRequest request, Throwable t) {
+    private void  send400BadRequest(ChannelHandlerContext ctx, HttpRequest request, Throwable t, String message) {
         TransportResponse handlerResponse = directHandlers.handler(DirectHandler.EventType.BAD_REQUEST)
                 .handle(new DirectHandlerRequest(request),
                         DirectHandler.EventType.BAD_REQUEST,
@@ -582,8 +579,13 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         ctx.writeAndFlush(response)
                 .addListener(future -> ctx.close());
 
+        // Log simple warning and more details if FINE level set
         Error error = new Error("400: Bad request");
-        LOGGER.log(Level.WARNING, error, error::getMessage);
+        LOGGER.log(Level.WARNING, error::getMessage);
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, message, error);
+        }
+
         failPublisher(error);
     }
 
@@ -606,8 +608,14 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         ctx.writeAndFlush(response)
                 .addListener(future -> ctx.close());
 
+        // Log simple warning and more details if FINE level set
         Error error = new Error("413: Payload is too large");
-        LOGGER.log(Level.WARNING, error, error::getMessage);
+        LOGGER.log(Level.WARNING, error::getMessage);
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, formatMsg("Chunked Payload over max %d > %d",
+                    ctx, actualPayloadSize, maxPayloadSize), error);
+        }
+
         failPublisher(error);
     }
 
@@ -649,7 +657,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
      * @param params template suffix params.
      * @return string to log.
      */
-    private String log(String template, ChannelHandlerContext ctx, Object... params) {
+    private String formatMsg(String template, ChannelHandlerContext ctx, Object... params) {
         List<Object> list = new ArrayList<>(params.length + 2);
         list.add(System.identityHashCode(this));
         list.add(ctx != null ? ctx.channel().id() : "N/A");


### PR DESCRIPTION
Log an entry in warning level for a 400 or 413 response returned by the ForwardingHandler. Note that the access log is not reached if an error is reported at this stage, so these log entries should help diagnose problems. (#5295)