### PR TITLE
Provide MP config profile support for application.yaml (#5565)

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
@@ -67,6 +67,7 @@ import io.helidon.config.ConfigValue;
 import io.helidon.config.metadata.Configured;
 import io.helidon.config.metadata.ConfiguredOption;
 import io.helidon.config.mp.spi.MpConfigFilter;
+import io.helidon.config.mp.spi.MpConfigSourceProvider;
 import io.helidon.config.mp.spi.MpMetaConfigProvider;
 
 import org.eclipse.microprofile.config.Config;
@@ -379,6 +380,10 @@ class MpConfigBuilder implements Builder<MpConfigBuilder, Config>, ConfigBuilder
 
         ServiceLoader.load(ConfigSourceProvider.class)
                 .forEach(it -> it.getConfigSources(classLoader)
+                        .forEach(source -> targetConfigSources.add(new OrdinalSource(source))));
+
+        ServiceLoader.load(MpConfigSourceProvider.class)
+                .forEach(it -> (profile == null ? it.getConfigSources(classLoader) : it.getConfigSources(classLoader, profile))
                         .forEach(source -> targetConfigSources.add(new OrdinalSource(source))));
     }
 

--- a/config/config-mp/src/main/java/io/helidon/config/mp/spi/MpConfigSourceProvider.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/spi/MpConfigSourceProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.mp.spi;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+/**
+ * Java Service loader interface for MP ConfigSource Providers that adds configuration profile support.
+ */
+public interface MpConfigSourceProvider extends ConfigSourceProvider {
+    /**
+     * Returns a list of configuration sources.
+     *
+     * @param classLoader classloader where resource will be retrieved from
+     * @param profile configuration profile to use, must not be null
+     *
+     * @return list of config sources
+     */
+    Iterable<ConfigSource> getConfigSources(ClassLoader classLoader, String profile);
+}

