### PR TITLE
Support for requested URI for web server requests.

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/Forwarded.java
+++ b/common/http/src/main/java/io/helidon/common/http/Forwarded.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.http;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static io.helidon.common.http.Http.Header.FORWARDED;
+
+/**
+ * A representation of the {@link Http.Header#FORWARDED} HTTP header.
+ */
+public class Forwarded {
+    private static final System.Logger LOGGER = System.getLogger(Forwarded.class.getName());
+    private final Optional<String> by;
+    private final Optional<String> forClient;
+    private final Optional<String> host;
+    private final Optional<String> proto;
+
+    private Forwarded(String by, String forClient, String host, String proto) {
+        this.by = Optional.ofNullable(by);
+        this.forClient = Optional.ofNullable(forClient);
+        this.host = Optional.ofNullable(host);
+        this.proto = Optional.ofNullable(proto);
+    }
+
+    /**
+     * Create forwarded from a value of a single forwarded header, such as {@code by=a.b.c;for=d.e.f;host=host;proto=https}.
+     *
+     * @param string string representation of a single forwarded header
+     * @return forwarded parsed from the string
+     * @see #create(Headers)
+     */
+    public static Forwarded create(String string) {
+        // first split by semicolon, as that separates the directives
+        String[] directives = string.split(";");
+        String by = null;
+        String forClient = null;
+        String host = null;
+        String proto = null;
+
+        for (String directive : directives) {
+            int index = directive.indexOf('=');
+            if (index == -1 && !directive.isEmpty()) {
+                throw new IllegalArgumentException("Invalid Forwarded header");
+            }
+            String name = directive.substring(0, index);
+            String value = unquote(directive.substring(index + 1));
+
+            switch (name.toLowerCase(Locale.ROOT)) {
+            case "by" -> {
+                by = value;
+            }
+            case "for" -> {
+                forClient = value;
+            }
+            case "host" -> {
+                host = value;
+            }
+            case "proto" -> {
+                proto = value;
+            }
+            default -> {
+                if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+                    String printableName = name.replaceAll("\\p{C}", "?");
+                    String printableValue = value.replaceAll("\\p{C}", "?");
+
+                    LOGGER.log(System.Logger.Level.DEBUG, "Encountered unknown directive of Forwarded header: \n"
+                            + printableName + "\nValue:\n" + printableValue);
+                }
+            }
+            }
+        }
+        return new Forwarded(by, forClient, host, proto);
+    }
+
+    /**
+     * Parse forwarded header(s) from the provided headers.
+     *
+     * @param headers header to process
+     * @return list of forwarded headers, will be empty if the header does not exist.
+     */
+    public static List<Forwarded> create(Headers headers) {
+        List<String> values = headers.values(FORWARDED);
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+
+        return values.stream()
+                    .flatMap(it -> Arrays.stream(it.split(",")))
+                    .map(String::trim)
+                    .map(Forwarded::create)
+                    .toList();
+    }
+
+    /**
+     * {@code by} directive of the forwarded header.
+     *
+     * @return by directive
+     */
+    public Optional<String> by() {
+        return by;
+    }
+
+    /**
+     * {@code for} directive of the forwarded header.
+     *
+     * @return for directive
+     */
+    public Optional<String> forClient() {
+        return forClient;
+    }
+
+    /**
+     * {@code host} directive of the forwarded header. The host of the original request.
+     *
+     * @return host directive
+     */
+    public Optional<String> host() {
+        return host;
+    }
+
+    /**
+     * {@code proto} directive of the forwarded header. The protocol of the original request (http or https).
+     *
+     * @return proto directive
+     */
+    public Optional<String> proto() {
+        return proto;
+    }
+
+    private static String unquote(String string) {
+        if (string.indexOf('"') == 0 && string.lastIndexOf('"') == string.length() - 1) {
+            return string.substring(1, string.length() - 1);
+        }
+        return string;
+    }
+}

