### PR TITLE
Fix problem when double quotes exist in the subject title during Create backport issues action

### DIFF
--- a/etc/scripts/actions/create-backport-issues.sh
+++ b/etc/scripts/actions/create-backport-issues.sh
@@ -70,7 +70,7 @@ readonly ISSUE=$(curl -s -X GET \
   "$GET_ISSUE_URL")
 
 # Get issue information
-ISSUE_TITLE=$(echo "$ISSUE" | jq -r ".title")
+issue_title=$(echo "$ISSUE" | jq -r ".title")
 readonly ISSUE_ASSIGNEE=$(echo "$ISSUE" | jq -r ".assignee.login")
 readonly ISSUE_LABELS=$(echo "$ISSUE" | jq -r ".labels") # JSON Array
 
@@ -109,7 +109,7 @@ if [ ${#version_labels[@]} -eq 0 ]; then
 fi
 
 # Replace all instances of " with ' in the Issue Title to avoid JSON parsing issue
-ISSUE_TITLE=$(sed "s/\"/'/g" <<< "$ISSUE_TITLE")
+issue_title=$(sed "s/\"/'/g" <<< "$issue_title")
 
 ############################################################
 # For each version that is not the issue's version, add backport
@@ -117,7 +117,7 @@ ISSUE_TITLE=$(sed "s/\"/'/g" <<< "$ISSUE_TITLE")
 for version in ${VERSIONS[@]}; do
   if [ "$version" != "$HELIDON_VERSION" ]; then
     # Create issue for all other versions and add the same labels and assignee
-    new_issue_title="[$version] ${ISSUE_TITLE}"
+    new_issue_title="[$version] ${issue_title}"
     new_issue_text="Backport of #${ISSUE_NUMBER} for Helidon ${version}"
 
     # by default, add label for the version we are backporting into, and for backport itself


### PR DESCRIPTION
**Goals of the change:**
1. Replace double quotes `"` with single quote `'` in the issues subject title to avoid Github JSON parsing issue.
2. Print out the Github API Server response if unable to parse the issue number. Also display the json payload that was sent so it can be inspected for problems if such issue occur. This will help in other unknown situations where the request is failing. Example output: 
   ```
   Encountered an error while attempting to create an issue: {
     "message": "Problems parsing JSON",
     "documentation_url": "https://docs.github.com/rest/reference/issues#create-an-issue"
   }
   Json payload: {"title":"[3.x] Grpc component does not handle "package" directive in proto files.","body":"Backport of #4567 for Helidon 3.x","assignees":["klustria"],"labels":["3.x","backport","bug","grpc","P2"]}
   ```

_Note: Potential fix was tested in local machine using a temporary github token_