### PR TITLE
NullPointerException when there is an illegal character in the request (#5470)

### DIFF
--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ForwardingHandler.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ForwardingHandler.java
@@ -340,6 +340,9 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         // New request ID
         long requestId = REQUEST_ID_GENERATOR.incrementAndGet();
 
+
+        requestEntityAnalyzed = new CompletableFuture<>();
+
         // If a problem with the request URI, return 400 response
         BareRequestImpl bareRequest;
         try {
@@ -394,8 +397,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         if (prevRequestFuture != null && prevRequestFuture.isDone()) {
             prevRequestFuture = null;
         }
-
-        requestEntityAnalyzed = new CompletableFuture<>();
 
         //If the keep alive is not set, we know we will be closing the connection
         if (!HttpUtil.isKeepAlive(requestContext.request())) {


### PR DESCRIPTION
Move requestEntityAnalyzed CompletableFuture instantiation way before it gets called channelReadHttpContent as a LastHttpContent