### PR TITLE
[main] Issue 5383: ContentEncodingContext Builder and passing ContentEncodingContext instance from WebServer to Http1Connection.

### DIFF
--- a/nima/http/encoding/encoding/pom.xml
+++ b/nima/http/encoding/encoding/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -28,6 +28,10 @@
     <name>Helidon Níma HTTP Encoding</name>
 
     <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-http</artifactId>

--- a/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncodingContext.java
+++ b/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncodingContext.java
@@ -24,8 +24,8 @@ import java.util.ServiceLoader;
 import java.util.Set;
 
 import io.helidon.common.HelidonServiceLoader;
-import io.helidon.common.http.Headers;
 import io.helidon.common.config.Config;
+import io.helidon.common.http.Headers;
 import io.helidon.nima.http.encoding.spi.ContentEncodingProvider;
 
 /**

--- a/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncodingContext.java
+++ b/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncodingContext.java
@@ -42,6 +42,16 @@ public interface ContentEncodingContext {
     }
 
     /**
+     * Create a new encoding support and apply provided configuration.
+     *
+     * @param config configuration to use
+     * @return content encoding support
+     */
+    static ContentEncodingContext create(Config config) {
+        return builder().config(config).build();
+    }
+
+    /**
      * There is at least one content encoder.
      *
      * @return whether there is at least one content encoder
@@ -132,7 +142,7 @@ public interface ContentEncodingContext {
         }
 
         /**
-         * Disable content encoding support.
+         * Whether Java Service Loader should be used to load {@link ContentEncodingProvider}.
          *
          * @return updated builder
          */

--- a/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncodingContext.java
+++ b/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncodingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,18 @@
 
 package io.helidon.nima.http.encoding;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.ServiceLoader;
+import java.util.Set;
 
+import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.http.Headers;
+import io.helidon.common.config.Config;
+import io.helidon.nima.http.encoding.spi.ContentEncodingProvider;
 
 /**
  * Content encoding support to obtain encoders and decoders.
@@ -30,7 +39,7 @@ public interface ContentEncodingContext {
      * @return content encoding support
      */
     static ContentEncodingContext create() {
-        return new ContentEncodingSupportImpl();
+        return builder().build();
     }
 
     /**
@@ -88,4 +97,109 @@ public interface ContentEncodingContext {
      * @return content encoder to use
      */
     ContentEncoder encoder(Headers headers);
+
+    /**
+     * Builder to set up this encoding support content.
+     *
+     * @return a new builder
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Fluent API builder for {@link ContentEncodingContext}.
+     */
+    class Builder implements io.helidon.common.Builder<Builder, ContentEncodingContext> {
+
+        private static final String IDENTITY_ENCODING = "identity";
+
+        private final HelidonServiceLoader.Builder<ContentEncodingProvider> encodingProviders
+                = HelidonServiceLoader.builder(ServiceLoader.load(ContentEncodingProvider.class));
+
+        // Force disable of encoders/decoders. Will build empty Maps when false.
+        private boolean enabled = true;
+
+        /**
+         * Update this builder from configuration.
+         * <p>
+         * Configuration:<ul>
+         *     <li><b>disable: true</b>  - to disable content encoding support</li>
+         * </ul>
+         *
+         * @param config configuration to use
+         * @return updated builder instance
+         */
+        public Builder config(Config config) {
+            config.get("disable").asBoolean().ifPresent(this::disableFromConfig);
+            return this;
+        }
+
+        /**
+         * Disable content encoding support.
+         *
+         * @return updated builder
+         */
+        public Builder disable() {
+            enabled = false;
+            return this;
+        }
+
+        /**
+         * Configure content encoding provider.
+         * This instance has priority over provider(s) discovered by service loader.
+         *
+         * @param encodingProvider explicit content encoding provider
+         * @return updated builder
+         */
+        public Builder addEncodingProvider(ContentEncodingProvider encodingProvider) {
+            encodingProviders.addService(encodingProvider);
+            return this;
+        }
+
+        @Override
+        public ContentEncodingContext build() {
+            List<ContentEncodingProvider> providers = encodingProviders.build().asList();
+            Map<String, ContentEncoder> encoders = enabled ? new HashMap<>() : Collections.emptyMap();
+            Map<String, ContentDecoder> decoders = enabled ? new HashMap<>() : Collections.emptyMap();
+            ContentEncoder firstEncoder = null;
+
+            if (enabled) {
+                for (ContentEncodingProvider provider : providers) {
+                    Set<String> ids = provider.ids();
+
+                    if (provider.supportsEncoding()) {
+                        for (String id : ids) {
+                            ContentEncoder encoder = provider.encoder();
+                            if (firstEncoder == null) {
+                                firstEncoder = encoder;
+                            }
+                            encoders.putIfAbsent(id, encoder);
+                        }
+                    }
+
+                    if (provider.supportsDecoding()) {
+                        for (String id : ids) {
+                            decoders.putIfAbsent(id, provider.decoder());
+                        }
+                    }
+
+                }
+
+                encoders.put(IDENTITY_ENCODING, ContentEncoder.NO_OP);
+                decoders.put(IDENTITY_ENCODING, ContentDecoder.NO_OP);
+            }
+
+            return new ContentEncodingSupportImpl(Map.copyOf(encoders), Map.copyOf(decoders), firstEncoder);
+        }
+
+        // Config helper: Disable encoders/decoders when forced by config value.
+        private void disableFromConfig(boolean disable) {
+            if (disable) {
+                enabled = false;
+            }
+        }
+
+    }
+
 }

