### PR TITLE
Use Hamcrest assertions instead of JUnit in examples/integrations/micronaut/data - backport 2.x (#1749)

### DIFF
--- a/examples/integrations/micronaut/data/src/test/java/io/helidon/examples/integrations/micronaut/data/MicronautExampleTest.java
+++ b/examples/integrations/micronaut/data/src/test/java/io/helidon/examples/integrations/micronaut/data/MicronautExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import io.helidon.microprofile.tests.junit5.HelidonTest;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @HelidonTest
 class MicronautExampleTest {
@@ -40,7 +41,7 @@ class MicronautExampleTest {
                 .request()
                 .get(JsonArray.class);
 
-        assertEquals(3, jsonValues.size(), "We should get all pets");
+        assertThat("We should get all pets", jsonValues.size(), is(3));
     }
 
     @Test
@@ -49,8 +50,8 @@ class MicronautExampleTest {
                 .request()
                 .get(JsonObject.class);
 
-        assertEquals("Dino", pet.getString("name"));
-        assertEquals(Pet.PetType.DOG.toString(), pet.getString("type"));
+        assertThat(pet.getString("name"), is("Dino"));
+        assertThat(pet.getString("type"), is(Pet.PetType.DOG.toString()));
     }
 
     @Test
@@ -58,7 +59,7 @@ class MicronautExampleTest {
         try (Response response = webTarget.path("/pets/Fino")
                 .request()
                 .get()) {
-            assertEquals(404, response.getStatus(), "Should be not found: 404");
+            assertThat("Should be not found: 404", response.getStatus(), is(404));
         }
     }
 
@@ -67,7 +68,7 @@ class MicronautExampleTest {
         try (Response response = webTarget.path("/pets/a")
                 .request()
                 .get()) {
-            assertEquals(400, response.getStatus(), "Should be bad request: 400");
+            assertThat("Should be bad request: 400", response.getStatus(), is(400));
         }
     }
 


### PR DESCRIPTION
Part of #1749

[Original PR](https://github.com/helidon-io/helidon/pull/5836)