### PR TITLE
Fix Guava version to match that required by the grpc-java libraries

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -57,7 +57,7 @@
         <version.lib.graphql-java.extended.scalars>17.1</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
         <version.lib.grpc>1.49.2</version.lib.grpc>
-        <version.lib.guava>30.0-jre</version.lib.guava>
+        <version.lib.guava>31.1-jre</version.lib.guava>
         <version.lib.h2>2.1.212</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.hibernate>6.1.4.Final</version.lib.hibernate>


### PR DESCRIPTION
The version of Guava used in the grpc/io.grpc module must match the version required by the gRPC Java libraries.