### PR TITLE
helidon metrics to oci integration

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1039,6 +1039,16 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.helidon.integrations.oci.metrics</groupId>
+                <artifactId>helidon-integrations-oci-metrics</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.integrations.oci.metrics</groupId>
+                <artifactId>helidon-integrations-oci-metrics-cdi</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.helidon.integrations.vault</groupId>
                 <artifactId>helidon-integrations-vault</artifactId>
                 <version>${helidon.version}</version>

--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations.oci.metrics</groupId>
+        <artifactId>helidon-integrations-oci-metrics-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-integrations-oci-metrics-cdi</artifactId>
+    <name>Helidon Integrations OCI Metrics CDI</name>
+    <description>Helidon Metrics to OCI via CDI</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.integrations.oci.metrics</groupId>
+            <artifactId>helidon-integrations-oci-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import io.helidon.config.Config;
+import io.helidon.integrations.oci.metrics.OciMetricsSupport;
+import io.helidon.microprofile.server.RoutingBuilders;
+
+import com.oracle.bmc.monitoring.Monitoring;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
+
+/**
+ * OCI metrics integration CDI extension.
+ */
+
+// This bean is added to handle injection on the ObserverMethod as it does not work on an Extension class.
+@Singleton
+public class OciMetricsBean {
+
+    // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
+    void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object ignore,
+                            Config config, Monitoring monitoringClient) {
+        Config helidonConfig =  config.get("ocimetrics");
+        if (helidonConfig.exists()) {
+            OciMetricsSupport.Builder builder = OciMetricsSupport.builder()
+                    .config(helidonConfig)
+                    .monitoringClient(monitoringClient);
+
+            RoutingBuilders.create(helidonConfig)
+                    .routingBuilder()
+                    .register(builder.build());
+        }
+    }
+}

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+
+/**
+ * OCI metrics integration CDI extension.
+ */
+public class OciMetricsCdiExtension implements Extension {
+
+    // A new bean is added to handle the Observer Method as injection does not work here
+    void addOciMetricsBean(@Observes BeforeBeanDiscovery event) {
+        event.addAnnotatedType(OciMetricsBean.class, OciMetricsBean.class.getName());
+    }
+}

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/package-info.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Integrating with OCI Metrics Using CDI.
+ */
+package io.helidon.integrations.oci.metrics.cdi;

--- a/integrations/oci/metrics/cdi/src/main/java/module-info.java
+++ b/integrations/oci/metrics/cdi/src/main/java/module-info.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Integrating with OCI Metrics Using CDI.
+ */
+module io.helidon.integrations.oci.metrics.cdi {
+    requires io.helidon.config.mp;
+    requires io.helidon.integrations.oci.metrics;
+    requires io.helidon.microprofile.config;
+    requires io.helidon.microprofile.server;
+
+    requires oci.java.sdk.monitoring;
+
+    requires jakarta.interceptor.api;
+    provides jakarta.enterprise.inject.spi.Extension with io.helidon.integrations.oci.metrics.cdi.OciMetricsCdiExtension;
+
+    opens io.helidon.integrations.oci.metrics.cdi to weld.core.impl, io.helidon.microprofile.cdi;
+
+    exports io.helidon.integrations.oci.metrics.cdi;
+}

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import static jakarta.interceptor.Interceptor.Priority.APPLICATION;
+
+import com.oracle.bmc.Region;
+import com.oracle.bmc.monitoring.Monitoring;
+import com.oracle.bmc.monitoring.MonitoringPaginators;
+import com.oracle.bmc.monitoring.MonitoringWaiters;
+import com.oracle.bmc.monitoring.model.MetricDataDetails;
+import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
+import com.oracle.bmc.monitoring.requests.*;
+import com.oracle.bmc.monitoring.responses.*;
+
+import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.microprofile.config.ConfigCdiExtension;
+import io.helidon.microprofile.server.ServerCdiExtension;
+import io.helidon.microprofile.server.JaxRsCdiExtension;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.DisableDiscovery;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest(resetPerTest = true)
+@AddBean(OciMetricsCdiExtensionTest.MockMonitoring.class)
+@DisableDiscovery
+// Helidon MP Extensions
+@AddExtension(ServerCdiExtension.class)
+@AddExtension(JaxRsCdiExtension.class)
+@AddExtension(ConfigCdiExtension.class)
+// OciMetricsCdiExtension
+@AddExtension(OciMetricsCdiExtension.class)
+// ConfigSources
+@AddConfig(key = "ocimetrics.compartmentId",
+           value = OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.compartmentId)
+@AddConfig(key = "ocimetrics.namespace",
+           value = OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.namespace)
+@AddConfig(key = "ocimetrics.resourceGroup",
+           value =  OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.resourceGroup)
+@AddConfig(key = "ocimetrics.initialDelay", value = "1")
+@AddConfig(key = "ocimetrics.delay", value = "2")
+public class OciMetricsCdiExtensionTest {
+    private final RegistryFactory rf = RegistryFactory.getInstance();
+    private final MetricRegistry baseMetricRegistry = rf.getRegistry(MetricRegistry.Type.BASE);
+    private final MetricRegistry vendorMetricRegistry = rf.getRegistry(MetricRegistry.Type.VENDOR);
+    private final MetricRegistry appMetricRegistry = rf.getRegistry(MetricRegistry.Type.APPLICATION);
+    private static volatile int testMetricCount = 0;
+    // Use countDownLatch1 to signal the test that results to be asserted has been retrieved
+    private static CountDownLatch countDownLatch1 = new CountDownLatch(1);
+    private static PostMetricDataDetails postMetricDataDetails;
+
+    @Test
+    public void testRegisterOciMetrics() throws InterruptedException {
+        baseMetricRegistry.counter("baseDummyCounter").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter").inc();
+        appMetricRegistry.counter("appDummyCounter").inc();
+        // Wait for signal from metric update that testMetricCount has been retrieved
+        countDownLatch1.await(10, TimeUnit.SECONDS);
+
+        assertThat(testMetricCount, is(equalTo(3)));
+
+        MetricDataDetails metricDataDetails = postMetricDataDetails.getMetricData().get(0);
+        assertThat(metricDataDetails.getCompartmentId(),
+                   is(equalTo(OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.compartmentId)));
+        assertThat(metricDataDetails.getNamespace(), is(equalTo(MetricDataDetailsOCIParams.namespace)));
+        assertThat(metricDataDetails.getResourceGroup(), is(equalTo(MetricDataDetailsOCIParams.resourceGroup)));
+    }
+
+    @Alternative
+    @Priority(APPLICATION + 1)
+    static class MockMonitoring implements Monitoring {
+        @Override
+        public void setEndpoint(String s) {}
+
+        @Override
+        public String getEndpoint() {return "http://www.DummyEndpoint.com";}
+
+        @Override
+        public void setRegion(Region region) {}
+
+        @Override
+        public void setRegion(String s) {}
+
+        @Override
+        public void refreshClient() {}
+
+        @Override
+        public ChangeAlarmCompartmentResponse changeAlarmCompartment(ChangeAlarmCompartmentRequest changeAlarmCompartmentRequest) {
+            return null;
+        }
+
+        @Override
+        public CreateAlarmResponse createAlarm(CreateAlarmRequest createAlarmRequest) {return null;}
+
+        @Override
+        public DeleteAlarmResponse deleteAlarm(DeleteAlarmRequest deleteAlarmRequest) {return null;}
+
+        @Override
+        public GetAlarmResponse getAlarm(GetAlarmRequest getAlarmRequest) {return null;}
+
+        @Override
+        public GetAlarmHistoryResponse getAlarmHistory(GetAlarmHistoryRequest getAlarmHistoryRequest) {return null;}
+
+        @Override
+        public ListAlarmsResponse listAlarms(ListAlarmsRequest listAlarmsRequest) {return null;}
+
+        @Override
+        public ListAlarmsStatusResponse listAlarmsStatus(ListAlarmsStatusRequest listAlarmsStatusRequest) {
+            return null;
+        }
+
+        @Override
+        public ListMetricsResponse listMetrics(ListMetricsRequest listMetricsRequest) {return null;}
+
+        @Override
+        public PostMetricDataResponse postMetricData(PostMetricDataRequest postMetricDataRequest) {
+            postMetricDataDetails = postMetricDataRequest.getPostMetricDataDetails();
+            testMetricCount = postMetricDataDetails.getMetricData().size();
+            // Give signal that testMetricCount was retrieved
+            countDownLatch1.countDown();
+            return PostMetricDataResponse.builder()
+                    .__httpStatusCode__(200)
+                    .build();
+        }
+
+        @Override
+        public RemoveAlarmSuppressionResponse removeAlarmSuppression(RemoveAlarmSuppressionRequest removeAlarmSuppressionRequest) {
+            return null;
+        }
+
+        @Override
+        public RetrieveDimensionStatesResponse retrieveDimensionStates(RetrieveDimensionStatesRequest retrieveDimensionStatesRequest) {
+            return null;
+        }
+
+        @Override
+        public SummarizeMetricsDataResponse summarizeMetricsData(SummarizeMetricsDataRequest summarizeMetricsDataRequest) {
+            return null;
+        }
+
+        @Override
+        public UpdateAlarmResponse updateAlarm(UpdateAlarmRequest updateAlarmRequest) {return null;}
+
+        @Override
+        public MonitoringWaiters getWaiters() {return null;}
+
+        @Override
+        public MonitoringPaginators getPaginators() {return null;}
+
+        @Override
+        public void close() throws Exception {}
+    }
+
+    public interface MetricDataDetailsOCIParams {
+        String compartmentId = "dummy.compartmentId";
+        String namespace = "dummy-namespace";
+        String resourceGroup = "dummy_resourceGroup";
+    }
+
+    private static void delay(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ignore) {
+        }
+    }
+}

