### PR TITLE
Remove trailing empty line in copyright comment (part 1)

### DIFF
--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/AbstractKafkaTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/AbstractKafkaTest.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.messaging.connectors.kafka;

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/EmittingPublisherTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/EmittingPublisherTest.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.messaging.connectors.kafka;

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaMpTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaMpTest.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.messaging.connectors.kafka;

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaPublisherTckTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaPublisherTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.messaging.connectors.kafka;

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.messaging.connectors.kafka;

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSubscriberTckTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSubscriberTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.messaging.connectors.kafka;

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/MessageTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/MessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.messaging.connectors.kafka;


### PR DESCRIPTION
There are many warnings in the build log:
<img width="1698" alt="Screenshot 2022-11-03 at 20 46 49" src="https://user-images.githubusercontent.com/4740207/199809103-986cde3a-78d8-47e7-8069-b8cf5ae2d92b.png">

It can be fixed really simply. I'll do it if it is necessary. The next PR will be bigger.