### PR TITLE
Use Hamcrest assertions instead of JUnit in examples/integrations/micrometer/mp - backport 2.x (#1749)

### DIFF
--- a/examples/integrations/micrometer/mp/pom.xml
+++ b/examples/integrations/micrometer/mp/pom.xml
@@ -59,6 +59,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.microprofile.tests</groupId>
             <artifactId>helidon-microprofile-tests-junit5</artifactId>
             <scope>test</scope>

--- a/examples/integrations/micrometer/mp/src/test/java/io/helidon/examples/integrations/micrometer/mp/TestEndpoint.java
+++ b/examples/integrations/micrometer/mp/src/test/java/io/helidon/examples/integrations/micrometer/mp/TestEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,8 @@ import org.junit.jupiter.api.Test;
 
 import static io.helidon.examples.integrations.micrometer.mp.GreetResource.PERSONALIZED_GETS_COUNTER_NAME;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 @HelidonTest
@@ -51,7 +52,7 @@ public class TestEndpoint {
 
         String responseString = jsonObject.getString("message");
 
-        assertEquals("Hello Joe!", responseString, "Response string");
+        assertThat("Response string", responseString, is("Hello Joe!"));
         Counter counter = registry.counter(PERSONALIZED_GETS_COUNTER_NAME);
         double before = counter.count();
 
@@ -62,9 +63,9 @@ public class TestEndpoint {
 
         responseString = jsonObject.getString("message");
 
-        assertEquals("Hello Jose!", responseString, "Response string");
+        assertThat("Response string", responseString, is("Hello Jose!"));
         double after = counter.count();
-        assertEquals(1d, after - before, "Difference in personalized greeting counter between successive calls");
+        assertThat("Difference in personalized greeting counter between successive calls", after - before, is(1d));
 
     }
 }


### PR DESCRIPTION
Part of #1749

[Original PR](https://github.com/helidon-io/helidon/pull/5937)