### PR TITLE
Remove trailing empty line in copyright comment (part 17)

### DIFF
--- a/examples/messaging/kafka-websocket-mp/src/main/resources/WEB/main.css
+++ b/examples/messaging/kafka-websocket-mp/src/main/resources/WEB/main.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 #root {

--- a/examples/messaging/kafka-websocket-se/src/main/java/io/helidon/examples/messaging/se/package-info.java
+++ b/examples/messaging/kafka-websocket-se/src/main/java/io/helidon/examples/messaging/se/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 /**

--- a/examples/messaging/kafka-websocket-se/src/main/resources/WEB/main.css
+++ b/examples/messaging/kafka-websocket-se/src/main/resources/WEB/main.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 #root {

--- a/examples/messaging/oracle-aq-websocket-mp/src/main/java/io/helidon/examples/messaging/mp/MsgProcessingBean.java
+++ b/examples/messaging/oracle-aq-websocket-mp/src/main/java/io/helidon/examples/messaging/mp/MsgProcessingBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.examples.messaging.mp;

--- a/examples/messaging/oracle-aq-websocket-mp/src/main/java/io/helidon/examples/messaging/mp/SendingResource.java
+++ b/examples/messaging/oracle-aq-websocket-mp/src/main/java/io/helidon/examples/messaging/mp/SendingResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.examples.messaging.mp;

--- a/examples/messaging/oracle-aq-websocket-mp/src/main/java/io/helidon/examples/messaging/mp/WebSocketEndpoint.java
+++ b/examples/messaging/oracle-aq-websocket-mp/src/main/java/io/helidon/examples/messaging/mp/WebSocketEndpoint.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.examples.messaging.mp;

--- a/examples/messaging/oracle-aq-websocket-mp/src/main/java/io/helidon/examples/messaging/mp/package-info.java
+++ b/examples/messaging/oracle-aq-websocket-mp/src/main/java/io/helidon/examples/messaging/mp/package-info.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 /**

--- a/examples/messaging/oracle-aq-websocket-mp/src/main/resources/WEB/main.css
+++ b/examples/messaging/oracle-aq-websocket-mp/src/main/resources/WEB/main.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 #root {

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetingMessage.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetingMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.examples.openapi;
 

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/SimpleAPIFilter.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/SimpleAPIFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.examples.openapi.internal;
 

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/SimpleAPIModelReader.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/SimpleAPIModelReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.examples.openapi.internal;
 

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/package-info.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 /**

--- a/health/health/src/test/java/io/helidon/health/HealthServerTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.health;
 


### PR DESCRIPTION
The last part of https://github.com/helidon-io/helidon/pull/5324 .

P.S. There is some misunderstanding in my head.
There are no warnings in the log, but I can see empty lines in the code.
<img width="1236" alt="Screenshot 2023-01-03 at 23 01 16" src="https://user-images.githubusercontent.com/4740207/210440782-4d62ef73-ea83-43a9-bfa2-96e1ff0bd48c.png">

Does the command `mvn validate  -Pcheckstyle` check all files? I run from the root folder. 

