### PR TITLE
[4.x.] - Deprecate MicroProfile Tracing

### DIFF
--- a/common/features/processor/src/main/java/io/helidon/common/features/processor/FeatureHandler.java
+++ b/common/features/processor/src/main/java/io/helidon/common/features/processor/FeatureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,12 +110,12 @@ class FeatureHandler {
                 annotation.getElementValues()
                         .forEach((method, value) -> {
                             if (method.getSimpleName().contentEquals("since")) {
-                                descriptor.since((String) value.getValue());
+                                descriptor.deprecatedSince((String) value.getValue());
                             }
                         });
                 if (descriptor.noDeprecatedSince()) {
                     messager.printMessage(Diagnostic.Kind.ERROR, "Failed to process feature metadata annotation processor. "
-                            + " Module " + moduleName + " has @Deprecated without since. Since must be defined");
+                            + " Module " + moduleName + " has @Deprecated without since. Since must be defined.");
                     throw new IllegalStateException("Deprecated without since in module " + moduleName);
                 }
                 break;

--- a/docs/mp/tracing.adoc
+++ b/docs/mp/tracing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -38,6 +38,9 @@ include::{rootdir}/includes/mp.adoc[]
 - <<Reference, Reference>>
 
 == Overview
+
+WARNING: MicroProfile Tracing specification is discontinued. This feature is marked as `@Deprecated` in
+Helidon. The specification is Superseded by link:https://github.com/eclipse/microprofile-telemetry[MicroProfile Telemetry specification].
 
 Distributed tracing is a critical feature of micro-service based applications, since it traces workflow both
 within a service and across multiple services. This provides insight to sequence and timing data for specific blocks of work,

--- a/docs/mp/tracing.adoc
+++ b/docs/mp/tracing.adoc
@@ -39,8 +39,8 @@ include::{rootdir}/includes/mp.adoc[]
 
 == Overview
 
-WARNING: MicroProfile Tracing specification is discontinued. This feature is marked as `@Deprecated` in
-Helidon. The specification is Superseded by link:https://github.com/eclipse/microprofile-telemetry[MicroProfile Telemetry specification].
+WARNING: The OpenTracing Specification that MP OpenTracing is based on is no longer maintained.
+The MP OpenTracing specification is no longer required by MicroProfile. This feature is marked as `@Deprecated` in Helidon. The specification is Superseded by link:https://github.com/eclipse/microprofile-telemetry[MicroProfile Telemetry specification].
 
 Distributed tracing is a critical feature of micro-service based applications, since it traces workflow both
 within a service and across multiple services. This provides insight to sequence and timing data for specific blocks of work,

--- a/microprofile/bundles/helidon-microprofile/pom.xml
+++ b/microprofile/bundles/helidon-microprofile/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -69,10 +69,6 @@
         <dependency>
             <groupId>io.helidon.microprofile.rest-client</groupId>
             <artifactId>helidon-microprofile-rest-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile.tracing</groupId>
-            <artifactId>helidon-microprofile-tracing</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/microprofile/bundles/helidon-microprofile/src/main/java/module-info.java
+++ b/microprofile/bundles/helidon-microprofile/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ module io.helidon.microprofile.bundle {
     requires transitive io.helidon.microprofile.metrics;
     requires transitive io.helidon.microprofile.faulttolerance;
     requires transitive io.helidon.microprofile.jwt.auth;
-    requires transitive io.helidon.microprofile.tracing;
     requires transitive io.helidon.microprofile.restclient;
     requires transitive io.helidon.microprofile.openapi;
     requires transitive jakarta.json.bind;

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -54,6 +54,11 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tracing</groupId>
+            <artifactId>helidon-microprofile-tracing</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microprofile/tracing/src/main/java/module-info.java
+++ b/microprofile/tracing/src/main/java/module-info.java
@@ -26,8 +26,8 @@ import io.helidon.common.features.api.HelidonFlavor;
         description = "MicroProfile tracing spec implementation",
         in = HelidonFlavor.MP,
         path = "Tracing",
-        since = "4.0.0"
-)
+        since = "1.0.0")
+@Deprecated(since="4.0.0", forRemoval = true)
 module io.helidon.microprofile.tracing {
     requires static io.helidon.common.features.api;
 

--- a/microprofile/tracing/src/main/java/module-info.java
+++ b/microprofile/tracing/src/main/java/module-info.java
@@ -25,7 +25,8 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Feature(value = "Tracing",
         description = "MicroProfile tracing spec implementation",
         in = HelidonFlavor.MP,
-        path = "Tracing"
+        path = "Tracing",
+        since = "4.0.0"
 )
 module io.helidon.microprofile.tracing {
     requires static io.helidon.common.features.api;

--- a/tests/integration/zipkin-mp-2.2/pom.xml
+++ b/tests/integration/zipkin-mp-2.2/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>helidon-tracing-zipkin</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.microprofile.tracing</groupId>
+            <artifactId>helidon-microprofile-tracing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>

--- a/tests/integration/zipkin-mp-2.2/pom.xml
+++ b/tests/integration/zipkin-mp-2.2/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Removed MP Tracing removed for bundled.
Marked for deprecation.

Resolves #5818 