### PR TITLE
Remove duplicated dependencies in some projects

### DIFF
--- a/examples/metrics/exemplar/pom.xml
+++ b/examples/metrics/exemplar/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -47,10 +47,6 @@
         <dependency>
             <groupId>io.helidon.media</groupId>
             <artifactId>helidon-media-jsonp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>

--- a/examples/security/idcs-login/pom.xml
+++ b/examples/security/idcs-login/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -85,10 +85,6 @@
             <!-- Encryption of secrets -->
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-encryption</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>


### PR DESCRIPTION
There are duplicated dependencies in some projects. Maven shows warnings:
<img width="1681" alt="Screenshot 2023-01-13 at 22 44 23" src="https://user-images.githubusercontent.com/4740207/212417904-57bf908c-096e-4f60-94f4-1bdd6abc2c37.png">

`helidon-metrics-api` in examples/metrics/exemplar/pom.xml
`helidon-config-yaml` in examples/security/idcs-login/pom.xml

It can be fixed. There are no duplicated dependencies in other branches (3.x and main).