### PR TITLE
[2.x] Switch default back-pressure strategy to AUTO_FLUSH from LINEAR

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -571,7 +571,7 @@ public interface ServerConfiguration extends SocketConfiguration {
          * <li>PREFETCH - After first data chunk arrives, probable number of chunks needed to fill the buffer up to watermark is calculated and requested.</li>
          * <li>NONE - No backpressure is applied, Long.MAX_VALUE(unbounded) is requested from upstream.</li>
          * </ul>
-         * @param backpressureStrategy One of NONE, PREFETCH or LINEAR, default is LINEAR
+         * @param backpressureStrategy One of NONE, PREFETCH, LINEAR or AUTO_FLUSH, default is AUTO_FLUSH
          * @return an updated builder
          */
         @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
@@ -226,11 +226,12 @@ public interface SocketConfiguration {
 
     /**
      * Strategy for applying backpressure to the reactive stream of response data.
+     * Switched default to {@link BackpressureStrategy#AUTO_FLUSH} since 2.5.6.
      *
      * @return strategy identifier for applying backpressure
      */
     default BackpressureStrategy backpressureStrategy() {
-        return BackpressureStrategy.LINEAR;
+        return BackpressureStrategy.AUTO_FLUSH;
     }
 
     /**
@@ -508,10 +509,10 @@ public interface SocketConfiguration {
          * <li>PREFETCH - After first data chunk arrives, probable number of chunks needed to fill the buffer up to watermark is calculated and requested.</li>
          * <li>NONE - No backpressure is applied, Long.MAX_VALUE(unbounded) is requested from upstream.</li>
          * </ul>
-         * @param backpressureStrategy One of NONE, PREFETCH or LINEAR, default is LINEAR
+         * @param backpressureStrategy One of NONE, PREFETCH, LINEAR or AUTO_FLUSH, default is AUTO_FLUSH
          * @return this builder
          */
-        @ConfiguredOption("LINEAR")
+        @ConfiguredOption("AUTO_FLUSH")
         B backpressureStrategy(BackpressureStrategy backpressureStrategy);
 
         /**
@@ -663,7 +664,7 @@ public interface SocketConfiguration {
         private int initialBufferSize = 128;
         private boolean enableCompression = false;
         private long maxPayloadSize = -1;
-        private BackpressureStrategy backpressureStrategy = BackpressureStrategy.LINEAR;
+        private BackpressureStrategy backpressureStrategy = BackpressureStrategy.AUTO_FLUSH;
         private boolean continueImmediately = false;
         private int maxUpgradeContentLength = 64 * 1024;
         private long maxBufferSize = 5 * 1024 * 1024;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
@@ -226,7 +226,7 @@ public interface SocketConfiguration {
 
     /**
      * Strategy for applying backpressure to the reactive stream of response data.
-     * Switched default to {@link BackpressureStrategy#AUTO_FLUSH} since 2.5.6.
+     * Switched default to {@link BackpressureStrategy#AUTO_FLUSH} since 2.5.7.
      *
      * @return strategy identifier for applying backpressure
      */

--- a/webserver/webserver/src/test/java/io/helidon/webserver/WaterMarkedBackpressureIT.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/WaterMarkedBackpressureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,19 @@ public class WaterMarkedBackpressureIT {
     @AfterMethod
     void tearDown() {
         executorService.shutdown();
+    }
+
+    /**
+     * Verifies default back-pressure strategy is {@link BackpressureStrategy#AUTO_FLUSH}
+     * on all sockets.
+     */
+    @Test
+    void defaultStrategy() {
+        WebServer webServer = WebServer.builder().build();
+        webServer.configuration()
+                .sockets()
+                .values()
+                .forEach(sc -> assertThat(sc.backpressureStrategy(), is(AUTO_FLUSH)));
     }
 
     @Test


### PR DESCRIPTION

Switch default back-pressure strategy to AUTO_FLUSH from LINEAR. LINEAR can cause problems writing payloads over 5 MB.