--- a/nima/http/encoding/encoding/src/main/java/module-info.java
+++ b/nima/http/encoding/encoding/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ module io.helidon.nima.http.encoding {
     requires static io.helidon.common.features.api;
 
     requires io.helidon.common;
+    requires transitive io.helidon.common.config;
     requires transitive io.helidon.common.http;
 
     exports io.helidon.nima.http.encoding;

--- a/nima/http2/webserver/src/test/java/io/helidon/nima/http2/webserver/ConnectionConfigTest.java
+++ b/nima/http2/webserver/src/test/java/io/helidon/nima/http2/webserver/ConnectionConfigTest.java
@@ -19,22 +19,16 @@ package io.helidon.nima.http2.webserver;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
-import io.helidon.common.buffers.DataReader;
-import io.helidon.common.buffers.DataWriter;
-import io.helidon.common.socket.PeerInfo;
+import org.junit.jupiter.api.Test;
+
 import io.helidon.config.Config;
 import io.helidon.nima.http2.Http2Setting;
 import io.helidon.nima.webserver.ConnectionContext;
 import io.helidon.nima.webserver.Router;
-import io.helidon.nima.webserver.Routing;
-import io.helidon.nima.webserver.spi.ServerConnectionSelector;
 import io.helidon.nima.webserver.ServerContext;
 import io.helidon.nima.webserver.WebServer;
-import io.helidon.nima.webserver.http.DirectHandlers;
-
-import org.junit.jupiter.api.Test;
+import io.helidon.nima.webserver.spi.ServerConnectionSelector;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -106,6 +100,8 @@ class ConnectionConfigTest {
     private static ConnectionContext mockContext() {
         ConnectionContext ctx = mock(ConnectionContext.class);
         when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.serverContext()).thenReturn(mock(ServerContext.class));
         return ctx;
     }
+
 }

--- a/nima/webserver/webserver/pom.xml
+++ b/nima/webserver/webserver/pom.xml
@@ -92,6 +92,12 @@
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Put gzip content encoder on test classpath to see whether it's loaded or not. -->
+        <dependency>
+            <artifactId>helidon-nima-http-encoding-gzip</artifactId>
+            <groupId>io.helidon.nima.http.encoding</groupId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
@@ -252,9 +252,8 @@ public interface WebServer {
                     });
             // Configure content encoding
             config.get("content-encoding")
-                    .asNode()
-                    .ifPresent(encodingConfig ->
-                            contentEncodingContext(ContentEncodingContext.builder().config(encodingConfig).build()));
+                    .as(ContentEncodingContext::create)
+                    .ifPresent(this::contentEncodingContext);
             // Store providers config node for later usage.
             providersConfig = config.get("connection-providers");
             return this;

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
@@ -250,9 +250,13 @@ public interface WebServer {
                             connConfig.get("tcp-no-delay").asBoolean().ifPresent(socketOptionsBuilder::tcpNoDelay);
                         });
                     });
+            // Configure content encoding
+            config.get("content-encoding")
+                    .asNode()
+                    .ifPresent(encodingConfig ->
+                            contentEncodingContext(ContentEncodingContext.builder().config(encodingConfig).build()));
             // Store providers config node for later usage.
             providersConfig = config.get("connection-providers");
