### PR TITLE
Shutdown hook alignment Níma and MP.

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,7 @@ public class ServerCdiExtension implements Extension {
     private final Map<Bean<?>, RoutingConfiguration> serviceBeans = Collections.synchronizedMap(new IdentityHashMap<>());
     // build time
     private WebServer.Builder serverBuilder = WebServer.builder()
+            .shutdownHook(false) // we use a custom CDI shutdown hook in HelidonContainerImpl
             .port(7001);
 
     private HttpRouting.Builder routingBuilder = HttpRouting.builder();

--- a/nima/webserver/webserver/src/main/java/module-info.java
+++ b/nima/webserver/webserver/src/main/java/module-info.java
@@ -41,6 +41,8 @@ module io.helidon.nima.webserver {
     requires io.helidon.pico.builder.config;
 
     requires java.management;
+    // only used to keep logging active until shutdown hook finishes
+    requires java.logging;
 
     requires jakarta.annotation;
     requires io.helidon.common.uri;


### PR DESCRIPTION
Resolves #5910 

Keep logging system active until shutdown hook completes.

This introduces a module dependency between Níma webserver and Java Util Logging. We may want to abstract this away through our logging abstraction in the future.