### PR TITLE
Fix incorrect tags comparison when trying to match metric IDs

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricStore.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricStore.java
@@ -414,7 +414,7 @@ class MetricStore<M extends HelidonMetric> {
             return null;
         }
         for (MetricID metricID : metricIDsForName) {
-            if (metricID.getName().equals(metricName) && Arrays.equals(metricID.getTagsAsArray(), tags)) {
+            if (metricID.getName().equals(metricName) && tagsMatch(tags, metricID.getTags())) {
                 return allMetrics.get(metricID);
             }
         }
@@ -554,6 +554,14 @@ class MetricStore<M extends HelidonMetric> {
         } finally {
             lock.unlock();
         }
+    }
+
+    private static boolean tagsMatch(Tag[] tags, Map<String, String> tagMap) {
+        Map<String, String> newTags = new TreeMap<>();
+        for (Tag tag : tags) {
+            newTags.put(tag.getTagName(), tag.getTagValue());
+        }
+        return newTags.equals(tagMap);
     }
 
     private static void enforceConsistentMetadata(Metadata existingMetadata, Metadata newMetadata) {


### PR DESCRIPTION
Resolves #5541 

The original code used an array comparison to compare the tags of a previously-registered metric with the tags of a candidate new metric.

Inside the MicroProfile Metrics implementation of `MetricID` the tags are stored in a `TreeMap`. So iterators deliver in key-order (that is, in order of ascending tag name). But the comparison in `MetricStore` did not order the candidate metric's tag array by tag name prior to comparing. Tag sets that should match might not, depending on the order in which the tags were specified in the array.

The PR just creates a temporary `TreeMap` to hold the candidate tags so it can compare that and the `MetricID`'s `TreeMap` directly. Metric registration is typically a relatively infrequent event, so creating the `TreeMap` for this purpose should not hurt performance noticeably.

(BTW, this is not an issue in 2.x because the implementation is different and that code created a candidate `MetricID` for each candidate new metric and our code compared the two `MetricID`s which did the right thing with the tags.)