### PR TITLE
Fix handling of entity length in HTTP/2.

### DIFF
--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandler.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandler.java
@@ -116,7 +116,6 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolProvider.SubProto
         try {
             while (data.available() > 0) {
                 // todo compression support
-                // todo one message could span multiple frames
                 boolean isCompressed = (data.read() == 1);
                 long length = data.readUnsignedInt32(); // if the result is > than data length, wait for next data?
                 byte[] bytes = new byte[(int) length];

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2Stream.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2Stream.java
@@ -217,14 +217,11 @@ public class Http2Stream implements Runnable, io.helidon.nima.http2.Http2Stream 
             writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()), flowControl);
             return;
         }
-        expectedLength -= header.length();
+        if (expectedLength != -1) {
+            expectedLength -= header.length();
+        }
         try {
             inboundData.put(new DataFrame(header, data));
-            // TODO this is a race condition
-            //            if (Http2FrameTypes.DATA.flags(header.flags())
-            //                    .endOfStream()) {
-            //                state = Http2StreamState.HALF_CLOSED_REMOTE;
-            //            }
         } catch (InterruptedException e) {
             throw new Http2Exception(Http2ErrorCode.INTERNAL, "Interrupted", e);
         }

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/GrpcServerTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/GrpcServerTest.java
@@ -35,7 +35,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -81,8 +80,7 @@ class GrpcServerTest {
         }
     }
 
-    @RepeatedTest(100)
-    @Disabled("Hangs when run from maven")
+    @RepeatedTest(20)
     void testUnary() {
         String text = "lower case original";
         StringMessage request = StringMessage.newBuilder().setText(text).build();
@@ -91,9 +89,7 @@ class GrpcServerTest {
         assertThat(response.getText(), is(text.toUpperCase(Locale.ROOT)));
     }
 
-    @RepeatedTest(100)
-    // TODO requires analysis + fix
-    @Disabled("Intermittently failing on RST_STREAM")
+    @RepeatedTest(20)
     void testBidi() throws Throwable {
         List<String> valuesToStream = List.of("A", "B", "C", "D");
 
@@ -111,9 +107,7 @@ class GrpcServerTest {
         assertThat(echoes, is(valuesToStream));
     }
 
-    // TODO requires analysis + fix
-    @Disabled("Intermittently failing on RST_STREAM")
-    @RepeatedTest(100)
+    @RepeatedTest(20)
     void testClientStream() throws Throwable {
         List<String> valuesToStream = List.of("A", "B", "C", "D");
         StringsCollector responseObserver = new StringsCollector();
@@ -129,9 +123,7 @@ class GrpcServerTest {
         assertThat(strings, contains("A B C D"));
     }
 
-    // TODO requires analysis + fix
-    @RepeatedTest(100)
-    @Disabled("Intermittent failures (timing related)")
+    @RepeatedTest(20)
     void testServerStream() throws Throwable {
         StringsCollector responseObserver = new StringsCollector();
         stub.split(StringMessage.newBuilder().setText("A B C D").build(), responseObserver);
@@ -150,7 +142,8 @@ class GrpcServerTest {
 
         @Override
         public void onError(Throwable throwable) {
-            future.completeExceptionally(throwable);
+            // wrap in our exception, so we can see who called this (onError) metehod
+            future.completeExceptionally(new RuntimeException(throwable));
         }
 
         @Override

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/GrpcServerTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/GrpcServerTest.java
@@ -142,7 +142,7 @@ class GrpcServerTest {
 
         @Override
         public void onError(Throwable throwable) {
-            // wrap in our exception, so we can see who called this (onError) metehod
+            // wrap in our exception, so we can see who called this (onError) method
             future.completeExceptionally(new RuntimeException(throwable));
         }
 

--- a/nima/tests/integration/grpc/server/src/test/resources/logging.properties
+++ b/nima/tests/integration/grpc/server/src/test/resources/logging.properties
@@ -13,10 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
 
-java.util.logging.ConsoleHandler.level=ALL
 # io.helidon.nima.level=FINEST

--- a/nima/tests/integration/grpc/server/src/test/resources/logging.properties
+++ b/nima/tests/integration/grpc/server/src/test/resources/logging.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+java.util.logging.ConsoleHandler.level=ALL
+# io.helidon.nima.level=FINEST


### PR DESCRIPTION
Re-enable grpc tests.

First part of #5418 & #5323 