### PR TITLE
Pass correct config to health providers 

### DIFF
--- a/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
+++ b/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
@@ -28,6 +28,7 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.config.ConfigValue;
+import io.helidon.config.spi.ConfigSource;
 import io.helidon.health.HealthCheck;
 import io.helidon.health.HealthCheckType;
 import io.helidon.health.spi.HealthCheckProvider;
@@ -258,12 +259,9 @@ public class HealthFeature extends HelidonFeatureSupport {
 
         private Config effectiveConfig() {
 
-            return Config.create(ConfigSources.create(configs.stream()
-                                                              .map(Config::asMap)
-                                                              .map(ConfigValue::get)
-                                                              .flatMap(map -> map.entrySet().stream())
-                                                              .collect(Collectors.toMap(Map.Entry::getKey,
-                                                                                        Map.Entry::getValue))));
+            return Config.create(configs.stream()
+                                         .map(ConfigSources::create)
+                                         .toArray(ConfigSource[]::new));
         }
     }
 }

--- a/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
+++ b/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
@@ -19,15 +19,12 @@ package io.helidon.nima.observe.health;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
-import io.helidon.config.ConfigValue;
 import io.helidon.config.spi.ConfigSource;
 import io.helidon.health.HealthCheck;
 import io.helidon.health.HealthCheckType;

--- a/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
+++ b/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
@@ -24,6 +24,8 @@ import java.util.ServiceLoader;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.config.spi.ConfigSource;
 import io.helidon.health.HealthCheck;
 import io.helidon.health.HealthCheckType;
 import io.helidon.health.spi.HealthCheckProvider;
@@ -139,6 +141,8 @@ public class HealthFeature extends HelidonFeatureSupport {
         private final List<HealthCheck> liveChecks = new ArrayList<>();
         private final List<HealthCheck> startChecks = new ArrayList<>();
 
+        private final List<Config> configs = new ArrayList<>();
+
         private boolean enabled = true;
         private boolean details = false;
 
@@ -148,11 +152,17 @@ public class HealthFeature extends HelidonFeatureSupport {
 
         @Override
         public HealthFeature build() {
+            // Optimize for the most common cases.
+            Config config =
+                    switch (configs.size()) {
+                        case 0 -> Config.empty();
+                        case 1 -> configs.get(0);
+                        default -> effectiveConfig();
+                    };
             providers.build()
                     .asList()
                     .stream()
-                    // TODO use configuration
-                    .map(provider -> provider.healthChecks(Config.empty()))
+                    .map(provider -> provider.healthChecks(config))
                     .flatMap(Collection::stream)
                     .forEach(it -> addCheck(it, it.type()));
             return new HealthFeature(this);
@@ -194,6 +204,7 @@ public class HealthFeature extends HelidonFeatureSupport {
          */
         public Builder config(Config config) {
             super.config(config);
+            configs.add(config);
 
             config.get("enabled").asBoolean().ifPresent(this::enabled);
             config.get("details").asBoolean().ifPresent(this::details);
@@ -241,6 +252,13 @@ public class HealthFeature extends HelidonFeatureSupport {
         public Builder useSystemServices(boolean useServices) {
             providers.useSystemServiceLoader(useServices);
             return this;
+        }
+
+        private Config effectiveConfig() {
+            return Config.create(configs.stream()
+                                         .filter(Config::exists)
+                                         .map(ConfigSources::create)
+                                         .toArray(ConfigSource[]::new));
         }
     }
 }

--- a/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
+++ b/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
@@ -18,13 +18,18 @@ package io.helidon.nima.observe.health;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
+import io.helidon.config.ConfigValue;
 import io.helidon.config.spi.ConfigSource;
 import io.helidon.health.HealthCheck;
 import io.helidon.health.HealthCheckType;
@@ -255,10 +260,14 @@ public class HealthFeature extends HelidonFeatureSupport {
         }
 
         private Config effectiveConfig() {
-            return Config.create(configs.stream()
-                                         .filter(Config::exists)
-                                         .map(ConfigSources::create)
-                                         .toArray(ConfigSource[]::new));
+
+            return Config.create(ConfigSources.create(configs.stream()
+                                                              .map(Config::asMap)
+                                                              .filter(ConfigValue::isPresent)
+                                                              .map(ConfigValue::get)
+                                                              .flatMap(map -> map.entrySet().stream())
+                                                              .collect(Collectors.toMap(Map.Entry::getKey,
+                                                                                        Map.Entry::getValue))));
         }
     }
 }

--- a/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
+++ b/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
@@ -18,19 +18,16 @@ package io.helidon.nima.observe.health;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.config.ConfigValue;
-import io.helidon.config.spi.ConfigSource;
 import io.helidon.health.HealthCheck;
 import io.helidon.health.HealthCheckType;
 import io.helidon.health.spi.HealthCheckProvider;

--- a/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
+++ b/nima/observe/health/src/main/java/io/helidon/nima/observe/health/HealthFeature.java
@@ -260,7 +260,6 @@ public class HealthFeature extends HelidonFeatureSupport {
 
             return Config.create(ConfigSources.create(configs.stream()
                                                               .map(Config::asMap)
-                                                              .filter(ConfigValue::isPresent)
                                                               .map(ConfigValue::get)
                                                               .flatMap(map -> map.entrySet().stream())
                                                               .collect(Collectors.toMap(Map.Entry::getKey,


### PR DESCRIPTION
Resolves #5427 

Save the `Config` instances passed to `HealthFeature.Builder#config`, then in `build` compute the effective config from the saved ones and pass that to the providers so they can set up their health checks correctly.