### PR TITLE
[3.x] Fix improper handling of metrics global tags

### DIFF
--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -92,6 +92,64 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <!-- Avoid any config pollution -->
+                                <exclude>**/TestGlobalTags.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Without the bug fix, this test fails with
+                            java.lang.IllegalArgumentException: Error(s) in global tag expression: [Missing '=': topLevel]
+                        -->
+                        <id>check-top-level-tags-only</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <testSelection>topLevel</testSelection>
+                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <tags>topLevel</tags>
+                            </environmentVariables>
+                            <includes>
+                                <include>**/TestGlobalTags.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Without the bug fix, this test fails with
+                            java.lang.IllegalArgumentException: Error(s) in global tag expression: [Missing '=': topLevel]
+                        -->
+                        <id>check-top-level-and-metrics-level-tags</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <testSelection>topLevelAndMetricsLevel</testSelection>
+                                <!-- Use properties for the metrics global tag instead of env var;
+                                     dots in env names seem to not always work. -->
+                                <metrics.tags>myTag=myValue</metrics.tags>
+                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <tags>topLevel</tags>
+                            </environmentVariables>
+                            <includes>
+                                <include>**/TestGlobalTags.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsSettings.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 public interface MetricsSettings {
 
     /**
-     * Returns default metrics settings based on default config.
+     * Returns default metrics settings based on the {@code metrics} section of the default config.
      *
-     * @return new settings reflecting the default config
+     * @return new settings reflecting the default metrics config
      */
     static MetricsSettings create() {
-        return create(Config.create());
+        return create(Config.create().get(Builder.METRICS_CONFIG_KEY));
     }
 
     /**

--- a/metrics/api/src/test/java/io/helidon/metrics/api/TestGlobalTags.java
+++ b/metrics/api/src/test/java/io/helidon/metrics/api/TestGlobalTags.java
@@ -16,12 +16,7 @@
 package io.helidon.metrics.api;
 
 import java.util.AbstractMap;
-import java.util.Properties;
 
-import io.helidon.config.Config;
-import io.helidon.config.ConfigSources;
-
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;

--- a/metrics/api/src/test/java/io/helidon/metrics/api/TestGlobalTags.java
+++ b/metrics/api/src/test/java/io/helidon/metrics/api/TestGlobalTags.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.api;
+
+import java.util.AbstractMap;
+import java.util.Properties;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.hasItem;
+
+class TestGlobalTags {
+
+    @Test
+    @DisabledIfSystemProperty(named = "testSelection", matches = "topLevelAndMetricsLevel")
+    void testTopLevelTagsIgnoredForMetrics() {
+        MetricsSettings metricsSettings = MetricsSettings.create();
+        assertThat("Global tags with top-level 'tags' assigned", metricsSettings.globalTags().entrySet(), emptyIterable());
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "testSelection", matches = "topLevelAndMetricsLevel")
+    void testGlobalTagsForMetrics() {
+        String tag = "myTag";
+        String value = "myValue";
+        String globalTags = tag + "=" + value;
+        MetricsSettings metricsSettings = MetricsSettings.create();
+        assertThat("Global tags with top-level and metrics 'tags' assigned",
+                   metricsSettings.globalTags().entrySet(),
+                   hasItem(new AbstractMap.SimpleEntry<>(tag, value)));
+    }
+}

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -118,6 +118,7 @@
                                 <exclude>**/TestExtendedKPIMetrics.java</exclude>
                                 <exclude>**/TestMetricsOnOwnSocket.java</exclude>
                                 <exclude>**/TestDisabledMetrics.java</exclude>
+                                <exclude>**/TestConfigProcessing.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -149,6 +150,20 @@
                                 <exclude>**/HelloWorldTest.java</exclude>
                                 <exclude>**/HelloWorldAsyncResponseWithRestRequestTest.java</exclude>
                             </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-config-with-top-level-tags</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestConfigProcessing.java</include>
+                            </includes>
+                            <environmentVariables>
+                                <TAGS>topLevel</TAGS>
+                            </environmentVariables>
                         </configuration>
                     </execution>
                 </executions>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -781,7 +781,9 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
 
         Config metricsConfig = mpConfig.get("metrics").detach();
 
-        Config.Builder builder = Config.builder();
+        Config.Builder builder = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource();
         if (!mpConfigSettings.isEmpty()) {
             builder.addSource(ConfigSources.create(mpConfigSettings));
         }

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestConfigProcessing.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestConfigProcessing.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import io.helidon.config.Config;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import jakarta.enterprise.inject.spi.CDI;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest()
+class TestConfigProcessing {
+
+    @Test
+    void checkTopLeveTagsIgnoredForMetrics() {
+        MetricsCdiExtension extension = CDI.current().getBeanManager().getExtension(MetricsCdiExtension.class);
+        Config seConfig = extension.seComponentConfig();
+        Config metricsTags = seConfig.get("tags");
+        assertThat("Tags setting is present", metricsTags.asString().isPresent(), is(false));
+    }
+}


### PR DESCRIPTION
Resolves #5791 

MP Metrics requires that the config setting`mp.metrics.tags` (format `tag1=value1,tag2=value2")` should cause MP metrics to assign the specified  "global tags" to decorate every `MetricID` during output. 

In our SE implementation, we follow the same approach except with `metrics.tags` as the config key.

Investigating the issue revealed one error and one not-great practice.

1. Error: `MetricsSettings`, (in SE), when using the default config to create an instance, used `Config.create()` without also using `.get("metrics")` to obtain the metrics-specific assignments. As a result, a top-level config key of "tags" (the issue described using an environment variable but a setting at the top level of any config source would show the problem) caused `MetricsSettings` to try to use _that_ as the global metrics tag settings. The value was not formatted as the code expected so it threw an exception.
2. Not-great practice: In `MetricsCdiExtension`, we have to merge settings from `mp.metrics` and `metrics` if both are present to create the metrics settings we use in preparing the `MetricsSupport` object. The code does this by creating a temporary `Config` object with config sources from the two config nodes at `mp.metrics` and `metrics`. But it did so by using `Config.builder()...` without disabling the built-in env. var. and system property sources. This should not have affected anything, but it was confusing because the `mp.metrics` and `metrics` sections of config used to create the temporary `Config` object would already have accounted for env. vars and properties. 

The code contains fixes in these two spots plus new tests that run in separate JVMs to avoid cross-contaminating the test configs with the tag settings. (I probably could have used custom `Config` objects in the tests to simplify the test executions but I wanted to reproduce the conditions reported in the issue, which used an env. var.)