### PR TITLE
4.x: Intermittent failure (WebClient tracing test)

### DIFF
--- a/tests/integration/webclient/pom.xml
+++ b/tests/integration/webclient/pom.xml
@@ -16,7 +16,7 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
@@ -93,6 +93,11 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <groupId>io.helidon.common.testing</groupId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/TracingPropagationTest.java
+++ b/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/TracingPropagationTest.java
@@ -36,7 +36,7 @@ import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
 import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -50,7 +50,7 @@ import static org.hamcrest.Matchers.hasSize;
 class TracingPropagationTest {
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
 
-    @RepeatedTest(100)
+    @Test
     void testTracingSuccess() throws ExecutionException, InterruptedException {
         MockTracer mockTracer = new MockTracer();
 

--- a/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/TracingPropagationTest.java
+++ b/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/TracingPropagationTest.java
@@ -20,10 +20,12 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.context.Context;
+import io.helidon.common.http.Http;
+import io.helidon.common.testing.junit5.MatcherWithRetry;
 import io.helidon.config.Config;
+import io.helidon.reactive.media.jsonp.JsonpSupport;
 import io.helidon.reactive.webclient.WebClient;
 import io.helidon.reactive.webclient.WebClientResponse;
 import io.helidon.reactive.webserver.WebServer;
@@ -32,14 +34,15 @@ import io.helidon.tracing.opentracing.OpenTracing;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
+import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 
 /**
  * Test tracing integration.
@@ -47,8 +50,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 class TracingPropagationTest {
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
 
-    @Test
-    @Disabled // intermittently failing on pipeline, issue 5754
+    @RepeatedTest(100)
     void testTracingSuccess() throws ExecutionException, InterruptedException {
         MockTracer mockTracer = new MockTracer();
 
@@ -63,18 +65,23 @@ class TracingPropagationTest {
                 .baseUri(uri)
                 .context(context)
                 .config(Config.create().get("client"))
+                .addMediaSupport(JsonpSupport.create())
                 .build();
 
-        client.get()
+        WebClientResponse response = client.get()
                 .queryParam("some", "value")
                 .fragment("fragment")
                 .request()
-                .forSingle(WebClientResponse::close)
                 .await(TIMEOUT);
+        assertThat(response.status(), is(Http.Status.OK_200));
+        assertThat(response.content().as(JsonObject.class).await(TIMEOUT), notNullValue());
+        response.close();
 
-        TimeUnit.MILLISECONDS.sleep(1);
+        // the server traces asynchronously, some spans may be written after we receive the response.
+        // we need to try to wait for such spans
+        MatcherWithRetry.assertThatWithRetry("There should be 3 spans reported", mockTracer::finishedSpans, hasSize(3));
+
         List<MockSpan> mockSpans = mockTracer.finishedSpans();
-        assertThat("At least one client and one server span expected", mockSpans.size(), greaterThanOrEqualTo(2));
 
         // we need the first span - parentId 0
         MockSpan clientSpan = findSpanWithParentId(mockSpans, 0);

--- a/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/TracingTest.java
+++ b/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/TracingTest.java
@@ -45,7 +45,7 @@ class TracingTest extends TestParent {
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
 
     @Test
-    void testTracingNoServerSuccess() throws ExecutionException, InterruptedException {
+    void testTracingNoServerSuccess() {
         MockTracer mockTracer = new MockTracer();
         String uri = "http://localhost:" + webServer.port() + "/greet";
         Context context = Context.builder().id("tracing-unit-test").build();


### PR DESCRIPTION
As tracing is reported after response is returned on webserver, we need to wait a bit for it to be available in mock tracer. Added delayed retries.

Resolves to #5754 