### PR TITLE
Name all threads.

### DIFF
--- a/common/socket/src/main/java/io/helidon/common/socket/SocketWriterAsync.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/SocketWriterAsync.java
@@ -110,6 +110,7 @@ class SocketWriterAsync extends SocketWriter implements DataWriter {
 
     private void run() {
         this.thread = Thread.currentThread();
+        this.thread.setName("[" + socket().socketId() + " " + socket().childSocketId() + "]");
         try {
             while (run) {
                 CompositeBufferData toWrite = BufferData.createComposite(writeQueue.take());  // wait if the queue is empty

--- a/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/AsyncImpl.java
+++ b/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/AsyncImpl.java
@@ -52,6 +52,8 @@ class AsyncImpl implements Async {
             }
         };
         Future<?> future = executor.get().submit(() -> {
+            Thread thread = Thread.currentThread();
+            thread.setName(thread.getName() + ": async");
             try {
                 T t = supplier.get();
                 result.complete(t);

--- a/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/FaultTolerance.java
+++ b/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/FaultTolerance.java
@@ -54,7 +54,9 @@ public final class FaultTolerance {
     private static final AtomicReference<Config> CONFIG = new AtomicReference<>(Config.empty());
 
     static {
-        EXECUTOR.set(LazyValue.create(Executors.newVirtualThreadPerTaskExecutor()));
+        EXECUTOR.set(LazyValue.create(() -> Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
+                                                          .name("helidon-ft-", 0)
+                                                          .factory())));
     }
 
     private FaultTolerance() {

--- a/nima/fault-tolerance/src/test/java/io/helidon/nima/faulttolerance/AsyncTest.java
+++ b/nima/fault-tolerance/src/test/java/io/helidon/nima/faulttolerance/AsyncTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -47,6 +49,16 @@ class AsyncTest {
                 .build();
         Thread thread = testAsync(async);
         assertThat(thread.isVirtual(), is(true));
+    }
+
+    @Test
+    void testThreadName() throws Exception {
+        String threadName = Async.create()
+                .invoke(() -> Thread.currentThread().getName())
+                .get(10, TimeUnit.SECONDS);
+
+        assertThat(threadName, startsWith("helidon-ft-"));
+        assertThat(threadName, endsWith(": async"));
     }
 
     private Thread testAsync(Async async) {

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ThreadNameTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ThreadNameTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.server;
+
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webclient.http1.Http1Client;
+import io.helidon.nima.webserver.http.HttpRules;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
+
+@ServerTest
+class ThreadNameTest {
+    private final Http1Client client;
+
+    ThreadNameTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.get("/", (req, res) -> {
+            String socketId = req.serverSocketId();
+            String clientSocketId = req.socketId();
+            boolean isVirtual = Thread.currentThread().isVirtual();
+
+            res.send(isVirtual + ":" + socketId + ":" + clientSocketId + ":" + Thread.currentThread().getName());
+        });
+    }
+
+    @Test
+    void testName() {
+        String message = client.get()
+                .request(String.class);
+        String[] parts = message.split(":");
+        // the parts must be 4 long
+        assertThat("Response should have four parts: isVirtual,serverSocketId,connSocketId,threadName", parts, arrayWithSize(4));
+        assertThat("Thread must be virtual", parts[0], is("true"));
+        String serverSocket = parts[1];
+        String clientSocket = parts[2];
+
+        assertThat(parts[3], is("[" + serverSocket + " " + clientSocket + "] Nima socket"));
+    }
+}

--- a/nima/tests/integration/websocket/server/src/test/java/io/helidon/nima/tests/integration/websocket/webserver/WebSocketTest.java
+++ b/nima/tests/integration/websocket/server/src/test/java/io/helidon/nima/tests/integration/websocket/webserver/WebSocketTest.java
@@ -85,8 +85,8 @@ class WebSocketTest {
                 .get(5, TimeUnit.SECONDS);
         ws.request(10);
 
-        ws.sendText("Hello", true);
-        ws.sendClose(CloseCodes.NORMAL_CLOSE, "normal");
+        ws.sendText("Hello", true).get(5, TimeUnit.SECONDS);
+        ws.sendClose(CloseCodes.NORMAL_CLOSE, "normal").get(5, TimeUnit.SECONDS);
 
         List<String> results = listener.getResults();
         assertThat(results, contains("Hello"));
@@ -101,9 +101,9 @@ class WebSocketTest {
                 .get(5, TimeUnit.SECONDS);
         ws.request(10);
 
-        ws.sendText("First", true);
-        ws.sendText("Second", true);
-        ws.sendClose(CloseCodes.NORMAL_CLOSE, "normal");
+        ws.sendText("First", true).get(5, TimeUnit.SECONDS);
+        ws.sendText("Second", true).get(5, TimeUnit.SECONDS);
+        ws.sendClose(CloseCodes.NORMAL_CLOSE, "normal").get(5, TimeUnit.SECONDS);
         assertThat(listener.getResults(), contains("First", "Second"));
     }
 
@@ -116,10 +116,10 @@ class WebSocketTest {
                 .get(5, TimeUnit.SECONDS);
         ws.request(10);
 
-        ws.sendText("First", false);
-        ws.sendText("Second", true);
-        ws.sendText("Third", true);
-        ws.sendClose(CloseCodes.NORMAL_CLOSE, "normal");
+        ws.sendText("First", false).get(5, TimeUnit.SECONDS);
+        ws.sendText("Second", true).get(5, TimeUnit.SECONDS);
+        ws.sendText("Third", true).get(5, TimeUnit.SECONDS);
+        ws.sendClose(CloseCodes.NORMAL_CLOSE, "normal").get(5, TimeUnit.SECONDS);
 
         assertThat(listener.getResults(), contains("FirstSecond", "Third"));
     }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionHandler.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionHandler.java
@@ -88,7 +88,7 @@ class ConnectionHandler implements Runnable {
 
     @Override
     public final void run() {
-        Thread.currentThread().setName("[" + socket.socketId() + " " + socket.childSocketId() + "]");
+        Thread.currentThread().setName("[" + socket.socketId() + " " + socket.childSocketId() + "] Nima socket");
         if (LOGGER.isLoggable(DEBUG)) {
             ctx.log(LOGGER, DEBUG, "accepted socket from %s", socket.remotePeer().host());
         }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionHandler.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ConnectionHandler.java
@@ -88,6 +88,7 @@ class ConnectionHandler implements Runnable {
 
     @Override
     public final void run() {
+        Thread.currentThread().setName("[" + socket.socketId() + " " + socket.childSocketId() + "]");
         if (LOGGER.isLoggable(DEBUG)) {
             ctx.log(LOGGER, DEBUG, "accepted socket from %s", socket.remotePeer().host());
         }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ServerListener.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ServerListener.java
@@ -118,6 +118,11 @@ class ServerListener {
         this.contentEncodingContext = contentEncodingContext;
     }
 
+    @Override
+    public String toString() {
+        return socketName + " (" + configuredAddress + ")";
+    }
+
     int port() {
         return connectedPort;
     }


### PR DESCRIPTION
Resolves #5359 

The executor services do not use a factory that names threads, the names are assigned from the runnables (name is related to the executed task)