### PR TITLE
Remove trailing empty line in copyright comment (part 21)

### DIFF
--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/AdHocConfigBuilderTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/AdHocConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/AssertThrowException.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/AssertThrowException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/AssertableTestBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/AssertableTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/AsyncTestBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/AsyncTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/ConnectorConfigTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/ConnectorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/CountableTestBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/CountableTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/ExtendedMessage.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/ExtendedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.microprofile.messaging;
 

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MessageUtilsTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MessageUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MethodSignatureResolverTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MethodSignatureResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/SignatureTypeConsistencyTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/SignatureTypeConsistencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/UncaughtExceptionTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/UncaughtExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/UnwrapProcessorTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/UnwrapProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/AbstractShapeTestBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/AbstractShapeTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/BadSignaturePublisherPayloadBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/BadSignaturePublisherPayloadBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV1Bean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV1Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV2Bean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV3Bean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV3Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV4Bean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV4Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV5Bean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ByRequestProcessorV5Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ChannelTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/CompletionStageV1Bean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/CompletionStageV1Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/MultipleProcessorBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/MultipleProcessorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/MultipleTypeProcessorChainV1Bean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/MultipleTypeProcessorChainV1Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/MultipleTypeProcessorChainV2Bean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/MultipleTypeProcessorChainV2Bean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ProcessorBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ProcessorBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ProcessorBuilderBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ProcessorBuilderBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/PullForEachBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/PullForEachBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ack/InvalidAckStrategy.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ack/InvalidAckStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner.ack;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ack/incoming/IncomingMsgManualAckBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ack/incoming/IncomingMsgManualAckBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner.ack.incoming;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ack/incoming/IncomingMsgNoneAckBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ack/incoming/IncomingMsgNoneAckBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner.ack.incoming;

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ack/incoming/IncomingMsgPostProcessExplicitAckBean.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/inner/ack/incoming/IncomingMsgPostProcessExplicitAckBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.messaging.inner.ack.incoming;

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/AsyncResourceTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/AsyncResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.server;

--- a/microprofile/tests/tck/tck-metrics/src/test/java/io/helidon/microprofile/metrics/tck/ArrayParamConverterProvider.java
+++ b/microprofile/tests/tck/tck-metrics/src/test/java/io/helidon/microprofile/metrics/tck/ArrayParamConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.microprofile.metrics.tck;
 


### PR DESCRIPTION
The next part of https://github.com/helidon-io/helidon/pull/5324 .