### PR TITLE
Declare `h1-prefix` as early as possible so it is used for the title prefix

### DIFF
--- a/docs/mp/metrics/metrics-capable-components.adoc
+++ b/docs/mp/metrics/metrics-capable-components.adoc
@@ -17,6 +17,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 = Metrics-Capable Modules
+:h1-prefix: MP
 :description: Helidon MP metrics-capable modules
 :keywords: helidon, metrics, metrics-capable, microprofile, guide
 :intro-project-name: {h1-prefix}


### PR DESCRIPTION
Fixes #5665 

Even though `includes/mp.adoc` declares `h1-prefix` as `MP`, and `mp/metrics/metrics-capable-components.adoc` `includes` `mp.adoc[]`, the only way I found to get the prefix on the rendered page to work was to declare `h1-prefix` really early in the `mp/metrics/metrics-capable-components.adoc` file.