### PR TITLE
[3.x] 100 continue triggered by content request

### DIFF
--- a/docs/config/io_helidon_webserver_SocketConfiguration.adoc
+++ b/docs/config/io_helidon_webserver_SocketConfiguration.adoc
@@ -91,6 +91,9 @@ Type: link:{javadoc-base-url}/io.helidon.webserver/io/helidon/webserver/SocketCo
  server socket.
 
  If `0` then use implementation default.
+
+|`continue-immediately`|boolean |`false` |When true answers to expect continue with 100 continue immediately, not waiting for user to actually request the data.
+ Default is `false`
 |`requested-uri-discovery.enabled` |boolean |`true if &#x27;types&#x27; or &#x27;trusted-proxies&#x27; is set; false otherwise` |Sets whether requested URI discovery is enabled for the socket.
 |`requested-uri-discovery.trusted-proxies` |xref:{rootdir}/config/io_helidon_common_configurable_AllowList.adoc[AllowList] |{nbsp} |Assigns the settings governing the acceptance and rejection of forwarded headers from incoming requests to this socket.
  This setting automatically enables discovery for the socket.

--- a/docs/config/io_helidon_webserver_WebServer.adoc
+++ b/docs/config/io_helidon_webserver_WebServer.adoc
@@ -87,6 +87,9 @@ This is a standalone configuration type, prefix from configuration root: `server
  server socket.
 
  If `0` then use implementation default.
+
+|`continue-immediately`|boolean |`false` |When true WebServer answers to expect continue with 100 continue immediately, not waiting for user to actually request the data.
+ Default is `false`
 |`requested-uri-discovery.enabled` |boolean |`true if &#x27;types&#x27; or &#x27;trusted-proxies&#x27; is set; false otherwise` |Sets whether requested URI discovery is enabled for the socket.
 |`requested-uri-discovery.trusted-proxies` |xref:{rootdir}/config/io_helidon_common_configurable_AllowList.adoc[AllowList] |{nbsp} |Assigns the settings governing the acceptance and rejection of forwarded headers from incoming requests to this socket.
  This setting automatically enables discovery for the socket.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ class BareResponseImpl implements BareResponse {
     private final AtomicBoolean internallyClosed = new AtomicBoolean(false);
     private final CompletableFuture<BareResponse> responseFuture;
     private final CompletableFuture<BareResponse> headersFuture;
+    private CompletableFuture<Boolean> entityRequested;
     private final RequestContext requestContext;
     private final long requestId;
     private final String http2StreamId;
@@ -98,6 +99,7 @@ class BareResponseImpl implements BareResponse {
      * @param requestId the correlation ID that is added to the log statements
      */
     BareResponseImpl(ChannelHandlerContext ctx,
+                     CompletableFuture<Boolean> entityRequested,
                      HttpRequest request,
                      RequestContext requestContext,
                      CompletableFuture<?> prevRequestChunk,
@@ -105,6 +107,7 @@ class BareResponseImpl implements BareResponse {
                      long backpressureBufferSize,
                      BackpressureStrategy backpressureStrategy,
                      long requestId) {
+        this.entityRequested = entityRequested;
         this.requestContext = requestContext;
         this.originalEntityAnalyzed = requestEntityAnalyzed;
         this.requestEntityAnalyzed = requestEntityAnalyzed;
@@ -112,7 +115,7 @@ class BareResponseImpl implements BareResponse {
         this.backpressureBufferSize = backpressureBufferSize;
         this.responseFuture = new CompletableFuture<>();
         this.headersFuture = new CompletableFuture<>();
-        this.channel = new NettyChannel(ctx.channel());
+        this.channel = new NettyChannel(ctx);
         this.requestId = requestId;
         this.keepAlive = HttpUtil.isKeepAlive(request);
         this.requestHeaders = request.headers();
@@ -166,6 +169,12 @@ class BareResponseImpl implements BareResponse {
         Objects.requireNonNull(status, "Parameter 'statusCode' was null!");
         if (!statusHeadersSent.compareAndSet(false, true)) {
             throw new IllegalStateException("Status and headers were already sent");
+        }
+
+        if (HttpUtil.is100ContinueExpected(requestContext.request()) && !requestContext.isDataRequested()) {
+            channel.expectationFailed();
+            entityRequested.complete(false);
+            originalEntityAnalyzed.complete(ChannelFutureListener.CLOSE_ON_FAILURE);
         }
 
         HttpResponseStatus nettyStatus;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -69,7 +69,7 @@ class BareResponseImpl implements BareResponse {
     private final AtomicBoolean internallyClosed = new AtomicBoolean(false);
     private final CompletableFuture<BareResponse> responseFuture;
     private final CompletableFuture<BareResponse> headersFuture;
-    private CompletableFuture<Boolean> entityRequested;
+    private final CompletableFuture<Boolean> entityRequested;
     private final RequestContext requestContext;
     private final long requestId;
     private final String http2StreamId;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -313,8 +313,11 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         IndirectReference<HttpRequestScopedPublisher, DataChunkHoldingQueue> publisherRef =
                 new IndirectReference<>(publisher, queues, queue);
 
+        CompletableFuture<Boolean> entityRequested = new CompletableFuture<>();
+
         // Set up read strategy for channel based on consumer demand
         publisher.onRequest((n, demand) -> {
+            entityRequested.complete(true);
             if (publisher.isUnbounded()) {
                 LOGGER.finest(() -> formatMsg("Netty autoread: true", ctx));
                 ctx.channel().config().setAutoRead(true);
@@ -399,6 +402,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         // Create response and handler for its completion
         BareResponseImpl bareResponse =
                 new BareResponseImpl(ctx,
+                                     entityRequested,
                                      request,
                                      requestContext,
                                      prevRequestFuture,
@@ -412,7 +416,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                 .thenRun(() -> {
                     // Mark response completed in context
                     requestContextRef.responseCompleted(true);
-
+                    entityRequested.complete(false);
                     // Consume and release any buffers in publisher
                     publisher.clearAndRelease();
 
@@ -430,13 +434,13 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                         LOGGER.fine(formatMsg("Response complete: %s", ctx, System.identityHashCode(msg)));
                     }
                 });
-        /*
-        TODO we should only send continue in case the entity is request (e.g. we found a route and user started reading it)
-        This would solve connection close for 404 for requests with entity
-         */
-        if (HttpUtil.is100ContinueExpected(request)) {
-            send100Continue(ctx, request);
-        }
+
+        // Send 100 continue only when entity is actually requested
+        entityRequested.thenAccept(requestedByUser -> {
+            if (requestedByUser && HttpUtil.is100ContinueExpected(request)) {
+                send100Continue(ctx, request);
+            }
+        });
 
         // If a problem during routing, return 400 response
         try {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyChannel.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.util.function.Function;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
+import io.netty.handler.codec.http.HttpExpectationFailedEvent;
 import io.netty.util.concurrent.Future;
 
 /**
@@ -40,10 +42,12 @@ import io.netty.util.concurrent.Future;
  */
 class NettyChannel {
     private final Channel channel;
+    private final ChannelHandlerContext ctx;
     private CompletionStage<ChannelFuture> writeFuture = CompletableFuture.completedFuture(null);
 
-    NettyChannel(Channel channel) {
-        this.channel = channel;
+    NettyChannel(ChannelHandlerContext ctx) {
+        this.ctx = ctx;
+        this.channel = ctx.channel();
     }
 
     /**
@@ -131,6 +135,14 @@ class NettyChannel {
         } else {
             completable.completeExceptionally(nettyFuture.cause());
         }
+    }
+
+
+    /**
+     * Reset HttpObjectDecoder to not expect data.
+     */
+    void expectationFailed(){
+        ctx.pipeline().fireUserEventTriggered(HttpExpectationFailedEvent.INSTANCE);
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,18 @@ class RequestContext {
     private final HttpRequestScopedPublisher publisher;
     private final HttpRequest request;
     private final Context scope;
+    private SocketConfiguration socketConfiguration;
     private volatile boolean responseCompleted;
     private volatile boolean emitted;
 
-    RequestContext(HttpRequestScopedPublisher publisher, HttpRequest request, Context scope) {
+    RequestContext(HttpRequestScopedPublisher publisher,
+                   HttpRequest request,
+                   Context scope,
+                   SocketConfiguration socketConfiguration) {
         this.publisher = publisher;
         this.request = request;
         this.scope = scope;
+        this.socketConfiguration = socketConfiguration;
     }
 
     Multi<DataChunk> publisher() {
@@ -123,5 +128,9 @@ class RequestContext {
 
     boolean responseCompleted() {
         return responseCompleted;
+    }
+
+    SocketConfiguration socketConfiguration() {
+        return socketConfiguration;
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
@@ -36,7 +36,7 @@ class RequestContext {
     private final HttpRequestScopedPublisher publisher;
     private final HttpRequest request;
     private final Context scope;
-    private SocketConfiguration socketConfiguration;
+    private final SocketConfiguration socketConfiguration;
     private volatile boolean responseCompleted;
     private volatile boolean emitted;
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
@@ -223,6 +223,7 @@ class ServerBasicConfig implements ServerConfiguration {
         private final long maxPayloadSize;
         private final long backpressureBufferSize;
         private final BackpressureStrategy backpressureStrategy;
+        private final boolean continueImmediately;
         private final int maxUpgradeContentLength;
         private final List<RequestedUriDiscoveryType> requestedUriDiscoveryTypes;
         private final AllowList trustedProxies;
@@ -248,6 +249,7 @@ class ServerBasicConfig implements ServerConfiguration {
             this.maxPayloadSize = builder.maxPayloadSize();
             this.backpressureBufferSize = builder.backpressureBufferSize();
             this.backpressureStrategy = builder.backpressureStrategy();
+            this.continueImmediately = builder.continueImmediately();
             this.maxUpgradeContentLength = builder.maxUpgradeContentLength();
             WebServerTls webServerTls = builder.tlsConfig();
             this.webServerTls = webServerTls.enabled() ? webServerTls : null;
@@ -364,6 +366,11 @@ class ServerBasicConfig implements ServerConfiguration {
         @Override
         public BackpressureStrategy backpressureStrategy() {
             return backpressureStrategy;
+        }
+
+        @Override
+        public boolean continueImmediately() {
+            return continueImmediately;
         }
 
         @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -554,6 +554,21 @@ public interface ServerConfiguration extends SocketConfiguration {
         }
 
         /**
+         * When true WebServer answers to expect continue with 100 continue immediately,
+         * not waiting for user to actually request the data.
+         * <p>
+         * Default is {@code false}
+         *
+         * @param continueImmediately , answer with 100 continue immediately after expect continue, default is false
+         * @return this builder
+         */
+        @Override
+        public Builder continueImmediately(boolean continueImmediately) {
+            defaultSocketBuilder().continueImmediately(continueImmediately);
+            return this;
+        }
+
+        /**
          * Set a maximum length of the content of an upgrade request.
          * <p>
          * Default is {@code 64*1024}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
@@ -248,6 +248,17 @@ public interface SocketConfiguration {
     }
 
     /**
+     * When true WebServer answers with 100 continue immediately,
+     * not waiting for user to actually request the data.
+     * False is default value.
+     *
+     * @return strategy identifier for applying backpressure
+     */
+    default boolean continueImmediately() {
+        return false;
+    }
+
+    /**
      * Initial size of the buffer used to parse HTTP line and headers.
      *
      * @return initial size of the buffer
@@ -506,6 +517,18 @@ public interface SocketConfiguration {
         B backpressureStrategy(BackpressureStrategy backpressureStrategy);
 
         /**
+         * When true WebServer answers to expect continue with 100 continue immediately,
+         * not waiting for user to actually request the data.
+         * <p>
+         * Default is {@code false}
+         *
+         * @param continueImmediately , answer with 100 continue immediately after expect continue, default is false
+         * @return this builder
+         */
+        @ConfiguredOption("false")
+        B continueImmediately(boolean continueImmediately);
+
+        /**
          * Set a maximum length of the content of an upgrade request.
          * <p>
          * Default is {@code 64*1024}
@@ -653,6 +676,7 @@ public interface SocketConfiguration {
         private boolean enableCompression = false;
         private long maxPayloadSize = -1;
         private BackpressureStrategy backpressureStrategy = BackpressureStrategy.LINEAR;
+        private boolean continueImmediately = false;
         private int maxUpgradeContentLength = 64 * 1024;
         private long maxBufferSize = 5 * 1024 * 1024;
         private final List<RequestedUriDiscoveryType> requestedUriDiscoveryTypes = new ArrayList<>();
@@ -841,6 +865,12 @@ public interface SocketConfiguration {
         @Override
         public Builder backpressureStrategy(BackpressureStrategy backpressureStrategy) {
             this.backpressureStrategy = backpressureStrategy;
+            return this;
+        }
+
+        @Override
+        public Builder continueImmediately(boolean continueImmediately) {
+            this.continueImmediately = continueImmediately;
             return this;
         }
 
@@ -1035,6 +1065,10 @@ public interface SocketConfiguration {
 
         BackpressureStrategy backpressureStrategy() {
             return backpressureStrategy;
+        }
+
+        boolean continueImmediately() {
+            return continueImmediately;
         }
 
         int maxUpgradeContentLength() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -604,6 +604,12 @@ public interface WebServer {
         }
 
         @Override
+        public Builder continueImmediately(boolean continueImmediately) {
+            configurationBuilder.continueImmediately(continueImmediately);
+            return this;
+        }
+
+        @Override
         public Builder maxUpgradeContentLength(int size) {
             configurationBuilder.maxUpgradeContentLength(size);
             return this;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/BareResponseSubscriberTckTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/BareResponseSubscriberTckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ public class BareResponseSubscriberTckTest extends FlowSubscriberWhiteboxVerific
         Mockito.when(channel.closeFuture()).thenReturn(channelFuture);
 
         return new BareResponseImpl(ctx,
+                CompletableFuture.completedFuture(false),
                 httpRequest,
                 requestContext,
                 CompletableFuture.completedFuture(null),

--- a/webserver/webserver/src/test/java/io/helidon/webserver/BareResponseSubscriberTckTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/BareResponseSubscriberTckTest.java
@@ -51,14 +51,15 @@ public class BareResponseSubscriberTckTest extends FlowSubscriberWhiteboxVerific
         Mockito.when(ctx.channel()).thenReturn(channel);
         Mockito.when(channel.closeFuture()).thenReturn(channelFuture);
 
+        SocketConfiguration socketConfiguration = SocketConfiguration.create("@default");
+
         return new BareResponseImpl(ctx,
                 CompletableFuture.completedFuture(false),
                 httpRequest,
                 requestContext,
                 CompletableFuture.completedFuture(null),
                 CompletableFuture.completedFuture(null),
-                100 * 1024,
-                BackpressureStrategy.LINEAR,
+                socketConfiguration,
                 0L) {
             @Override
             public void onSubscribe(Flow.Subscription subscription) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/Continue100Test.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/Continue100Test.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import io.helidon.common.LogConfig;
+import io.helidon.common.http.Http;
+import io.helidon.webserver.utils.SocketHttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+
+public class Continue100Test {
+
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10);
+    private static WebServer webServer;
+
+    @BeforeAll
+    static void beforeAll() {
+        Logger.getLogger("io.helidon.webserver.HttpInitializer").setLevel(Level.FINE);
+        LogConfig.configureRuntime();
+        webServer = WebServer.builder()
+                .port(8080)
+                .routing(r -> r
+                        .any("/redirect", (req, res) ->
+                                res.status(301)
+                                        .addHeader(Http.Header.LOCATION, "/")
+                                        // force 301 to not use chunked encoding
+                                        // https://github.com/helidon-io/helidon/issues/5713
+                                        .addHeader(Http.Header.CONTENT_LENGTH, "0")
+                                        .send()
+                        )
+                        .any("/", (req, res) -> {
+                            if(Boolean.parseBoolean(req.headers().first("test-fail-before-read").orElse("false"))){
+                                res.status(Http.Status.EXPECTATION_FAILED_417).send();
+                                return;
+                            }
+                            req.content().as(String.class)
+                                    // Requesting date from content triggers 100 continue
+                                    .forSingle(s -> res.send("Got "+s.getBytes().length+" bytes of data"));
+                        })
+                )
+                .build()
+                .start()
+                .await(TEST_TIMEOUT);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        webServer.shutdown().await(TEST_TIMEOUT);
+    }
+
+    @Test
+    void continue100POST() throws Exception {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+            String content = "looong payload data";
+            socketHttpClient
+                    .manualReq("""                            
+                            POST / HTTP/1.1
+                            Host: localhost:8080
+                            Expect: 100-continue
+                            Accept: */*
+                            test-fail-before-read: false
+                            Content-Length: %d
+                            Content-Type: application/x-www-form-urlencoded
+                                                             
+                            """, content.length())
+                    .awaitResponse("HTTP/1.1 100 Continue", "\n\n")
+                    .continuePayload(content);
+
+            String received = socketHttpClient.receive();
+            assertThat(received, startsWith("HTTP/1.1 200 OK"));
+            assertThat(received, endsWith("Got 19 bytes of data"));
+        }
+    }
+
+    @Test
+    void redirect() throws Exception {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+            String content = "looong payload data";
+            socketHttpClient
+                    .manualReq("""                            
+                            POST /redirect HTTP/1.1
+                            Host: localhost:8080
+                            Expect: 100-continue
+                            Accept: */*
+                            test-fail-before-read: false
+                            Content-Length: %d
+                            Content-Type: application/x-www-form-urlencoded
+                                                             
+                            """, content.length())
+                    .awaitResponse("HTTP/1.1 301 Moved Permanently\n", "\n\n");
+            socketHttpClient
+                    .manualReq("""                            
+                            POST / HTTP/1.1
+                            Host: localhost:8080
+                            Expect: 100-continue
+                            Accept: */*
+                            test-fail-before-read: false
+                            Content-Length: %d
+                            Content-Type: application/x-www-form-urlencoded
+                                                             
+                            """, content.length())
+                    .awaitResponse("HTTP/1.1 100 Continue", "\n\n")
+                    .continuePayload(content);
+
+            String received = socketHttpClient.receive();
+            assertThat(received, startsWith("HTTP/1.1 200 OK"));
+            assertThat(received, endsWith("Got 19 bytes of data"));
+        }
+    }
+
+    /**
+     * RFC9110 10.1.1
+     *
+     * A client that sends a 100-continue expectation is not required to wait for any specific length of time;
+     * such a client MAY proceed to send the content even if it has not yet received a response. Furthermore,
+     * since 100 (Continue) responses cannot be sent through an HTTP/1.0 intermediary, such a client SHOULD NOT
+     * wait for an indefinite period before sending the content.
+     *
+     * @throws Exception
+     */
+    @Test
+    void continueWithoutContinue() throws Exception {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+            String content = "looong payload data";
+            socketHttpClient
+                    .manualReq("""                            
+                            POST / HTTP/1.1
+                            Host: localhost:8080
+                            Expect: 100-continue
+                            Accept: */*
+                            test-fail-before-read: false
+                            Content-Length: %d
+                            Content-Type: application/x-www-form-urlencoded
+                                                             
+                            """, content.length())
+                    // Don't wait for continue
+                    .continuePayload(content)
+                    // Skip continue
+                    .awaitResponse("HTTP/1.1 100 Continue", "\n\n");
+
+            String received = socketHttpClient.receive();
+            assertThat(received, startsWith("HTTP/1.1 200 OK"));
+            assertThat(received, endsWith("Got 19 bytes of data"));
+        }
+    }
+    @Test
+    void continue100PUT() throws Exception {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+            String content = "looong payload data";
+            socketHttpClient
+                    .manualReq("""                            
+                            PUT / HTTP/1.1
+                            Host: localhost:8080
+                            Expect: 100-continue
+                            Accept: */*
+                            test-fail-before-read: false
+                            Content-Length: %d
+                            Content-Type: application/x-www-form-urlencoded
+                                                             
+                            """, content.length())
+                    .awaitResponse("HTTP/1.1 100 Continue", "\n\n")
+                    .continuePayload(content);
+
+            String received = socketHttpClient.receive();
+            assertThat(received, startsWith("HTTP/1.1 200 OK"));
+            assertThat(received, endsWith("Got 19 bytes of data"));
+        }
+    }
+
+    @Test
+    void expectationFailed() throws Exception {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+            String content = "looong payload data";
+            socketHttpClient
+                    .manualReq("""                            
+                            POST / HTTP/1.1
+                            Host: localhost:8080
+                            Expect: 100-continue
+                            Accept: */*
+                            test-fail-before-read: true
+                            Content-Length: %d
+                            Content-Type: application/x-www-form-urlencoded
+                                                             
+                            """, content.length());
+
+            String received = socketHttpClient.receive();
+            assertThat(received, startsWith("HTTP/1.1 417"));
+        }
+    }
+
+    @Test
+    void notFound404() throws Exception {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+            String content = "looong payload data";
+            socketHttpClient
+                    .manualReq("""                            
+                            POST /test HTTP/1.1
+                            Host: localhost:8080
+                            Expect: 100-continue
+                            Accept: */*
+                            test-fail-before-read: false
+                            Content-Length: %d
+                            Content-Type: application/x-www-form-urlencoded
+                                                             
+                            """, content.length());
+
+            String received = socketHttpClient.receive();
+            assertThat(received, startsWith("HTTP/1.1 404"));
+        }
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/Continue100Test.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/Continue100Test.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 
-public class Continue100Test {
+class Continue100Test {
 
     private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10);
     private static WebServer webServer;
@@ -72,11 +72,11 @@ public class Continue100Test {
     }
 
     @Test
-    void continue100POST() throws Exception {
+    void continue100Post() throws Exception {
         try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
             String content = "looong payload data";
             socketHttpClient
-                    .manualReq("""                            
+                    .manualRequest("""                            
                             POST / HTTP/1.1
                             Host: localhost:8080
                             Expect: 100-continue
@@ -100,7 +100,7 @@ public class Continue100Test {
         try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
             String content = "looong payload data";
             socketHttpClient
-                    .manualReq("""                            
+                    .manualRequest("""                            
                             POST /redirect HTTP/1.1
                             Host: localhost:8080
                             Expect: 100-continue
@@ -112,7 +112,7 @@ public class Continue100Test {
                             """, content.length())
                     .awaitResponse("HTTP/1.1 301 Moved Permanently\n", "\n\n");
             socketHttpClient
-                    .manualReq("""                            
+                    .manualRequest("""                            
                             POST / HTTP/1.1
                             Host: localhost:8080
                             Expect: 100-continue
@@ -146,7 +146,7 @@ public class Continue100Test {
         try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
             String content = "looong payload data";
             socketHttpClient
-                    .manualReq("""                            
+                    .manualRequest("""                            
                             POST / HTTP/1.1
                             Host: localhost:8080
                             Expect: 100-continue
@@ -167,11 +167,11 @@ public class Continue100Test {
         }
     }
     @Test
-    void continue100PUT() throws Exception {
+    void continue100Put() throws Exception {
         try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
             String content = "looong payload data";
             socketHttpClient
-                    .manualReq("""                            
+                    .manualRequest("""                            
                             PUT / HTTP/1.1
                             Host: localhost:8080
                             Expect: 100-continue
@@ -195,7 +195,7 @@ public class Continue100Test {
         try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
             String content = "looong payload data";
             socketHttpClient
-                    .manualReq("""                            
+                    .manualRequest("""                            
                             POST / HTTP/1.1
                             Host: localhost:8080
                             Expect: 100-continue
@@ -216,7 +216,7 @@ public class Continue100Test {
         try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
             String content = "looong payload data";
             socketHttpClient
-                    .manualReq("""                            
+                    .manualRequest("""                            
                             POST /test HTTP/1.1
                             Host: localhost:8080
                             Expect: 100-continue

--- a/webserver/webserver/src/test/java/io/helidon/webserver/Continue100Test.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/Continue100Test.java
@@ -18,12 +18,21 @@ package io.helidon.webserver;
 
 import io.helidon.common.LogConfig;
 import io.helidon.common.http.Http;
+import io.helidon.common.reactive.Single;
 import io.helidon.webserver.utils.SocketHttpClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -34,36 +43,54 @@ import static org.hamcrest.Matchers.endsWith;
 class Continue100Test {
 
     private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final String CONTINUE_IMMEDIATELY_SOCKET = "continueImmediately";
+    private static final Map<String, CompletableFuture<String>> BLOCKER_MAP = new ConcurrentHashMap<>();
     private static WebServer webServer;
+    private static int defaultPort;
+    private static int contImmediatelyPort;
 
     @BeforeAll
     static void beforeAll() {
         Logger.getLogger("io.helidon.webserver.HttpInitializer").setLevel(Level.FINE);
         LogConfig.configureRuntime();
-        webServer = WebServer.builder()
-                .port(8080)
-                .routing(r -> r
-                        .any("/redirect", (req, res) ->
-                                res.status(301)
-                                        .addHeader(Http.Header.LOCATION, "/")
-                                        // force 301 to not use chunked encoding
-                                        // https://github.com/helidon-io/helidon/issues/5713
-                                        .addHeader(Http.Header.CONTENT_LENGTH, "0")
-                                        .send()
-                        )
-                        .any("/", (req, res) -> {
-                            if(Boolean.parseBoolean(req.headers().first("test-fail-before-read").orElse("false"))){
-                                res.status(Http.Status.EXPECTATION_FAILED_417).send();
-                                return;
-                            }
-                            req.content().as(String.class)
-                                    // Requesting date from content triggers 100 continue
-                                    .forSingle(s -> res.send("Got "+s.getBytes().length+" bytes of data"));
-                        })
+
+        Routing routing = Routing.builder()
+                .any("/redirect", (req, res) ->
+                        res.status(301)
+                                .addHeader(Http.Header.LOCATION, "/")
+                                // force 301 to not use chunked encoding
+                                // https://github.com/helidon-io/helidon/issues/5713
+                                .addHeader(Http.Header.CONTENT_LENGTH, "0")
+                                .send()
                 )
+                .any("/", (req, res) -> {
+                    if (Boolean.parseBoolean(req.headers().first("test-fail-before-read").orElse("false"))) {
+                        res.status(Http.Status.EXPECTATION_FAILED_417).send();
+                        return;
+                    }
+
+                    Optional<String> blockId = req.headers().first("test-block-id");
+                    // Block request content dump if blocker assigned
+                    Single.create(blockId.map(BLOCKER_MAP::get).orElse(CompletableFuture.completedFuture("")))
+                            .flatMapSingle(unused -> req.content().as(String.class))
+                            // Requesting date from content triggers 100 continue by default
+                            .forSingle(s -> {
+                                res.send("Got " + s.getBytes().length + " bytes of data");
+                            });
+                }).build();
+
+        webServer = WebServer.builder()
+                .routing(() -> routing)
+                .addSocket(SocketConfiguration.builder()
+                        .name(CONTINUE_IMMEDIATELY_SOCKET)
+                        .continueImmediately(true)
+                        .build(), routing)
                 .build()
                 .start()
                 .await(TEST_TIMEOUT);
+
+        defaultPort = webServer.port();
+        contImmediatelyPort = webServer.port(CONTINUE_IMMEDIATELY_SOCKET);
     }
 
     @AfterAll
@@ -73,20 +100,49 @@ class Continue100Test {
 
     @Test
     void continue100Post() throws Exception {
-        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(defaultPort)) {
             String content = "looong payload data";
             socketHttpClient
                     .manualRequest("""                            
                             POST / HTTP/1.1
-                            Host: localhost:8080
+                            Host: localhost:%d
                             Expect: 100-continue
                             Accept: */*
                             test-fail-before-read: false
                             Content-Length: %d
                             Content-Type: application/x-www-form-urlencoded
                                                              
-                            """, content.length())
+                            """, defaultPort, content.length())
                     .awaitResponse("HTTP/1.1 100 Continue", "\n\n")
+                    .continuePayload(content);
+
+            String received = socketHttpClient.receive();
+            assertThat(received, startsWith("HTTP/1.1 200 OK"));
+            assertThat(received, endsWith("Got 19 bytes of data"));
+        }
+    }
+    @Test
+    void continue100ImmediatelyPost() throws Exception {
+        String blockId = "continue100ImmediatelyPost - " + UUID.randomUUID();
+        BLOCKER_MAP.put(blockId, new CompletableFuture<>());
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(contImmediatelyPort)) {
+            String content = "looong payload data";
+            socketHttpClient
+                    .manualRequest("""                            
+                            POST / HTTP/1.1
+                            Host: localhost:%d
+                            Expect: 100-continue
+                            Accept: */*
+                            test-fail-before-read: false
+                            test-block-id: %s
+                            Content-Length: %d
+                            Content-Type: application/x-www-form-urlencoded
+                                                             
+                            """, contImmediatelyPort, blockId, content.length())
+                    // Needs to respond continue before request content is requested
+                    .awaitResponse("HTTP/1.1 100 Continue", "\n\n")
+                    // Unblock request data dump
+                    .then(sc -> BLOCKER_MAP.get(blockId).complete(blockId))
                     .continuePayload(content);
 
             String received = socketHttpClient.receive();
@@ -97,31 +153,31 @@ class Continue100Test {
 
     @Test
     void redirect() throws Exception {
-        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(defaultPort)) {
             String content = "looong payload data";
             socketHttpClient
                     .manualRequest("""                            
                             POST /redirect HTTP/1.1
-                            Host: localhost:8080
+                            Host: localhost:%d
                             Expect: 100-continue
                             Accept: */*
                             test-fail-before-read: false
                             Content-Length: %d
                             Content-Type: application/x-www-form-urlencoded
                                                              
-                            """, content.length())
+                            """, defaultPort, content.length())
                     .awaitResponse("HTTP/1.1 301 Moved Permanently\n", "\n\n");
             socketHttpClient
                     .manualRequest("""                            
                             POST / HTTP/1.1
-                            Host: localhost:8080
+                            Host: localhost:%d
                             Expect: 100-continue
                             Accept: */*
                             test-fail-before-read: false
                             Content-Length: %d
                             Content-Type: application/x-www-form-urlencoded
                                                              
-                            """, content.length())
+                            """, defaultPort, content.length())
                     .awaitResponse("HTTP/1.1 100 Continue", "\n\n")
                     .continuePayload(content);
 
@@ -143,19 +199,19 @@ class Continue100Test {
      */
     @Test
     void continueWithoutContinue() throws Exception {
-        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(defaultPort)) {
             String content = "looong payload data";
             socketHttpClient
                     .manualRequest("""                            
                             POST / HTTP/1.1
-                            Host: localhost:8080
+                            Host: localhost:%d
                             Expect: 100-continue
                             Accept: */*
                             test-fail-before-read: false
                             Content-Length: %d
                             Content-Type: application/x-www-form-urlencoded
                                                              
-                            """, content.length())
+                            """, defaultPort, content.length())
                     // Don't wait for continue
                     .continuePayload(content)
                     // Skip continue
@@ -168,19 +224,19 @@ class Continue100Test {
     }
     @Test
     void continue100Put() throws Exception {
-        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(defaultPort)) {
             String content = "looong payload data";
             socketHttpClient
                     .manualRequest("""                            
                             PUT / HTTP/1.1
-                            Host: localhost:8080
+                            Host: localhost:%d
                             Expect: 100-continue
                             Accept: */*
                             test-fail-before-read: false
                             Content-Length: %d
                             Content-Type: application/x-www-form-urlencoded
                                                              
-                            """, content.length())
+                            """, defaultPort, content.length())
                     .awaitResponse("HTTP/1.1 100 Continue", "\n\n")
                     .continuePayload(content);
 
@@ -192,19 +248,19 @@ class Continue100Test {
 
     @Test
     void expectationFailed() throws Exception {
-        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(defaultPort)) {
             String content = "looong payload data";
             socketHttpClient
                     .manualRequest("""                            
                             POST / HTTP/1.1
-                            Host: localhost:8080
+                            Host: localhost:%d
                             Expect: 100-continue
                             Accept: */*
                             test-fail-before-read: true
                             Content-Length: %d
                             Content-Type: application/x-www-form-urlencoded
                                                              
-                            """, content.length());
+                            """, defaultPort, content.length());
 
             String received = socketHttpClient.receive();
             assertThat(received, startsWith("HTTP/1.1 417"));
@@ -213,19 +269,19 @@ class Continue100Test {
 
     @Test
     void notFound404() throws Exception {
-        try (SocketHttpClient socketHttpClient = new SocketHttpClient(webServer)) {
+        try (SocketHttpClient socketHttpClient = new SocketHttpClient(defaultPort)) {
             String content = "looong payload data";
             socketHttpClient
                     .manualRequest("""                            
                             POST /test HTTP/1.1
-                            Host: localhost:8080
+                            Host: localhost:%d
                             Expect: 100-continue
                             Accept: */*
                             test-fail-before-read: false
                             Content-Length: %d
                             Content-Type: application/x-www-form-urlencoded
                                                              
-                            """, content.length());
+                            """, defaultPort, content.length());
 
             String received = socketHttpClient.receive();
             assertThat(received, startsWith("HTTP/1.1 404"));

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -65,6 +66,18 @@ public class SocketHttpClient implements AutoCloseable {
      */
     public SocketHttpClient(WebServer webServer) throws IOException {
         socket = new Socket("localhost", webServer.port());
+        socket.setSoTimeout(10000);
+        socketReader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Creates the instance linked with the provided webserver.
+     *
+     * @param port the port to link this client with
+     * @throws IOException in case of an error
+     */
+    public SocketHttpClient(int port) throws IOException {
+        socket = new Socket("localhost", port);
         socket.setSoTimeout(10000);
         socketReader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
     }
@@ -293,7 +306,20 @@ public class SocketHttpClient implements AutoCloseable {
     }
 
     /**
+     * Execute immediately given consumer with this
+     * socket client as an argument.
+     *
+     * @param exec consumer to execute
+     * @return this http client
+     */
+    public SocketHttpClient then(Consumer<SocketHttpClient> exec){
+        exec.accept(this);
+        return this;
+    }
+
+    /**
      * Wait for text coming from socket.
+     *
      * @param expectedStartsWith expected beginning
      * @param expectedEndsWith expected end
      * @return this http client

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -407,14 +407,15 @@ public class SocketHttpClient implements AutoCloseable {
 
     /**
      * Send supplied text manually to socket.
-     * @param requestString text to send
+     *
+     * @param formatString text to send
      * @param args format arguments
      * @return this http client
      * @throws IOException
      */
-    public SocketHttpClient manualReq(String requestString, Object... args) throws IOException {
+    public SocketHttpClient manualRequest(String formatString, Object... args) throws IOException {
         PrintWriter pw = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8));
-        pw.printf(requestString.replaceAll("\\n",EOL), args);
+        pw.printf(formatString.replaceAll("\\n",EOL), args);
         pw.flush();
         return this;
     }

--- a/webserver/webserver/src/test/resources/logging-test.properties
+++ b/webserver/webserver/src/test/resources/logging-test.properties
@@ -22,9 +22,7 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #All log level details
 .level=INFO
 
-io.helidon.webserver.level=FINE
-#io.helidon.webserver.HttpInitializer.level=FINE
-io.helidon.common.reactive.level=ALL
-io.netty.handler.logging.LoggingHandler.level=ALL
+io.helidon.webserver.level=INFO
+io.helidon.common.reactive.level=INFO
 io.helidon.webserver.RequestRouting.level=SEVERE
 org.glassfish.jersey.internal.Errors.level=SEVERE

--- a/webserver/webserver/src/test/resources/logging-test.properties
+++ b/webserver/webserver/src/test/resources/logging-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #All log level details
 .level=INFO
 
-io.helidon.webserver.level=INFO
-io.helidon.common.reactive.level=INFO
+io.helidon.webserver.level=FINE
+#io.helidon.webserver.HttpInitializer.level=FINE
+io.helidon.common.reactive.level=ALL
+io.netty.handler.logging.LoggingHandler.level=ALL
 io.helidon.webserver.RequestRouting.level=SEVERE
 org.glassfish.jersey.internal.Errors.level=SEVERE


### PR DESCRIPTION
Fixes #4912

100 Continue is triggered by requesting content data.
```java
req.content()
    .as(String.class)
     // Requesting data from content triggers 100 continue
    .forSingle(s -> res.send("Got "+s.getBytes().length+" bytes of data"));
```