### PR TITLE
Use Hamcrest assertions instead of JUnit in tests/functional/jax-rs-multiple-apps - backport 2.x (#1749)

### DIFF
--- a/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
+++ b/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
@@ -24,11 +24,11 @@ import javax.ws.rs.core.Response;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasKey;
 
 @HelidonTest
 class MainTest {
@@ -43,13 +43,13 @@ class MainTest {
                 .request()
                 .header("who", "World 1")
                 .get();
-        assertEquals(response.getStatus(), 200);
-        assertTrue(response.getHeaders().containsKey("sharedfilter"));
-        assertTrue(response.getHeaders().containsKey("filter1"));
-        assertFalse(response.getHeaders().containsKey("filter2"));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getHeaders(), hasKey("sharedfilter"));
+        assertThat(response.getHeaders(), hasKey("filter1"));
+        assertThat(response.getHeaders(), not(hasKey("filter2")));
         JsonObject jsonObject = response.readEntity(JsonObject.class);
-        assertEquals("Hello World 1!", jsonObject.getString("message"),
-                "default message");
+        assertThat("default message", jsonObject.getString("message"),
+                is("Hello World 1!"));
     }
 
     @Test
@@ -59,14 +59,14 @@ class MainTest {
                 .request()
                 .header("who", "World 2")
                 .get();
-        assertEquals(response.getStatus(), 200);
-        assertTrue(response.getHeaders().containsKey("sharedfilter"));
-        assertTrue(response.getHeaders().containsKey("filter2"));
-        assertTrue(response.getHeaders().containsKey("filter3"));       // MyFeature
-        assertFalse(response.getHeaders().containsKey("filter1"));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getHeaders(), hasKey("sharedfilter"));
+        assertThat(response.getHeaders(), hasKey("filter2"));
+        assertThat(response.getHeaders(), hasKey("filter3"));       // MyFeature
+        assertThat(response.getHeaders(), not(hasKey("filter1")));
         JsonObject jsonObject = response.readEntity(JsonObject.class);
-        assertEquals("Hello World 2!", jsonObject.getString("message"),
-                "default message");
+        assertThat("default message", jsonObject.getString("message"),
+                is("Hello World 2!"));
     }
 
     @Test


### PR DESCRIPTION
Part of #1749 

[Original PR](https://github.com/helidon-io/helidon/pull/5634) .