### PR TITLE
enable Brotli compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.2.10</version.lib.rxjava>
         <version.lib.scala>2.12.10</version.lib.scala>
+        <version.lib.brotli4j>1.11.0</version.lib.brotli4j>
         <!-- This is to force upgrade of transitive dep from arquillian -->
         <!-- 2.x versions used http (not https) to access maven central -->
         <version.lib.shrinkwrap-resolver>3.0.1</version.lib.shrinkwrap-resolver>
@@ -916,6 +917,41 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${version.lib.zookeeper}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>brotli4j</artifactId>
+                <version>${version.lib.brotli4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-x86_64</artifactId>
+                <version>${version.lib.brotli4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-aarch64</artifactId>
+                <version>${version.lib.brotli4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-linux-armv7</artifactId>
+                <version>${version.lib.brotli4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-osx-x86_64</artifactId>
+                <version>${version.lib.brotli4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-osx-aarch64</artifactId>
+                <version>${version.lib.brotli4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.aayushatharva.brotli4j</groupId>
+                <artifactId>native-windows-x86_64</artifactId>
+                <version>${version.lib.brotli4j}</version>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -223,6 +223,41 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-linux-x86_64</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-linux-aarch64</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-linux-armv7</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-osx-x86_64</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-osx-aarch64</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-windows-x86_64</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
             <scope>test</scope>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -36,6 +36,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.compression.CompressionOptions;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.logging.LogLevel;
@@ -178,7 +179,7 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         // Enable compression via "Accept-Encoding" header if configured
         if (serverConfig.enableCompression()) {
             log("Compression negotiation enabled (gzip, deflate)", ch);
-            p.addLast(new HttpContentCompressor());
+            p.addLast(new HttpContentCompressor((CompressionOptions[]) null));
         }
 
         RequestRouting requestRouting = router.routing(RequestRouting.class, null);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/CompressionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/CompressionTest.java
@@ -123,6 +123,22 @@ public class CompressionTest {
     }
 
     /**
+     * Test that "content-encoding" header is "br". Note that we use a
+     * {@code SocketHttpClient} as other clients may remove this header after
+     * processing.
+     *
+     * @throws Exception if error occurs.
+     */
+    @Test
+    public void testBrotliHeader() throws Exception {
+        List<String> requestHeaders = Arrays.asList("Accept-Encoding: br");
+        String s = SocketHttpClient.sendAndReceive("/compressed", Http.Method.GET, null,
+                requestHeaders, webServer);
+        Map<String, String> responseHeaders = cutHeaders(s);
+        assertThat(responseHeaders, hasEntry("content-encoding", "br"));
+    }
+
+    /**
      * Test that the entity is decompressed using the correct algorithm.
      *
      * @throws Exception if error occurs.
@@ -146,6 +162,21 @@ public class CompressionTest {
     public void testDeflateContent() throws Exception {
         WebClientRequestBuilder builder = webClient.get();
         builder.headers().add("Accept-Encoding", "deflate");
+        WebClientResponse response = builder.path("/compressed")
+                .request()
+                .await(TIME_OUT);
+        assertThat(response.content().as(String.class).get(), equalTo("It works!"));
+    }
+
+    /**
+     * Test that the entity is decompressed using the correct algorithm.
+     *
+     * @throws Exception if error occurs.
+     */
+    @Test
+    public void testBrotliContent() throws Exception {
+        WebClientRequestBuilder builder = webClient.get();
+        builder.headers().add("Accept-Encoding", "br");
         WebClientResponse response = builder.path("/compressed")
                 .request()
                 .await(TIME_OUT);


### PR DESCRIPTION
# Summary

Netty's HttpContentCompressor class has more than 1 constructor.

The zero arg constructor initializes the compressor object with "supportsCompressionOptions = false"

The alternate constructor:
```
HttpContentCompressor(CompressionOptions... compressionOptions)
```

will utilize Netty's StandardCompressionOptions to initialize Gzip, Deflate, and Brotli

```
        if (compressionOptions == null || compressionOptions.length == 0) {
            brotliOptions = Brotli.isAvailable() ? StandardCompressionOptions.brotli() : null;
            gzipOptions = StandardCompressionOptions.gzip();
            deflateOptions = StandardCompressionOptions.deflate();
            zstdOptions = Zstd.isAvailable() ? StandardCompressionOptions.zstd() : null;
        }
```

The alternate constructor will enable Brotli compression (if brotli4j is on the runtime classpath)

