### PR TITLE
Use Hamcrest assertions instead of JUnit in tests/integration/mp-bean-validation - backport 2.x (#1749)

### DIFF
--- a/tests/integration/mp-bean-validation/pom.xml
+++ b/tests/integration/mp-bean-validation/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -55,6 +55,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/integration/mp-bean-validation/src/test/java/io/helidon/tests/integration/bean/validation/TestValidationEndpoint.java
+++ b/tests/integration/mp-bean-validation/src/test/java/io/helidon/tests/integration/bean/validation/TestValidationEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import javax.inject.Inject;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * When enabled, endpoints with bean validation should return response with BAD REQUEST status.
@@ -46,7 +47,7 @@ public class TestValidationEndpoint {
                 .get()
                 .getStatusInfo();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), statusInfo.getStatusCode(), "Endpoint should return BAD REQUEST");
+        assertThat("Endpoint should return BAD REQUEST", statusInfo.getStatusCode(), is(Response.Status.BAD_REQUEST.getStatusCode()));
 
     }
 
@@ -61,7 +62,7 @@ public class TestValidationEndpoint {
                 .request()
                 .get()
                 .getStatusInfo();
-        assertEquals(Response.Status.OK.getStatusCode(), statusInfo.getStatusCode(), "Endpoint should return OK");
+        assertThat("Endpoint should return OK", statusInfo.getStatusCode(), is(Response.Status.OK.getStatusCode()));
 
     }
 }


### PR DESCRIPTION
Part of #1749

[Original PR](https://github.com/helidon-io/helidon/pull/5796)