### PR TITLE
NullPointerException when there is an illegal character in the request

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -334,6 +334,9 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         // New request ID
         long requestId = REQUEST_ID_GENERATOR.incrementAndGet();
 
+
+        requestEntityAnalyzed = new CompletableFuture<>();
+
         // If a problem with the request URI, return 400 response
         BareRequestImpl bareRequest;
         try {
@@ -388,8 +391,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         if (prevRequestFuture != null && prevRequestFuture.isDone()) {
             prevRequestFuture = null;
         }
-
-        requestEntityAnalyzed = new CompletableFuture<>();
 
         //If the keep alive is not set, we know we will be closing the connection
         if (!HttpUtil.isKeepAlive(requestContext.request())) {


### PR DESCRIPTION
Move requestEntityAnalyzed CompletableFuture instantiation way before it gets called channelReadHttpContent as a LastHttpContent