### PR TITLE
Use Hamcrest assertions instead of JUnit in jersey/connector - backport 2.x (#1749)

### DIFF
--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/AsyncRequestTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/AsyncRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,10 @@ import java.util.concurrent.TimeUnit;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import org.glassfish.jersey.client.ClientConfig;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AsyncRequestTest extends AbstractTest {
 
@@ -102,7 +103,7 @@ public class AsyncRequestTest extends AbstractTest {
     @ParamTest
     public void testTwoClientsAsync(String entityType) throws ExecutionException, InterruptedException {
         try (Response resetResponse = target("async", entityType).path("reset").request().get()) {
-            Assertions.assertEquals(204, resetResponse.getStatus());
+            assertThat(resetResponse.getStatus(), is(204));
         }
 
         ClientConfig config = new ClientConfig();
@@ -118,15 +119,15 @@ public class AsyncRequestTest extends AbstractTest {
         Future<Response> futureShortResponse = shortRequest.async().get();
 
         try (Response shortResponse = futureShortResponse.get()) {
-            Assertions.assertEquals(200, shortResponse.getStatus());
-            Assertions.assertEquals("short", shortResponse.readEntity(String.class));
+            assertThat(shortResponse.getStatus(), is(200));
+            assertThat(shortResponse.readEntity(String.class), is("short"));
         }
 
         try (Response longResponse = futureLongResponse.get()) {
-            Assertions.assertEquals(200, longResponse.getStatus());
-            Assertions.assertEquals("long", longResponse.readEntity(String.class));
+            assertThat(longResponse.getStatus(), is(200));
+            assertThat(longResponse.readEntity(String.class), is("long"));
         }
 
-        Assertions.assertEquals(0, asyncResource.shortLong.getCount());
+        assertThat(asyncResource.shortLong.getCount(), is(0L));
     }
 }

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/BasicRequestTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/BasicRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,10 @@ import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import org.glassfish.jersey.client.JerseyCompletionStageRxInvoker;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
 
 public class BasicRequestTest extends AbstractTest {
     private static BasicResource basicResource = new BasicResource();
@@ -162,8 +166,8 @@ public class BasicRequestTest extends AbstractTest {
     @ParamTest
     public void testBasicGet(String entityType) {
         try (Response response = target("basic", entityType).path("get").request().get()) {
-            Assertions.assertEquals(200, response.getStatus());
-            Assertions.assertEquals("ok", response.readEntity(String.class));
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.readEntity(String.class), is("ok"));
         }
     }
 
@@ -171,8 +175,8 @@ public class BasicRequestTest extends AbstractTest {
     public void testBasicPost(String entityType) {
         try (Response response = target("basic", entityType).path("post").request()
                 .buildPost(Entity.entity("ok", MediaType.TEXT_PLAIN_TYPE)).invoke()) {
-            Assertions.assertEquals(200, response.getStatus());
-            Assertions.assertEquals("okok", response.readEntity(String.class));
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.readEntity(String.class), is("okok"));
         }
     }
 
@@ -182,8 +186,8 @@ public class BasicRequestTest extends AbstractTest {
                 .queryParam("first", "hello")
                 .queryParam("second", "world")
                 .request().get()) {
-            Assertions.assertEquals(200, response.getStatus());
-            Assertions.assertEquals("helloworld", response.readEntity(String.class));
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.readEntity(String.class), is("helloworld"));
         }
     }
 
@@ -193,11 +197,11 @@ public class BasicRequestTest extends AbstractTest {
         MultivaluedHashMap<String, Object> map = new MultivaluedHashMap<>();
         Arrays.stream(headers).forEach(a -> map.add(a[0], a[1]));
         try (Response response = target("basic", entityType).path("headers").request().headers(map).get()) {
-            Assertions.assertEquals(200, response.getStatus());
-            Assertions.assertEquals("ok", response.readEntity(String.class));
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.readEntity(String.class), is("ok"));
             for (int i = 0; i != headers.length; i++) {
-                Assertions.assertTrue(response.getHeaders().containsKey(headers[i][0]));
-                Assertions.assertEquals(headers[i][1], response.getStringHeaders().getFirst(headers[i][0]));
+                assertThat(response.getHeaders(), hasKey(headers[i][0]));
+                assertThat(response.getStringHeaders().getFirst(headers[i][0]), is(headers[i][1]));
             }
         }
     }
@@ -206,14 +210,14 @@ public class BasicRequestTest extends AbstractTest {
     public void testProduces(String entityType) {
         try (Response response = target("basic", entityType).path("produces/consumes").request("test/z-test")
                 .put(Entity.entity("ok", new MediaType("test", "x-test")))) {
-            Assertions.assertEquals(406, response.getStatus());
+            assertThat(response.getStatus(), is(406));
         }
 
         try (Response response = target("basic", entityType).path("produces/consumes").request("test/y-test")
                 .put(Entity.entity("ok", new MediaType("test", "x-test")))) {
-            Assertions.assertEquals(200, response.getStatus());
-            Assertions.assertEquals("okok", response.readEntity(String.class));
-            Assertions.assertEquals("test/y-test", response.getStringHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.readEntity(String.class), is("okok"));
+            assertThat(response.getStringHeaders().getFirst(HttpHeaders.CONTENT_TYPE), is("test/y-test"));
         }
     }
 
@@ -221,8 +225,8 @@ public class BasicRequestTest extends AbstractTest {
     public void testAsyncGet(String entityType) throws ExecutionException, InterruptedException {
         Future<Response> futureResponse = target("basic", entityType).path("get").request().async().get();
         try (Response response = futureResponse.get()) {
-            Assertions.assertEquals(200, response.getStatus());
-            Assertions.assertEquals("ok", response.readEntity(String.class));
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.readEntity(String.class), is("ok"));
         }
     }
 
@@ -230,14 +234,14 @@ public class BasicRequestTest extends AbstractTest {
     public void testConsumes(String entityType) {
         try (Response response = target("basic", entityType).path("produces/consumes").request("test/y-test")
                 .put(Entity.entity("ok", new MediaType("test", "z-test")))) {
-            Assertions.assertEquals(415, response.getStatus());
+            assertThat(response.getStatus(), is(415));
         }
 
         try (Response response = target("basic", entityType).path("produces/consumes").request("test/y-test")
                 .put(Entity.entity("ok", new MediaType("test", "x-test")))) {
-            Assertions.assertEquals(200, response.getStatus());
-            Assertions.assertEquals("okok", response.readEntity(String.class));
-            Assertions.assertEquals("test/y-test", response.getStringHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.readEntity(String.class), is("okok"));
+            assertThat(response.getStringHeaders().getFirst(HttpHeaders.CONTENT_TYPE), is("test/y-test"));
         }
     }
 
@@ -248,18 +252,18 @@ public class BasicRequestTest extends AbstractTest {
                 target("basic", entityType).path("get").request().rx(JerseyCompletionStageRxInvoker.class).get();
 
         try (Response response = futureResponse.get()) {
-            Assertions.assertEquals(200, response.getStatus());
-            Assertions.assertEquals("ok", response.readEntity(String.class));
+            assertThat(response.getStatus(), is(200));
+            assertThat(response.readEntity(String.class), is("ok"));
         }
     }
 
     @ParamTest
     public void testInputStreamEntity(String entityType) throws IOException {
         try (Response response = target("basic", entityType).path("get").request().get()) {
-            Assertions.assertEquals(200, response.getStatus());
+            assertThat(response.getStatus(), is(200));
             final InputStream is = response.readEntity(InputStream.class);
-            Assertions.assertEquals('o', is.read());
-            Assertions.assertEquals('k', is.read());
+            assertThat(is.read(), is((int)('o')));
+            assertThat(is.read(), is((int)('k')));
             is.close();
         }
     }

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/FollowRedirectsTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/FollowRedirectsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,10 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.ClientResponse;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Helidon connector follow redirect tests.
@@ -103,18 +105,17 @@ public class FollowRedirectsTest extends AbstractTest {
     @ParamTest
     public void testDoFollow(String entityType) {
         Response r = target("test/redirect", entityType).register(RedirectTestFilter.class).request().get();
-        Assertions.assertEquals(200, r.getStatus());
-        Assertions.assertEquals("GET", r.readEntity(String.class));
+        assertThat(r.getStatus(), is(200));
+        assertThat(r.readEntity(String.class), is("GET"));
 
-        Assertions.assertEquals(
-                UriBuilder.fromUri(getBaseUri()).path(RedirectResource.class).build().toString(),
-                r.getHeaderString(RedirectTestFilter.RESOLVED_URI_HEADER));
+        assertThat(r.getHeaderString(RedirectTestFilter.RESOLVED_URI_HEADER),
+                is(UriBuilder.fromUri(getBaseUri()).path(RedirectResource.class).build().toString()));
     }
 
     @ParamTest
     public void testDontFollow(String entityType) {
         WebTarget t = target("test/redirect", entityType);
         t.property(ClientProperties.FOLLOW_REDIRECTS, false);
-        Assertions.assertEquals(303, t.request().get().getStatus());
+        assertThat(t.request().get().getStatus(), is(303));
     }
 }

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/LargeDataTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/LargeDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,9 +36,11 @@ import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * The LargeDataTest reproduces a problem when bytes of large data sent are incorrectly sent.
@@ -114,10 +116,10 @@ public class LargeDataTest extends AbstractTest {
                 throw exception;
             }
 
-            Assertions.assertEquals(
-                    Response.Status.Family.SUCCESSFUL,
+            assertThat("Unexpected error: " + response.getStatus(),
                     response.getStatusInfo().getFamily(),
-                    "Unexpected error: " + response.getStatus());
+                    is(Response.Status.Family.SUCCESSFUL)
+                    );
         } finally {
             response.close();
         }

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/ParallelTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/ParallelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,11 @@ import java.util.logging.Logger;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.Extension;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests the parallel execution of multiple requests.
@@ -110,7 +111,7 @@ public class ParallelTest extends AbstractTest {
                             startBarrier.await();
                             Response response;
                             response = target.path(PATH).request().get();
-                            Assertions.assertEquals("GET", response.readEntity(String.class));
+                            assertThat(response.readEntity(String.class), is("GET"));
                             receivedCounter.incrementAndGet();
                         } catch (InterruptedException ex) {
                             Thread.currentThread().interrupt();
@@ -129,17 +130,17 @@ public class ParallelTest extends AbstractTest {
 
             startBarrier.await(1, TimeUnit.SECONDS);
 
-            Assertions.assertTrue(
+            assertThat("Waiting for clients to finish has timed out.",
                     doneLatch.await(10, TimeUnit.SECONDS),
-                    "Waiting for clients to finish has timed out."
+                    is(true)
             );
 
-            Assertions.assertEquals(PARALLEL_CLIENTS, resourceCounter.get(), "Resource counter");
+            assertThat("Resource counter", resourceCounter.get(), is(PARALLEL_CLIENTS));
 
-            Assertions.assertEquals(PARALLEL_CLIENTS, receivedCounter.get(), "Received counter");
+            assertThat("Received counter", receivedCounter.get(), is(PARALLEL_CLIENTS));
         } finally {
             executor.shutdownNow();
-            Assertions.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Executor termination");
+            assertThat("Executor termination", executor.awaitTermination(5, TimeUnit.SECONDS), is(true));
         }
     }
 }

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/TimeoutTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/TimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,9 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TimeoutTest extends AbstractTest {
     private static TimeoutResource timeoutResource;
@@ -80,8 +83,8 @@ public class TimeoutTest extends AbstractTest {
     @Test
     public void testFast() {
         Response r = target("test").request().get();
-        Assertions.assertEquals(200, r.getStatus());
-        Assertions.assertEquals("GET", r.readEntity(String.class));
+        assertThat(r.getStatus(), is(200));
+        assertThat(r.readEntity(String.class), is("GET"));
     }
 
     @Test


### PR DESCRIPTION
Part of #1749

[Original PR](https://github.com/helidon-io/helidon/pull/5935)