### PR TITLE
Fix problems causing MP metrics TCK failures

### DIFF
--- a/metrics/service-api/src/main/java/io/helidon/metrics/serviceapi/JsonFormat.java
+++ b/metrics/service-api/src/main/java/io/helidon/metrics/serviceapi/JsonFormat.java
@@ -160,7 +160,7 @@ public final class JsonFormat {
         return toJson(JsonFormat::jsonMeta, registries);
     }
 
-    private static JsonObject jsonMeta(Registry registry) {
+    public static JsonObject jsonMeta(Registry registry) {
         return toJson((builder, entry) -> {
             MetricID metricID = entry.id();
             HelidonMetric metric = entry.metric();

--- a/metrics/service-api/src/main/java/io/helidon/metrics/serviceapi/JsonFormat.java
+++ b/metrics/service-api/src/main/java/io/helidon/metrics/serviceapi/JsonFormat.java
@@ -160,6 +160,12 @@ public final class JsonFormat {
         return toJson(JsonFormat::jsonMeta, registries);
     }
 
+    /**
+     * Create JSON metric metadata response for a single registry.
+     *
+     * @param registry registry to use
+     * @return JSON with all metadata for metrics in the specified registry
+     */
     public static JsonObject jsonMeta(Registry registry) {
         return toJson((builder, entry) -> {
             MetricID metricID = entry.id();

--- a/microprofile/tests/tck/pom.xml
+++ b/microprofile/tests/tck/pom.xml
@@ -33,8 +33,7 @@
     <modules>
         <module>tck-config</module>
         <module>tck-health</module>
-        <!-- TODO:Níma - fails for now, requires analysis -->
-<!--        <module>tck-metrics</module>-->
+        <module>tck-metrics</module>
         <module>tck-messaging</module>
         <module>tck-graphql</module>
         <!-- TODO:Java19 - fails

--- a/nima/observe/metrics/src/main/java/io/helidon/nima/observe/metrics/MetricsFeature.java
+++ b/nima/observe/metrics/src/main/java/io/helidon/nima/observe/metrics/MetricsFeature.java
@@ -28,6 +28,7 @@ import io.helidon.config.metadata.ConfiguredOption;
 import io.helidon.metrics.api.MetricsSettings;
 import io.helidon.metrics.api.Registry;
 import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.metrics.api.SystemTagsManager;
 import io.helidon.metrics.serviceapi.JsonFormat;
 import io.helidon.metrics.serviceapi.PrometheusFormat;
 import io.helidon.nima.servicecommon.HelidonFeatureSupport;
@@ -90,6 +91,7 @@ public class MetricsFeature extends HelidonFeatureSupport {
 
         this.registryFactory = builder.registryFactory();
         this.metricsSettings = builder.metricsSettings();
+        SystemTagsManager.create(metricsSettings);
     }
 
     /**

--- a/reactive/metrics/src/main/java/io/helidon/reactive/metrics/MetricsSupport.java
+++ b/reactive/metrics/src/main/java/io/helidon/reactive/metrics/MetricsSupport.java
@@ -29,6 +29,7 @@ import io.helidon.config.metadata.ConfiguredOption;
 import io.helidon.metrics.api.MetricsSettings;
 import io.helidon.metrics.api.Registry;
 import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.metrics.api.SystemTagsManager;
 import io.helidon.metrics.serviceapi.JsonFormat;
 import io.helidon.metrics.serviceapi.PrometheusFormat;
 import io.helidon.reactive.media.common.MessageBodyWriter;
@@ -93,6 +94,7 @@ public class MetricsSupport extends HelidonRestServiceSupport {
 
         this.registryFactory = builder.registryFactory();
         this.metricsSettings = builder.metricsSettings();
+        SystemTagsManager.create(metricsSettings);
     }
 
     /**


### PR DESCRIPTION
Resolves #5402 

Two problems:

1. `MetricsSupport` and `MetricsFeature` did not initialize the `SystemTagsManager`. 
2. `JsonFormat` did not publicly expose the single-registry variant of `jsonMeta`, with the result that requests to `/metrics/application` (for example) incorrectly returned the metrics nested inside an `application` node when they should have appeared a level higher. (That's because the calls invoked the multi-registry variant of the method which _does_ correctly insert JSON nodes for the registries included in the response.)