--- a/config/config-mp/src/main/java/module-info.java
+++ b/config/config-mp/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module io.helidon.config.mp {
     uses org.eclipse.microprofile.config.spi.ConfigSourceProvider;
     uses org.eclipse.microprofile.config.spi.Converter;
     uses io.helidon.config.mp.spi.MpConfigFilter;
+    uses io.helidon.config.mp.spi.MpConfigSourceProvider;
     uses io.helidon.config.mp.spi.MpMetaConfigProvider;
     uses io.helidon.config.spi.ConfigParser;
 

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
@@ -192,14 +192,31 @@ public class YamlMpConfigSource implements ConfigSource {
      * Create from YAML file(s) on classpath with profile support.
      *
      * @param resource resource name to locate on classpath (looks for all instances)
-     * @param profile name of the profile to use
+     * @param profile configuration profile to use, must not be null
      * @return list of config sources discovered (may be zero length)
      */
     public static List<ConfigSource> classPath(String resource, String profile) {
+        return classPathConfigSources(resource, profile, Thread.currentThread().getContextClassLoader());
+    }
+
+    /**
+     * Create from YAML file(s) on classpath from specified classloader with profile support.
+     *
+     * @param resource resource name to locate on classpath (looks for all instances)
+     * @param profile configuration profile to use, must not be null
+     * @param classLoader classloader where resource will be retrieved from
+     * @return list of config sources discovered (may be zero length)
+     */
+    public static List<ConfigSource> classPath(String resource, String profile, ClassLoader classLoader) {
         Objects.requireNonNull(profile, "Profile must be defined");
+        Objects.requireNonNull(classLoader, "ClassLoader must be defined");
+
+        return classPathConfigSources(resource, profile, classLoader);
+    }
+
+    private static List<ConfigSource> classPathConfigSources(String resource, String profile, ClassLoader classLoader) {
 
         List<ConfigSource> sources = new LinkedList<>();
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
         try {
             Enumeration<URL> baseResources = classLoader.getResources(resource);

--- a/config/yaml-mp/src/main/java/module-info.java
+++ b/config/yaml-mp/src/main/java/module-info.java
@@ -27,6 +27,6 @@ module io.helidon.config.yaml.mp {
 
     exports io.helidon.config.yaml.mp;
 
-    provides org.eclipse.microprofile.config.spi.ConfigSourceProvider with io.helidon.config.yaml.mp.YamlConfigSourceProvider;
+    provides io.helidon.config.mp.spi.MpConfigSourceProvider with io.helidon.config.yaml.mp.YamlConfigSourceProvider;
     provides io.helidon.config.mp.spi.MpMetaConfigProvider with io.helidon.config.yaml.mp.YamlMetaConfigProvider;
 }

--- a/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpConfigSourceProviderTest.java
+++ b/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpConfigSourceProviderTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.yaml.mp;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import io.helidon.config.mp.MpConfigSources;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class YamlMpConfigSourceProviderTest {
+    private static ConfigProviderResolver configResolver;
+    private Config config;
+    private static final String MP_CONFIG_PROFILE = "mp.config.profile";
+    public static final String PROFILE_TYPE_CONFIG_KEY = "profile.type";
+    public static final String PROFILE_VALUE_CONFIG_KEY = "profile.value";
+    public static final String DEFAULT_PROFILE = "default";
+    public static final String DEV_PROFILE = "dev";
+    public static final String TEST_PROFILE = "test";
+    public static final String DEFAULT_PROFILE_VALUE = "Production";
+    public static final Map<String, String> profileConfigValues = Map.of(
+            DEFAULT_PROFILE, DEFAULT_PROFILE_VALUE,
+            DEV_PROFILE, "Development",
+            TEST_PROFILE, "Test"
+    );
+
+    @BeforeAll
+    static void init() {
+        configResolver = ConfigProviderResolver.instance();
+    }
+
+    @AfterAll
+    static void reset() {
+        System.clearProperty(MP_CONFIG_PROFILE);
+    }
+
+    @BeforeEach
+    void resetConfig() {
+        if (config == null) {
+            System.clearProperty(MP_CONFIG_PROFILE);
+            configResolver.releaseConfig(ConfigProvider.getConfig());
+        } else {
+            configResolver.releaseConfig(config);
+            config = null;
+        }
+    }
+
+    @Test
+    void testNoProfileFromSystemPropertyWithOverride() {
+        // if using DEFAULT_PROFILE, mp.config.profile system property will not be set
+        validateUsingSystemProperty(DEFAULT_PROFILE, PROFILE_TYPE_CONFIG_KEY, profileConfigValues.get(DEFAULT_PROFILE));
+    }
+
+    @Test
+    void testDevProfileFromSystemPropertyWithOverride() {
+        validateUsingSystemProperty(DEV_PROFILE, PROFILE_TYPE_CONFIG_KEY, profileConfigValues.get(DEV_PROFILE));
+    }
+
+    @Test
+    void testTestProfileFromSystemPropertyWithOverride() {
+        validateUsingSystemProperty(TEST_PROFILE, PROFILE_VALUE_CONFIG_KEY, DEFAULT_PROFILE_VALUE);
+    }
+
+    @Test
+    void testNoProfileFromSystemPropertyWithNoOverride() {
+        // if using DEFAULT_PROFILE, mp.config.profile will not be added in the config source
+        validateUsingSystemProperty(DEFAULT_PROFILE, PROFILE_TYPE_CONFIG_KEY, profileConfigValues.get(DEFAULT_PROFILE));
+    }
+
+    @Test
+    void testDevProfileFromSystemPropertyWithNoOverride() {
+        validateUsingSystemProperty(TEST_PROFILE, PROFILE_TYPE_CONFIG_KEY, profileConfigValues.get(TEST_PROFILE));
+    }
+
+    @Test
+    void testTestProfileFromSystemPropertyWithNoOverride() {
+        validateUsingSystemProperty(DEV_PROFILE, PROFILE_TYPE_CONFIG_KEY, profileConfigValues.get(DEV_PROFILE));
+    }
+
+    @Test
+    void testNoProfileFromFromConfigSourceWithOverride() {
+        // if using DEFAULT_PROFILE, mp.config.profile will not be added in the config source
+        validateUsingConfigSource(DEFAULT_PROFILE, PROFILE_VALUE_CONFIG_KEY, DEFAULT_PROFILE_VALUE);
+    }
+
+    @Test
+    void testDevProfileFromFromConfigSourceWithOverride() {
+        validateUsingConfigSource(DEV_PROFILE, PROFILE_VALUE_CONFIG_KEY, DEFAULT_PROFILE_VALUE);
+    }
+
+    @Test
+    void testTestProfileFromFromConfigSourceWithOverride() {
+        validateUsingConfigSource(TEST_PROFILE, PROFILE_VALUE_CONFIG_KEY, DEFAULT_PROFILE_VALUE);
+    }
+
+    @Test
+    void testNoProfileFromFromConfigSourceWithNoOverride() {
+        // if using DEFAULT_PROFILE, mp.config.profile will not be added in the config source
+        validateUsingConfigSource(DEFAULT_PROFILE, PROFILE_VALUE_CONFIG_KEY, DEFAULT_PROFILE_VALUE);
+    }
+
+    @Test
+    void testDevProfileFromFromConfigSourceWithNoOverride() {
+        validateUsingConfigSource(DEV_PROFILE, PROFILE_VALUE_CONFIG_KEY, DEFAULT_PROFILE_VALUE);
+    }
+
+    @Test
+    void testTestProfileFromFromConfigSourceWithNoOverride() {
+        validateUsingConfigSource(TEST_PROFILE, PROFILE_VALUE_CONFIG_KEY, DEFAULT_PROFILE_VALUE);
+    }
+
+    private void validateUsingSystemProperty(String profile, String profileConfigKey, String profileConfigValue) {
+        // Don't set mp.config.profile system property if using DEFAULT_PROFILE
+        if (!profile.equals(DEFAULT_PROFILE)) {
+            System.setProperty(MP_CONFIG_PROFILE, profile);
+        }
+        validateConfigValues(profile, profileConfigKey, profileConfigValue);
+    }
+
+    private void validateUsingConfigSource(String profile, String profileConfigKey, String profileConfigValue){
+        // Don't set mp.config.profile in config source if using DEFAULT_PROFILE
+        Map<String, String> configMap = profile == DEFAULT_PROFILE ? Map.of() : Map.of(MP_CONFIG_PROFILE, profile);
+        Config mpConfigProfile = configResolver.getBuilder()
+                .addDiscoveredSources()
+                .withSources(MpConfigSources.create(configMap))
+                .build();
+        configResolver.registerConfig(mpConfigProfile, Thread.currentThread().getContextClassLoader());
+        validateConfigValues(profile, profileConfigKey, profileConfigValue);
+    }
+
+    private void validateConfigValues(String profile, String profileConfigKey, String profileConfigValue) {
+        config = ConfigProvider.getConfig();
+        // If using DEFAULT_PROFILE, mp.config.profile should not exist in the Config
+        if (profile == DEFAULT_PROFILE) {
+            assertThrows(NoSuchElementException.class, () -> {
+                config.getValue(MP_CONFIG_PROFILE, String.class);
+            });
+        } else {
+            assertThat(config.getValue(MP_CONFIG_PROFILE, String.class), is(profile));
+        }
+        assertThat(config.getValue(profileConfigKey, String.class), is(profileConfigValue));
+    }
+}

--- a/config/yaml-mp/src/test/resources/application-dev.yaml
+++ b/config/yaml-mp/src/test/resources/application-dev.yaml
@@ -14,16 +14,5 @@
 # limitations under the License.
 #
 
-yaml:
-  string: String
-  number: 10
-  array:
-    - "Array 1"
-    - "Array 2"
-    - "Array 3"
-  boolean: true
-
-# Will be used for config profile testing
 profile:
-  type: "Production"
-  value: "Production"
+  type: "Development"

--- a/config/yaml-mp/src/test/resources/application-test.yaml
+++ b/config/yaml-mp/src/test/resources/application-test.yaml
@@ -14,16 +14,5 @@
 # limitations under the License.
 #
 
-yaml:
-  string: String
-  number: 10
-  array:
-    - "Array 1"
-    - "Array 2"
-    - "Array 3"
-  boolean: true
-
-# Will be used for config profile testing
 profile:
-  type: "Production"
-  value: "Production"
+  type: "Test"


### PR DESCRIPTION
Change includes the following:
1. Create a new interface MpConfigSourceProvider that extends ConfigSourceProvider and adds profile support.
2. Use MpConfigSourceProviderWithProfile as the provider for Java Service Loader when processing application.yaml.
3. Added unit tests to exercise setting of mp.config.profile using system property or config source.