-
             return this;
         }
 

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
@@ -507,6 +507,7 @@ public interface WebServer {
         }
 
         List<ServerConnectionSelector> connectionProviders() {
+            providersConfig.get("discover-services").asBoolean().ifPresent(connectionProviders::useSystemServiceLoader);
             List<ServerConnectionProvider> providers = connectionProviders.build().asList();
             // Send configuration nodes to providers
             return providers.stream()

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Connection.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Connection.java
@@ -68,8 +68,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     private final boolean canUpgrade;
     private final Http1Headers http1headers;
     private final Http1Prologue http1prologue;
-    // todo pass from server config
-    private final ContentEncodingContext contentEncodingContext = ContentEncodingContext.create();
+    private final ContentEncodingContext contentEncodingContext;
     private final HttpRouting routing;
     private final long maxPayloadSize;
     private final Http1ConnectionListener recvListener;
@@ -103,6 +102,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         this.reader.listener(recvListener, ctx);
         this.http1headers = new Http1Headers(reader, http1Config.maxHeadersSize(), http1Config.validateHeaders());
         this.http1prologue = new Http1Prologue(reader, http1Config.maxPrologueLength(), http1Config.validatePath());
+        this.contentEncodingContext = ctx.serverContext().contentEncodingContext();
         this.routing = ctx.router().routing(HttpRouting.class, HttpRouting.empty());
         this.maxPayloadSize = ctx.maxPayloadSize();
     }

--- a/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/WebServerConfigTest.java
+++ b/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/WebServerConfigTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webserver;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+import io.helidon.config.Config;
+import io.helidon.nima.http.encoding.ContentEncodingContext;
+import io.helidon.nima.webserver.spi.ServerConnectionSelector;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class WebServerConfigTest {
+
+    @Test
+    void testConnectionProvidersEnabled() {
+        // This will pick up application.yaml from the classpath as default configuration file
+        Config config = Config.create();
+        WebServer.Builder wsBuilder = WebServer.builder().config(config.get("server"));
+        List<ServerConnectionSelector> providers = wsBuilder.connectionProviders();
+        // Providers shall be loaded with ServiceLoader.
+        assertThat(providers, notNullValue());
+        assertThat(providers, is(not(empty())));
+    }
+
+    @Test
+    void testConnectionProvidersDisabled() {
+        // This will pick up application.yaml from the classpath as default configuration file
+        Config config = Config.create();
+        WebServer.Builder wsBuilder = WebServer.builder().config(config.get("server2"));
+        List<ServerConnectionSelector> providers = wsBuilder.connectionProviders();
+        // No providers shall be loaded with ServiceLoader disabled for connection providers.
+        assertThat(providers, notNullValue());
+        assertThat(providers, is(empty()));
+    }
+
+    // Check that WebServer ContentEncodingContext is disabled when disable is present in config
+    @Test
+    void testContentEncodingConfig() {
+        // This will pick up application.yaml from the classpath as default configuration file
+        Config config = Config.create();
+        WebServer.Builder wsBuilder = WebServer.builder().config(config.get("server"));
+        ContentEncodingContext contentEncodingContext = wsBuilder.contentEncodingContext();
+        assertThat(contentEncodingContext.contentEncodingEnabled(), is(true));
+        assertThat(contentEncodingContext.contentDecodingEnabled(), is(true));
+        failsWith(() -> contentEncodingContext.decoder("gzip"), NoSuchElementException.class);
+        failsWith(() -> contentEncodingContext.decoder("gzip"), NoSuchElementException.class);
+        failsWith(() -> contentEncodingContext.encoder("gzip"), NoSuchElementException.class);
+        failsWith(() -> contentEncodingContext.decoder("x-gzip"), NoSuchElementException.class);
+        failsWith(() -> contentEncodingContext.encoder("x-gzip"), NoSuchElementException.class);
+    }
+
+    // Verify that provided task throws an exception
+    private static void failsWith(Runnable task, Class<? extends Exception> exception) {
+        try {
+            task.run();
+            // Fail the test when no Exception was thrown
+            fail(String.format("Exception %s was not thrown", exception.getName()));
+        } catch (Exception ex) {
+            if (!exception.isAssignableFrom(ex.getClass())) {
+                throw ex;
+            }
+        }
+    }
+
+}

--- a/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/http1/ConnectionConfigTest.java
+++ b/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/http1/ConnectionConfigTest.java
@@ -19,149 +19,23 @@ package io.helidon.nima.webserver.http1;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-
-import io.helidon.common.buffers.BufferData;
-import io.helidon.common.buffers.DataReader;
-import io.helidon.common.buffers.DataWriter;
-import io.helidon.common.socket.HelidonSocket;
-import io.helidon.common.socket.PeerInfo;
-import io.helidon.config.Config;
-import io.helidon.nima.webserver.ConnectionContext;
-import io.helidon.nima.webserver.Router;
-import io.helidon.nima.webserver.Routing;
-import io.helidon.nima.webserver.spi.ServerConnectionSelector;
-import io.helidon.nima.webserver.ServerContext;
-import io.helidon.nima.webserver.WebServer;
-import io.helidon.nima.webserver.http.DirectHandlers;
 
 import org.junit.jupiter.api.Test;
 
