### PR TITLE
New subsection describing enhancement to support WebSocket application bindings on different ports

### DIFF
--- a/docs/mp/websocket.adoc
+++ b/docs/mp/websocket.adoc
@@ -174,6 +174,47 @@ All endpoint methods in Helidon MP are executed in a separate thread pool, indep
 
 For more information see the link:{helidon-github-tree-url}/examples/webserver/websocket[example].
 
+=== WebSocket Endpoints on Different Ports
+
+The Helidon Reactive Webserver can listen on multiple ports or sockets. This can be useful when APIs for different type of users need to be exposed (such as admin vs. non-admin users). Just like for REST resources, it is possible to expose  WebSocket applications on different ports _provided that the routing paths are different_ --this is due to a constraint in Tyrus, given that it is simply unaware that the endpoints are bound to different ports in the Helidon Webserver.
+
+NOTE: In practice, this implies that the value of `@RoutingPath`, or the equivalent entry in config, must be different across sockets to satisfy the restriction in Tyrus.
+
+We can modify the `MessageBoardApplication` above and bind it to a non-default socket as follows:
+
+[source,java]
+----
+@ApplicationScoped
+@RoutingPath("/web")
+@RoutingName(value = "admin", required = true)
+public class MessageBoardApplication implements ServerApplicationConfig {
+    @Override
+    public Set<ServerEndpointConfig> getEndpointConfigs(
+            Set<Class<? extends Endpoint>> endpoints) {
+        assert endpoints.isEmpty();
+        return Collections.emptySet();      // No programmatic endpoints
+    }
+
+    @Override
+    public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> endpoints) {
+        return endpoints;       // Returned scanned endpoints
+    }
+}
+----
+
+The value of the `@RoutingName` annotation must match that of a configured application socket as shown in the following `application.yaml` file:
+
+[source]
+----
+server:
+  port: 8080
+  host: 0.0.0.0
+  sockets:
+    - name: admin
+      port: 8888
+----
+
+This example assumes that port 8888 is reserved for admin users and binds the `MessageBoardApplication` to it.
 
 == Reference
 

--- a/docs/mp/websocket.adoc
+++ b/docs/mp/websocket.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -176,7 +176,7 @@ For more information see the link:{helidon-github-tree-url}/examples/webserver/w
 
 === WebSocket Endpoints on Different Ports
 
-The Helidon Reactive Webserver can listen on multiple ports or sockets. This can be useful when APIs for different type of users need to be exposed (such as admin vs. non-admin users). Just like for REST resources, it is possible to expose  WebSocket applications on different ports _provided that the routing paths are different_ --this is due to a constraint in Tyrus, given that it is simply unaware that the endpoints are bound to different ports in the Helidon Webserver.
+The Helidon WebServer can listen on multiple ports or sockets. This can be useful when APIs for different type of users need to be exposed (such as admin vs. non-admin users). Just like for REST resources, it is possible to expose  WebSocket applications on different ports _provided that the routing paths are different_ --this is due to a constraint in Tyrus, given that it is simply unaware that the endpoints are bound to different ports in the Helidon WebServer.
 
 NOTE: In practice, this implies that the value of `@RoutingPath`, or the equivalent entry in config, must be different across sockets to satisfy the restriction in Tyrus.
 

--- a/docs/mp/websocket.adoc
+++ b/docs/mp/websocket.adoc
@@ -178,7 +178,7 @@ For more information see the link:{helidon-github-tree-url}/examples/webserver/w
 
 The Helidon WebServer can listen on multiple ports or sockets. This can be useful when APIs for different type of users need to be exposed (such as admin vs. non-admin users). Just like for REST resources, it is possible to expose  WebSocket applications on different ports _provided that the routing paths are different_ --this is due to a constraint in Tyrus, given that it is simply unaware that the endpoints are bound to different ports in the Helidon WebServer.
 
-NOTE: In practice, this implies that the value of `@RoutingPath`, or the equivalent entry in config, must be different across sockets to satisfy the restriction in Tyrus.
+NOTE: In practice, this implies that the value of `@RoutingPath`, or the equivalent entry in config, must be different across sockets to satisfy the restriction in Tyrus. An attempt to register two or more endpoints on the same path, even if they belong to applications registered on different ports, shall result in a `jakarta.websocket.DeploymentException` being thrown.
 
 We can modify the `MessageBoardApplication` above and bind it to a non-default socket as follows:
 


### PR DESCRIPTION
New subsection describing enhancement to support WebSocket application bindings on different ports.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>