### PR TITLE
3.x: Upgrade Netty to 4.1.86.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -122,7 +122,7 @@
         <version.lib.mysql-connector-java>8.0.28</version.lib.mysql-connector-java>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>4.4.3</version.lib.neo4j>
-        <version.lib.netty>4.1.77.Final</version.lib.netty>
+        <version.lib.netty>4.1.86.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.8.Final</version.lib.netty-io_uring>
         <version.lib.oci>2.45.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <version.lib.junit4>4.13.1</version.lib.junit4>
         <version.lib.kafka-junit5>3.2.3</version.lib.kafka-junit5>
         <version.lib.mockito>2.23.4</version.lib.mockito>
-        <version.lib.netty.tcnative>2.0.52.Final</version.lib.netty.tcnative>
+        <version.lib.netty.tcnative>2.0.54.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.2.10</version.lib.rxjava>

--- a/webserver/webserver/src/test/java/io/helidon/webserver/TestNettyRejectRequest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/TestNettyRejectRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/test/java/io/helidon/webserver/TestNettyRejectRequest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/TestNettyRejectRequest.java
@@ -74,6 +74,6 @@ public class TestNettyRejectRequest {
 
         assertThat(headers, hasKey(equalToIgnoringCase("content-length")));
         assertThat(status, is(Http.Status.BAD_REQUEST_400));
-        assertThat(entity, containsString("prohibited characters"));
+        assertThat(entity, containsString("invalid character"));
     }
 }


### PR DESCRIPTION
Needed to update a test because the text of a Netty exception was changed.