### PR TITLE
#5685 - Add ServerResponse.reset() to support ErrorHandlers

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -330,7 +330,7 @@ class JaxRsService implements HttpService {
             if (contentLength > 0) {
                 res.header(Header.create(Header.CONTENT_LENGTH, String.valueOf(contentLength)));
             }
-            this.outputStream = res.outputStream();
+            this.outputStream = new NoFlushOutputStream(res.outputStream());
             return outputStream;
         }
 
@@ -384,6 +384,39 @@ class JaxRsService implements HttpService {
             } catch (InterruptedException e) {
                 throw new RuntimeException("Failed to wait for Jersey to write response");
             }
+        }
+    }
+
+    private static class NoFlushOutputStream extends OutputStream {
+        private final OutputStream delegate;
+
+        private NoFlushOutputStream(OutputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            delegate.write(b, off, len);
+        }
+
+        @Override
+        public void flush() {
+            // intentional no-op, flush did not work nicely with Jersey
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            delegate.write(b);
         }
     }
 }

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
@@ -119,6 +119,17 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     }
 
     @Override
+    public boolean reset() {
+        if (isSent) {
+            return false;
+        }
+        headers.clear();
+        streamingEntity = false;
+        outputStream = null;
+        return true;
+    }
+
+    @Override
     public OutputStream outputStream() {
         if (isSent) {
             throw new IllegalStateException("Response already sent");

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
@@ -119,17 +119,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     }
 
     @Override
-    public boolean reset() {
-        if (isSent) {
-            return false;
-        }
-        headers.clear();
-        streamingEntity = false;
-        outputStream = null;
-        return true;
-    }
-
-    @Override
     public OutputStream outputStream() {
         if (isSent) {
             throw new IllegalStateException("Response already sent");
@@ -164,6 +153,24 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     @Override
     public boolean hasEntity() {
         return isSent || streamingEntity;
+    }
+
+    @Override
+    public boolean reset() {
+        if (isSent || outputStream != null && outputStream.bytesWritten > 0) {
+            return false;
+        }
+        headers.clear();
+        streamingEntity = false;
+        outputStream = null;
+        return true;
+    }
+
+    @Override
+    public void commit() {
+        if (outputStream != null) {
+            outputStream.commit();
+        }
     }
 
     private static class BlockingOutputStream extends OutputStream {
@@ -211,7 +218,18 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
 
         @Override
+        public void flush() throws IOException {
+            if (firstByte && firstBuffer != null) {
+                write(BufferData.empty());
+            }
+        }
+
+        @Override
         public void close() {
+            // does nothing, we expect commit(), so we can reset response when no bytes were written to response
+        }
+
+        void commit() {
             if (closed) {
                 return;
             }
@@ -292,6 +310,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             headers.setIfAbsent(Header.create(Header.DATE, true, false, Http.DateTime.rfc1123String()));
 
             Http2Headers http2Headers = Http2Headers.create(headers);
+            http2Headers.status(status);
             http2Headers.validateResponse();
             int written = writer.writeHeaders(http2Headers,
                                               streamId,

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2Stream.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2Stream.java
@@ -258,10 +258,10 @@ public class Http2Stream implements Runnable, io.helidon.nima.http2.Http2Stream 
                                  + ctx.childSocketId() + " ] - " + streamId);
         try {
             handle();
-        } catch (SocketWriterException e) {
-            throw new CloseConnectionException(e.getMessage(), e);
-        } catch (CloseConnectionException | UncheckedIOException e) {
-            throw e;
+        } catch (SocketWriterException | CloseConnectionException | UncheckedIOException e) {
+            Http2RstStream rst = new Http2RstStream(Http2ErrorCode.STREAM_CLOSED);
+            writer.write(rst.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()), flowControl);
+            // no sense in throwing an exception, as this is invoked from an executor service directly
         } catch (RequestException e) {
             DirectHandler handler = ctx.directHandlers().handler(e.eventType());
             DirectHandler.TransportResponse response = handler.handle(e.request(),

--- a/nima/tests/integration/http2/server/src/test/java/io/helidon/nima/tests/integration/http2/webserver/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/nima/tests/integration/http2/server/src/test/java/io/helidon/nima/tests/integration/http2/webserver/Http2ErrorHandlingWithOutputStreamTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.http2.webserver;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.http.Http;
+import io.helidon.common.pki.KeyConfig;
+import io.helidon.nima.common.tls.Tls;
+import io.helidon.nima.http2.webserver.Http2Route;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.testing.junit5.webserver.SetUpServer;
+import io.helidon.nima.webserver.WebServer;
+import io.helidon.nima.webserver.http.ErrorHandler;
+import io.helidon.nima.webserver.http.HttpRouting;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+
+import static io.helidon.common.http.Http.Method.GET;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ServerTest
+class Http2ErrorHandlingWithOutputStreamTest {
+
+    private static final Http.HeaderName MAIN_HEADER_NAME = Http.Header.create("main-handler");
+    private static final Http.HeaderName ERROR_HEADER_NAME = Http.Header.create("error-handler");
+
+    private final int plainPort;
+    private final int tlsPort;
+    private static HttpClient httpClient;
+
+
+    Http2ErrorHandlingWithOutputStreamTest(WebServer server) {
+        this.plainPort = server.port();
+        this.tlsPort = server.port("https");
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServer.Builder serverBuilder) {
+        KeyConfig privateKeyConfig = KeyConfig.keystoreBuilder()
+                .keystore(Resource.create("certificate.p12"))
+                .keystorePassphrase("helidon")
+                .build();
+
+        Tls tls = Tls.builder()
+                .privateKey(privateKeyConfig.privateKey().get())
+                .privateKeyCertChain(privateKeyConfig.certChain())
+                .build();
+
+        serverBuilder.socket("https",
+                socketBuilder -> socketBuilder.tls(tls));
+        httpClient = http2Client();
+    }
+
+    @SetUpRoute
+    static void router(HttpRouting.Builder router) {
+        // explicitly on HTTP/2 only, to make sure we do upgrade
+        router.error(CustomException.class, new CustomRoutingHandler())
+                .route(Http2Route.route(GET, "get-outputStream", (req, res) -> {
+                    res.status(Http.Status.OK_200);
+                    res.header(MAIN_HEADER_NAME, "x");
+                    res.outputStream();
+                    throw new CustomException();
+                }))
+                .route(Http2Route.route(GET, "get-outputStream-writeOnceThenError", (req, res) -> {
+                    res.status(Http.Status.OK_200);
+                    res.header(MAIN_HEADER_NAME, "x");
+                    OutputStream os = res.outputStream();
+                    os.write("writeOnceOnly".getBytes(StandardCharsets.UTF_8));
+                    throw new CustomException();
+                }))
+                .route(Http2Route.route(GET, "get-outputStream-writeTwiceThenError", (req, res) -> {
+                    res.status(Http.Status.OK_200);
+                    res.header(Http.Header.create("status"), "200");
+                    res.header(MAIN_HEADER_NAME, "x");
+                    OutputStream os = res.outputStream();
+                    os.write("writeOnce".getBytes(StandardCharsets.UTF_8));
+                    os.write("|writeTwice".getBytes(StandardCharsets.UTF_8));
+                    throw new CustomException();
+                }))
+                .route(Http2Route.route(GET, "get-outputStream-writeFlushThenError", (req, res) -> {
+                    res.status(Http.Status.OK_200);
+                    res.header(MAIN_HEADER_NAME, "x");
+                    OutputStream os = res.outputStream();
+                    os.write("writeOnce".getBytes(StandardCharsets.UTF_8));
+                    os.flush();
+                    throw new CustomException();
+                }))
+                .route(Http2Route.route(GET, "", ((req, res) ->
+                        res.send("ok"))));
+    }
+
+    private static HttpClient http2Client() {
+        return HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+    }
+
+    private HttpResponse<String> request(String uriSuffix) {
+        try {
+            return httpClient.send(httpRequest(uriSuffix), HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpRequest httpRequest(String uriSuffix) {
+        return HttpRequest.newBuilder()
+                .timeout(Duration.ofSeconds(30))
+                .uri(URI.create("http://localhost:" + plainPort + uriSuffix))
+                .GET()
+                .build();
+    }
+
+    @Test
+    void testOk() {
+        var response = request("/");
+
+        assertEquals(200, response.statusCode());
+        assertThat(response.body(), is("ok"));
+    }
+
+    @Test
+    void testGetOutputStreamThenError_expect_CustomErrorHandlerMessage() {
+        var response = request("/get-outputStream");
+
+        assertEquals(418, response.statusCode());
+        assertThat(response.body(), is("TeaPotIAm"));
+        assertThat(response.headers().firstValue(ERROR_HEADER_NAME.lowerCase()), is(Optional.of("err")));
+        assertThat(response.headers().firstValue(MAIN_HEADER_NAME.lowerCase()), is(emptyOptional()));
+    }
+
+
+    @Test
+    void testGetOutputStreamWriteOnceThenError_expect_CustomErrorHandlerMessage() {
+        var response = request("/get-outputStream-writeOnceThenError");
+
+        assertEquals(418, response.statusCode());
+        assertThat(response.body(), is("TeaPotIAm"));
+        assertThat(response.headers().firstValue(ERROR_HEADER_NAME.lowerCase()), is(Optional.of("err")));
+        assertThat(response.headers().firstValue(MAIN_HEADER_NAME.lowerCase()), is(emptyOptional()));
+    }
+
+// ------------------
+// This test hangs
+// ------------------
+//    @Test
+//    void testGetOutputStreamWriteTwiceThenError_expect_invalidResponse() {
+//        try {
+//            var response = request("/get-outputStream-writeTwiceThenError");
+//            assertEquals(500, response.statusCode());
+//            //String body = response.body();
+//        } catch (Exception e) {
+//            System.err.println("never get here ---------------");
+//            e.printStackTrace();
+//        }
+//    }
+
+// ------------------
+// This test hangs
+// ------------------
+//    @Test
+//    void testGetOutputStreamWriteFlushThenError_expect_invalidResponse() {
+//        try {
+//            var response = request("/get-outputStream-writeFlushThenError");
+//            assertEquals(500, response.statusCode());
+//            //String body = response.body();
+//        } catch (Exception e) {
+//            System.err.println("never get here ---------------");
+//            e.printStackTrace();
+//        }
+//    }
+
+    private static class CustomRoutingHandler implements ErrorHandler<CustomException> {
+        @Override
+        public void handle(ServerRequest req, ServerResponse res, CustomException throwable) {
+            res.status(Http.Status.I_AM_A_TEAPOT_418);
+            res.header(ERROR_HEADER_NAME, "err");
+            res.send("TeaPotIAm");
+        }
+    }
+
+    private static class CustomException extends RuntimeException {
+
+    }
+
+    public static <T> Matcher<? super Optional<T>> emptyOptional() {
+        return new EmptyOptionalMatcher<>();
+    }
+
+    static class EmptyOptionalMatcher<T> extends BaseMatcher<Optional<T>> {
+
+        private Optional<T> optionalActual;
+
+        public EmptyOptionalMatcher() {
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            optionalActual = (Optional<T>) item;
+
+            if (optionalActual == null) {
+                return false;
+            }
+
+            boolean empty = !optionalActual.isPresent();
+            return empty;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("optional is empty");
+        }
+
+        @Override
+        public void describeMismatch(Object item, Description description) {
+            if (optionalActual == null) {
+                description.appendText(" optional was NULL?");
+            } else {
+                description.appendText(" was: " + optionalActual.get());
+            }
+        }
+
+    }
+
+}

--- a/nima/tests/integration/http2/server/src/test/resources/logging-test.properties
+++ b/nima/tests/integration/http2/server/src/test/resources/logging-test.properties
@@ -18,4 +18,4 @@ java.util.logging.ConsoleHandler.level=FINEST
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.nima.level=FINEST
+io.helidon.nima.level=INFO

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ErrorHandlingWithOutputStreamTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ErrorHandlingWithOutputStreamTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.server;
+
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.http.Headers;
+import io.helidon.common.http.Http;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webclient.http1.Http1Client;
+import io.helidon.nima.webclient.http1.Http1ClientResponse;
+import io.helidon.nima.webserver.http.ErrorHandler;
+import io.helidon.nima.webserver.http.HttpRouting;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ServerTest
+class ErrorHandlingWithOutputStreamTest {
+
+    private static final Http.HeaderName MAIN_HEADER_NAME = Http.Header.create("main-handler");
+    private static final Http.HeaderName ERROR_HEADER_NAME = Http.Header.create("error-handler");
+
+    private final Http1Client client;
+
+    ErrorHandlingWithOutputStreamTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void router(HttpRouting.Builder router) {
+        router.error(CustomException.class, new CustomRoutingHandler())
+                .get("get-outputStream", (req, res) -> {
+                    res.header(MAIN_HEADER_NAME, "x");
+                    res.outputStream();
+                    throw new CustomException();
+                })
+                .get("get-outputStream-writeOnceThenError", (req, res) -> {
+                    res.header(MAIN_HEADER_NAME, "x");
+                    OutputStream os = res.outputStream();
+                    os.write("writeOnceOnly".getBytes(StandardCharsets.UTF_8));
+                    throw new CustomException();
+                })
+                .get("get-outputStream-writeTwiceThenError", (req, res) -> {
+                    res.header(MAIN_HEADER_NAME, "x");
+                    OutputStream os = res.outputStream();
+                    os.write("writeOnce".getBytes(StandardCharsets.UTF_8));
+                    os.write("|writeTwice".getBytes(StandardCharsets.UTF_8));
+                    throw new CustomException();
+                })
+                .get("get-outputStream-writeFlushThenError", (req, res) -> {
+                    res.header(MAIN_HEADER_NAME, "x");
+                    OutputStream os = res.outputStream();
+                    os.write("writeOnce".getBytes(StandardCharsets.UTF_8));
+                    os.flush();
+                    throw new CustomException();
+                })
+                .get((req, res) -> res.send("ok"));
+    }
+
+    @Test
+    void testOk() {
+        var response = client.get().request();
+
+        assertThat(response.status(), is(Http.Status.OK_200));
+        assertThat(response.entity().as(String.class), is("ok"));
+    }
+
+    @Test
+    void testGetOutputStreamThenError_expect_CustomErrorHandlerMessage() {
+        var response = client.get("/get-outputStream").request();
+
+        assertThat(response.status(), is(Http.Status.I_AM_A_TEAPOT_418));
+        assertThat(response.entity().as(String.class), is("CustomErrorContent"));
+        assertThat(response.headers().contains(ERROR_HEADER_NAME), is(true));
+        assertThat(response.headers().contains(MAIN_HEADER_NAME), is(false));
+    }
+
+    @Test
+    void testGetOutputStreamWriteOnceThenError_expect_CustomErrorHandlerMessage() {
+        var response = client.get("/get-outputStream-writeOnceThenError").request();
+
+        assertThat(response.status(), is(Http.Status.I_AM_A_TEAPOT_418));
+        assertThat(response.entity().as(String.class), is("CustomErrorContent"));
+        assertThat(response.headers().contains(ERROR_HEADER_NAME), is(true));
+        assertThat(response.headers().contains(MAIN_HEADER_NAME), is(false));
+    }
+
+    @Test
+    void testGetOutputStreamWriteTwiceThenError_expect_invalidResponse() {
+        try (Http1ClientResponse response = client.method(Http.Method.GET)
+                .uri("/get-outputStream-writeTwiceThenError")
+                .request()) {
+            assertThat(response.status(), is(Http.Status.OK_200));
+            assertThrows(DataReader.InsufficientDataAvailableException.class, () -> response.entity().as(String.class));
+        }
+    }
+
+    @Test
+    void testGetOutputStreamWriteFlushThenError_expect_invalidResponse() {
+        Headers headers;
+        try (Http1ClientResponse response = client.method(Http.Method.GET)
+                .uri("/get-outputStream-writeFlushThenError")
+                .request()) {
+
+            assertThat(response.status(), is(Http.Status.OK_200));
+            assertThrows(DataReader.InsufficientDataAvailableException.class, () -> response.entity().as(String.class));
+        }
+    }
+
+    private static class CustomRoutingHandler implements ErrorHandler<CustomException> {
+        @Override
+        public void handle(ServerRequest req, ServerResponse res, CustomException throwable) {
+            res.status(Http.Status.I_AM_A_TEAPOT_418);
+            res.header(ERROR_HEADER_NAME, "z");
+            res.send("CustomErrorContent");
+        }
+    }
+
+    private static class CustomException extends RuntimeException {
+
+    }
+}

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ErrorHandlers.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ErrorHandlers.java
@@ -66,9 +66,15 @@ public final class ErrorHandlers {
      * @param response HTTP server response
      * @param task     task to execute
      */
-    public void runWithErrorHandling(ConnectionContext ctx, ServerRequest request, ServerResponse response, Callable<Void> task) {
+    public void runWithErrorHandling(ConnectionContext ctx,
+                                     RoutingRequest request,
+                                     RoutingResponse response,
+                                     Callable<Void> task) {
         try {
             task.call();
+            if (response.hasEntity()) {
+                response.commit();
+            }
         } catch (CloseConnectionException | UncheckedIOException e) {
             // these errors must "bubble up"
             throw e;
@@ -139,11 +145,13 @@ public final class ErrorHandlers {
 
     private void handleRequestException(ConnectionContext ctx,
                                         ServerRequest request,
-                                        ServerResponse response,
+                                        RoutingResponse response,
                                         RequestException e) {
-        if (response.isSent()) {
+        if (!response.reset()) {
             ctx.log(LOGGER, System.Logger.Level.WARNING, "Request failed: " + request.prologue()
                     + ", cannot send error response, as response already sent", e);
+            throw new CloseConnectionException(
+                    "Cannot send response of an error handler, status and headers already written");
         }
         boolean keepAlive = e.keepAlive();
         if (keepAlive && !request.content().consumed()) {
@@ -155,15 +163,16 @@ public final class ErrorHandlers {
             }
         }
         ctx.directHandlers().handle(e, response, keepAlive);
+        response.commit();
     }
 
-    private void handleError(ConnectionContext ctx, ServerRequest request, ServerResponse response, Throwable e) {
+    private void handleError(ConnectionContext ctx, RoutingRequest request, RoutingResponse response, Throwable e) {
         errorHandler(e.getClass())
                 .ifPresentOrElse(it -> handleError(ctx, request, response, e, (ErrorHandler<Throwable>) it),
                                  () -> unhandledError(ctx, request, response, e));
     }
 
-    private void unhandledError(ConnectionContext ctx, ServerRequest request, ServerResponse response, Throwable e) {
+    private void unhandledError(ConnectionContext ctx, ServerRequest request, RoutingResponse response, Throwable e) {
         if (e instanceof HttpException httpException) {
             handleRequestException(ctx, request, response, RequestException.builder()
                     .cause(e)
@@ -185,8 +194,8 @@ public final class ErrorHandlers {
     }
 
     private void handleError(ConnectionContext ctx,
-                             ServerRequest request,
-                             ServerResponse response,
+                             RoutingRequest request,
+                             RoutingResponse response,
                              Throwable e,
                              ErrorHandler<Throwable> it) {
         if (!response.reset()) {
@@ -196,6 +205,7 @@ public final class ErrorHandlers {
         }
         try {
             it.handle(request, response, e);
+            response.commit();
         } catch (Exception ex) {
             ctx.log(LOGGER, System.Logger.Level.TRACE, "Failed to handle exception.", ex);
             unhandledError(ctx, request, response, e);

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ErrorHandlers.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ErrorHandlers.java
@@ -189,6 +189,11 @@ public final class ErrorHandlers {
                              ServerResponse response,
                              Throwable e,
                              ErrorHandler<Throwable> it) {
+        if (!response.reset()) {
+            ctx.log(LOGGER, System.Logger.Level.WARNING, "Unable to reset response for error handler.");
+            throw new CloseConnectionException(
+                    "Cannot send response of a simple handler, status and headers already written");
+        }
         try {
             it.handle(request, response, e);
         } catch (Exception ex) {

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRouting.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRouting.java
@@ -412,6 +412,7 @@ public final class HttpRouting implements Routing {
             RoutingResult result = doRoute(ctx, request, response);
 
             if (result == RoutingResult.FINISH) {
+                response.commit();
                 return null;
             }
             if (result == RoutingResult.NONE) {
@@ -434,6 +435,7 @@ public final class HttpRouting implements Routing {
 
             // finished and done
             if (result == RoutingResult.FINISH) {
+                response.commit();
                 return null;
             }
             throw new NotFoundException("Endpoint not found");

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/RoutingResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/RoutingResponse.java
@@ -55,4 +55,19 @@ public interface RoutingResponse extends ServerResponse {
      * @return whether has entity
      */
     boolean hasEntity();
+
+    /**
+     * Return true if the underlying response buffers and headers can be reset and a new response can be sent.
+     *
+     * @return {@code true} if reset was successful and a new response can be created instead of the existing one,
+     *      {@code false} if reset failed and status and headers (and maybe entity bytes) were already sent
+     */
+    boolean reset();
+
+    /**
+     * Commit the response. This is mostly useful for output stream based responses, where we may want to delay
+     * closing the output stream to handle errors, when route uses try with resources.
+     * After this method is called, response cannot be {@link #reset()}.
+     */
+    void commit();
 }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
@@ -116,6 +116,11 @@ public interface ServerResponse {
     boolean isSent();
 
     /**
+     * Return true if the underlying response buffers and headers can be reset.
+     */
+    boolean reset();
+
+    /**
      * Alternative way to send an entity, using an output stream. This should be used for entities that are big
      * and that should not be materialized into memory.
      *

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
@@ -116,11 +116,6 @@ public interface ServerResponse {
     boolean isSent();
 
     /**
-     * Return true if the underlying response buffers and headers can be reset.
-     */
-    boolean reset();
-
-    /**
      * Alternative way to send an entity, using an output stream. This should be used for entities that are big
      * and that should not be materialized into memory.
      *

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -142,6 +142,17 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
     }
 
     @Override
+    public boolean reset() {
+        if (isSent || outputStream != null && outputStream.totalBytesWritten() > 0) {
+            return false;
+        }
+        headers.clear();
+        streamingEntity = false;
+        outputStream = null;
+        return true;
+    }
+
+    @Override
     public OutputStream outputStream() {
         if (isSent) {
             throw new IllegalStateException("Response already sent");
@@ -290,6 +301,13 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
             write(BufferData.create(b, off, len));
+        }
+
+        @Override
+        public void flush() throws IOException {
+            if (firstByte && firstBuffer != null) {
+                write(BufferData.empty());
+            }
         }
 
         @Override

--- a/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/http/ErrorHandlersTest.java
+++ b/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/http/ErrorHandlersTest.java
@@ -96,7 +96,7 @@ class ErrorHandlersTest {
 
     @ParameterizedTest
     @MethodSource("testData")
-    void testHandleFound(TestData testData) {
+    void testHandlerFound(TestData testData) {
         ErrorHandlers handlers = testData.handlers();
 
         assertAll(
@@ -120,9 +120,10 @@ class ErrorHandlersTest {
     }
 
     private void testNoHandler(ErrorHandlers handlers, Exception e, String message) {
-        ServerRequest req = mock(ServerRequest.class);
-        ServerResponse res = mock(ServerResponse.class);
         ConnectionContext ctx = mock(ConnectionContext.class);
+        RoutingRequest req = mock(RoutingRequest.class);
+        RoutingResponse res = mock(RoutingResponse.class);
+        when(res.reset()).thenReturn(true);
 
         when(req.prologue()).thenReturn(HttpPrologue.create("http/1.0",
                                                             "http",
@@ -149,8 +150,8 @@ class ErrorHandlersTest {
 
     private void testHandler(ErrorHandlers handlers, Exception e, String message) {
         ConnectionContext ctx = mock(ConnectionContext.class);
-        ServerRequest req = mock(ServerRequest.class);
-        ServerResponse res = mock(ServerResponse.class);
+        RoutingRequest req = mock(RoutingRequest.class);
+        RoutingResponse res = mock(RoutingResponse.class);
         when(res.reset()).thenReturn(true);
 
         handlers.runWithErrorHandling(ctx, req, res, () -> {

--- a/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/http/ErrorHandlersTest.java
+++ b/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/http/ErrorHandlersTest.java
@@ -148,9 +148,10 @@ class ErrorHandlersTest {
     }
 
     private void testHandler(ErrorHandlers handlers, Exception e, String message) {
+        ConnectionContext ctx = mock(ConnectionContext.class);
         ServerRequest req = mock(ServerRequest.class);
         ServerResponse res = mock(ServerResponse.class);
-        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(res.reset()).thenReturn(true);
 
         handlers.runWithErrorHandling(ctx, req, res, () -> {
             throw e;

--- a/tests/apps/bookstore/bookstore-mp/src/test/java/io/helidon/tests/apps/bookstore/mp/BookResourceTest.java
+++ b/tests/apps/bookstore/bookstore-mp/src/test/java/io/helidon/tests/apps/bookstore/mp/BookResourceTest.java
@@ -54,7 +54,6 @@ class BookResourceTest {
                 .request()
                 .get();
         assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
-        assertNotNull(res.getHeaderString("content-length"));
 
         assertBookStoreSize(1);
 
@@ -88,7 +87,6 @@ class BookResourceTest {
                 .request()
                 .get();
         assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
-        assertNotNull(res.getHeaderString("content-length"));
 
         assertBookStoreSize(1);
 


### PR DESCRIPTION
- Fix for #5685 - IllegalStateException("OutputStream already obtained"), when ErrorHandler uses ServerResponse.outputStream()
- Adds ServerResponse.reset() to reset response headers and buffers
- Only allowed to reset() when isSent is false

Fixes the test at: https://github.com/rbygrave/nima-error-handler/blob/main/src/test/java/org/example/MainTest.java