--- a/integrations/oci/metrics/metrics/pom.xml
+++ b/integrations/oci/metrics/metrics/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations.oci.metrics</groupId>
+        <artifactId>helidon-integrations-oci-metrics-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-integrations-oci-metrics</artifactId>
+    <name>Helidon Integrations OCI Metrics</name>
+    <description>Helidon Metrics to OCI</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.nima.webserver</groupId>
+            <artifactId>helidon-nima-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-monitoring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-metadata</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-metadata-processor</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsData.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsData.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import com.oracle.bmc.monitoring.model.Datapoint;
+import com.oracle.bmc.monitoring.model.MetricDataDetails;
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.SimpleTimer;
+import org.eclipse.microprofile.metrics.Snapshot;
+import org.eclipse.microprofile.metrics.Timer;
+
+class OciMetricsData {
+    private static final UnitConverter STORAGE_UNIT_CONVERTER = UnitConverter.storageUnitConverter();
+    private static final UnitConverter TIME_UNIT_CONVERTER = UnitConverter.timeUnitConverter();
+    private static final List<UnitConverter> UNIT_CONVERTERS = List.of(STORAGE_UNIT_CONVERTER, TIME_UNIT_CONVERTER);
+
+    private final Map<MetricRegistry, MetricRegistry.Type> metricRegistries;
+    private final OciMetricsSupport.NameFormatter nameFormatter;
+    private final String compartmentId;
+    private final String namespace;
+    private final String resourceGroup;
+    private final boolean descriptionEnabled;
+
+    OciMetricsData(
+            Map<MetricRegistry, MetricRegistry.Type> metricRegistries,
+            OciMetricsSupport.NameFormatter nameFormatter,
+            String compartmentId,
+            String namespace,
+            String resourceGroup,
+            boolean descriptionEnabled) {
+        this.metricRegistries = metricRegistries;
+        this.compartmentId = compartmentId;
+        this.nameFormatter = nameFormatter;
+        this.namespace = namespace;
+        this.resourceGroup = resourceGroup;
+        this.descriptionEnabled = descriptionEnabled;
+    }
+
+    List<MetricDataDetails> getMetricDataDetails() {
+        List<MetricDataDetails> allMetricDataDetails = new ArrayList<>();
+        for (MetricRegistry metricRegistry : metricRegistries.keySet()) {
+            metricRegistry.getMetrics().entrySet().stream()
+                    .flatMap(entry -> metricDataDetails(metricRegistry, entry.getKey(), entry.getValue()))
+                    .forEach(allMetricDataDetails::add);
+        }
+        return allMetricDataDetails;
+    }
+
+    Stream<MetricDataDetails> metricDataDetails(MetricRegistry metricRegistry, MetricID metricId, Metric metric) {
+        if (metric instanceof Counter) {
+            return forCounter(metricRegistry, metricId, ((Counter) metric));
+        } else if (metric instanceof ConcurrentGauge) {
+            return forConcurrentGauge(metricRegistry, metricId, ((ConcurrentGauge) metric));
+        } else if (metric instanceof Meter) {
+            return forMeter(metricRegistry, metricId, ((Meter) metric));
+        } else if (metric instanceof Gauge<?>) {
+            return forGauge(metricRegistry, metricId, ((Gauge<? extends Number>) metric));
+        } else if (metric instanceof SimpleTimer) {
+            return forSimpleTimer(metricRegistry, metricId, ((SimpleTimer) metric));
+        } else if (metric instanceof Timer) {
+            return forTimer(metricRegistry, metricId, ((Timer) metric));
+        } else if (metric instanceof Histogram) {
+            return forHistogram(metricRegistry, metricId, ((Histogram) metric));
+        } else {
+            return Stream.empty();
+        }
+    }
+
+    private Stream<MetricDataDetails> forCounter(MetricRegistry metricRegistry, MetricID metricId, Counter counter) {
+        return Stream.of(metricDataDetails(metricRegistry, metricId, null, counter.getCount()));
+    }
+
+    private Stream<MetricDataDetails> forConcurrentGauge(
+            MetricRegistry metricRegistry, MetricID metricId, ConcurrentGauge concurrentGauge) {
+        Stream.Builder<MetricDataDetails> result = Stream.builder();
+        long count = concurrentGauge.getCount();
+        result.add(metricDataDetails(metricRegistry, metricId, null, count));
+        if (count > 0) {
+            result.add(metricDataDetails(metricRegistry, metricId, "min", concurrentGauge.getMin()));
+            result.add(metricDataDetails(metricRegistry, metricId, "max", concurrentGauge.getMax()));
+        }
+        return result.build();
+    }
+
+    private Stream<MetricDataDetails> forMeter(MetricRegistry metricRegistry, MetricID metricId, Meter meter) {
+        Stream.Builder<MetricDataDetails> result = Stream.builder();
+        long count = meter.getCount();
+        result.add(metricDataDetails(metricRegistry, metricId, "total", count));
+        if (count > 0) {
+            result.add(metricDataDetails(metricRegistry, metricId, "gauge", meter.getMeanRate()));
+            result.add(metricDataDetails(metricRegistry, metricId, "one_minute_rate", meter.getOneMinuteRate()));
+            result.add(metricDataDetails(metricRegistry, metricId, "five_minute_rate", meter.getFiveMinuteRate()));
+            result.add(metricDataDetails(metricRegistry, metricId, "fifteen_minute_rate", meter.getFifteenMinuteRate()));
+        }
+        return result.build();
+    }
+
+    private Stream<MetricDataDetails> forGauge(MetricRegistry metricRegistry, MetricID metricId, Gauge<? extends Number> gauge) {
+        return Stream.of(metricDataDetails(metricRegistry, metricId, null, gauge.getValue().doubleValue()));
+    }
+
+    private Stream<MetricDataDetails> forSimpleTimer(MetricRegistry metricRegistry, MetricID metricId, SimpleTimer simpleTimer) {
+        Stream.Builder<MetricDataDetails> result = Stream.builder();
+        long count = simpleTimer.getCount();
+        result.add(metricDataDetails(metricRegistry, metricId, "total", count));
+        if (count > 0) {
+            result.add(metricDataDetails(metricRegistry,
+                                         metricId,
+                                         "elapsedTime_seconds",
+                                         simpleTimer.getElapsedTime().toSeconds()));
+        }
+        return result.build();
+    }
+
+    private Stream<MetricDataDetails> forTimer(MetricRegistry metricRegistry, MetricID metricId, Timer timer) {
+        Stream.Builder<MetricDataDetails> result = Stream.builder();
+        long count = timer.getCount();
+        result.add(metricDataDetails(metricRegistry, metricId, "seconds_count", count));
+        if (count > 0) {
+            Snapshot snapshot = timer.getSnapshot();
+            result.add(metricDataDetails(metricRegistry,
+                                         metricId,
+                                         "mean_seconds",
+                                         snapshot.getMean()));
+            result.add(metricDataDetails(metricRegistry,
+                                         metricId,
+                                         "min_seconds",
+                                         snapshot.getMin()));
+            result.add(metricDataDetails(metricRegistry,
+                                         metricId,
+                                        "max_seconds",
+                                         snapshot.getMax()));
+        }
+        return result.build();
+    }
+
+    private Stream<MetricDataDetails> forHistogram(MetricRegistry metricRegistry, MetricID metricId, Histogram histogram) {
+        Stream.Builder<MetricDataDetails> result = Stream.builder();
+        long count = histogram.getCount();
+        Metadata metadata = metricRegistry.getMetadata().get(metricId.getName());
+        String units = metadata.getUnit();
+        String unitsPrefix = units != null && !Objects.equals(units, MetricUnits.NONE) ? units + "_" : "";
+        String unitsSuffix = units != null && !Objects.equals(units, MetricUnits.NONE) ? "_" + units : "";
+        result.add(metricDataDetails(metricRegistry, metricId, unitsPrefix + "count", count));
+        if (count > 0) {
+            Snapshot snapshot = histogram.getSnapshot();
+            result.add(metricDataDetails(metricRegistry,
+                                         metricId,
+                                         "mean" + unitsSuffix,
+                                         snapshot.getMean()));
+            result.add(metricDataDetails(metricRegistry,
+                                         metricId,
+                                         "min" + unitsSuffix,
+                                         snapshot.getMin()));
+            result.add(metricDataDetails(metricRegistry,
+                                         metricId,
+                                         "max" + unitsSuffix,
+                                         snapshot.getMax()));
+        }
+        return result.build();
+    }
+
+    private MetricDataDetails metricDataDetails(
+            MetricRegistry metricRegistry, MetricID metricId, String suffix, double value) {
+        if (Double.isNaN(value)) {
+            return null;
+        }
+
+        Metadata metadata = metricRegistry.getMetadata().get(metricId.getName());
+        Map<String, String> dimensions = dimensions(metricId, metricRegistry);
+        List<Datapoint> datapoints = datapoints(metadata, value);
+        String metricName = nameFormatter.format(metricId, suffix, metadata);
+        return MetricDataDetails.builder()
+                .compartmentId(compartmentId)
+                .name(metricName)
+                .namespace(namespace)
+                .resourceGroup(resourceGroup)
+                .metadata(ociMetadata(metadata))
+                .datapoints(datapoints)
+                .dimensions(dimensions)
+                .build();
+    }
+
+    private Map<String, String> dimensions(MetricID metricId, MetricRegistry metricRegistry) {
+        String registryType = metricRegistries.get(metricRegistry).getName();
+        Map<String, String> result = new HashMap<>(metricId.getTags());
+        result.put("scope", registryType);
+        return result;
+    }
+
+    private double convertUnits(String metricUnits, double value) {
+        for (UnitConverter converter : UNIT_CONVERTERS) {
+            if (converter.handles(metricUnits)) {
+                return converter.convert(metricUnits, value);
+            }
+        }
+        return value;
+    }
+
+    private List<Datapoint> datapoints(Metadata metadata, double value) {
+        return Collections.singletonList(Datapoint.builder()
+                                                 .value(convertUnits(metadata.getUnit(), value))
+                                                 .timestamp(new Date())
+                                                 .build());
+    }
+
+    private Map<String, String> ociMetadata(Metadata metadata) {
+        return (descriptionEnabled && metadata.getDescription() != null && !metadata.getDescription().isEmpty())
+                ? Collections.singletonMap("description",
+                                           metadata.getDescription().length() <= 256
+                                                   ? metadata.getDescription()
+                                                   // trim metadata value as oci metadata.value has a maximum of 256 characters
+                                                   : metadata.getDescription().substring(0, 256))
+                : null;
+    }
+}

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import io.helidon.config.Config;
+import io.helidon.config.metadata.Configured;
+import io.helidon.config.metadata.ConfiguredOption;
+import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.nima.webserver.Routing;
+import io.helidon.nima.webserver.http.HttpRules;
+import io.helidon.nima.webserver.http.HttpService;
+
+import com.oracle.bmc.monitoring.Monitoring;
+import com.oracle.bmc.monitoring.model.MetricDataDetails;
+import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
+import com.oracle.bmc.monitoring.requests.PostMetricDataRequest;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
+
+/**
+ * OCI Metrics Support
+ * <p>
+ * Even though this service does not create an endpoint, a calling SE app should still register it by invoking
+ * {@link Routing.Rules#register(io.helidon.webserver.Service...)}, as it should with any service it uses. That allows
+ * this service to detect when the webserver shuts down so it can shut down as well.
+ * </p>
+ */
+public class OciMetricsSupport implements HttpService {
+    private static final Logger LOGGER = Logger.getLogger(OciMetricsSupport.class.getName());
+
+    private static final UnitConverter STORAGE_UNIT_CONVERTER = UnitConverter.storageUnitConverter();
+    private static final UnitConverter TIME_UNIT_CONVERTER = UnitConverter.timeUnitConverter();
+    private static final List<UnitConverter> UNIT_CONVERTERS = List.of(STORAGE_UNIT_CONVERTER, TIME_UNIT_CONVERTER);
+    private static final NameFormatter DEFAULT_NAME_FORMATTER = new NameFormatter() { };
+
+    private ScheduledExecutorService scheduledExecutorService;
+
+    private final String compartmentId;
+    private final String namespace;
+    private final NameFormatter nameFormatter;
+    private final long initialDelay;
+    private final long delay;
+    private final long batchDelay;
+    private final TimeUnit schedulingTimeUnit;
+    private final String resourceGroup;
+    private final boolean descriptionEnabled;
+    private final Type[] scopes;
+    private final int batchSize;
+    private final boolean enabled;
+    private final AtomicInteger webServerCounter = new AtomicInteger(0);
+
+    private final Monitoring monitoringClient;
+
+    private final Map<MetricRegistry, Type> metricRegistries = new HashMap<>();
+    private OciMetricsData ociMetricsData;
+
+    private OciMetricsSupport(Builder builder) {
+        initialDelay = builder.initialDelay;
+        delay = builder.delay;
+        batchDelay = builder.batchDelay;
+        schedulingTimeUnit = builder.schedulingTimeUnit;
+        compartmentId = builder.compartmentId;
+        namespace = builder.namespace;
+        nameFormatter = builder.nameFormatter;
+        resourceGroup = builder.resourceGroup;
+        descriptionEnabled = builder.descriptionEnabled;
+        scopes = builder.scopes;
+        batchSize = builder.batchSize;
+        enabled = builder.enabled;
+        this.monitoringClient = builder.monitoringClient;
+    }
+
+    /**
+     * Returns a new {@code Builder} for creating an instance of {@code OciMetricsSupport}.
+     *
+     * @return new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Prescribes behavior for formatting metric names for use by OCI.
+     */
+    public interface NameFormatter {
+
+        /**
+         * Formats a metric name for OCI.
+         * <p>
+         *     The default implementation creates an OCI metric name with this format:
+         *     {@code metric-name[_suffix][_units]}
+         *     where {@code _suffix} is omitted if the caller passes a null suffix, and {@code _units} is omitted if the metrics
+         *     metadata does not have units set or, in translating the units for OCI, the result is blank.
+         * </p>
+         *
+         * @param metricId {@code MetricID} of the metric being formatted
+         * @param suffix name suffix to append to the recorded metric name (e.g, "total"); can be null
+         * @param metadata metric metadata describing the metric
+         * @return the formatted metric name
+         */
+        default String format(MetricID metricId, String suffix, Metadata metadata) {
+
+            MetricType metricType = metadata.getTypeRaw();
+
+            StringBuilder result = new StringBuilder(metricId.getName());
+            if (suffix != null) {
+                result.append("_").append(suffix);
+            }
+            result.append("_").append(metricType.toString().replace(" ", "_"));
+
+            String units = formattedBaseUnits(metadata.getUnit());
+            if (units != null && !units.isBlank()) {
+                result.append("_").append(units);
+            }
+            return result.toString();
+        }
+    }
+
+    static String formattedBaseUnits(String metricUnits) {
+        String baseUnits = baseMetricUnits(metricUnits);
+        return baseUnits == null ? "" : baseUnits;
+    }
+
+    static String baseMetricUnits(String metricUnits) {
+        if (!MetricUnits.NONE.equals(metricUnits) && !metricUnits.isEmpty()) {
+            for (UnitConverter converter : UNIT_CONVERTERS) {
+                if (converter.handles(metricUnits)) {
+                    return converter.baseUnits();
+                }
+            }
+        }
+        return null;
+    }
+
+    private void startExecutor() {
+        scheduledExecutorService = Executors.newScheduledThreadPool(1);
+        scheduledExecutorService.scheduleAtFixedRate(this::pushMetrics, initialDelay, delay, schedulingTimeUnit);
+    }
+
+    private void pushMetrics() {
+        List<MetricDataDetails> allMetricDataDetails = ociMetricsData.getMetricDataDetails();
+        LOGGER.finest(String.format("Processing %d metrics", allMetricDataDetails.size()));
+
+        if (allMetricDataDetails.size() > 0) {
+            while (true) {
+                if (allMetricDataDetails.size() > batchSize) {
+                    postBatch(allMetricDataDetails.subList(0, batchSize));
+                    // discard metrics that had been posted
+                    allMetricDataDetails.subList(0, batchSize).clear();
+                    if (batchDelay > 0L) {
+                        try {
+                            schedulingTimeUnit.sleep(batchDelay);
+                        } catch (InterruptedException ignore) {
+                        }
+                    }
+                } else {
+                    postBatch(allMetricDataDetails);
+                    break;
+                }
+            }
+        }
+    }
+
+    private void postBatch(List<MetricDataDetails> metricDataDetailsList) {
+        PostMetricDataDetails postMetricDataDetails = PostMetricDataDetails.builder()
+                .metricData(metricDataDetailsList)
+                .build();
+
+        PostMetricDataRequest postMetricDataRequest = PostMetricDataRequest.builder()
+                .postMetricDataDetails(postMetricDataDetails)
+                .build();
+
+        LOGGER.finest(String.format("Pushing %d metrics to OCI", metricDataDetailsList.size()));
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            metricDataDetailsList
+                    .forEach(m -> {
+                        LOGGER.finest(String.format(
+                                "Metric details: name=%s, namespace=%s, dimensions=%s, "
+                                        + "datapoints.timestamp=%s, datapoints.value=%f, metadata=%s",
+                                m.getName(),
+                                m.getNamespace(),
+                                m.getDimensions(),
+                                m.getDatapoints().get(0).getTimestamp(),
+                                m.getDatapoints().get(0).getValue(),
+                                m.getMetadata()));
+                    });
+        }
+        String originalMonitoringEndpoint = this.monitoringClient.getEndpoint();
+        try {
+            // Use the ingestion endpoint for posting
+            this.monitoringClient.setEndpoint(
+                    monitoringClient.getEndpoint().replaceFirst("telemetry\\.", "telemetry-ingestion."));
+            this.monitoringClient.postMetricData(postMetricDataRequest);
+            LOGGER.finest(String.format("Successfully posted %d metrics to OCI", metricDataDetailsList.size()));
+        } catch (Throwable e) {
+            LOGGER.warning(String.format("Unable to send metrics to OCI: %s", e.getMessage()));
+        } finally {
+            // restore original endpoint
+            this.monitoringClient.setEndpoint(originalMonitoringEndpoint);
+        }
+    }
+
+    @Override
+    public void routing(HttpRules rules) {
+        // noop
+    }
+
+    @Override
+    public void beforeStart() {
+        if (!enabled) {
+            LOGGER.info("Metric push to OCI is disabled!");
+            return;
+        }
+
+        if (scopes.length == 0) {
+            LOGGER.info("No selected metric scopes to push to OCI");
+            return;
+        }
+
+        LOGGER.fine("Starting OCI Metrics agent");
+
+        RegistryFactory rf = RegistryFactory.getInstance();
+        Stream.of(scopes)
+                .forEach(type -> metricRegistries.put(rf.getRegistry(type), type));
+
+        ociMetricsData = new OciMetricsData(
+                metricRegistries, nameFormatter, compartmentId, namespace, resourceGroup, descriptionEnabled);
+        startExecutor();
+    }
+
+    @Override
+    public void afterStop() {
+        // Shutdown executor if created
+        if (scheduledExecutorService != null) {
+            LOGGER.fine("Shutting down OCI Metrics agent");
+            scheduledExecutorService.shutdownNow();
+        }
+    }
+
+    /**
+     * Fluent API builder to create {@link OciMetricsSupport}.
+     */
+    @Configured
+    public static class Builder implements io.helidon.common.Builder<Builder, OciMetricsSupport> {
+
+        private static final long DEFAULT_SCHEDULER_INITIAL_DELAY = 1L;
+        private static final long DEFAULT_SCHEDULER_DELAY = 60L;
+        private static final long DEFAULT_BATCH_DELAY = 1L;
+        private static final TimeUnit DEFAULT_SCHEDULER_TIME_UNIT = TimeUnit.SECONDS;
+        private static final int DEFAULT_BATCH_SIZE = 50;
+
+        private static final Map<String, Type> SCOPE_TYPES = Map.of(
+                Type.BASE.getName(), Type.BASE,
+                Type.VENDOR.getName(), Type.VENDOR,
+                Type.APPLICATION.getName(), Type.APPLICATION
+        );
+
+        private long initialDelay = DEFAULT_SCHEDULER_INITIAL_DELAY;
+        private long delay = DEFAULT_SCHEDULER_DELAY;
+        private long batchDelay = DEFAULT_BATCH_DELAY;
+        private TimeUnit schedulingTimeUnit = DEFAULT_SCHEDULER_TIME_UNIT;
+        private String compartmentId;
+        private String namespace;
+        private NameFormatter nameFormatter = DEFAULT_NAME_FORMATTER;
+        private String resourceGroup;
+        private Type[] scopes = getAllMetricScopes();
+        private boolean descriptionEnabled = true;
+        private int batchSize = DEFAULT_BATCH_SIZE;
+        private boolean enabled = true;
+        private Monitoring monitoringClient;
+
+        @Override
+        public OciMetricsSupport build() {
+            if (monitoringClient == null) {
+                throw new IllegalArgumentException("Monitoring client must be set in builder before building it");
+            }
+            return new OciMetricsSupport(this);
+        }
+
+        /**
+         * Sets the initial delay before metrics are sent to OCI
+         * (defaults to {@value #DEFAULT_SCHEDULER_INITIAL_DELAY}).
+         *
+         * @param value initial delay, expressed in time units set by {@link #schedulingTimeUnit(TimeUnit)}
+         * @return updated builder
+         */
+        @ConfiguredOption(value = "1")
+        public Builder initialDelay(long value) {
+            initialDelay = value;
+            return this;
+        }
+
+        /**
+         * Sets the delay interval between metric posting
+         * (defaults to {@value #DEFAULT_SCHEDULER_DELAY}).
+         *
+         * @param value delay, expressed in time units set by {@link #schedulingTimeUnit(TimeUnit)}
+         * @return updated builder
+         */
+        @ConfiguredOption(value = "60")
+        public Builder delay(long value) {
+            delay = value;
+            return this;
+        }
+
+        /**
+         * Sets the delay interval if metrics are posted in batches
+         * (defaults to {@value #DEFAULT_BATCH_DELAY}).
+         *
+         * @param value batch delay, expressed in time units set by {@link #schedulingTimeUnit(TimeUnit)}
+         * @return updated builder
+         */
+        @ConfiguredOption(value = "1")
+        public Builder batchDelay(long value) {
+            batchDelay = value;
+            return this;
+        }
+
+        /**
+         * Sets the time unit applied to the initial delay and delay values (defaults to {@code TimeUnit.SECONDS}).
+         *
+         * @param timeUnit unit of time
+         * @return updated builder
+         */
+        @ConfiguredOption(value = "TimeUnit.SECONDS")
+        public Builder schedulingTimeUnit(TimeUnit timeUnit) {
+            Objects.requireNonNull(timeUnit);
+
+            schedulingTimeUnit = timeUnit;
+            return this;
+        }
+
+        /**
+         * Sets the compartment ID.
+         *
+         * @param value compartment ID
+         * @return updated builder
+         */
+        @ConfiguredOption
+        public Builder compartmentId(String value) {
+            Objects.requireNonNull(value);
+
+            compartmentId = value;
+            return this;
+        }
+
+        /**
+         * Sets the namespace.
+         *
+         * @param value namespace
+         * @return updated builder
+         */
+        @ConfiguredOption
+        public Builder namespace(String value) {
+            Objects.requireNonNull(value);
+
+            namespace = value;
+            return this;
+        }
+
+        /**
+         * Sets the {@link NameFormatter} to use in formatting metric
+         * names. See the
+         * {@link NameFormatter#format(
+         * MetricID, String, Metadata)} method for details
+         * about the default formatting.
+         *
+         * @param nameFormatter the formatter to use
+         * @return updated builder
+         */
+        public Builder nameFormatter(NameFormatter nameFormatter) {
+            Objects.requireNonNull(nameFormatter);
+
+            this.nameFormatter = nameFormatter;
+            return this;
+        }
+
+        /**
+         * Sets the resource group.
+         *
+         * @param value resource group
+         * @return updated builder
+         */
+        @ConfiguredOption
+        public Builder resourceGroup(String value) {
+            Objects.requireNonNull(value);
+
+            resourceGroup = value;
+            return this;
+        }
+
+        /**
+         * Sets whether the description should be enabled or not.
+         * <p>
+         *     Defaults to {@code true}.
+         * </p>
+         *
+         * @param value enabled
+         * @return updated builder
+         */
+        @ConfiguredOption(value = "true")
+        public Builder descriptionEnabled(boolean value) {
+            descriptionEnabled = value;
+            return this;
+        }
+
+        /**
+         * Sets which metrics scopes (e.g., base, vendor, application) should be sent to OCI.
+         * <p>
+         *     If this method is never invoked, defaults to all scopes.
+         * </p>
+         *
+         * @param value array of metric scopes to process
+         * @return updated builder
+         */
+        @ConfiguredOption(value = "All scopes")
+        public Builder scopes(String[] value) {
+            Objects.requireNonNull(value);
+
+            return scopes(Arrays.asList(value));
+        }
+
+        private Builder scopes(List<String> value) {
+            if (value == null || value.isEmpty()) {
+                this.scopes = getAllMetricScopes();
+            } else {
+                List<Type> convertedScope = new ArrayList<>();
+                for (String element: value) {
+                    Type scopeItem = SCOPE_TYPES.get(element.toLowerCase(Locale.ROOT).trim());
+                    if (scopeItem != null) {
+                        convertedScope.add(scopeItem);
+                    }
+                }
+                this.scopes = convertedScope.toArray(new Type[convertedScope.size()]);
+            }
+            return this;
+        }
+
+        /**
+         * Sets whether metrics transmission to OCI is enabled.
+         * <p>
+         *     Defaults to {@code true}.
+         * </p>
+         * @param value whether metrics transmission should be enabled
+         * @return updated builder
+         */
+        @ConfiguredOption(value = "true")
+        public Builder enabled(boolean value) {
+            enabled = value;
+            return this;
+        }
+
+        /**
+         * Sets the maximum no. of metrics to send in a batch
+         * (defaults to {@value #DEFAULT_BATCH_SIZE}).
+         *
+         * @param value maximum no. of metrics to send in a batch
+         * @return updated builder
+         */
+        @ConfiguredOption(value = "50")
+        public Builder batchSize(int value) {
+            batchSize = value;
+            return this;
+        }
+
+        /**
+         * Updates the builder using the specified OCI metrics {@link Config} node.
+         * @param config {@code Config} node containing the OCI metrics settings
+         * @return updated builder
+         */
+        public Builder config(Config config) {
+            config.get("initialDelay").asLong().ifPresent(this::initialDelay);
+            config.get("delay").asLong().ifPresent(this::delay);
+            config.get("batchDelay").asLong().ifPresent(this::batchDelay);
+            config.get("schedulingTimeUnit").as(Builder::toSchedulingTimeUnit).ifPresent(this::schedulingTimeUnit);
+            config.get("compartmentId").asString().ifPresent(this::compartmentId);
+            config.get("namespace").asString().ifPresent(this::namespace);
+            config.get("resourceGroup").asString().ifPresent(this::resourceGroup);
+            config.get("scopes").asList(String.class).ifPresent(this::scopes);
+            config.get("batchSize").asInt().ifPresent(this::batchSize);
+            config.get("enabled").asBoolean().ifPresent(this::enabled);
+            config.get("descriptionEnabled").asBoolean().ifPresent(this::descriptionEnabled);
+            return this;
+        }
+
+        /**
+         * Sets the {@link Monitoring} client instance to use in sending metrics to OCI.
+         *
+         * @param monitoringClient the {@code MonitoringClient} instance
+         * @return updated builder
+         */
+        public Builder monitoringClient(Monitoring monitoringClient) {
+            this.monitoringClient = monitoringClient;
+            return this;
+        }
+
+        private static Type[] getAllMetricScopes() {
+            return new ArrayList<>(SCOPE_TYPES.values()).toArray(new Type[SCOPE_TYPES.size()]);
+        }
+
+        private static TimeUnit toSchedulingTimeUnit(Config value) {
+            Optional<String> timeUnitValue = value.asString().map(s -> s.toUpperCase(Locale.ROOT));
+            if (timeUnitValue.isEmpty() || timeUnitValue.get().isBlank()) {
+                throw new IllegalArgumentException("Required value for schedulingTimeUnit is missing");
+            }
+            return TimeUnit.valueOf(timeUnitValue.get());
+        }
+    }
+}

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
@@ -35,7 +35,6 @@ import io.helidon.config.Config;
 import io.helidon.config.metadata.Configured;
 import io.helidon.config.metadata.ConfiguredOption;
 import io.helidon.metrics.api.RegistryFactory;
