### PR TITLE
[nima][performance] http1 server response BlockingOutputStream has necessary byte[] copy

### DIFF
--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -361,8 +361,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             }
             // try chunked data optimization
             if (firstByte && firstBuffer == null) {
-                // if somebody re-uses the byte buffer sent to us, we must copy it
-                firstBuffer = buffer.copy();
+                // buffer always created locally so no need for buffer.copy() here
+                firstBuffer = buffer;
                 return;
             }
 


### PR DESCRIPTION
For BlockingOutputStream in Http1ServerResponse for the first buffer it currently has:

  // if somebody re-uses the byte buffer sent to us, we must copy it
  firstBuffer = buffer.copy();

 but the buffer here is always created locally via the 3
 BlockingOutputStream.write() methods so this buffer instance
 can never be re-used and the copy() is unnecessary performance
 overhead