### PR TITLE
Use Hamcrest assertions instead of JUnit in common/reactive - backport main (#1749)

### DIFF
--- a/common/reactive/pom.xml
+++ b/common/reactive/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -54,6 +54,11 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/common/reactive/src/test/java/io/helidon/common/reactive/IgnoreElementsTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/IgnoreElementsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
 
 public class IgnoreElementsTest {
     @Test
@@ -39,7 +39,7 @@ public class IgnoreElementsTest {
                 .peek(i -> latch.countDown())
                 .ignoreElements(); // should trigger subscription on its own
 
-        assertTrue(latch.await(200, TimeUnit.MILLISECONDS));
+        assertThat(latch.await(200, TimeUnit.MILLISECONDS), is(true));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class IgnoreElementsTest {
                 .peek(i -> latch.countDown())
                 .ignoreElement(); // should trigger subscription on its own
 
-        assertTrue(latch.await(200, TimeUnit.MILLISECONDS));
+        assertThat(latch.await(200, TimeUnit.MILLISECONDS), is(true));
     }
 
     @Test

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiDefaultIfEmptyTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiDefaultIfEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import java.util.concurrent.SubmissionPublisher;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 public class MultiDefaultIfEmptyTest {
 
@@ -128,13 +128,13 @@ public class MultiDefaultIfEmptyTest {
                 .defaultIfEmpty(2)
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
     @Test
@@ -146,13 +146,13 @@ public class MultiDefaultIfEmptyTest {
                 .defaultIfEmpty(() -> 2)
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,11 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class MultiFlatMapPublisherTest {
@@ -153,7 +154,7 @@ public class MultiFlatMapPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Arrays.asList(6));
+        assertThat(ts.getItems(), contains(6));
         assertThat(ts.getLastError(), instanceOf(ArithmeticException.class));
         assertThat(ts.isComplete(), is(false));
     }
@@ -169,7 +170,7 @@ public class MultiFlatMapPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Arrays.asList(6, -6));
+        assertThat(ts.getItems(), contains(6, -6));
         assertThat(ts.getLastError(), instanceOf(ArithmeticException.class));
         assertThat(ts.isComplete(), is(false));
     }
@@ -256,7 +257,7 @@ public class MultiFlatMapPublisherTest {
 
         ts.request1();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
     }
@@ -274,7 +275,7 @@ public class MultiFlatMapPublisherTest {
                 .flatMap(Single::just)
                 .subscribe(ts);
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
     }
@@ -306,12 +307,11 @@ public class MultiFlatMapPublisherTest {
 
     @RepeatedTest(500)
     public void multi() throws ExecutionException, InterruptedException {
-        assertEquals(EXPECTED_EMISSION_COUNT, Multi.create(TEST_DATA)
+        assertThat(Multi.create(TEST_DATA)
                 .flatMap(MultiFlatMapPublisherTest::asyncFlowPublisher, MAX_CONCURRENCY, false, PREFETCH)
                 .distinct()
                 .collectList()
-                .await(800, TimeUnit.MILLISECONDS)
-                .size());
+                .await(800, TimeUnit.MILLISECONDS), hasSize(EXPECTED_EMISSION_COUNT));
     }
 
     private static Flow.Publisher<? extends String> asyncFlowPublisher(Integer i) {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiRetryTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultiRetryTest {
 
@@ -46,7 +48,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(count.get(), 5);
+        assertThat(count.get(), is(5));
     }
 
     @Test
@@ -58,7 +60,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(NullPointerException.class);
-        assertTrue(ts.getLastError().getSuppressed()[0] instanceof IOException, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
     }
 
     @Test
@@ -72,7 +74,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertTrue(ts.getLastError().getSuppressed()[0] instanceof IOException, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
     }
 
     @Test
@@ -86,7 +88,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -120,7 +122,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -145,7 +147,7 @@ public class MultiRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -165,7 +167,7 @@ public class MultiRetryTest {
             ts.awaitDone(5, TimeUnit.SECONDS)
                     .assertResult(1);
 
-            assertEquals(count.get(), 5);
+            assertThat(count.get(), is(5));
         } finally {
             executor.shutdown();
         }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiSkipPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiSkipPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
 
 package io.helidon.common.reactive;
 
-import java.util.Collections;
 import java.util.Iterator;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiSkipPublisherTest {
 
@@ -67,7 +66,7 @@ public class MultiSkipPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(3));
+        assertThat(ts.getItems(), contains(3));
         assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
         assertThat(ts.isComplete(), is(false));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiSwitchIfEmptyTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiSwitchIfEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import java.util.concurrent.SubmissionPublisher;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultiSwitchIfEmptyTest {
 
@@ -92,13 +92,13 @@ public class MultiSwitchIfEmptyTest {
                 .switchIfEmpty(Multi.singleton(2))
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
     @Test
@@ -110,13 +110,13 @@ public class MultiSwitchIfEmptyTest {
                 .switchIfEmpty(Multi.create(sp))
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTakeWhilePublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTakeWhilePublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,14 @@
 package io.helidon.common.reactive;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiTakeWhilePublisherTest {
 
@@ -53,7 +52,7 @@ public class MultiTakeWhilePublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Arrays.asList(1, 2, 3));
+        assertThat(ts.getItems(), contains(1, 2, 3));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTappedPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTappedPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,15 @@
 package io.helidon.common.reactive;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiTappedPublisherTest {
 
@@ -161,7 +160,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -182,7 +181,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -206,7 +205,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -233,7 +232,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -326,7 +325,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -345,7 +344,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -364,7 +363,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -383,7 +382,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -447,7 +446,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -473,7 +472,7 @@ public class MultiTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTimeoutTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultiTimeoutTest {
 
@@ -127,11 +127,11 @@ public class MultiTimeoutTest {
             Thread.sleep(10);
         }
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
 
         ts.assertValuesOnly(1L);
 
-        assertTrue(sp2.hasSubscribers());
+        assertThat(sp2.hasSubscribers(), is(true));
 
         sp2.submit(2L);
         sp2.close();

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SequentialSubscriberTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SequentialSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SequentialSubscriberTest {
     int counter = 0;
@@ -98,7 +99,7 @@ public class SequentialSubscriberTest {
         } catch (InterruptedException e) {
             executorService.shutdownNow();
         }
-        assertFalse(errorFound.isPresent(), () -> errorFound.get());
+        assertThat(errorFound.orElse(""), errorFound.isPresent(), is(false));
     }
 
     private void sleep(long millis) {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SequentialSubscriberTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SequentialSubscriberTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SequentialSubscriberTest {
@@ -99,7 +99,7 @@ public class SequentialSubscriberTest {
         } catch (InterruptedException e) {
             executorService.shutdownNow();
         }
-        assertThat(errorFound.orElse(""), errorFound.isPresent(), is(false));
+        assertThat(errorFound, optionalEmpty());
     }
 
     private void sleep(long millis) {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleDefaultIfEmptyTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleDefaultIfEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,8 @@ import java.util.concurrent.SubmissionPublisher;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SingleDefaultIfEmptyTest {
 
@@ -128,13 +127,13 @@ public class SingleDefaultIfEmptyTest {
                 .defaultIfEmpty(2)
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
     @Test
@@ -146,13 +145,13 @@ public class SingleDefaultIfEmptyTest {
                 .defaultIfEmpty(() -> 2)
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleRetryTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SingleRetryTest {
 
@@ -46,7 +48,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(count.get(), 5);
+        assertThat(count.get(), is(5));
     }
 
     @Test
@@ -58,7 +60,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(NullPointerException.class);
-        assertTrue(ts.getLastError().getSuppressed()[0] instanceof IOException, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
     }
 
     @Test
@@ -72,7 +74,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertTrue(ts.getLastError().getSuppressed()[0] instanceof IOException, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
     }
 
     @Test
@@ -86,7 +88,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -120,7 +122,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -145,7 +147,7 @@ public class SingleRetryTest {
                 .subscribe(ts);
 
         ts.assertFailure(IllegalArgumentException.class);
-        assertEquals(ts.getLastError().getSuppressed().length, 0, "" + ts.getLastError());
+        assertThat("" + ts.getLastError(), ts.getLastError().getSuppressed(), emptyArray());
     }
 
     @Test
@@ -165,7 +167,7 @@ public class SingleRetryTest {
             ts.awaitDone(5, TimeUnit.SECONDS)
                     .assertResult(1);
 
-            assertEquals(count.get(), 5);
+            assertThat(count.get(), is(5));
         } finally {
             executor.shutdown();
         }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleSwitchIfEmptyTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleSwitchIfEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SingleSwitchIfEmptyTest {
 
@@ -105,13 +105,13 @@ public class SingleSwitchIfEmptyTest {
                 .switchIfEmpty(Single.just(2))
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
     @Test
@@ -123,13 +123,13 @@ public class SingleSwitchIfEmptyTest {
                 .switchIfEmpty(Single.create(sp))
                 .subscribe(ts);
 
-        assertTrue(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(true));
 
         ts.assertEmpty();
 
         ts.cancel();
 
-        assertFalse(sp.hasSubscribers());
+        assertThat(sp.hasSubscribers(), is(false));
     }
 
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTappedPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTappedPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,15 @@
 package io.helidon.common.reactive;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SingleTappedPublisherTest {
 
@@ -170,7 +169,7 @@ public class SingleTappedPublisherTest {
                 .subscribe(ts);
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -192,7 +191,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -217,7 +216,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -245,7 +244,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -341,7 +340,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -360,7 +359,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -379,7 +378,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -398,7 +397,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -462,7 +461,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 
@@ -488,7 +487,7 @@ public class SingleTappedPublisherTest {
 
         ts.requestMax();
 
-        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getItems(), contains(1));
         assertThat(ts.getLastError(), is(nullValue()));
         assertThat(ts.isComplete(), is(true));
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/TerminatedFutureTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/TerminatedFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class TerminatedFutureTest {
@@ -38,11 +36,11 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.cancel(ref);
 
-        assertSame(ref.get(), TerminatedFuture.CANCELED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.CANCELED));
 
         TerminatedFuture.cancel(ref);
 
-        assertSame(ref.get(), TerminatedFuture.CANCELED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.CANCELED));
     }
 
     @Test
@@ -54,9 +52,9 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.cancel(ref);
 
-        assertSame(ref.get(), TerminatedFuture.CANCELED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.CANCELED));
 
-        assertTrue(cf.isCancelled());
+        assertThat(cf.isCancelled(), is(true));
     }
 
     @Test
@@ -67,7 +65,7 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.setFuture(ref, cf);
 
-        assertSame(ref.get(), cf);
+        assertThat(ref.get(), sameInstance(cf));
     }
 
     @Test
@@ -77,7 +75,7 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.cancel(ref);
 
-        assertSame(ref.get(), TerminatedFuture.FINISHED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.FINISHED));
     }
 
     @Test
@@ -89,11 +87,11 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.setFuture(ref, cf);
 
-        assertSame(ref.get(), cf);
+        assertThat(ref.get(), sameInstance(cf));
 
         TerminatedFuture.setFuture(ref, cf1);
 
-        assertSame(ref.get(), cf);
+        assertThat(ref.get(), sameInstance(cf));
     }
 
     @Test
@@ -105,7 +103,7 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.setFuture(ref, cf);
 
-        assertSame(ref.get(), TerminatedFuture.FINISHED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.FINISHED));
     }
 
 
@@ -118,31 +116,31 @@ public class TerminatedFutureTest {
 
         TerminatedFuture.setFuture(ref, cf);
 
-        assertSame(ref.get(), TerminatedFuture.CANCELED);
+        assertThat(ref.get(), sameInstance(TerminatedFuture.CANCELED));
 
-        assertTrue(cf.isCancelled());
+        assertThat(cf.isCancelled(), is(true));
     }
 
     @Test
     public void finishedMethods() {
-        assertFalse(TerminatedFuture.FINISHED.cancel(true));
+        assertThat(TerminatedFuture.FINISHED.cancel(true), is(false));
 
-        assertFalse(TerminatedFuture.FINISHED.isCancelled());
+        assertThat(TerminatedFuture.FINISHED.isCancelled(), is(false));
 
-        assertTrue(TerminatedFuture.FINISHED.isDone());
+        assertThat(TerminatedFuture.FINISHED.isDone(), is(true));
 
-        assertNull(TerminatedFuture.FINISHED.get());
+        assertThat(TerminatedFuture.FINISHED.get(), nullValue());
 
-        assertNull(TerminatedFuture.FINISHED.get(1, TimeUnit.MINUTES));
+        assertThat(TerminatedFuture.FINISHED.get(1, TimeUnit.MINUTES), nullValue());
     }
 
     @Test
     public void canceledMethods() {
-        assertFalse(TerminatedFuture.CANCELED.cancel(true));
+        assertThat(TerminatedFuture.CANCELED.cancel(true), is(false));
 
-        assertTrue(TerminatedFuture.CANCELED.isCancelled());
+        assertThat(TerminatedFuture.CANCELED.isCancelled(), is(true));
 
-        assertTrue(TerminatedFuture.CANCELED.isDone());
+        assertThat(TerminatedFuture.CANCELED.isDone(), is(true));
     }
 
     @Test


### PR DESCRIPTION
Part of #1749

[Original PR](https://github.com/helidon-io/helidon/pull/4908)