-import io.helidon.nima.webserver.Routing;
 import io.helidon.nima.webserver.http.HttpRules;
 import io.helidon.nima.webserver.http.HttpService;
 
@@ -53,9 +52,8 @@ import org.eclipse.microprofile.metrics.MetricUnits;
 /**
  * OCI Metrics Support
  * <p>
- * Even though this service does not create an endpoint, a calling SE app should still register it by invoking
- * {@link Routing.Rules#register(io.helidon.webserver.Service...)}, as it should with any service it uses. That allows
- * this service to detect when the webserver shuts down so it can shut down as well.
+ * When used in a NIMA app, ensure that this HttpService implementation is registered on the default routing created via
+ * {@link io.helidon.nima.webserver.http.HttpRouting#builder()}.
  * </p>
  */
 public class OciMetricsSupport implements HttpService {

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/UnitConverter.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/UnitConverter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.metrics.MetricUnits;
+
+abstract class UnitConverter {
+
+    private final String baseUnits;
+    private final Map<String, Double> conversions;
+
+    static StorageUnitConverter storageUnitConverter() {
+        return new StorageUnitConverter();
+    }
+
+    static TimeUnitConverter timeUnitConverter() {
+        return new TimeUnitConverter();
+    }
+
+    UnitConverter(String baseUnits, Map<String, Double> conversions) {
+        this.baseUnits = baseUnits;
+        this.conversions = conversions;
+    }
+
+    String baseUnits() {
+        return baseUnits;
+    }
+
+    double convert(String metricUnits, double value) {
+        return conversions.get(metricUnits) * value;
+    }
+
+    boolean handles(String metricUnits) {
+        return conversions.containsKey(metricUnits);
+    }
+
+    private static class StorageUnitConverter extends UnitConverter {
+
+        private static final Map<String, Double> CONVERSIONS = Map.of(
+                MetricUnits.BITS, 1.0 / 8.0,
+                MetricUnits.KILOBITS, 1.0D / 8.0 * 1000.0,
+                MetricUnits.MEGABITS, 1.0 / 8.0 * 1000.0 * 1000.0,
+                MetricUnits.GIGABITS, 1.0 / 8.0 * 1000.0 * 1000.0 * 1000.0,
+                MetricUnits.BYTES, 1.0,
+                MetricUnits.KILOBYTES, 1000.0,
+                MetricUnits.MEGABYTES, 1000.0 * 1000.0,
+                MetricUnits.GIGABYTES, 1000.0 * 1000.0 * 1000.0
+        );
+
+        StorageUnitConverter() {
+            super(MetricUnits.BYTES, CONVERSIONS);
+        }
+    }
+
+    private static class TimeUnitConverter extends UnitConverter {
+
+        private static final Map<String, Double> CONVERSIONS = Map.of(
+                MetricUnits.NANOSECONDS, 1.0 / 1000.0 / 1000.0 / 1000.0,
+                MetricUnits.MICROSECONDS, 1.0 / 1000.0 / 1000.0,
+                MetricUnits.MILLISECONDS, 1.0 / 1000.0,
+                MetricUnits.SECONDS, 1.0,
+                MetricUnits.MINUTES, 60.0,
+                MetricUnits.HOURS, 60.0 * 60.0,
+                MetricUnits.DAYS, 60.0 * 60.0 * 24.0
+        );
+
+        TimeUnitConverter() {
+            super(MetricUnits.SECONDS, CONVERSIONS);
+        }
+    }
+}

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/package-info.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Integrating with OCI Metrics.
+ */
+package io.helidon.integrations.oci.metrics;

--- a/integrations/oci/metrics/metrics/src/main/java/module-info.java
+++ b/integrations/oci/metrics/metrics/src/main/java/module-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Integrating with OCI Metrics.
+ */
+module io.helidon.integrations.oci.metrics {
+    requires java.logging;
+
+    requires transitive io.helidon.config;
+    requires transitive io.helidon.common;
+    requires io.helidon.common.http;
+    requires io.helidon.nima.webserver;
+    requires static io.helidon.config.metadata;
+    requires io.helidon.metrics.api;
+
+    requires oci.java.sdk.monitoring;
+    requires oci.java.sdk.common;
+
+    requires transitive microprofile.metrics.api;
+
+    exports io.helidon.integrations.oci.metrics;
+ }

--- a/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsDataTest.java
+++ b/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsDataTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics;
+
+import org.eclipse.microprofile.metrics.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.metrics.api.RegistryFactory;
+
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
+
+import com.oracle.bmc.monitoring.model.MetricDataDetails;
+
+public class OciMetricsDataTest {
+    private final OciMetricsSupport.NameFormatter nameFormatter = new OciMetricsSupport.NameFormatter() { };
+    private final Type[] types = {Type.BASE, Type.VENDOR, Type.APPLICATION};
+    private final String dimensionScopeName = "scope";
+
+    private final RegistryFactory rf = RegistryFactory.getInstance();
+    private final MetricRegistry baseMetricRegistry = rf.getRegistry(Type.BASE);
+    private final MetricRegistry vendorMetricRegistry = rf.getRegistry(Type.VENDOR);
+    private final MetricRegistry appMetricRegistry = rf.getRegistry(Type.APPLICATION);
+
+    @BeforeEach
+    private void beforeEach() {
+        // clear all registry
+        for (Type type: types) {
+            MetricRegistry metricRegistry = rf.getRegistry(type);
+            metricRegistry.removeMatching(new MetricFilter() {
+                @Override
+                public boolean matches(MetricID metricID, Metric metric) {
+                    return true;
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testMetricRegistries() {
+        String counterName = "DummyCounter";
+        String meterName = "DummyMeter";
+        String timerName = "DummyTimer";
+
+        Map<MetricRegistry, Type> metricRegistries = new HashMap<>();
+        metricRegistries.put(baseMetricRegistry, Type.BASE);
+        metricRegistries.put(vendorMetricRegistry, Type.VENDOR);
+        metricRegistries.put(appMetricRegistry, Type.APPLICATION);
+        baseMetricRegistry.counter(counterName).inc();
+        int counterMetricCount = 1;
+        vendorMetricRegistry.meter(meterName).mark();
+        int meterMetricCount = 5;
+        appMetricRegistry.timer(timerName).update(Duration.of(100, ChronoUnit.MILLIS));
+        int timerMetricCount = 4;
+        int totalMetricCount = counterMetricCount + meterMetricCount + timerMetricCount;
+        OciMetricsData ociMetricsData = new OciMetricsData(
+                metricRegistries, nameFormatter, "compartmentId", "namespace", "resourceGroup", false);
+        List<MetricDataDetails> allMetricDataDetails = ociMetricsData.getMetricDataDetails();
+        allMetricDataDetails.stream().forEach((c) -> {
+            if (c.getName().contains(counterName)) {
+                assertThat(c.getDimensions().get(dimensionScopeName), is(equalTo(Type.BASE.getName())));
+            } else if (c.getName().contains(meterName)) {
+                assertThat(c.getDimensions().get(dimensionScopeName), is(equalTo(Type.VENDOR.getName())));
+            } else if (c.getName().contains(timerName)) {
+                assertThat(c.getDimensions().get(dimensionScopeName), is(equalTo(Type.APPLICATION.getName())));
+            }
+            else {
+                fail("Unknown metric: " + c.getName());
+            }
+        });
+        assertThat(allMetricDataDetails.size(), is(equalTo(totalMetricCount)));
+    }
+
+    @Test
+    public void testOciMonitoringParameters() {
+        String compartmentId = "dummy.compartmentId";
+        String namespace = "dummy-namespace";
+        String resourceGroup = "dummy_resourceGroup";
+
+        Map<MetricRegistry, Type> metricRegistries = new HashMap<>();
+        baseMetricRegistry.counter("dummy.counter").inc();
+        metricRegistries.put(baseMetricRegistry, Type.BASE);
+        OciMetricsData ociMetricsData = new OciMetricsData(
+                metricRegistries, nameFormatter, compartmentId, namespace, resourceGroup, false);
+        List<MetricDataDetails> allMetricDataDetails = ociMetricsData.getMetricDataDetails();
+        MetricDataDetails metricDataDetails = allMetricDataDetails.get(0);
+        assertThat(metricDataDetails.getCompartmentId(), is(equalTo(compartmentId)));
+        assertThat(metricDataDetails.getNamespace(), is(equalTo(namespace)));
+        assertThat(metricDataDetails.getResourceGroup(), is(equalTo(resourceGroup)));
+    }
+
+    @Test
+    public void testDimensions() {
+        String dummyTagName = "DummyTag";
+        String dummyTagValue = "DummyValue";
+
+        Map<MetricRegistry, Type> metricRegistries = new HashMap<>();
+        baseMetricRegistry.counter("dummy.counter", new Tag(dummyTagName, dummyTagValue)).inc();
+        metricRegistries.put(baseMetricRegistry, Type.BASE);
+        OciMetricsData ociMetricsData = new OciMetricsData(
+                metricRegistries, nameFormatter, "compartmentId", "namespace", "resourceGroup", false);
+        List<MetricDataDetails> allMetricDataDetails = ociMetricsData.getMetricDataDetails();
+        MetricDataDetails metricDataDetails = allMetricDataDetails.get(0);
+        Map<String, String> dimensions = metricDataDetails.getDimensions();
+        assertThat(dimensions.get(dimensionScopeName), is(equalTo(Type.BASE.getName())));
+        assertThat(dimensions.get(dummyTagName), is(equalTo(dummyTagValue)));
+    }
+}

--- a/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsSupportTest.java
+++ b/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsSupportTest.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.nima.webserver.http.HttpRouting;
+import io.helidon.nima.webserver.WebServer;
+
+import com.oracle.bmc.monitoring.Monitoring;
+import com.oracle.bmc.monitoring.model.MetricDataDetails;
+import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
+import com.oracle.bmc.monitoring.requests.PostMetricDataRequest;
+import com.oracle.bmc.monitoring.responses.PostMetricDataResponse;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricFilter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+public class OciMetricsSupportTest {
+    private final OciMetricsSupport.NameFormatter nameFormatter = new OciMetricsSupport.NameFormatter() { };
+    private static final Monitoring monitoringClient = mock(Monitoring.class);
+    private final Type[] types = {Type.BASE, Type.VENDOR, Type.APPLICATION};
+
+    private static volatile Double[] testMetricUpdateCounterValue = new Double[2];
+    private static volatile int testMetricCount = 0;
+    // Use CountDownLatch to signal when to start testing, for example, test only after results has been retrieved.
+    private static CountDownLatch countDownLatch1;
+    private static int noOfExecutions;
+    private static int noOfMetrics;
+
+    private final RegistryFactory rf = RegistryFactory.getInstance();
+    private final MetricRegistry baseMetricRegistry = rf.getRegistry(Type.BASE);
+    private final MetricRegistry vendorMetricRegistry = rf.getRegistry(Type.VENDOR);
+    private final MetricRegistry appMetricRegistry = rf.getRegistry(Type.APPLICATION);
+    private static String endPoint = "https://telemetry.DummyEndpoint.com";
+    private static String postingEndPoint;
+
+    @BeforeAll
+    static void mockSetGetEndpoints() {
+        doAnswer(invocation -> {
+            endPoint = invocation.getArgument(0);
+            return null;
+        }).when(monitoringClient).setEndpoint(any());
+        doAnswer(invocation -> {
+            return endPoint;
+        }).when(monitoringClient).getEndpoint();
+    }
+
+    @BeforeEach
+    private void beforeEach() {
+        // clear all registry
+        for (Type type: types) {
+            MetricRegistry metricRegistry = rf.getRegistry(type);
+            metricRegistry.removeMatching(new MetricFilter() {
+                @Override
+                public boolean matches(MetricID metricID, Metric metric) {
+                    return true;
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testMetricUpdate() throws InterruptedException {
+        Counter counter = baseMetricRegistry.counter("DummyCounter");
+
+        countDownLatch1 = new CountDownLatch(1);
+        noOfExecutions = 0;
+
+        doAnswer(invocationOnMock -> {
+            noOfExecutions++;
+            PostMetricDataRequest postMetricDataRequest = invocationOnMock.getArgument(0);
+            PostMetricDataDetails postMetricDataDetails = postMetricDataRequest.getPostMetricDataDetails();
+            List<MetricDataDetails> allMetricDataDetails = postMetricDataDetails.getMetricData();
+            // put 1st result in testMetricUpdateCounterValue index 0 and succeeding update in index 1 to ensure
+            // that the 1st update result does not overwrite the 2nd update in rare situations where all metric
+            // updates have already completed before the process to assert results has even started
+            testMetricUpdateCounterValue[noOfExecutions == 1 ? 0 : 1] =
+                    allMetricDataDetails.get(0).getDatapoints().get(0).getValue();
+            if (noOfExecutions == 1) {
+                counter.inc();
+            } else {
+                // Give signal that multiple metric updates have been triggered
+                countDownLatch1.countDown();
+            }
+            return PostMetricDataResponse.builder()
+                    .__httpStatusCode__(200)
+                    .build();
+        }).when(monitoringClient).postMetricData(any());
+
+        OciMetricsSupport.Builder ociMetricsSupportBuilder = OciMetricsSupport.builder()
+                .compartmentId("compartmentId")
+                .namespace("namespace")
+                .resourceGroup("resourceGroup")
+                .initialDelay(1L)
+                .delay(2L)
+                .descriptionEnabled(false)
+                .monitoringClient(monitoringClient);
+
+        HttpRouting routing = createRouting(ociMetricsSupportBuilder);
+
+        counter.inc();
+        WebServer webServer = createWebServer(routing);
+
+        // Wait for metric updates to complete
+        countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
+
+        // Test the 1st and 2nd metric counter updates
+        assertThat(testMetricUpdateCounterValue[0].intValue(), is(equalTo(1)));
+        assertThat(testMetricUpdateCounterValue[1].intValue(), is(equalTo(2)));
+
+        webServer.stop();
+    }
+
+    @Test
+    public void testEndpoint() throws InterruptedException {
+        String originalEndPoint = endPoint;
+
+        baseMetricRegistry.counter("baseDummyCounter1").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter1").inc();
+        appMetricRegistry.counter("appDummyCounter1").inc();
+
+        countDownLatch1 = new CountDownLatch(1);
+        noOfExecutions = 0;
+
+        doAnswer(invocationOnMock -> {
+            PostMetricDataRequest postMetricDataRequest = invocationOnMock.getArgument(0);
+            PostMetricDataDetails postMetricDataDetails = postMetricDataRequest.getPostMetricDataDetails();
+            postingEndPoint = monitoringClient.getEndpoint();
+            // Give signal that metrics has been posted
+            countDownLatch1.countDown();
+            return PostMetricDataResponse.builder()
+                    .__httpStatusCode__(200)
+                    .build();
+        }).when(monitoringClient).postMetricData(any());
+
+        OciMetricsSupport.Builder ociMetricsSupportBuilder = OciMetricsSupport.builder()
+                .compartmentId("compartmentId")
+                .namespace("namespace")
+                .resourceGroup("resourceGroup")
+                .initialDelay(0L)
+                .delay(20L)
+                .descriptionEnabled(false)
+                .monitoringClient(monitoringClient);
+
+        HttpRouting routing = createRouting(ociMetricsSupportBuilder);
+
+        WebServer webServer = createWebServer(routing);
+
+        // Wait for metrics to be posted
+        countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
+
+        // Verify that telemetry-ingestion endpoint is properly set during postin
+        assertThat(postingEndPoint, startsWith("https://telemetry-ingestion."));
+        // Verify that original endpoint is restored after metric posting
+        assertThat(monitoringClient.getEndpoint(), is(equalTo(originalEndPoint)));
+
+        webServer.stop();
+    }
+
+    @Test
+    public void testBatchSize() throws InterruptedException {
+        baseMetricRegistry.counter("baseDummyCounter1").inc();
+        baseMetricRegistry.counter("baseDummyCounter2").inc();
+        baseMetricRegistry.counter("baseDummyCounter3").inc();
+
+        vendorMetricRegistry.counter("vendorDummyCounter1").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter2").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter3").inc();
+
+        appMetricRegistry.counter("appDummyCounter1").inc();
+        appMetricRegistry.counter("appDummyCounter2").inc();
+        appMetricRegistry.counter("appDummyCounter3").inc();
+        appMetricRegistry.counter("appDummyCounter4").inc();
+
+        // Should be 10 metrics
+        int totalMetrics =
+                baseMetricRegistry.getMetrics().size() +
+                        vendorMetricRegistry.getMetrics().size() +
+                        appMetricRegistry.getMetrics().size();
+
+        int batchSize = 3;
+        long batchDelay = 100L;
+        // Should be 1
+        int remainder = totalMetrics % batchSize;
+        // Should be 4
+        int noOfBatches = Math.round(totalMetrics / batchSize) + (remainder > 0 ? 1 : 0);
+
+        countDownLatch1 = new CountDownLatch(1);
+        noOfExecutions = 0;
+        noOfMetrics = 0;
+
+        doAnswer(invocationOnMock -> {
+            noOfExecutions++;
+            PostMetricDataRequest postMetricDataRequest = invocationOnMock.getArgument(0);
+            PostMetricDataDetails postMetricDataDetails = postMetricDataRequest.getPostMetricDataDetails();
+            int metricSizeToPost = postMetricDataDetails.getMetricData().size();
+            noOfMetrics += metricSizeToPost;
+            // Give signal that the last remaining metric in the last batch has been posted
+            if (metricSizeToPost == remainder) {
+                countDownLatch1.countDown();
+            }
+            return PostMetricDataResponse.builder()
+                    .__httpStatusCode__(200)
+                    .build();
+        }).when(monitoringClient).postMetricData(any());
+
+        OciMetricsSupport.Builder ociMetricsSupportBuilder = OciMetricsSupport.builder()
+                .compartmentId("compartmentId")
+                .namespace("namespace")
+                .resourceGroup("resourceGroup")
+                .initialDelay(0L)
+                .delay(20000L)
+                .batchDelay(batchDelay)
+                .schedulingTimeUnit(TimeUnit.MILLISECONDS)
+                .descriptionEnabled(false)
+                .batchSize(batchSize)
+                .monitoringClient(monitoringClient);
+
+
+        Instant start = Instant.now();
+
+        HttpRouting routing = createRouting(ociMetricsSupportBuilder);
+
+        WebServer webServer = createWebServer(routing);
+
+        // Wait for last batch to be completed
+        countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
+        Instant finish = Instant.now();
+
+        // Batch size of 3 for 10 metrics should yield 4 batches to post
+        assertThat(totalMetrics, is(10));
+        assertThat(noOfBatches, is(4));
+        assertThat(noOfExecutions, is(noOfBatches));
+        assertThat(noOfMetrics, is(totalMetrics));
+
+        // Last batch is not delayed so compute only the delays for prior batches
+        long estimatedTotalBatchDelay = batchDelay * (noOfBatches - 1);
+        // Test total batch delay
+        assertThat(Duration.between(start, finish).toMillis(), is(greaterThanOrEqualTo(estimatedTotalBatchDelay)));
+
+        webServer.stop();
+    }
+
+    @Test
+    public void testConfigSources() {
+        mockPostMetricDataAndGetTestMetricCount();
+
+        baseMetricRegistry.counter("baseDummyCounter1").inc();
+
+        vendorMetricRegistry.counter("vendorDummyCounter1").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter2").inc();
+
+        appMetricRegistry.counter("appDummyCounter1").inc();
+        appMetricRegistry.counter("appDummyCounter2").inc();
+        appMetricRegistry.counter("appDummyCounter3").inc();
+
+        validateMetricCount("base, vendor, application", 6);
+        validateMetricCount("base", 1);
+        validateMetricCount("vendor", 2);
+        validateMetricCount("application", 3);
+        validateMetricCount("base, vendor", 3);
+    }
+
+    @Test
+    public void testMetricScope() {
+        mockPostMetricDataAndGetTestMetricCount();
+
+        baseMetricRegistry.counter("baseDummyCounter1").inc();
+
+        vendorMetricRegistry.counter("vendorDummyCounter1").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter2").inc();
+
+        appMetricRegistry.counter("appDummyCounter1").inc();
+        appMetricRegistry.counter("appDummyCounter2").inc();
+        appMetricRegistry.counter("appDummyCounter3").inc();
+
+        validateMetricCount(new String[]{}, 6);
+        validateMetricCount(new String[]{Type.BASE.getName(), Type.VENDOR.getName(), Type.APPLICATION.getName()}, 6);
+        validateMetricCount(new String[]{Type.BASE.getName()}, 1);
+        validateMetricCount(new String[]{Type.VENDOR.getName()}, 2);
+        validateMetricCount(new String[]{Type.APPLICATION.getName()}, 3);
+        validateMetricCount(new String[]{"base", "vendor", "application"}, 6);
+        validateMetricCount(new String[]{"base"}, 1);
+        validateMetricCount(new String[]{"vendor"}, 2);
+        validateMetricCount(new String[]{"application"}, 3);
+    }
+
+    @Test
+    public void testDisableMetrics() {
+        mockPostMetricDataAndGetTestMetricCount();
+
+        baseMetricRegistry.counter("baseDummyCounter1").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter1").inc();
+        appMetricRegistry.counter("appDummyCounter1").inc();
+
+        OciMetricsSupport.Builder ociMetricsSupportBuilder = OciMetricsSupport.builder()
+                .namespace("namespace")
+                .compartmentId("compartmentId")
+                .resourceGroup("resourceGroup")
+                .initialDelay(50L)
+                .delay(500L)
+                .schedulingTimeUnit(TimeUnit.MILLISECONDS)
+                .descriptionEnabled(false)
+                .monitoringClient(monitoringClient)
+                .enabled(false);
+
+        testMetricCount = 0;
+        HttpRouting routing = createRouting(ociMetricsSupportBuilder);
+        WebServer webServer = createWebServer(routing);
+
+        delay(1000L);
+
+        webServer.stop();
+        // metric count should remain 0 as metrics is disabled
+        assertThat(testMetricCount, is(equalTo(0)));
+    }
+
+    private void mockPostMetricDataAndGetTestMetricCount() {
+        // mock monitoringClient.postMetricData()
+        doAnswer(invocationOnMock -> {
+            PostMetricDataRequest postMetricDataRequest = invocationOnMock.getArgument(0);
+            PostMetricDataDetails postMetricDataDetails = postMetricDataRequest.getPostMetricDataDetails();
+            testMetricCount = postMetricDataDetails.getMetricData().size();
+            // Give signal that testMetricCount was retrieved
+            countDownLatch1.countDown();
+            return PostMetricDataResponse.builder()
+                    .__httpStatusCode__(200)
+                    .build();
+        }).when(monitoringClient).postMetricData(any());
+    }
+
+    private WebServer createWebServer(HttpRouting routing) {
+        WebServer webServer = WebServer.builder()
+                .host("localhost")
+                .port(8888)
+                .addRouting(routing)
+                .build();
+        webServer.start();
+        return webServer;
+    }
+
+    private HttpRouting createRouting(OciMetricsSupport.Builder ociMetricsSupportBuilder) {
+        HttpRouting routing = HttpRouting.builder()
+                .put("/test", (req, res) -> {
+                    res.send();
+                })
+                .register(ociMetricsSupportBuilder)
+                .build();
+        return routing;
+    }
+
+    private void validateMetricCount(String scopesList, int expectedMetricCount) {
+        Config config = Config.just(ConfigSources.create(Map.of(
+                "compartmentId", "compartmentId",
+                "namespace", "namespace",
+                "resourceGroup", "resourceGroup",
+                "initialDelay", "50",
+                "delay", "15000",
+                "schedulingTimeUnit", "milliseconds",
+                "scopes", scopesList)
+        ));
+        OciMetricsSupport.Builder ociMetricsSupportBuilder = OciMetricsSupport.builder()
+                .config(config)
+                .monitoringClient(monitoringClient);
+
+        validateMetricCount(ociMetricsSupportBuilder, expectedMetricCount);
+    }
+
+    private void validateMetricCount(String[] scopes, int expectedMetricCount) {
+        OciMetricsSupport.Builder ociMetricsSupportBuilder = OciMetricsSupport.builder()
+                .namespace("namespace")
+                .compartmentId("compartmentId")
+                .resourceGroup("resourceGroup")
+                .initialDelay(50L)
+                .delay(2000L)
+                .schedulingTimeUnit(TimeUnit.MILLISECONDS)
+                .descriptionEnabled(false)
+                .scopes(scopes)
+                .monitoringClient(monitoringClient);
+
+        validateMetricCount(ociMetricsSupportBuilder, expectedMetricCount);
+    }
+
+    private void validateMetricCount(OciMetricsSupport.Builder ociMetricsSupportBuilder, int expectedMetricCount) {
+        testMetricCount = 0;
+        countDownLatch1 = new CountDownLatch(1);
+        HttpRouting routing = createRouting(ociMetricsSupportBuilder);
+        WebServer webServer = createWebServer(routing);
+
+        try {
+            // Wait for signal from metric update that testMetricCount has been retrieved
+            countDownLatch1.await(10, TimeUnit.SECONDS);
+        } catch(InterruptedException e) {
+            fail("Error while waiting for testMetricCount: " + e.getMessage());
+        }
+        webServer.stop();
+        assertThat(testMetricCount, is(equalTo(expectedMetricCount)));
+    }
+
+    private static void delay(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ie) {
+            fail("InterruptedException received in delay(" + millis + ") with message: " + ie.getMessage());
+        }
+    }
+}

--- a/integrations/oci/metrics/pom.xml
+++ b/integrations/oci/metrics/pom.xml
@@ -16,24 +16,22 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.integrations</groupId>
-        <artifactId>helidon-integrations-project</artifactId>
+        <groupId>io.helidon.integrations.oci</groupId>
+        <artifactId>helidon-integrations-oci-project</artifactId>
         <version>4.0.0-SNAPSHOT</version>
     </parent>
-
-    <groupId>io.helidon.integrations.oci</groupId>
-    <artifactId>helidon-integrations-oci-project</artifactId>
-    <name>Helidon Integrations OCI Project</name>
-
-    <description>OCI integrations</description>
+    <groupId>io.helidon.integrations.oci.metrics</groupId>
+    <artifactId>helidon-integrations-oci-metrics-project</artifactId>
+    <name>Helidon Integrations OCI Metrics Project</name>
+    <description>Helidon Metrics to OCI Project</description>
     <packaging>pom</packaging>
 
     <modules>
         <module>metrics</module>
-        <module>sdk</module>
+        <module>cdi</module>
     </modules>
 </project>


### PR DESCRIPTION
The change includes the following:
1. Port of v3 PR https://github.com/helidon-io/helidon/pull/5829 that includes additional changes and fixes.
2. Changes related to OciMetricsSupport use of Nima instead of SE Webserver dependency.