### PR TITLE
Remove trailing empty line in copyright comment (part 8)

### DIFF
--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiOnTerminateTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiOnTerminateTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiPeekTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiPeekTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiPeekTwiceTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiPeekTwiceTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiRangeLongTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiRangeLongTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.common.reactive;
 

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiRangeTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiRangeTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.common.reactive;
 

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiReduceFullTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiReduceFullTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.common.reactive;
 

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiReduceTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiReduceTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.common.reactive;
 

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiSkipPublisherNoSkipTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiSkipPublisherNoSkipTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiSkipPublisherTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiSkipPublisherTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiTakeUntilPublisherTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiTakeUntilPublisherTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.common.reactive;
 

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiTakeWhilePublisherTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/MultiTakeWhilePublisherTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleDeferTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleDeferTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.common.reactive;
 

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleFlatMapIterableTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleFlatMapIterableTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.common.reactive;
 

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleFlatMapMultiTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleFlatMapMultiTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleFlatMapSingleTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleFlatMapSingleTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnCompleteResumeWithSingleCompletedTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnCompleteResumeWithSingleCompletedTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnCompleteResumeWithSingleTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnCompleteResumeWithSingleTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeFailureTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeFailureTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeSuccessTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeSuccessTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeWithSuccessTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeWithSuccessTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SinglePeekTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SinglePeekTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SinglePeekTwiceTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SinglePeekTwiceTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleTakeUntilPublisherTckTest.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/SingleTakeUntilPublisherTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.common.reactive;
 

--- a/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/TidyTestExecutor.java
+++ b/tests/tck/tck-reactive-streams/src/test/java/io/helidon/common/reactive/TidyTestExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.common.reactive;


### PR DESCRIPTION
Next part of https://github.com/helidon-io/helidon/pull/5324