### PR TITLE
Suppress incorrect start-up log message related to requested URI discovery

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
@@ -1098,7 +1098,7 @@ public interface SocketConfiguration {
                 }
             } else {
                 // Discovery is disabled so ignore any explicit settings of discovery type and use HOST discovery.
-                if (!requestedUriDiscoveryTypes.isEmpty()) {
+                if (!requestedUriDiscoveryTypes.isEmpty() && !isDiscoveryTypesOnlyHost()) {
                     LOGGER.log(Level.INFO, """
                             Ignoring explicit settings of requested-uri-discovery types and trusted-proxies because
                             requested-uri-discovery.enabled {0} to false


### PR DESCRIPTION
Resolves #5859 

Users can configure requested URI discovery explicitly as `enabled=false` with the discovery type of `HOST`. That's legitimate and is the normal case.

In fact, the code creates these settings internally if the user has not set up discovery settings explicitly.

Further, in the case of the default socket, the socket init code invokes `SocketConfiguration#prepareAndCheckRequestedUriSettings` twice, and the second time through the code was incorrectly logging the message (because it had itself previously established these settings).

In these cases, the code should not log the `INFO` message about ignoring explicit discovery type or trusted proxy settings when the feature is disabled.