### PR TITLE
Throw an exception when route does not finish, reroute, or next

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/HttpPrologue.java
+++ b/common/http/src/main/java/io/helidon/common/http/HttpPrologue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -248,7 +248,7 @@ public class HttpPrologue {
 
     @Override
     public String toString() {
-        return "HttpPrologueRecord["
+        return "HttpPrologue["
                 + "protocol=" + protocol + ", "
                 + "protocolVersion=" + protocolVersion + ", "
                 + "method=" + method + ", "

--- a/microprofile/lra/jax-rs/pom.xml
+++ b/microprofile/lra/jax-rs/pom.xml
@@ -90,6 +90,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <artifactId>helidon-nima-webclient</artifactId>
+            <groupId>io.helidon.nima.webclient</groupId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nima/tests/integration/webserver/access-log/src/test/resources/logging-test.properties
+++ b/nima/tests/integration/webserver/access-log/src/test/resources/logging-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS %4$s %3$s %5$s%6$s%n
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
-io.helidon.nima.level=FINEST
+
 io.helidon.nima.webserver.accesslog.MemoryLogHandler.level=FINEST
 io.helidon.nima.webserver.accesslog.MemoryLogHandler.append=false
 io.helidon.nima.webserver.AccessLog.level=INFO

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/MaxPayloadSizeTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/MaxPayloadSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,10 +77,9 @@ class MaxPayloadSizeTest {
     @Test
     void testContentLengthExceeded() {
         try (Http1ClientResponse response = client.method(Http.Method.POST)
-                .header(Header.CONTENT_LENGTH, "512")
                 .path("/maxpayload")
                 .header(HeaderValues.CONTENT_TYPE_OCTET_STREAM)
-                .request()) {
+                .submit(new byte[512])) {
             assertThat(response.status(), is(Http.Status.REQUEST_ENTITY_TOO_LARGE_413));
             assertThat(response.headers(), hasHeader(HeaderValues.CONNECTION_CLOSE));
         }

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/UnsentResponseTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/UnsentResponseTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.server;
+
+import io.helidon.common.http.Http;
+import io.helidon.nima.testing.junit5.webserver.DirectClient;
+import io.helidon.nima.testing.junit5.webserver.RoutingTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webclient.http1.Http1ClientResponse;
+import io.helidon.nima.webserver.http.Handler;
+import io.helidon.nima.webserver.http.HttpRules;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RoutingTest
+class UnsentResponseTest {
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.get("/no-response", new NoResponseHandler())
+                .get("/response", (req, res) -> {
+                    res.send();
+                });
+    }
+
+    @Test
+    void testUnsentResponseThrowsException(DirectClient client) {
+        try (Http1ClientResponse response = client.get("/no-response")
+                .request()) {
+
+            assertThat(response.status(), is(Http.Status.INTERNAL_SERVER_ERROR_500));
+            assertThat(response.entity().as(String.class), is("Internal Server Error"));
+        }
+    }
+
+    @Test
+    void testNormalResponse(DirectClient client) {
+        try (Http1ClientResponse response = client.get("/response")
+                .request()) {
+
+            assertThat(response.status(), is(Http.Status.OK_200));
+        }
+    }
+
+    // to have a bit nicer error output for the internal server error
+    private static final class NoResponseHandler implements Handler {
+        @Override
+        public void handle(ServerRequest req, ServerResponse res) {
+        }
+
+        @Override
+        public String toString() {
+            return "NoResponseHandler";
+        }
+    }
+}

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientRequest.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,12 @@ package io.helidon.nima.webclient;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
+import io.helidon.common.http.ClientRequestHeaders;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.uri.UriEncoding;
 import io.helidon.nima.common.tls.Tls;
 
@@ -86,6 +90,14 @@ public interface ClientRequest<B extends ClientRequest<B, R>, R extends ClientRe
     default B header(Http.HeaderName name, String value) {
         return header(Http.Header.create(name, true, false, value));
     }
+
+    /**
+     * Update headers.
+     *
+     * @param headersConsumer consumer of client request headers
+     * @return updated request
+     */
+    B headers(Function<ClientRequestHeaders, WritableHeaders<?>> headersConsumer);
 
     /**
      * Replace a placeholder in URI with an actual value.

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientRequest.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientRequest.java
@@ -19,7 +19,6 @@ package io.helidon.nima.webclient;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.helidon.common.http.ClientRequestHeaders;

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
@@ -60,7 +62,7 @@ class ClientRequestImpl implements Http1ClientRequest {
     private static final String HTTPS = "https";
     private static final Map<KeepAliveKey, Queue<Http1ClientConnection>> CHANNEL_CACHE = new ConcurrentHashMap<>();
 
-    private final WritableHeaders<?> explicitHeaders = WritableHeaders.create();
+    private WritableHeaders<?> explicitHeaders = WritableHeaders.create();
     private final UriQueryWriteable query;
     private final Map<String, String> pathParams = new HashMap<>();
 
@@ -121,6 +123,12 @@ class ClientRequestImpl implements Http1ClientRequest {
     }
 
     @Override
+    public Http1ClientRequest headers(Function<ClientRequestHeaders, WritableHeaders<?>> headersConsumer) {
+        this.explicitHeaders = headersConsumer.apply(ClientRequestHeaders.create(explicitHeaders));
+        return this;
+    }
+
+    @Override
     public Http1ClientRequest pathParam(String name, String value) {
         pathParams.put(name, value);
         return this;
@@ -164,7 +172,7 @@ class ClientRequestImpl implements Http1ClientRequest {
             entityBytes = entityBytes(entity, headers);
         }
 
-        headers.setIfAbsent(Header.create(Header.CONTENT_LENGTH, String.valueOf(entityBytes.length)));
+        headers.set(Header.create(Header.CONTENT_LENGTH, entityBytes.length));
 
         writeHeaders(headers, writeBuffer);
         if (entityBytes.length > 0) {

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.helidon.common.GenericType;


### PR DESCRIPTION
Resolves #5779 

In Níma, we expect the response to be finished on the request thread (so we do not need to be thread safe). 
This is now enforced and when response is neither nexted, rerourted or sent, and internal server error is raised and logged.
I have added a test validating this behavior (that failed on original code)