### PR TITLE
Provide MP config profile support for application.yaml

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
@@ -64,7 +64,7 @@ import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigMappers;
 import io.helidon.config.ConfigValue;
 import io.helidon.config.mp.spi.MpConfigFilter;
-import io.helidon.config.mp.spi.MpConfigSourceProviderWithProfile;
+import io.helidon.config.mp.spi.MpConfigSourceProvider;
 import io.helidon.config.mp.spi.MpMetaConfigProvider;
 
 import org.eclipse.microprofile.config.Config;
@@ -380,8 +380,8 @@ public class MpConfigBuilder implements ConfigBuilder {
                 .forEach(it -> it.getConfigSources(classLoader)
                         .forEach(source -> targetConfigSources.add(new OrdinalSource(source))));
 
-        ServiceLoader.load(MpConfigSourceProviderWithProfile.class)
-                .forEach(it -> it.getConfigSources(classLoader, profile)
+        ServiceLoader.load(MpConfigSourceProvider.class)
+                .forEach(it -> (profile == null ? it.getConfigSources(classLoader) : it.getConfigSources(classLoader, profile))
                         .forEach(source -> targetConfigSources.add(new OrdinalSource(source))));
     }
 

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
@@ -64,6 +64,7 @@ import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigMappers;
 import io.helidon.config.ConfigValue;
 import io.helidon.config.mp.spi.MpConfigFilter;
+import io.helidon.config.mp.spi.MpConfigSourceProviderWithProfile;
 import io.helidon.config.mp.spi.MpMetaConfigProvider;
 
 import org.eclipse.microprofile.config.Config;
@@ -377,6 +378,10 @@ public class MpConfigBuilder implements ConfigBuilder {
 
         ServiceLoader.load(ConfigSourceProvider.class)
                 .forEach(it -> it.getConfigSources(classLoader)
+                        .forEach(source -> targetConfigSources.add(new OrdinalSource(source))));
+
+        ServiceLoader.load(MpConfigSourceProviderWithProfile.class)
+                .forEach(it -> it.getConfigSources(classLoader, profile)
                         .forEach(source -> targetConfigSources.add(new OrdinalSource(source))));
     }
 

--- a/config/config-mp/src/main/java/io/helidon/config/mp/spi/MpConfigSourceProvider.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/spi/MpConfigSourceProvider.java
@@ -22,13 +22,12 @@ import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 /**
  * Java Service loader interface for MP ConfigSource Providers that adds configuration profile support.
  */
-public interface MpConfigSourceProviderWithProfile extends ConfigSourceProvider {
+public interface MpConfigSourceProvider extends ConfigSourceProvider {
     /**
      * Returns a list of configuration sources.
      *
-     * @param classLoader classloader where resource will be retrieved from (will use the
-     *                    current thread's classloader if value is {@code null})
-     * @param profile configuration profile to use
+     * @param classLoader classloader where resource will be retrieved from
+     * @param profile configuration profile to use, must not be null
      *
      * @return list of config sources
      */

--- a/config/config-mp/src/main/java/io/helidon/config/mp/spi/MpConfigSourceProviderWithProfile.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/spi/MpConfigSourceProviderWithProfile.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.mp.spi;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+/**
+ * Java Service loader interface for MP ConfigSource Providers that adds configuration profile support.
+ */
+public interface MpConfigSourceProviderWithProfile extends ConfigSourceProvider {
+    /**
+     * Returns a list of configuration sources.
+     *
+     * @param classLoader classloader where resource will be retrieved from (will use the
+     *                    current thread's classloader if value is {@code null})
+     * @param profile configuration profile to use
+     *
+     * @return list of config sources
+     */
+    Iterable<ConfigSource> getConfigSources(ClassLoader classLoader, String profile);
+}

--- a/config/config-mp/src/main/java/module-info.java
+++ b/config/config-mp/src/main/java/module-info.java
@@ -32,7 +32,7 @@ module io.helidon.config.mp {
     uses org.eclipse.microprofile.config.spi.ConfigSourceProvider;
     uses org.eclipse.microprofile.config.spi.Converter;
     uses io.helidon.config.mp.spi.MpConfigFilter;
-    uses io.helidon.config.mp.spi.MpConfigSourceProviderWithProfile;
+    uses io.helidon.config.mp.spi.MpConfigSourceProvider;
     uses io.helidon.config.mp.spi.MpMetaConfigProvider;
     uses io.helidon.config.spi.ConfigParser;
 

--- a/config/config-mp/src/main/java/module-info.java
+++ b/config/config-mp/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module io.helidon.config.mp {
     uses org.eclipse.microprofile.config.spi.ConfigSourceProvider;
     uses org.eclipse.microprofile.config.spi.Converter;
     uses io.helidon.config.mp.spi.MpConfigFilter;
+    uses io.helidon.config.mp.spi.MpConfigSourceProviderWithProfile;
     uses io.helidon.config.mp.spi.MpMetaConfigProvider;
     uses io.helidon.config.spi.ConfigParser;
 

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
@@ -21,9 +21,11 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import io.helidon.config.ConfigException;
-import io.helidon.config.mp.spi.MpConfigSourceProviderWithProfile;
+import io.helidon.config.mp.spi.MpConfigSourceProvider;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -31,18 +33,23 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * YAML config source provider for MicroProfile config that supports file {@code application.yaml}.
  * This class should not be used directly - it is loaded automatically by Java service loader.
  */
-public class YamlConfigSourceProvider implements MpConfigSourceProviderWithProfile {
+public class YamlConfigSourceProvider implements MpConfigSourceProvider {
     private static final String RESOURCE_NAME = "application.yaml";
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader) {
-        return getConfigSources(classLoader, null);
+        return getConfigSources(classLoader, Optional.empty());
     }
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader, String profile) {
+        Objects.requireNonNull(profile, "Profile must not be null");
+        return getConfigSources(classLoader, Optional.of(profile));
+    }
+
+    private Iterable<ConfigSource> getConfigSources(ClassLoader classLoader, Optional<String> profile) {
         List<ConfigSource> result = new LinkedList<>();
-        if (profile == null) {
+        if (profile.isEmpty()) {
             Enumeration<URL> resources;
             try {
                 resources = classLoader.getResources(RESOURCE_NAME);
@@ -54,7 +61,7 @@ public class YamlConfigSourceProvider implements MpConfigSourceProviderWithProfi
                 result.add(YamlMpConfigSource.create(url));
             }
         } else {
-            result.addAll(YamlMpConfigSource.classPath(RESOURCE_NAME, profile, classLoader));
+            result.addAll(YamlMpConfigSource.classPath(RESOURCE_NAME, profile.get(), classLoader));
         }
 
         return result;

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,28 +23,38 @@ import java.util.LinkedList;
 import java.util.List;
 
 import io.helidon.config.ConfigException;
+import io.helidon.config.mp.spi.MpConfigSourceProviderWithProfile;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
-import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 
 /**
  * YAML config source provider for MicroProfile config that supports file {@code application.yaml}.
  * This class should not be used directly - it is loaded automatically by Java service loader.
  */
-public class YamlConfigSourceProvider implements ConfigSourceProvider {
+public class YamlConfigSourceProvider implements MpConfigSourceProviderWithProfile {
+    private static final String RESOURCE_NAME = "application.yaml";
+
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader) {
-        Enumeration<URL> resources;
-        try {
-            resources = classLoader.getResources("application.yaml");
-        } catch (IOException e) {
-            throw new ConfigException("Failed to read resources from classpath", e);
-        }
+        return getConfigSources(classLoader, null);
+    }
 
+    @Override
+    public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader, String profile) {
         List<ConfigSource> result = new LinkedList<>();
-        while (resources.hasMoreElements()) {
-            URL url = resources.nextElement();
-            result.add(YamlMpConfigSource.create(url));
+        if (profile == null) {
+            Enumeration<URL> resources;
+            try {
+                resources = classLoader.getResources(RESOURCE_NAME);
+            } catch (IOException e) {
+                throw new ConfigException("Failed to read resources from classpath", e);
+            }
+            while (resources.hasMoreElements()) {
+                URL url = resources.nextElement();
+                result.add(YamlMpConfigSource.create(url));
+            }
+        } else {
+            result.addAll(YamlMpConfigSource.classPath(RESOURCE_NAME, profile, classLoader));
         }
 
         return result;

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
@@ -22,7 +22,6 @@ import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import io.helidon.config.ConfigException;
 import io.helidon.config.mp.spi.MpConfigSourceProvider;

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
@@ -38,18 +38,18 @@ public class YamlConfigSourceProvider implements MpConfigSourceProvider {
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader) {
-        return getConfigSources(classLoader, Optional.empty());
+        return configSources(classLoader, null);
     }
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader, String profile) {
         Objects.requireNonNull(profile, "Profile must not be null");
-        return getConfigSources(classLoader, Optional.of(profile));
+        return configSources(classLoader, profile);
     }
 
-    private Iterable<ConfigSource> getConfigSources(ClassLoader classLoader, Optional<String> profile) {
+    private Iterable<ConfigSource> configSources(ClassLoader classLoader, String profile) {
         List<ConfigSource> result = new LinkedList<>();
-        if (profile.isEmpty()) {
+        if (profile == null) {
             Enumeration<URL> resources;
             try {
                 resources = classLoader.getResources(RESOURCE_NAME);
@@ -61,7 +61,7 @@ public class YamlConfigSourceProvider implements MpConfigSourceProvider {
                 result.add(YamlMpConfigSource.create(url));
             }
         } else {
-            result.addAll(YamlMpConfigSource.classPath(RESOURCE_NAME, profile.get(), classLoader));
+            result.addAll(YamlMpConfigSource.classPath(RESOURCE_NAME, profile, classLoader));
         }
 
         return result;

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
@@ -196,7 +196,7 @@ public class YamlMpConfigSource implements ConfigSource {
      * @return list of config sources discovered (may be zero length)
      */
     public static List<ConfigSource> classPath(String resource, String profile) {
-        return classPath(resource, profile, Thread.currentThread().getContextClassLoader());
+        return classPathConfigSources(resource, profile, Thread.currentThread().getContextClassLoader());
     }
 
     /**
@@ -210,6 +210,11 @@ public class YamlMpConfigSource implements ConfigSource {
     public static List<ConfigSource> classPath(String resource, String profile, ClassLoader classLoader) {
         Objects.requireNonNull(profile, "Profile must be defined");
         Objects.requireNonNull(classLoader, "ClassLoader must be defined");
+
+        return classPathConfigSources(resource, profile, classLoader);
+    }
+
+    private static List<ConfigSource> classPathConfigSources(String resource, String profile, ClassLoader classLoader) {
 
         List<ConfigSource> sources = new LinkedList<>();
 

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
@@ -196,10 +196,25 @@ public class YamlMpConfigSource implements ConfigSource {
      * @return list of config sources discovered (may be zero length)
      */
     public static List<ConfigSource> classPath(String resource, String profile) {
+        return classPath(resource, profile, null);
+    }
+
+    /**
+     * Create from YAML file(s) on classpath from specified classloader with profile support.
+     *
+     * @param resource resource name to locate on classpath (looks for all instances)
+     * @param profile configuration profile to use
+     * @param classLoader classloader where resource will be retrieved from (will use the
+     *                    current thread's classloader if value is {@code null})
+     * @return list of config sources discovered (may be zero length)
+     */
+    public static List<ConfigSource> classPath(String resource, String profile, ClassLoader classLoader) {
         Objects.requireNonNull(profile, "Profile must be defined");
 
         List<ConfigSource> sources = new LinkedList<>();
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = Thread.currentThread().getContextClassLoader();
+        }
 
         try {
             Enumeration<URL> baseResources = classLoader.getResources(resource);

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
@@ -192,29 +192,26 @@ public class YamlMpConfigSource implements ConfigSource {
      * Create from YAML file(s) on classpath with profile support.
      *
      * @param resource resource name to locate on classpath (looks for all instances)
-     * @param profile name of the profile to use
+     * @param profile configuration profile to use, must not be null
      * @return list of config sources discovered (may be zero length)
      */
     public static List<ConfigSource> classPath(String resource, String profile) {
-        return classPath(resource, profile, null);
+        return classPath(resource, profile, Thread.currentThread().getContextClassLoader());
     }
 
     /**
      * Create from YAML file(s) on classpath from specified classloader with profile support.
      *
      * @param resource resource name to locate on classpath (looks for all instances)
-     * @param profile configuration profile to use
-     * @param classLoader classloader where resource will be retrieved from (will use the
-     *                    current thread's classloader if value is {@code null})
+     * @param profile configuration profile to use, must not be null
+     * @param classLoader classloader where resource will be retrieved from
      * @return list of config sources discovered (may be zero length)
      */
     public static List<ConfigSource> classPath(String resource, String profile, ClassLoader classLoader) {
         Objects.requireNonNull(profile, "Profile must be defined");
+        Objects.requireNonNull(classLoader, "ClassLoader must be defined");
 
         List<ConfigSource> sources = new LinkedList<>();
-        if (classLoader == null) {
-            classLoader = Thread.currentThread().getContextClassLoader();
-        }
 
         try {
             Enumeration<URL> baseResources = classLoader.getResources(resource);

--- a/config/yaml-mp/src/main/java/module-info.java
+++ b/config/yaml-mp/src/main/java/module-info.java
@@ -27,6 +27,6 @@ module io.helidon.config.yaml.mp {
 
     exports io.helidon.config.yaml.mp;
 
-    provides org.eclipse.microprofile.config.spi.ConfigSourceProvider with io.helidon.config.yaml.mp.YamlConfigSourceProvider;
+    provides io.helidon.config.mp.spi.MpConfigSourceProviderWithProfile with io.helidon.config.yaml.mp.YamlConfigSourceProvider;
     provides io.helidon.config.mp.spi.MpMetaConfigProvider with io.helidon.config.yaml.mp.YamlMetaConfigProvider;
 }

--- a/config/yaml-mp/src/main/java/module-info.java
+++ b/config/yaml-mp/src/main/java/module-info.java
@@ -27,6 +27,6 @@ module io.helidon.config.yaml.mp {
 
     exports io.helidon.config.yaml.mp;
 
-    provides io.helidon.config.mp.spi.MpConfigSourceProviderWithProfile with io.helidon.config.yaml.mp.YamlConfigSourceProvider;
+    provides io.helidon.config.mp.spi.MpConfigSourceProvider with io.helidon.config.yaml.mp.YamlConfigSourceProvider;
     provides io.helidon.config.mp.spi.MpMetaConfigProvider with io.helidon.config.yaml.mp.YamlMetaConfigProvider;
 }

--- a/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpConfigSourceProviderTest.java
+++ b/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpConfigSourceProviderTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.yaml.mp;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import io.helidon.config.mp.MpConfigSources;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class YamlMpConfigSourceProviderTest {
+    private static ConfigProviderResolver configResolver;
+    private Config config;
+    private static final String MP_CONFIG_PROFILE = "mp.config.profile";
+    public static final String PROFILE_CONFIG_KEY = "profile.type";
+    public static final String DEFAULT_PROFILE = "default";
+    public static final String DEV_PROFILE = "dev";
+    public static final String TEST_PROFILE = "test";
+
+    public static final Map<String, String> profileConfigValues = Map.of(
+            DEFAULT_PROFILE, "Production",
+            DEV_PROFILE, "Development",
+            TEST_PROFILE, "Test"
+    );
+
+    @BeforeAll
+    static void init() {
+        configResolver = ConfigProviderResolver.instance();
+    }
+
+    @AfterAll
+    static void reset() {
+        System.clearProperty(MP_CONFIG_PROFILE);
+    }
+
+    @BeforeEach
+    void resetConfig() {
+        if (config == null) {
+            System.clearProperty(MP_CONFIG_PROFILE);
+            configResolver.releaseConfig(ConfigProvider.getConfig());
+        } else {
+            configResolver.releaseConfig(config);
+            config = null;
+        }
+    }
+
+    @Test
+    void testNoProfile() {
+        // if using DEFAULT_PROFILE, mp.config.profile system property will not be set
+        validateUsingSystemProperty(DEFAULT_PROFILE);
+    }
+
+    @Test
+    void testWithDevelopmentProfileFromSystemProperty() {
+        validateUsingSystemProperty(DEV_PROFILE);
+    }
+
+    @Test
+    void testWithTestProfileFromSystemProperty() {
+        validateUsingSystemProperty(TEST_PROFILE);
+    }
+
+    @Test
+    void testNoProfileFromConfigSource() {
+        // if using DEFAULT_PROFILE, mp.config.profile will not be added in the config source
+        validateUsingConfigSource(DEFAULT_PROFILE);
+    }
+
+    @Test
+    void testWithDevelopmentProfileFromConfigSource() {
+        validateUsingConfigSource(DEV_PROFILE);
+    }
+
+    @Test
+    void testWithTestProfileFromConfigSource() {
+        validateUsingConfigSource(TEST_PROFILE);
+    }
+
+    private void validateUsingSystemProperty(String profile) {
+        // Don't set mp.config.profile system property if using DEFAULT_PROFILE
+        if (profile != DEFAULT_PROFILE) {
+            System.setProperty(MP_CONFIG_PROFILE, profile);
+        }
+        validateConfigValues(profile, profileConfigValues.get(profile));
+    }
+
+    private void validateUsingConfigSource(String profile) {
+        // Don't set mp.config.profile in config source if using DEFAULT_PROFILE
+        Map<String, String> configMap = profile == DEFAULT_PROFILE ? Map.of() : Map.of(MP_CONFIG_PROFILE, profile);
+        Config mpConfigProfile = configResolver.getBuilder()
+                .addDiscoveredSources()
+                .withSources(MpConfigSources.create(configMap))
+                .build();
+        configResolver.registerConfig(mpConfigProfile, Thread.currentThread().getContextClassLoader());
+        validateConfigValues(profile, profileConfigValues.get(profile));
+    }
+
+    private void validateConfigValues(String profile, String profileConfigValue) {
+        config = ConfigProvider.getConfig();
+        // If using DEFAULT_PROFILE, mp.config.profile should not exist in the Config
+        if (profile == DEFAULT_PROFILE) {
+            assertThrows(NoSuchElementException.class, () -> {
+                config.getValue(MP_CONFIG_PROFILE, String.class);
+            });
+        } else {
+            assertThat(config.getValue(MP_CONFIG_PROFILE, String.class), is(profile));
+        }
+        assertThat(config.getValue(PROFILE_CONFIG_KEY, String.class), is(profileConfigValue));
+    }
+}

--- a/config/yaml-mp/src/test/resources/application-dev.yaml
+++ b/config/yaml-mp/src/test/resources/application-dev.yaml
@@ -14,15 +14,5 @@
 # limitations under the License.
 #
 
-yaml:
-  string: String
-  number: 10
-  array:
-    - "Array 1"
-    - "Array 2"
-    - "Array 3"
-  boolean: true
-
-# Will be used for config profile testing
 profile:
-  type: "Production"
+  type: "Development"

--- a/config/yaml-mp/src/test/resources/application-test.yaml
+++ b/config/yaml-mp/src/test/resources/application-test.yaml
@@ -14,15 +14,5 @@
 # limitations under the License.
 #
 
-yaml:
-  string: String
-  number: 10
-  array:
-    - "Array 1"
-    - "Array 2"
-    - "Array 3"
-  boolean: true
-
-# Will be used for config profile testing
 profile:
-  type: "Production"
+  type: "Test"

--- a/config/yaml-mp/src/test/resources/application.yaml
+++ b/config/yaml-mp/src/test/resources/application.yaml
@@ -26,3 +26,4 @@ yaml:
 # Will be used for config profile testing
 profile:
   type: "Production"
+  value: "Production"


### PR DESCRIPTION
Change includes the following:
1. Create a new interface MpConfigSourceProviderWithProfile that extends ConfigSourceProvider and adds profile support.
2. Use MpConfigSourceProviderWithProfile as the provider for Java Service Loader when processing application.yaml.
3. Added unit tests to exercise setting of mp.config.profile using system property or config source.