### PR TITLE
Use Hamcrest assertions instead of JUnit in examples/integrations/microstream/greetings-se - backport 2.x (#1749)

### DIFF
--- a/examples/integrations/microstream/greetings-se/pom.xml
+++ b/examples/integrations/microstream/greetings-se/pom.xml
@@ -61,6 +61,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
         </dependency>

--- a/examples/integrations/microstream/greetings-se/src/test/java/io/helidon/examples/integrations/microstream/greetings/se/MicrostreamExampleGreetingsSeTest.java
+++ b/examples/integrations/microstream/greetings-se/src/test/java/io/helidon/examples/integrations/microstream/greetings/se/MicrostreamExampleGreetingsSeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,13 @@ import io.helidon.webclient.WebClient;
 import io.helidon.webserver.WebServer;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MicrostreamExampleGreetingsSeTest {
 
@@ -65,7 +68,7 @@ public class MicrostreamExampleGreetingsSeTest {
                 .request(JsonObject.class)
                 .await(10, TimeUnit.SECONDS);
 
-        Assertions.assertEquals("Hello Joe!", jsonObject.getString("message"));
+        assertThat(jsonObject.getString("message"), is("Hello Joe!"));
 
         JsonArray jsonArray = webClient
                 .get()
@@ -73,7 +76,7 @@ public class MicrostreamExampleGreetingsSeTest {
                 .request(JsonArray.class)
                 .await(10, TimeUnit.SECONDS);
 
-        Assertions.assertEquals("Joe", jsonArray.get(0).asJsonObject().getString("name"));
-        Assertions.assertNotNull(jsonArray.get(0).asJsonObject().getString("time"));
+        assertThat(jsonArray.get(0).asJsonObject().getString("name"), is("Joe"));
+        assertThat(jsonArray.get(0).asJsonObject().getString("time"), notNullValue());
     }
 }


### PR DESCRIPTION
Part of #1749

[Original PR](https://github.com/helidon-io/helidon/pull/5962)