### PR TITLE
Fix Guava version to match that required by the grpc-java libraries

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -62,7 +62,7 @@
         <version.lib.graphql-java.extended.scalars>17.1</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
         <version.lib.grpc>1.49.2</version.lib.grpc>
-        <version.lib.guava>30.0-jre</version.lib.guava>
+        <version.lib.guava>31.1-android</version.lib.guava>
         <version.lib.h2>1.4.200</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.hibernate>5.6.11.Final</version.lib.hibernate>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -62,7 +62,7 @@
         <version.lib.graphql-java.extended.scalars>17.1</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
         <version.lib.grpc>1.49.2</version.lib.grpc>
-        <version.lib.guava>31.1-android</version.lib.guava>
+        <version.lib.guava>31.1-jre</version.lib.guava>
         <version.lib.h2>1.4.200</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.hibernate>5.6.11.Final</version.lib.hibernate>

--- a/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/AdpSelectionStrategy.java
+++ b/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/AdpSelectionStrategy.java
@@ -134,8 +134,8 @@ enum AdpSelectionStrategy {
             c.get(OCI_AUTH_PASSPHRASE, String.class).or(() -> c.get(OCI_AUTH_PASSPHRASE + "Characters", String.class))
                 .ifPresent(b::passPhrase);
             c.get(OCI_AUTH_PRIVATE_KEY, String.class).or(() -> c.get("oci.auth.privateKey", String.class))
-                .ifPresentOrElse(pk -> b.privateKeySupplier((Supplier< InputStream>) new StringPrivateKeySupplier(pk)),
-                                 () -> b.privateKeySupplier((Supplier< InputStream>) new SimplePrivateKeySupplier(c.get(OCI_AUTH_PRIVATE_KEY + "-path", String.class)
+                .ifPresentOrElse(pk -> b.privateKeySupplier((Supplier<InputStream>) new StringPrivateKeySupplier(pk)),
+                                 () -> b.privateKeySupplier((Supplier<InputStream>) new SimplePrivateKeySupplier(c.get(OCI_AUTH_PRIVATE_KEY + "-path", String.class)
                                                                                          .orElse(c.get("oci.auth.keyFile", String.class)
                                                                                                  .orElse(Paths.get(System.getProperty("user.home"), ".oci", "oci_api_key.pem").toString())))));
             c.get(OCI_AUTH_REGION, Region.class)

--- a/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/AdpSelectionStrategy.java
+++ b/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/AdpSelectionStrategy.java
@@ -17,6 +17,7 @@ package io.helidon.integrations.oci.sdk.cdi;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.annotation.Annotation;
 import java.net.ConnectException;
@@ -133,8 +134,8 @@ enum AdpSelectionStrategy {
             c.get(OCI_AUTH_PASSPHRASE, String.class).or(() -> c.get(OCI_AUTH_PASSPHRASE + "Characters", String.class))
                 .ifPresent(b::passPhrase);
             c.get(OCI_AUTH_PRIVATE_KEY, String.class).or(() -> c.get("oci.auth.privateKey", String.class))
-                .ifPresentOrElse(pk -> b.privateKeySupplier(new StringPrivateKeySupplier(pk)),
-                                 () -> b.privateKeySupplier(new SimplePrivateKeySupplier(c.get(OCI_AUTH_PRIVATE_KEY + "-path", String.class)
+                .ifPresentOrElse(pk -> b.privateKeySupplier((Supplier< InputStream>) new StringPrivateKeySupplier(pk)),
+                                 () -> b.privateKeySupplier((Supplier< InputStream>) new SimplePrivateKeySupplier(c.get(OCI_AUTH_PRIVATE_KEY + "-path", String.class)
                                                                                          .orElse(c.get("oci.auth.keyFile", String.class)
                                                                                                  .orElse(Paths.get(System.getProperty("user.home"), ".oci", "oci_api_key.pem").toString())))));
             c.get(OCI_AUTH_REGION, Region.class)


### PR DESCRIPTION
The version of Guava used in the `grpc/io.grpc` module must match the version required by the gRPC Java libraries. Ideally we would just pull in the correct version as a transitive dependency, but due to how the shading and repackaging is done, the `module-info.java` file will not compile without Guava as a dependency in the `pom.xml`. 