+import io.helidon.common.buffers.DataReader;
+import io.helidon.config.Config;
+import io.helidon.nima.webserver.ConnectionContext;
+import io.helidon.nima.webserver.Router;
+import io.helidon.nima.webserver.ServerContext;
+import io.helidon.nima.webserver.WebServer;
+import io.helidon.nima.webserver.spi.ServerConnectionSelector;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ConnectionConfigTest {
-
-    // ConnectionContext mockup
-    private static class TestContext implements ConnectionContext {
-
-        @Override
-        public PeerInfo remotePeer() {
-            return null;
-        }
-
-        @Override
-        public PeerInfo localPeer() {
-            return null;
-        }
-
-        @Override
-        public boolean isSecure() {
-            return false;
-        }
-
-        @Override
-        public String socketId() {
-            return null;
-        }
-
-        @Override
-        public String childSocketId() {
-            return null;
-        }
-
-        @Override
-        public ServerContext serverContext() {
-            return null;
-        }
-
-        @Override
-        public ExecutorService sharedExecutor() {
-            return null;
-        }
-
-        @Override
-        public DataWriter dataWriter() {
-            return null;
-        }
-
-        @Override
-        public DataReader dataReader() {
-            return new DataReader(new HelidonSocket() {
-                @Override
-                public void close() {
-                }
-
-                @Override
-                public int read(BufferData buffer) {
-                    return 0;
-                }
-
-                @Override
-                public void write(BufferData buffer) {
-                }
-
-                @Override
-                public PeerInfo remotePeer() {
-                    return null;
-                }
-
-                @Override
-                public PeerInfo localPeer() {
-                    return null;
-                }
-
-                @Override
-                public boolean isSecure() {
-                    return false;
-                }
-
-                @Override
-                public String socketId() {
-                    return null;
-                }
-
-                @Override
-                public String childSocketId() {
-                    return null;
-                }
-
-                @Override
-                public byte[] get() {
-                    return new byte[0];
-                }
-            });
-        }
-
-        @Override
-        public Router router() {
-            return new Router() {
-                @Override
-                public <T extends Routing> T routing(Class<T> routingType, T defaultValue) {
-                    return null;
-                }
-
-                @Override
-                public void afterStop() {
-                }
-
-                @Override
-                public void beforeStart() {
-                }
-            };
-        }
-
-        @Override
-        public long maxPayloadSize() {
-            return 0;
-        }
-
-        @Override
-        public DirectHandlers directHandlers() {
-            return null;
-        }
-
-    }
 
     @Test
     void testConnectionConfig()
@@ -188,7 +62,7 @@ public class ConnectionConfigTest {
         for (ServerConnectionSelector provider : providers) {
             if (provider instanceof Http1ConnectionSelector) {
                 haveHttp1Provider = true;
-                Http1Connection conn = (Http1Connection) provider.connection(new TestContext());
+                Http1Connection conn = (Http1Connection) provider.connection(mockContext());
                 // Verify values to be updated from configuration file
                 assertThat(conn.config().maxPrologueLength(), is(4096));
                 assertThat(conn.config().maxHeadersSize(), is(8192));
@@ -197,6 +71,14 @@ public class ConnectionConfigTest {
             }
         }
         assertThat("No Http12ConnectionProvider was found", haveHttp1Provider, is(true));
+    }
+
+    private static ConnectionContext mockContext() {
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+        when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.serverContext()).thenReturn(mock(ServerContext.class));
+        return ctx;
     }
 
 }

--- a/nima/webserver/webserver/src/test/resources/application.yaml
+++ b/nima/webserver/webserver/src/test/resources/application.yaml
@@ -26,4 +26,11 @@ server:
       validate-path: false
 
   content-encoding:
-    disable: true
+    discover-services: false
+
+server2:
+  port: 8079
+  host: 127.0.0.1
+
+  connection-providers:
+    discover-services: false

--- a/nima/webserver/webserver/src/test/resources/application.yaml
+++ b/nima/webserver/webserver/src/test/resources/application.yaml
@@ -24,3 +24,6 @@ server:
       max-headers-size: 8192
       validate-headers: false
       validate-path: false
+
+  content-encoding:
+    disable: true

--- a/nima/websocket/webserver/pom.xml
+++ b/nima/websocket/webserver/pom.xml
@@ -57,6 +57,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <artifactId>mockito-core</artifactId>
+            <groupId>org.mockito</groupId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Added `ContentEncodingSupport.Builder` and removed static content.
`ContentEncodingContext` in `Http1Connection` is taken from `ctx.serverContext()` instead of creating a new instance.
