### PR TITLE
Allow @CrossOrigin to appear at the class level (#5260)

### DIFF
--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOrigin.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOrigin.java
@@ -22,12 +22,13 @@ import java.lang.annotation.Target;
 
 import static io.helidon.webserver.cors.CrossOriginConfig.DEFAULT_AGE;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * CrossOrigin annotation.
  */
-@Target(METHOD)
+@Target({TYPE, METHOD})
 @Retention(RUNTIME)
 @Documented
 public @interface CrossOrigin {

--- a/microprofile/cors/src/main/java/module-info.java
+++ b/microprofile/cors/src/main/java/module-info.java
@@ -19,6 +19,8 @@
  */
 module io.helidon.microprofile.cors {
 
+    requires java.logging;
+
     requires jakarta.ws.rs;
     requires io.helidon.config;
     requires io.helidon.config.mp;


### PR DESCRIPTION
Fixes #5260

[Mini spec](https://github.com/helidon-io/helidon/issues/5260#issuecomment-1307550103)

Done:
* Main logic
* Some tests (to be discussed below)

Not Done:
* `examples/microprofile/cors`  (I need some feedback about this draft)

Some questions:
1. How can I check logging? I can't see it in my tests. Test `CrossOriginTest#testPreFlightMethodLevelAnnotationTakesPrecedenceOverClassLevel` should log. Did I miss something?

2. Should I add some additional tests? For example `testPreFlightConfigFileTakesPrecedenceOverMethodLevelAnnotation`? I've done it only for class-level annotation. I'm not sure.

3. I can't run tests from my IDE. I get error
<img width="1682" alt="Screenshot 2022-11-17 at 19 52 16" src="https://user-images.githubusercontent.com/4740207/202525761-0d4e7617-0a27-498f-a101-cca8b5207288.png">
But I can run tests via maven. Should I do some specific actions with my IDE? It uses Java 17.


4. Error messages can be changed. Sorry for my English :) .

@tjquinno Any advice will be appreciated. Don't hesitate to write comments. It's my first important PR.

