### PR TITLE
Níma: Static content handling rework

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/LruCache.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/LruCache.java
@@ -207,6 +207,18 @@ public final class LruCache<K, V> {
         return capacity;
     }
 
+    /**
+     * Clear all records in the cache.
+     */
+    public void clear() {
+        writeLock.lock();
+        try {
+            backingMap.clear();
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
     // for unit testing
     V directGet(K key) {
         return backingMap.get(key);

--- a/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/HttpHeaderMatcher.java
+++ b/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/HttpHeaderMatcher.java
@@ -191,7 +191,7 @@ public final class HttpHeaderMatcher {
                 mismatchDescription.appendValue(name.defaultCase()).appendText(" header is present with wrong values ");
                 valuesMatcher.describeMismatch(all, mismatchDescription);
             } else {
-                mismatchDescription.appendValue(name.defaultCase()).appendText("header is not present");
+                mismatchDescription.appendValue(name.defaultCase()).appendText(" header is not present");
             }
         }
     }

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -447,6 +447,13 @@ public class ServerCdiExtension implements Extension {
         config.get("tmp-dir")
                 .as(Path.class)
                 .ifPresent(cpBuilder::tmpDir);
+
+        config.get("cache-in-memory")
+                .asList(String.class)
+                .stream()
+                .flatMap(List::stream)
+                .forEach(cpBuilder::addCacheInMemory);
+
         StaticContentSupport staticContent = cpBuilder.build();
 
         if (context.exists()) {

--- a/nima/webserver/static-content/etc/spotbugs/exclude.xml
+++ b/nima/webserver/static-content/etc/spotbugs/exclude.xml
@@ -33,4 +33,10 @@
         <Class name="io.helidon.nima.webserver.staticcontent.ClassPathContentHandler"/>
         <Bug pattern="URLCONNECTION_SSRF_FD"/>
     </Match>
+
+    <Match>
+        <!-- URL is obtained from classloader for a resource on classpath and then used to read it -->
+        <Class name="io.helidon.nima.webserver.staticcontent.CachedHandlerUrlStream"/>
+        <Bug pattern="URLCONNECTION_SSRF_FD"/>
+    </Match>
 </FindBugsFilter>

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandler.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandler.java
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
-/**
- * Helidon Níma WebServer static content support.
- */
-module io.helidon.nima.webserver.staticcontent {
-    requires java.logging;
+package io.helidon.nima.webserver.staticcontent;
 
-    requires transitive io.helidon.nima.webserver;
-    requires transitive io.helidon.common.configurable;
+import java.io.IOException;
 
-    exports io.helidon.nima.webserver.staticcontent;
+import io.helidon.common.configurable.LruCache;
+import io.helidon.common.http.Http;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+
+interface CachedHandler {
+    boolean handle(LruCache<String, CachedHandler> cache,
+                   Http.Method method,
+                   ServerRequest request,
+                   ServerResponse response,
+                   String requestedResource) throws IOException;
 }

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerInMemory.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerInMemory.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webserver.staticcontent;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import io.helidon.common.configurable.LruCache;
+import io.helidon.common.http.Http;
+import io.helidon.common.http.HttpException;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.ServerResponseHeaders;
+import io.helidon.common.media.type.MediaType;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+
+import static io.helidon.nima.webserver.staticcontent.StaticContentHandler.processEtag;
+import static io.helidon.nima.webserver.staticcontent.StaticContentHandler.processModifyHeaders;
+
+record CachedHandlerInMemory(MediaType mediaType,
+                             Instant lastModified,
+                             BiConsumer<ServerResponseHeaders, Instant> setLastModifiedHeader,
+                             byte[] bytes,
+                             int contentLength,
+                             Http.HeaderValue contentLengthHeader) implements CachedHandler {
+
+    @Override
+    public boolean handle(LruCache<String, CachedHandler> cache,
+                          Http.Method method,
+                          ServerRequest request,
+                          ServerResponse response,
+                          String requestedResource) {
+        // etag etc.
+        if (lastModified != null) {
+            processEtag(String.valueOf(lastModified.toEpochMilli()), request.headers(), response.headers());
+            processModifyHeaders(lastModified, request.headers(), response.headers(), setLastModifiedHeader);
+        }
+
+        response.headers().contentType(mediaType);
+
+        if (method == Http.Method.GET) {
+            send(request, response);
+        } else {
+            response.headers().set(contentLengthHeader());
+            response.send();
+        }
+
+        return true;
+    }
+
+    private void send(ServerRequest request, ServerResponse response) {
+        ServerRequestHeaders headers = request.headers();
+
+        if (headers.contains(Http.Header.RANGE)) {
+            long contentLength = contentLength();
+            List<ByteRangeRequest> ranges = ByteRangeRequest.parse(request,
+                                                                   response,
+                                                                   headers.get(Http.Header.RANGE).values(),
+                                                                   contentLength);
+            if (ranges.size() == 1) {
+                // single response
+                ByteRangeRequest range = ranges.get(0);
+
+                if (range.offset() > contentLength()) {
+                    throw new HttpException("Invalid range offset", Http.Status.REQUESTED_RANGE_NOT_SATISFIABLE_416, true);
+                }
+                if (range.length() > (contentLength() - range.offset())) {
+                    throw new HttpException("Invalid length", Http.Status.REQUESTED_RANGE_NOT_SATISFIABLE_416, true);
+                }
+
+                range.setContentRange(response);
+
+                // only send a part of the file
+                response.send(Arrays.copyOfRange(bytes(), (int) range.offset(), (int) range.length()));
+            } else {
+                // not supported, send full
+                send(response);
+            }
+        } else {
+            send(response);
+        }
+    }
+
+    private void send(ServerResponse response) {
+        response.headers().set(contentLengthHeader());
+        response.send(bytes());
+    }
+}

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerJar.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerJar.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package io.helidon.nima.webserver.staticcontent;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.function.BiConsumer;
+
+import io.helidon.common.configurable.LruCache;
+import io.helidon.common.http.Http;
+import io.helidon.common.http.ServerResponseHeaders;
+import io.helidon.common.media.type.MediaType;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+
+import static io.helidon.nima.webserver.staticcontent.FileBasedContentHandler.contentLength;
+import static io.helidon.nima.webserver.staticcontent.FileBasedContentHandler.send;
+import static io.helidon.nima.webserver.staticcontent.StaticContentHandler.processEtag;
+import static io.helidon.nima.webserver.staticcontent.StaticContentHandler.processModifyHeaders;
+
+record CachedHandlerJar(Path path,
+                        MediaType mediaType,
+                        Instant lastModified,
+                        BiConsumer<ServerResponseHeaders, Instant> setLastModifiedHeader) implements CachedHandler {
+    private static final System.Logger LOGGER = System.getLogger(CachedHandlerJar.class.getName());
+
+    @Override
+    public boolean handle(LruCache<String, CachedHandler> cache,
+                          Http.Method method,
+                          ServerRequest request,
+                          ServerResponse response,
+                          String requestedResource) throws IOException {
+
+        // check if file still exists (the tmp may have been removed, file may have been removed
+        // there is still a race change, but we do not want to keep cached records for invalid files
+        if (!Files.exists(path)) {
+            cache.remove(requestedResource);
+            return false;
+        }
+
+        if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+            LOGGER.log(System.Logger.Level.TRACE, "Sending static content from jar: " + requestedResource);
+        }
+
+        // etag etc.
+        if (lastModified != null) {
+            processEtag(String.valueOf(lastModified.toEpochMilli()), request.headers(), response.headers());
+            processModifyHeaders(lastModified, request.headers(), response.headers(), setLastModifiedHeader());
+        }
+
+        response.headers().contentType(mediaType);
+
+        if (method == Http.Method.GET) {
+            send(request, response, path);
+        } else {
+            response.headers().contentLength(contentLength(path));
+            response.send();
+        }
+
+        return true;
+    }
+}

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerPath.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerPath.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webserver.staticcontent;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import io.helidon.common.configurable.LruCache;
+import io.helidon.common.http.ForbiddenException;
+import io.helidon.common.http.Http;
+import io.helidon.common.http.ServerResponseHeaders;
+import io.helidon.common.media.type.MediaType;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+
+import static io.helidon.nima.webserver.staticcontent.FileBasedContentHandler.processContentLength;
+import static io.helidon.nima.webserver.staticcontent.FileBasedContentHandler.send;
+import static io.helidon.nima.webserver.staticcontent.StaticContentHandler.processEtag;
+import static io.helidon.nima.webserver.staticcontent.StaticContentHandler.processModifyHeaders;
+
+record CachedHandlerPath(Path path,
+                         MediaType mediaType,
+                         IoFunction<Path, Optional<Instant>> lastModified,
+                         BiConsumer<ServerResponseHeaders, Instant> setLastModifiedHeader) implements CachedHandler {
+    private static final System.Logger LOGGER = System.getLogger(CachedHandlerPath.class.getName());
+
+    @Override
+    public boolean handle(LruCache<String, CachedHandler> cache,
+                          Http.Method method,
+                          ServerRequest request,
+                          ServerResponse response,
+                          String requestedResource) throws IOException {
+
+        if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+            LOGGER.log(System.Logger.Level.TRACE, "Sending static content from path: " + path);
+        }
+
+        // now it exists and is a file
+        if (!Files.exists(path) || !Files.isRegularFile(path) || !Files.isReadable(path) || Files.isHidden(path)) {
+            // check if file still exists (the tmp may have been removed, file may have been removed
+            // there is still a race change, but we do not want to keep cached records for invalid files
+            cache.remove(requestedResource);
+            throw new ForbiddenException("File is not accessible");
+        }
+
+        Instant lastModified = lastModified().apply(path).orElse(null);
+
+        // etag etc.
+        if (lastModified != null) {
+            processEtag(String.valueOf(lastModified.toEpochMilli()), request.headers(), response.headers());
+            processModifyHeaders(lastModified, request.headers(), response.headers(), setLastModifiedHeader());
+        }
+
+        response.headers().contentType(mediaType);
+
+        if (method == Http.Method.GET) {
+            send(request, response, path);
+        } else {
+            processContentLength(path, response.headers());
+            response.send();
+        }
+
+        return true;
+    }
+}

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerRedirect.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerRedirect.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webserver.staticcontent;
+
+import java.io.IOException;
+
+import io.helidon.common.configurable.LruCache;
+import io.helidon.common.http.Http;
+import io.helidon.common.uri.UriQuery;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+
+record CachedHandlerRedirect(String location) implements CachedHandler {
+    @Override
+    public boolean handle(LruCache<String, CachedHandler> cache,
+                          Http.Method method,
+                          ServerRequest request,
+                          ServerResponse response,
+                          String requestedResource) throws IOException {
+
+        UriQuery query = request.query();
+        String locationWithQuery;
+        if (query.isEmpty()) {
+            locationWithQuery = location();
+        } else {
+            locationWithQuery = location() + "?" + query.rawValue();
+        }
+
+        response.status(Http.Status.MOVED_PERMANENTLY_301);
+        response.headers().set(Http.Header.LOCATION, locationWithQuery);
+        response.send();
+        return true;
+    }
+}

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerUrlStream.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/CachedHandlerUrlStream.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webserver.staticcontent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.time.Instant;
+
+import io.helidon.common.configurable.LruCache;
+import io.helidon.common.http.Http;
+import io.helidon.common.media.type.MediaType;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+
+import static io.helidon.nima.webserver.staticcontent.StaticContentHandler.processEtag;
+import static io.helidon.nima.webserver.staticcontent.StaticContentHandler.processModifyHeaders;
+
+record CachedHandlerUrlStream(MediaType mediaType, URL url) implements CachedHandler {
+    private static final System.Logger LOGGER = System.getLogger(CachedHandlerUrlStream.class.getName());
+
+    @Override
+    public boolean handle(LruCache<String, CachedHandler> cache,
+                          Http.Method method,
+                          ServerRequest request,
+                          ServerResponse response,
+                          String requestedResource) throws IOException {
+
+        if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+            LOGGER.log(System.Logger.Level.DEBUG, "Sending static content using stream from classpath: " + url);
+        }
+
+        URLConnection urlConnection = url.openConnection();
+        long lastModified = urlConnection.getLastModified();
+
+        if (lastModified != 0) {
+            processEtag(String.valueOf(lastModified), request.headers(), response.headers());
+            processModifyHeaders(Instant.ofEpochMilli(lastModified), request.headers(), response.headers());
+        }
+
+        response.headers().contentType(mediaType);
+
+        if (method == Http.Method.HEAD) {
+            response.send();
+            return true;
+        }
+
+        try (InputStream in = url.openStream(); OutputStream outputStream = response.outputStream()) {
+            in.transferTo(outputStream);
+        }
+        return true;
+    }
+}

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/ClassPathContentHandler.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/ClassPathContentHandler.java
@@ -16,28 +16,32 @@
 
 package io.helidon.nima.webserver.staticcontent;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.System.Logger.Level;
 import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import io.helidon.common.http.Http;
 import io.helidon.common.http.InternalServerException;
+import io.helidon.common.media.type.MediaType;
 import io.helidon.nima.webserver.http.ServerRequest;
 import io.helidon.nima.webserver.http.ServerResponse;
 
@@ -47,10 +51,12 @@ import io.helidon.nima.webserver.http.ServerResponse;
 class ClassPathContentHandler extends FileBasedContentHandler {
     private static final System.Logger LOGGER = System.getLogger(ClassPathContentHandler.class.getName());
 
+    private final AtomicBoolean populatedInMemoryCache = new AtomicBoolean();
     private final ClassLoader classLoader;
     private final String root;
     private final String rootWithTrailingSlash;
     private final BiFunction<String, String, Path> tmpFile;
+    private final Set<String> cacheInMemory;
 
     // URL's hash code and equal are not suitable for map or set
     private final Map<String, ExtractedJarEntry> extracted = new ConcurrentHashMap<>();
@@ -59,6 +65,7 @@ class ClassPathContentHandler extends FileBasedContentHandler {
         super(builder);
 
         this.classLoader = builder.classLoader();
+        this.cacheInMemory = new HashSet<>(builder.cacheInMemory());
         this.root = builder.root();
         this.rootWithTrailingSlash = root + '/';
 
@@ -92,11 +99,117 @@ class ClassPathContentHandler extends FileBasedContentHandler {
         return path;
     }
 
+    @Override
+    public void beforeStart() {
+        if (populatedInMemoryCache.compareAndSet(false, true)) {
+            for (String resource : cacheInMemory) {
+                try {
+                    addToInMemoryCache(resource);
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Failed to add file to in-memory cache", e);
+                }
+            }
+        }
+        super.beforeStart();
+    }
+
+    @Override
+    void releaseCache() {
+        populatedInMemoryCache.set(false);
+    }
+
     @SuppressWarnings("checkstyle:RegexpSinglelineJava")
     @Override
     boolean doHandle(Http.Method method, String requestedPath, ServerRequest request, ServerResponse response)
             throws IOException, URISyntaxException {
 
+        String rawPath = request.prologue().uriPath().rawPath();
+        String requestedResource = requestedResource(rawPath, requestedPath);
+
+        if (!requestedResource.equals(root) && !requestedResource.startsWith(rootWithTrailingSlash)) {
+            // trying to get path outside of project root (such as requesting ../../etc/hosts)
+            return false;
+        }
+
+        // we have a resource that we support, let's try to use one from the cache
+        Optional<CachedHandler> cached = cacheHandler(requestedResource);
+
+        if (cached.isPresent()) {
+            // this requested resource is cached and can be safely returned
+            return cached.get().handle(handlerCache(), method, request, response, requestedResource);
+        }
+
+        // if it is not cached, find the resource and cache it (or return 404 and do not cache)
+
+        // try to find the resource on classpath (cannot use root URL and then resolve, as root and sub-resource
+        // may be from different jar files/directories
+        URL url = classLoader.getResource(requestedResource);
+
+        String welcomeFileName = welcomePageName();
+        if (welcomeFileName != null) {
+            String welcomeFileResource = requestedResource
+                    + (requestedResource.endsWith("/") ? "" : "/")
+                    + welcomeFileName;
+            URL welcomeUrl = classLoader.getResource(welcomeFileResource);
+            if (welcomeUrl != null) {
+                // there is a welcome file under requested resource, ergo requested resource was a directory
+                if (rawPath.endsWith("/")) {
+                    // this is OK, as the path ends with a forward slash
+
+                    // first check if this is an in-memory resource
+                    Optional<CachedHandlerInMemory> inMemoryMaybe = cacheInMemory(welcomeFileResource);
+                    if (inMemoryMaybe.isPresent()) {
+                        // reference to the same definition, never times out
+                        cacheInMemory(requestedResource, inMemoryMaybe.get());
+                        return inMemoryMaybe.get().handle(handlerCache(),
+                                                          method,
+                                                          request,
+                                                          response,
+                                                          requestedResource);
+                    }
+
+                    url = welcomeUrl;
+                } else {
+                    // must redirect
+                    String redirectLocation = rawPath + "/";
+                    CachedHandlerRedirect handler = new CachedHandlerRedirect(redirectLocation);
+                    cacheHandler(requestedResource, handler);
+                    return handler.handle(handlerCache(), method, request, response, requestedResource);
+                }
+            }
+        }
+
+        if (url == null || url.getPath().endsWith("/")) {
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE, "Requested resource " + requestedResource
+                        + " does not exist or is a directory without welcome file.");
+            }
+            // not caching 404, to prevent intentional cache pollution by users
+            return false;
+        }
+
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            LOGGER.log(Level.TRACE, "Located resource url. Resource: " + requestedResource + ", URL: " + url);
+        }
+
+        // now read the URL - we have direct support for files and jar files, others are handled by stream only
+        Optional<CachedHandler> handler = switch (url.getProtocol()) {
+            case "file" -> fileHandler(Paths.get(url.toURI()));
+            case "jar" -> jarHandler(requestedResource, url);
+            default -> urlStreamHandler(url);
+        };
+
+        if (handler.isEmpty()) {
+            return false;
+        }
+
+        CachedHandler cachedHandler = handler.get();
+        cacheHandler(requestedResource, cachedHandler);
+
+        return cachedHandler.handle(handlerCache(), method, request, response, requestedResource);
+    }
+
+    private String requestedResource(String rawPath, String requestedPath) throws URISyntaxException {
         String resource = requestedPath.isEmpty() ? root : (rootWithTrailingSlash + requestedPath);
 
         if (LOGGER.isLoggable(Level.TRACE)) {
@@ -106,95 +219,36 @@ class ClassPathContentHandler extends FileBasedContentHandler {
         // this MUST be done, so we do not escape the bounds of configured directory
         // We use multi-arg constructor so it performs url encoding
         URI myuri = new URI(null, null, resource, null);
-        String requestedResource = myuri.normalize().getPath();
 
-        if (!requestedResource.equals(root) && !requestedResource.startsWith(rootWithTrailingSlash)) {
-            return false;
-        }
-
-        // try to find the resource on classpath (cannot use root URL and then resolve, as root and sub-resource
-        // may be from different jar files/directories
-        URL url = classLoader.getResource(resource);
-
-        String welcomeFileName = welcomePageName();
-        if (null != welcomeFileName) {
-            String welcomeFileResource = requestedResource + "/" + welcomeFileName;
-            URL welcomeUrl = classLoader.getResource(welcomeFileResource);
-            if (null != welcomeUrl) {
-                // there is a welcome file under requested resource, ergo requested resource was a directory
-                String rawFullPath = request.prologue().uriPath().rawPath();
-                if (rawFullPath.endsWith("/")) {
-                    // this is OK, as the path ends with a forward slash
-                    url = welcomeUrl;
-                } else {
-                    // must redirect
-                    redirect(request, response, rawFullPath + "/");
-                    return true;
-                }
-            }
-        }
-
-        if (url == null) {
-            if (LOGGER.isLoggable(Level.TRACE)) {
-                LOGGER.log(Level.TRACE, "Requested resource " + resource + " does not exist");
-            }
-            return false;
-        }
-
-        URL logUrl = url; // need to be effectively final to use in lambda
-        if (LOGGER.isLoggable(Level.TRACE)) {
-            LOGGER.log(Level.TRACE, "Located resource url. Resource: " + resource + ", URL: " + logUrl);
-        }
-
-        // now read the URL - we have direct support for files and jar files, others are handled by stream only
-        switch (url.getProtocol()) {
-        case "file":
-            sendFile(method, Paths.get(url.toURI()), request, response, welcomePageName());
-            break;
-        case "jar":
-            return sendJar(method, requestedResource, url, request, response);
-        default:
-            sendUrlStream(method, url, request, response);
-            break;
-        }
-
-        return true;
+        String result = myuri.normalize().getPath();
+        return rawPath.endsWith("/") ? result + "/" : result;
     }
 
-    boolean sendJar(Http.Method method,
-                    String requestedResource,
-                    URL url,
-                    ServerRequest request,
-                    ServerResponse response) throws IOException {
+    private Optional<CachedHandler> jarHandler(String requestedResource, URL url) {
+        ExtractedJarEntry extrEntry = extracted.compute(requestedResource, (key, entry) -> existOrCreate(url, entry));
 
-        if (LOGGER.isLoggable(Level.TRACE)) {
-            LOGGER.log(Level.TRACE, "Sending static content from classpath: " + url);
-        }
-
-        ExtractedJarEntry extrEntry = extracted
-                .compute(requestedResource, (key, entry) -> existOrCreate(url, entry));
         if (extrEntry.tempFile == null) {
-            return false;
-        }
-        if (extrEntry.lastModified != null) {
-            processEtag(String.valueOf(extrEntry.lastModified.toEpochMilli()), request.headers(), response.headers());
-            processModifyHeaders(extrEntry.lastModified, request.headers(), response.headers());
+            // once again, not caching 404
+            return Optional.empty();
         }
 
-        String entryName = (extrEntry.entryName == null) ? fileName(url) : extrEntry.entryName;
-
-        processContentType(entryName,
-                           request.headers(),
-                           response.headers());
-
-        if (method == Http.Method.HEAD) {
-            processContentLength(extrEntry.tempFile, response.headers());
-            response.send();
+        Instant lastModified = extrEntry.lastModified();
+        if (lastModified == null) {
+            return Optional.of(new CachedHandlerJar(extrEntry.tempFile,
+                                                    detectType(extrEntry.entryName),
+                                                    null,
+                                                    null));
         } else {
-            send(request, response, extrEntry.tempFile);
+            // we can cache this, as this is a jar record
+            Http.HeaderValue lastModifiedHeader = Http.Header.create(Http.Header.LAST_MODIFIED,
+                                                                     true,
+                                                                     false,
+                                                                     formatLastModified(lastModified));
+            return Optional.of(new CachedHandlerJar(extrEntry.tempFile,
+                                                    detectType(extrEntry.entryName),
+                                                    extrEntry.lastModified(),
+                                                    (headers, instant) -> headers.set(lastModifiedHeader)));
         }
-
-        return true;
     }
 
     private ExtractedJarEntry existOrCreate(URL url, ExtractedJarEntry entry) {
@@ -210,29 +264,8 @@ class ClassPathContentHandler extends FileBasedContentHandler {
         return entry;
     }
 
-    private void sendUrlStream(Http.Method method, URL url, ServerRequest request, ServerResponse response)
-            throws IOException {
-
-        LOGGER.log(Level.DEBUG, "Sending static content using stream from classpath: " + url);
-
-        URLConnection urlConnection = url.openConnection();
-        long lastModified = urlConnection.getLastModified();
-
-        if (lastModified != 0) {
-            processEtag(String.valueOf(lastModified), request.headers(), response.headers());
-            processModifyHeaders(Instant.ofEpochMilli(lastModified), request.headers(), response.headers());
-        }
-
-        processContentType(fileName(url), request.headers(), response.headers());
-
-        if (method == Http.Method.HEAD) {
-            response.send();
-            return;
-        }
-
-        try (InputStream in = url.openStream(); OutputStream outputStream = response.outputStream()) {
-            in.transferTo(outputStream);
-        }
+    private Optional<CachedHandler> urlStreamHandler(URL url) {
+        return Optional.of(new CachedHandlerUrlStream(detectType(fileName(url)), url));
     }
 
     private ExtractedJarEntry extractJarEntry(URL url) {
@@ -243,13 +276,13 @@ class ClassPathContentHandler extends FileBasedContentHandler {
             if (jarEntry.isDirectory()) {
                 return new ExtractedJarEntry(jarEntry.getName()); // a directory
             }
-            Instant lastModified = getLastModified(jarFile.getName());
+            Optional<Instant> lastModified = lastModified(jarFile.getName());
 
             // Extract JAR entry to file
             try (InputStream is = jarFile.getInputStream(jarEntry)) {
                 Path tempFile = tmpFile.apply("ws", ".je");
                 Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING);
-                return new ExtractedJarEntry(tempFile, lastModified, jarEntry.getName());
+                return new ExtractedJarEntry(tempFile, lastModified.orElse(null), jarEntry.getName());
             } finally {
                 if (!jarUrlConnection.getUseCaches()) {
                     jarFile.close();
@@ -260,34 +293,74 @@ class ClassPathContentHandler extends FileBasedContentHandler {
         }
     }
 
-    private Instant getLastModified(String path) throws IOException {
-        Path file = Paths.get(path);
+    private void addToInMemoryCache(String resource) throws IOException, URISyntaxException {
+        /*
+          we need to know:
+          - content size
+          - media type
+          - last modified timestamp
+          - content
+         */
 
-        if (Files.exists(file) && Files.isRegularFile(file)) {
-            return Files.getLastModifiedTime(file).toInstant();
-        } else {
-            return null;
+        String requestedResource;
+        try {
+            requestedResource = requestedResource("", resource);
+        } catch (URISyntaxException e) {
+            LOGGER.log(Level.WARNING, "Resource " + resource + " cannot be added to in memory cache, as it is not a valid"
+                    + " identifier", e);
+            return;
         }
+
+        if (!requestedResource.equals(root) && !requestedResource.startsWith(rootWithTrailingSlash)) {
+            LOGGER.log(Level.WARNING, "Resource " + resource + " cannot be added to in memory cache, as it is not within"
+                    + " the resource root directory.");
+            return;
+        }
+
+        URL url = classLoader.getResource(requestedResource);
+        if (url == null) {
+            LOGGER.log(Level.WARNING, "Resource " + resource + " cannot be added to in memory cache, as it does "
+                    + "not exist on classpath");
+            return;
+        }
+
+        // now we do have a resource, and we want to load it into memory
+        // we are not checking the size, as this is explicitly configured by the user, and if we run out of memory, we just do...
+        Optional<Instant> lastModified = lastModified(url);
+        MediaType contentType = detectType(fileName(url));
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (InputStream in = url.openStream()) {
+            in.transferTo(baos);
+        }
+        byte[] entityBytes = baos.toByteArray();
+
+        cacheInMemory(requestedResource, contentType, entityBytes, lastModified);
     }
 
-    private static class ExtractedJarEntry {
-        private final Path tempFile;
-        private final Instant lastModified;
-        private final String entryName;
+    private Optional<Instant> lastModified(URL url) throws URISyntaxException, IOException {
+        return switch (url.getProtocol()) {
+            case "file" -> lastModified(Paths.get(url.toURI()));
+            case "jar" -> lastModifiedFromJar(url);
+            default -> Optional.empty();
+        };
+    }
 
-        ExtractedJarEntry(Path tempFile, Instant lastModified, String entryName) {
-            this.tempFile = tempFile;
-            this.lastModified = lastModified;
-            this.entryName = entryName;
-        }
+    private Optional<Instant> lastModifiedFromJar(URL url) throws IOException {
+        JarURLConnection jarUrlConnection = (JarURLConnection) url.openConnection();
+        JarFile jarFile = jarUrlConnection.getJarFile();
+        return lastModified(jarFile.getName());
+    }
 
+    private Optional<Instant> lastModified(String path) throws IOException {
+        return lastModified(Paths.get(path));
+    }
+
+    private record ExtractedJarEntry(Path tempFile, Instant lastModified, String entryName) {
         /**
          * Creates directory representation.
          */
         ExtractedJarEntry(String entryName) {
-            this.tempFile = null;
-            this.lastModified = null;
-            this.entryName = entryName;
+            this(null, null, entryName);
         }
     }
 }

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/FileSystemContentHandler.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/FileSystemContentHandler.java
@@ -18,10 +18,16 @@ package io.helidon.nima.webserver.staticcontent;
 
 import java.io.IOException;
 import java.lang.System.Logger.Level;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.helidon.common.http.Http;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.nima.webserver.http.ServerRequest;
 import io.helidon.nima.webserver.http.ServerResponse;
 
@@ -31,42 +37,146 @@ import io.helidon.nima.webserver.http.ServerResponse;
 class FileSystemContentHandler extends FileBasedContentHandler {
     private static final System.Logger LOGGER = System.getLogger(FileSystemContentHandler.class.getName());
 
+    private final AtomicBoolean populatedInMemoryCache = new AtomicBoolean();
     private final Path root;
+    private final Set<String> cacheInMemory;
 
     FileSystemContentHandler(StaticContentSupport.FileSystemBuilder builder) {
         super(builder);
 
         this.root = builder.root();
+        this.cacheInMemory = new HashSet<>(builder.cacheInMemory());
     }
 
     @Override
-    boolean doHandle(Http.Method method, String requestedPath, ServerRequest request, ServerResponse response)
-            throws IOException {
-        Path resolved;
-        if (requestedPath.isEmpty()) {
-            resolved = root;
-        } else {
-            resolved = root.resolve(requestedPath).normalize();
-            if (LOGGER.isLoggable(Level.DEBUG)) {
-                LOGGER.log(Level.DEBUG, "Requested file: " + resolved.toAbsolutePath());
-            }
-            if (!resolved.startsWith(root)) {
-                return false;
+    public void beforeStart() {
+        if (populatedInMemoryCache.compareAndSet(false, true)) {
+            for (String resource : cacheInMemory) {
+                try {
+                    addToInMemoryCache(resource);
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Failed to add file to in-memory cache", e);
+                }
             }
         }
-
-        return doHandle(method, resolved, request, response);
+        super.beforeStart();
     }
 
-    boolean doHandle(Http.Method method, Path path, ServerRequest request, ServerResponse response) throws IOException {
-        // Check existence
-        if (!Files.exists(path)) {
+    @Override
+    void releaseCache() {
+        populatedInMemoryCache.set(false);
+    }
+
+    @Override
+    boolean doHandle(Http.Method method, String requestedPath, ServerRequest req, ServerResponse res) throws IOException {
+        Path path = requestedPath(requestedPath);
+        if (LOGGER.isLoggable(Level.DEBUG)) {
+            LOGGER.log(Level.DEBUG, "Requested file: " + path.toAbsolutePath());
+        }
+        if (!path.startsWith(root)) {
             return false;
         }
 
-        sendFile(method, path, request, response, welcomePageName());
+        String rawPath = req.path().rawPath();
 
-        return true;
+        String relativePath = root.relativize(path).toString();
+        String requestedResource = rawPath.endsWith("/") ? relativePath + "/" : relativePath;
+
+        // we have a resource that we support, let's try to use one from the cache
+        Optional<CachedHandler> cached = cacheHandler(requestedResource);
+
+        if (cached.isPresent()) {
+            // this requested resource is cached and can be safely returned
+            return cached.get().handle(handlerCache(), method, req, res, requestedResource);
+        }
+
+        // if it is not cached, find the resource and cache it (or return 404 and do not cache)
+        return doHandle(method, requestedResource, req, res, rawPath, path);
     }
 
+    boolean doHandle(Http.Method method,
+                     String requestedResource,
+                     ServerRequest req,
+                     ServerResponse res,
+                     String rawPath,
+                     Path path) throws IOException {
+
+        // Check existence
+        if (!Files.exists(path)) {
+            // not caching 404
+            return false;
+        }
+
+        // we know the file exists, though it may be a directory
+        // First doHandle a directory case
+        String welcomeFileName = welcomePageName();
+        if (welcomeFileName != null) {
+            if (Files.isDirectory(path)) {
+                String welcomeFileResource = requestedResource
+                        + (requestedResource.endsWith("/") ? "" : "/")
+                        + welcomeFileName;
+
+                if (rawPath.endsWith("/")) {
+                    Optional<CachedHandlerInMemory> inMemoryMaybe = cacheInMemory(welcomeFileResource);
+                    if (inMemoryMaybe.isPresent()) {
+                        // reference to the same definition, never times out
+                        cacheInMemory(requestedResource, inMemoryMaybe.get());
+                        return inMemoryMaybe.get().handle(handlerCache(),
+                                                          method,
+                                                          req,
+                                                          res,
+                                                          requestedResource);
+                    }
+
+                    // Try to find welcome file
+                    path = resolveWelcomeFile(path, welcomePageName());
+                } else {
+                    // Or redirect to slash ended
+                    String redirectLocation = rawPath + "/";
+                    CachedHandlerRedirect handler = new CachedHandlerRedirect(redirectLocation);
+                    cacheHandler(requestedResource, handler);
+                    return handler.handle(handlerCache(), method, req, res, requestedResource);
+                }
+            }
+        }
+
+        CachedHandler handler = new CachedHandlerPath(path,
+                                                      detectType(fileName(path)),
+                                                      FileBasedContentHandler::lastModified,
+                                                      ServerResponseHeaders::lastModified);
+        cacheHandler(requestedResource, handler);
+        return handler.handle(handlerCache(), method, req, res, requestedResource);
+    }
+
+    private void addToInMemoryCache(String resource) throws IOException, URISyntaxException {
+        /*
+          we need to know:
+          - content size
+          - media type
+          - last modified timestamp
+          - content
+         */
+        Path path = requestedPath(resource);
+        if (!path.startsWith(root)) {
+            LOGGER.log(Level.WARNING, "File " + resource + " cannot be added to in memory cache, as it is not within"
+                    + " the root directory.");
+            return;
+        }
+
+        if (!Files.exists(path)) {
+            LOGGER.log(Level.WARNING, "File " + resource + " cannot be added to in memory cache, as it does not exist");
+            return;
+        }
+
+        byte[] fileBytes = Files.readAllBytes(path);
+
+        cacheInMemory(resource, detectType(fileName(path)), fileBytes, lastModified(path));
+    }
+
+    private Path requestedPath(String requestedPath) {
+        if (requestedPath.isEmpty()) {
+            return root;
+        }
+        return root.resolve(requestedPath).normalize();
+    }
 }

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/IoFunction.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/IoFunction.java
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-/**
- * Helidon Níma WebServer static content support.
- */
-module io.helidon.nima.webserver.staticcontent {
-    requires java.logging;
+package io.helidon.nima.webserver.staticcontent;
 
-    requires transitive io.helidon.nima.webserver;
-    requires transitive io.helidon.common.configurable;
+import java.io.IOException;
 
-    exports io.helidon.nima.webserver.staticcontent;
+@FunctionalInterface
+interface IoFunction<P, R> {
+    R apply(P param) throws IOException;
 }

--- a/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/CachedHandlerTest.java
+++ b/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/CachedHandlerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webserver.staticcontent;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.http.Http;
+import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.ServerResponseHeaders;
+import io.helidon.common.media.type.MediaType;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.common.uri.UriQuery;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalPresent;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CachedHandlerTest {
+    private static final MediaType MEDIA_TYPE_ICON = MediaTypes.create("image/x-icon");
+    private static final Http.HeaderValue ICON_TYPE = Http.Header.create(Http.Header.CONTENT_TYPE, MEDIA_TYPE_ICON.text());
+    private static final Http.HeaderValue RESOURCE_CONTENT_LENGTH = Http.Header.create(Http.Header.CONTENT_LENGTH, 7);
+
+    private static ClassPathContentHandler handler;
+
+    @BeforeAll
+    static void initTestClass() {
+        handler = (ClassPathContentHandler) StaticContentSupport.builder("/web")
+                .addCacheInMemory("favicon.ico")
+                .welcomeFileName("resource.txt")
+                .build();
+        handler.beforeStart();
+    }
+
+    @Test
+    void testInMemoryCache() {
+        Optional<CachedHandlerInMemory> cachedHandlerInMemory = handler.cacheInMemory("web/favicon.ico");
+        assertThat("Handler should be cached in memory", cachedHandlerInMemory, optionalPresent());
+        CachedHandlerInMemory cached = cachedHandlerInMemory.get();
+        assertThat("Cached bytes must not be null", cached.bytes(), notNullValue());
+        assertThat("Cached bytes must not be empty", cached.bytes(), not(BufferData.EMPTY_BYTES));
+        assertThat("Content length", cached.contentLength(), is(1230));
+        assertThat("Last modified", cached.lastModified(), notNullValue());
+        assertThat("Media type", cached.mediaType(), is(MEDIA_TYPE_ICON));
+    }
+
+    @Test
+    void testFromInMemory() throws IOException, URISyntaxException {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+
+        ServerRequest req = mock(ServerRequest.class);
+        when(req.headers()).thenReturn(ServerRequestHeaders.create());
+        when(req.prologue()).thenReturn(HttpPrologue.create("http", "1.1", Http.Method.GET, "/favicon.ico", false));
+
+        ServerResponse res = mock(ServerResponse.class);
+        when(res.headers()).thenReturn(responseHeaders);
+
+        boolean result = handler.doHandle(Http.Method.GET, "favicon.ico", req, res);
+
+        assertThat("Handler should have found favicon.ico", result, is(true));
+        assertThat(responseHeaders, hasHeader(ICON_TYPE));
+        assertThat(responseHeaders, hasHeader(Http.Header.ETAG));
+        assertThat(responseHeaders, hasHeader(Http.Header.LAST_MODIFIED));
+    }
+
+    @Test
+    void testCacheFound() throws IOException, URISyntaxException {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+
+        ServerRequest req = mock(ServerRequest.class);
+        when(req.headers()).thenReturn(ServerRequestHeaders.create());
+        when(req.prologue()).thenReturn(HttpPrologue.create("http", "1.1", Http.Method.GET, "/resource.txt", false));
+
+        ServerResponse res = mock(ServerResponse.class);
+        when(res.headers()).thenReturn(responseHeaders);
+        when(res.outputStream()).thenReturn(new ByteArrayOutputStream());
+
+        boolean result = handler.doHandle(Http.Method.GET, "resource.txt", req, res);
+
+        assertThat("Handler should have found resource.txt", result, is(true));
+        assertThat(responseHeaders, hasHeader(Http.HeaderValues.CONTENT_TYPE_TEXT_PLAIN));
+        assertThat(responseHeaders, hasHeader(RESOURCE_CONTENT_LENGTH));
+        assertThat(responseHeaders, hasHeader(Http.Header.ETAG));
+        assertThat(responseHeaders, hasHeader(Http.Header.LAST_MODIFIED));
+
+        // now make sure it is cached
+        Optional<CachedHandler> cachedHandler = handler.cacheHandler("web/resource.txt");
+        assertThat("Handler should be cached", cachedHandler, optionalPresent());
+        CachedHandler cached = cachedHandler.get();
+        assertThat("During tests, classpath should be loaded from file system", cached, instanceOf(CachedHandlerPath.class));
+        CachedHandlerPath pathHandler = (CachedHandlerPath) cached;
+        assertThat("Path", pathHandler.path(), notNullValue());
+        assertThat("Last modified function", pathHandler.lastModified(), notNullValue());
+        assertThat("Last modified", pathHandler.lastModified().apply(pathHandler.path()), notNullValue());
+        assertThat("Media type", pathHandler.mediaType(), is(MediaTypes.TEXT_PLAIN));
+    }
+
+    @Test
+    void testCacheRedirectFound() throws IOException, URISyntaxException {
+        ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+
+        ServerRequest req = mock(ServerRequest.class);
+        when(req.headers()).thenReturn(ServerRequestHeaders.create());
+        when(req.prologue()).thenReturn(HttpPrologue.create("http", "1.1", Http.Method.GET, "/nested", false));
+        when(req.query()).thenReturn(UriQuery.empty());
+
+        ServerResponse res = mock(ServerResponse.class);
+        when(res.headers()).thenReturn(responseHeaders);
+        when(res.outputStream()).thenReturn(new ByteArrayOutputStream());
+
+        boolean result = handler.doHandle(Http.Method.GET, "/nested", req, res);
+
+        assertThat("Handler should have redirected", result, is(true));
+        assertThat(responseHeaders, hasHeader(Http.Header.LOCATION, "/nested/"));
+
+        // now make sure it is cached
+        Optional<CachedHandler> cachedHandler = handler.cacheHandler("web/nested");
+        assertThat("Handler should be cached", cachedHandler, optionalPresent());
+        CachedHandler cached = cachedHandler.get();
+        assertThat("This should be a cached redirect handler", cached, instanceOf(CachedHandlerRedirect.class));
+        CachedHandlerRedirect redirectHandler = (CachedHandlerRedirect) cached;
+        assertThat(redirectHandler.location(), is("/nested/"));
+    }
+}

--- a/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/StaticContentHandlerTest.java
@@ -24,6 +24,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.helidon.common.configurable.LruCache;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.HttpException;
@@ -32,6 +33,7 @@ import io.helidon.common.http.RoutedPath;
 import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.parameters.Parameters;
+import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriPath;
 import io.helidon.common.uri.UriQuery;
@@ -145,15 +147,17 @@ class StaticContentHandlerTest {
     }
 
     @Test
-    void redirect() {
+    void redirect() throws IOException {
         ServerResponseHeaders resh = mock(ServerResponseHeaders.class);
         ServerResponse res = mock(ServerResponse.class);
         ServerRequest req = mock(ServerRequest.class);
         when(res.headers()).thenReturn(resh);
         when(req.query()).thenReturn(UriQuery.empty());
-        StaticContentHandler.redirect(req, res, "/foo/");
+
+        CachedHandlerRedirect redirectHandler = new CachedHandlerRedirect("/foo/");
+        redirectHandler.handle(LruCache.create(), Http.Method.GET, req, res, "/foo");
         verify(res).status(Http.Status.MOVED_PERMANENTLY_301);
-        verify(res).header(LOCATION, "/foo/");
+        verify(resh).set(LOCATION, "/foo/");
         verify(res).send();
     }
 
@@ -173,6 +177,7 @@ class StaticContentHandlerTest {
         ServerResponse response = mock(ServerResponse.class);
         TestContentHandler handler = TestContentHandler.create(true);
         handler.handle(request, response);
+        // the file is valid, but it does not exist
         verify(response, never()).next();
         assertThat(handler.path, is(Paths.get("foo/some.txt").toAbsolutePath().normalize()));
     }
@@ -283,7 +288,13 @@ class StaticContentHandlerTest {
         }
 
         @Override
-        boolean doHandle(Http.Method method, Path path, ServerRequest request, ServerResponse response) {
+        boolean doHandle(Http.Method method,
+                         String requestedResource,
+                         ServerRequest req,
+                         ServerResponse res,
+                         String rawPath,
+                         Path path) {
+
             this.counter.incrementAndGet();
             this.path = path;
             return returnValue;

--- a/nima/webserver/static-content/src/test/resources/web/nested/resource.txt
+++ b/nima/webserver/static-content/src/test/resources/web/nested/resource.txt
@@ -1,0 +1,1 @@
+Content

--- a/nima/webserver/static-content/src/test/resources/web/resource.txt
+++ b/nima/webserver/static-content/src/test/resources/web/resource.txt
@@ -1,0 +1,1 @@
+Content

--- a/tests/integration/mp-gh-4654/src/test/java/io/helidon/tests/integration/gh4654/Gh4654StaticContentTest.java
+++ b/tests/integration/mp-gh-4654/src/test/java/io/helidon/tests/integration/gh4654/Gh4654StaticContentTest.java
@@ -100,9 +100,9 @@ class Gh4654StaticContentTest {
             "/index.html,Root Index HTML,path should serve index.html",
             "/foo.txt,Foo TXT,path should serve foo.txt",
             "/css/a.css,A CSS,path should serve css/a.css",
-            "/other,Other Index,path should serve other/index.html",
+            "/other/,Other Index,path should serve other/index.html",
             "/other/index.html,Other Index,path should serve other/index.html",
-            "/classpath,classpath index,classpath should serve index.html",
+            "/classpath/,classpath index,classpath should serve index.html",
             "/classpath/index.html,classpath index,classpath should serve index.html"
     })
     void testExists(String path, String expectedContent, String name) {


### PR DESCRIPTION
Static content now uses cache of computed values (not cache of bytes).
Support for in-memory caching of bytes added as well, must be explicitly configured using configuration.
For classpath, each file must be listed.
For file system, directories can be listed as well (only first level depths is done).

The caching uses the same path that is requested by a user