### PR TITLE
Use property to skip execution of eclipselink weave

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/custom/database.xml
+++ b/archetypes/helidon/src/main/archetype/mp/custom/database.xml
@@ -130,6 +130,7 @@
                                 <argument>${project.build.outputDirectory}</argument>
                                 <argument>${project.build.outputDirectory}</argument>
                             </arguments>
+                            <skip>${eclipselink.weave.skip}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
See #5215

Signed-off-by: tvallin <thibault.vallin@oracle.com>