### PR TITLE
[4.x] Oidc tenant name now properly escaped

### DIFF
--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -292,7 +292,8 @@ class TenantAuthenticationHandler {
             String authorizationEndpoint = tenant.authorizationEndpointUri();
             String nonce = UUID.randomUUID().toString();
             String redirectUri =
-                    encode(redirectUri(providerRequest.env()) + "?" + oidcConfig.tenantParamName() + "=" + tenantId);
+                    encode(redirectUri(providerRequest.env()) + "?"
+                                   + encode(oidcConfig.tenantParamName()) + "=" + encode(tenantId));
 
 
             StringBuilder queryString = new StringBuilder("?");

--- a/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/CookieBasedLoginIT.java
+++ b/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/CookieBasedLoginIT.java
@@ -101,6 +101,29 @@ class CookieBasedLoginIT extends CommonLoginBase {
         }
     }
 
+    @Test
+    public void testDefaultTenantUsage(WebTarget webTarget) {
+        String formUri;
+
+        //greet endpoint is protected, and we need to get JWT token out of the Keycloak. We will get redirected to the Keycloak.
+        try (Response response = client.target(webTarget.getUri()).path("/test")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            //We need to get form URI out of the HTML
+            formUri = getRequestUri(response.readEntity(String.class));
+        }
+
+        //Sending authentication to the Keycloak and getting redirected back to the running Helidon app.
+        Entity<Form> form = Entity.form(new Form().param("username", "userone")
+                                   .param("password", "12345")
+                                   .param("credentialId", ""));
+        try (Response response = client.target(formUri).request().post(form)) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            assertThat(response.readEntity(String.class), is(EXPECTED_TEST_MESSAGE));
+        }
+    }
+
     private String getRequestUri(String html) {
         Document document = Jsoup.parse(html);
         return document.getElementById("kc-form-login").attr("action");

--- a/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/QueryBasedLoginIT.java
+++ b/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/QueryBasedLoginIT.java
@@ -128,6 +128,28 @@ class QueryBasedLoginIT extends CommonLoginBase {
             assertThat(response.readEntity(String.class), is(EXPECTED_TEST_MESSAGE));
         }
     }
+    @Test
+    public void testDefaultTenantUsage(WebTarget webTarget) {
+        String formUri;
+
+        //greet endpoint is protected, and we need to get JWT token out of the Keycloak. We will get redirected to the Keycloak.
+        try (Response response = client.target(webTarget.getUri()).path("/test")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            //We need to get form URI out of the HTML
+            formUri = getRequestUri(response.readEntity(String.class));
+        }
+
+        //Sending authentication to the Keycloak and getting redirected back to the running Helidon app.
+        Entity<Form> form = Entity.form(new Form().param("username", "userone")
+                                                .param("password", "12345")
+                                                .param("credentialId", ""));
+        try (Response response = client.target(formUri).request().post(form)) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            assertThat(response.readEntity(String.class), is(EXPECTED_TEST_MESSAGE));
+        }
+    }
 
     private String getRequestUri(String html) {
         Document document = Jsoup.parse(html);


### PR DESCRIPTION
Fixes #5858