### PR TITLE
[3.x] Oidc tenant name now properly escaped

### DIFF
--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -294,7 +294,8 @@ class TenantAuthenticationHandler {
             String authorizationEndpoint = tenant.authorizationEndpointUri();
             String nonce = UUID.randomUUID().toString();
             String redirectUri =
-                    encode(redirectUri(providerRequest.env()) + "?" + oidcConfig.tenantParamName() + "=" + tenantId);
+                    encode(redirectUri(providerRequest.env()) + "?"
+                                   + encode(oidcConfig.tenantParamName()) + "=" + encode(tenantId));
 
 
             StringBuilder queryString = new StringBuilder("?");

--- a/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/CookieBasedLoginIT.java
+++ b/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/CookieBasedLoginIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,29 @@ class CookieBasedLoginIT extends CommonLoginBase {
 
         //Sending authentication to the Keycloak and getting redirected back to the running Helidon app.
         form = Entity.form(new Form().param("username", "userone")
+                                   .param("password", "12345")
+                                   .param("credentialId", ""));
+        try (Response response = client.target(formUri).request().post(form)) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            assertThat(response.readEntity(String.class), is(EXPECTED_TEST_MESSAGE));
+        }
+    }
+
+    @Test
+    public void testDefaultTenantUsage(WebTarget webTarget) {
+        String formUri;
+
+        //greet endpoint is protected, and we need to get JWT token out of the Keycloak. We will get redirected to the Keycloak.
+        try (Response response = client.target(webTarget.getUri()).path("/test")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            //We need to get form URI out of the HTML
+            formUri = getRequestUri(response.readEntity(String.class));
+        }
+
+        //Sending authentication to the Keycloak and getting redirected back to the running Helidon app.
+        Entity<Form> form = Entity.form(new Form().param("username", "userone")
                                    .param("password", "12345")
                                    .param("credentialId", ""));
         try (Response response = client.target(formUri).request().post(form)) {

--- a/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/QueryBasedLoginIT.java
+++ b/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/QueryBasedLoginIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,6 +123,28 @@ class QueryBasedLoginIT extends CommonLoginBase {
         form = Entity.form(new Form().param("username", "userone")
                                    .param("password", "12345")
                                    .param("credentialId", ""));
+        try (Response response = client.target(formUri).request().post(form)) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            assertThat(response.readEntity(String.class), is(EXPECTED_TEST_MESSAGE));
+        }
+    }
+    @Test
+    public void testDefaultTenantUsage(WebTarget webTarget) {
+        String formUri;
+
+        //greet endpoint is protected, and we need to get JWT token out of the Keycloak. We will get redirected to the Keycloak.
+        try (Response response = client.target(webTarget.getUri()).path("/test")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            //We need to get form URI out of the HTML
+            formUri = getRequestUri(response.readEntity(String.class));
+        }
+
+        //Sending authentication to the Keycloak and getting redirected back to the running Helidon app.
+        Entity<Form> form = Entity.form(new Form().param("username", "userone")
+                                                .param("password", "12345")
+                                                .param("credentialId", ""));
         try (Response response = client.target(formUri).request().post(form)) {
             assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
             assertThat(response.readEntity(String.class), is(EXPECTED_TEST_MESSAGE));


### PR DESCRIPTION
Fixes https://github.com/helidon-io/helidon/issues/5857