--- a/common/http/src/main/java/io/helidon/common/http/Http.java
+++ b/common/http/src/main/java/io/helidon/common/http/Http.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -777,6 +777,31 @@ public final class Http {
          * Disclose original information of a client connecting to a web server through an HTTP proxy.
          */
         public static final String FORWARDED = "Forwarded";
+        /**
+         * The {@code X-Forwarded-For} header name.
+         * Used to represent the original host requested by a client, when request passed through a proxy server.
+         */
+        public static final String X_FORWARDED_FOR = "X-Forwarded-For";
+        /**
+         * The {@code X-Forwarded-Host} header name.
+         * Used to represent the original host requested by a client, when request passed through a proxy server.
+         */
+        public static final String X_FORWARDED_HOST = "X-Forwarded-Host";
+        /**
+         * The {@code X-Forwarded-Port} header name.
+         * Used to represent the original port requested by a client, when request passed through a proxy server.
+         */
+        public static final String X_FORWARDED_PORT = "X-Forwarded-Port";
+        /**
+         * The {@code X-Forwarded-Prefix} header name.
+         * Used to represent the original path prefix requested by a client, when request passed through a proxy server.
+         */
+        public static final String X_FORWARDED_PREFIX = "X-Forwarded-Prefix";
+        /**
+         * The {@code X-Forwarded-Proto} header name.
+         * Used to represent the original protocol used by a client, when request passed through a proxy server.
+         */
+        public static final String X_FORWARDED_PROTO = "X-Forwarded-Proto";
         /**
          * The <code>{@value}</code> header name.
          * The email address of the user making the request.

--- a/common/http/src/main/java/io/helidon/common/http/UriInfo.java
+++ b/common/http/src/main/java/io/helidon/common/http/UriInfo.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.http;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+/**
+ * Information about URI.
+ *
+ * @param scheme Scheme of the request ({@code http}, {@code https})
+ * @param host Host part of authority of the request
+ * @param port Port part of authority of the request
+ * @param path Path of the request
+ * @param query Query of the request
+ */
+public record UriInfo(String scheme,
+                      String host,
+                      int port,
+                      String path,
+                      Optional<String> query) {
+
+    /**
+     * Create URI from the information. This operation is expensive.
+     *
+     * @return URI to use
+     */
+    public URI toUri() {
+        try {
+            return new URI(scheme, authority(), path, query.orElse(null), null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("UriInfo cannot be used to create a URI: " + this, e);
+        }
+    }
+
+    /**
+     * Authority (host:port) of this URI.
+     *
+     * @return authority
+     */
+    public String authority() {
+        return host + ":" + port;
+    }
+}

--- a/common/http/src/test/java/io/helidon/common/http/ForwardedTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/ForwardedTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.http;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.testing.OptionalMatcher.empty;
+import static io.helidon.config.testing.OptionalMatcher.value;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+class ForwardedTest {
+    @Test
+    void testForOnly() {
+        String header = "for=\"_mdn\"";
+        Forwarded forwarded = Forwarded.create(header);
+
+        assertThat(forwarded.by(), is(empty()));
+        assertThat(forwarded.host(), is(empty()));
+        assertThat(forwarded.proto(), is(empty()));
+        assertThat(forwarded.forClient(), value(is("_mdn")));
+    }
+
+    @Test
+    void testForCaseInsensitive() {
+        String header = "For=\"[2001:db8:cafe::17]:4711\"";
+        Forwarded forwarded = Forwarded.create(header);
+
+        assertThat(forwarded.by(), is(empty()));
+        assertThat(forwarded.host(), is(empty()));
+        assertThat(forwarded.proto(), is(empty()));
+        assertThat(forwarded.forClient(), value(is("[2001:db8:cafe::17]:4711")));
+    }
+
+    @Test
+    void testForProtoAndBy() {
+        String header = "for=192.0.2.60;proto=http;by=203.0.113.43";
+        Forwarded forwarded = Forwarded.create(header);
+
+        assertThat(forwarded.by(), value(is("203.0.113.43")));
+        assertThat(forwarded.host(), is(empty()));
+        assertThat(forwarded.proto(), value(is("http")));
+        assertThat(forwarded.forClient(), value(is("192.0.2.60")));
+    }
+
+    @Test
+    void testAll() {
+        String header = "for=192.0.2.60;proto=http;by=203.0.113.43;Host=10.10.10.10";
+        Forwarded forwarded = Forwarded.create(header);
+
+        assertThat(forwarded.by(), value(is("203.0.113.43")));
+        assertThat(forwarded.host(), value(is("10.10.10.10")));
+        assertThat(forwarded.proto(), value(is("http")));
+        assertThat(forwarded.forClient(), value(is("192.0.2.60")));
+    }
+
+    @Test
+    void testMultiValuesCommaSeparated() {
+        HashHeaders headers = HashHeaders.create();
+        headers.add(Http.Header.FORWARDED, "for=192.0.2.60;proto=http;by=203.0.113.43;Host=10.10.10.10,by=\"192.0.2.60\"");
+        List<Forwarded> forwardedList = Forwarded.create(headers);
+
+        assertThat(forwardedList, hasSize(2));
+        Forwarded forwarded = forwardedList.get(0);
+
+        assertThat(forwarded.by(), value(is("203.0.113.43")));
+        assertThat(forwarded.host(), value(is("10.10.10.10")));
+        assertThat(forwarded.proto(), value(is("http")));
+        assertThat(forwarded.forClient(), value(is("192.0.2.60")));
+
+        forwarded = forwardedList.get(1);
+        assertThat(forwarded.by(), value(is("192.0.2.60")));
+        assertThat(forwarded.host(), is(empty()));
+        assertThat(forwarded.proto(), is(empty()));
+        assertThat(forwarded.forClient(), is(empty()));
+    }
+
+    @Test
+    void testMultiValues() {
+        HashHeaders headers = HashHeaders.create();
+        headers.add(Http.Header.FORWARDED, "for=192.0.2.60;proto=http;by=203.0.113.43;Host=10.10.10.10",
+                    "by=\"192.0.2.60\"");
+        List<Forwarded> forwardedList = Forwarded.create(headers);
+
+        assertThat(forwardedList, hasSize(2));
+        Forwarded forwarded = forwardedList.get(0);
+
+        assertThat(forwarded.by(), value(is("203.0.113.43")));
+        assertThat(forwarded.host(), value(is("10.10.10.10")));
+        assertThat(forwarded.proto(), value(is("http")));
+        assertThat(forwarded.forClient(), value(is("192.0.2.60")));
+
+        forwarded = forwardedList.get(1);
+        assertThat(forwarded.by(), value(is("192.0.2.60")));
+        assertThat(forwarded.host(), is(empty()));
+        assertThat(forwarded.proto(), is(empty()));
+        assertThat(forwarded.forClient(), is(empty()));
+    }
+
+    @Test
+    void testMultiValuesAndCommaSeparated() {
+        HashHeaders headers = HashHeaders.create();
+        headers.add(Http.Header.FORWARDED, "for=192.0.2.60;proto=http;by=203.0.113.43;Host=10.10.10.10",
+                    "by=\"192.0.2.60\",for=\"14.22.11.22\"");
+        List<Forwarded> forwardedList = Forwarded.create(headers);
+
+        assertThat(forwardedList, hasSize(3));
+        Forwarded forwarded = forwardedList.get(0);
+
+        assertThat(forwarded.by(), value(is("203.0.113.43")));
+        assertThat(forwarded.host(), value(is("10.10.10.10")));
+        assertThat(forwarded.proto(), value(is("http")));
+        assertThat(forwarded.forClient(), value(is("192.0.2.60")));
+
+        forwarded = forwardedList.get(1);
+        assertThat(forwarded.by(), value(is("192.0.2.60")));
+        assertThat(forwarded.host(), is(empty()));
+        assertThat(forwarded.proto(), is(empty()));
+        assertThat(forwarded.forClient(), is(empty()));
+
+        forwarded = forwardedList.get(2);
+        assertThat(forwarded.by(), is(empty()));
+        assertThat(forwarded.host(), is(empty()));
+        assertThat(forwarded.proto(), is(empty()));
+        assertThat(forwarded.forClient(), value(is("14.22.11.22")));
+    }
+}

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -297,6 +297,7 @@ public class JerseySupport implements Service {
 
             requestContext.setProperty("io.helidon.jaxrs.remote-host", remoteHost);
             requestContext.setProperty("io.helidon.jaxrs.remote-port", remotePort);
+            requestContext.setProperty("io.helidon.jaxrs.requested-uri", req.requestedUri());
 
             requestContext.setWriter(responseWriter);
 

--- a/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/TestClient.java
+++ b/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/TestClient.java
@@ -43,6 +43,7 @@ import io.helidon.webserver.BackpressureStrategy;
 import io.helidon.webserver.BareRequest;
 import io.helidon.webserver.BareResponse;
 import io.helidon.webserver.Routing;
+import io.helidon.webserver.SocketConfiguration;
 
 /**
  * Client API designed to create request directly on {@link Routing} without a network layer.
@@ -252,6 +253,11 @@ public class TestClient {
         @Override
         public Single<Void> closeConnection() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SocketConfiguration socketConfiguration() {
+            return SocketConfiguration.create("@default");
         }
     }
 

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -243,5 +243,10 @@
             <artifactId>reactive-streams-tck-flow</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,13 @@ public interface BareRequest {
      * @return Actual {@code WebServer} instance.
      */
     WebServer webServer();
+
+    /**
+     * Configuration of the socket that received this request.
+     *
+     * @return socket configuration
+     */
+    SocketConfiguration socketConfiguration();
 
     /**
      * Gets an HTTP request method.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -340,11 +340,12 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         // If a problem with the request URI, return 400 response
         BareRequestImpl bareRequest;
         try {
-            bareRequest = new BareRequestImpl(request,
-                                              requestContextRef.publisher(),
-                                              webServer,
-                                              ctx,
+            bareRequest = new BareRequestImpl(webServer,
+                                              soConfig,
                                               sslEngine,
+                                              ctx,
+                                              request,
+                                              requestContextRef.publisher(),
                                               requestId);
         } catch (IllegalArgumentException e) {
             send400BadRequest(ctx, request, e);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Request.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Request.java
@@ -101,7 +101,7 @@ abstract class Request implements ServerRequest {
         this.headers = request.headers;
         this.content = request.content;
         this.eventListener = request.eventListener;
-        this.requestedUri = request.requestedUri;
+        this.requestedUri = LazyValue.create(this::createRequestedUri);
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -183,7 +184,10 @@ class ServerBasicConfig implements ServerConfiguration {
         return socketConfig.enableCompression();
     }
 
-
+    @Override
+    public List<RequestedUriDiscoveryType> requestedUriDiscoveryTypes() {
+        return socketConfig.requestedUriDiscoveryTypes();
+    }
 
     static class SocketConfig implements SocketConfiguration {
 
@@ -205,6 +209,7 @@ class ServerBasicConfig implements ServerConfiguration {
         private final long backpressureBufferSize;
         private final BackpressureStrategy backpressureStrategy;
         private final int maxUpgradeContentLength;
+        private List<RequestedUriDiscoveryType> requestedUriDiscoveryTypes;
 
         /**
          * Creates new instance.
@@ -229,6 +234,7 @@ class ServerBasicConfig implements ServerConfiguration {
             this.maxUpgradeContentLength = builder.maxUpgradeContentLength();
             WebServerTls webServerTls = builder.tlsConfig();
             this.webServerTls = webServerTls.enabled() ? webServerTls : null;
+            this.requestedUriDiscoveryTypes = builder.requestedUriDiscoveryTypes();
         }
 
         @Override
@@ -339,6 +345,11 @@ class ServerBasicConfig implements ServerConfiguration {
         @Override
         public BackpressureStrategy backpressureStrategy() {
             return backpressureStrategy;
+        }
+
+        @Override
+        public List<RequestedUriDiscoveryType> requestedUriDiscoveryTypes() {
+            return requestedUriDiscoveryTypes;
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -566,6 +566,18 @@ public interface ServerConfiguration extends SocketConfiguration {
             return this;
         }
 
+        @Override
+        public Builder addRequestedUriDiscoveryType(RequestedUriDiscoveryType type) {
+            defaultSocketBuilder().addRequestedUriDiscoveryType(type);
+            return this;
+        }
+
+        @Override
+        public Builder requestedUriDiscoveryEnabled(boolean enabled) {
+            defaultSocketBuilder().requestedUriDiscoveryEnabled(enabled);
+            return this;
+        }
+
         /**
          * Configure the maximum amount of time that the server will wait to shut
          * down regardless of the value of any additionally requested

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerRequest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import io.helidon.common.context.Context;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpRequest;
+import io.helidon.common.http.UriInfo;
 import io.helidon.common.reactive.Single;
 import io.helidon.media.common.MessageBodyReadableContent;
 import io.helidon.tracing.SpanContext;
@@ -149,6 +150,16 @@ public interface ServerRequest extends HttpRequest {
      * @return Single completed when connection is closed.
      */
     Single<Void> closeConnection();
+
+    /**
+     * URI as it was requested by the user (to the best of our knowledge).
+     * By default, the information is taken from {@link Http.Header#HOST} header and current request.
+     * If enabled by configuration, additional headers may be used to determine the user invoked URI (such as
+     * {@link Http.Header#FORWARDED}).
+     *
+     * @return uri info that can be used for redirects
+     */
+    UriInfo requestedUri();
 
     /**
      * Absolute URI of the incoming request, including query parameters and fragment.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -607,6 +607,18 @@ public interface WebServer {
             return this;
         }
 
+        @Override
+        public Builder addRequestedUriDiscoveryType(SocketConfiguration.RequestedUriDiscoveryType type) {
+            defaultSocket(it -> it.addRequestedUriDiscoveryType(type));
+            return this;
+        }
+
+        @Override
+        public Builder requestedUriDiscoveryEnabled(boolean enabled) {
+            defaultSocket(it -> it.requestedUriDiscoveryEnabled(enabled));
+            return this;
+        }
+
         /**
          * A helper method to support fluentAPI when invoking another method.
          * <p>


### PR DESCRIPTION
Related to #4725 

Added support for `requestedUri` to `ServerRequest` and as a property in Jersey.
This adds support for (configurable) way of obtaining the URI originally requested by remote user, using `Forwarded` and the `X-Forwarded-*` headers.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>