### PR TITLE
Use Hamcrest assertions instead of JUnit in  microprofile/openapi - backport main (#1749)

### DIFF
--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestMultiJandex.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestMultiJandex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestMultiJandex {
 
@@ -42,9 +43,9 @@ public class TestMultiJandex {
         DotName testApp2Name = DotName.createSimple(TestApp2.class.getName());
 
         ClassInfo testAppInfo = indexView.getClassByName(testAppName);
-        assertNotNull(testAppInfo, "Expected index entry for TestApp not found");
+        assertThat("Expected index entry for TestApp not found", testAppInfo, notNullValue());
 
         ClassInfo testApp2Info = indexView.getClassByName(testApp2Name);
-        assertNotNull(testApp2Info, "Expected index entry for TestApp2 not found");
+        assertThat("Expected index entry for TestApp2 not found", testApp2Info, notNullValue());
     }
 }

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestServerWithConfig.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestServerWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 class TestServerWithConfig {
 
@@ -63,6 +64,6 @@ class TestServerWithConfig {
     @Test
     public void testAlternatePath() throws Exception {
         String goSummary = TestUtil.fromYaml(yaml, "paths./testapp/go.get.summary", String.class);
-        assertEquals(TestApp.GO_SUMMARY, goSummary);
+        assertThat(goSummary, is(TestApp.GO_SUMMARY));
     }
 }

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ import io.helidon.microprofile.server.Server;
 import jakarta.ws.rs.core.Application;
 import org.yaml.snakeyaml.Yaml;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -126,8 +127,8 @@ public class TestUtil {
      */
     public static String stringYAMLFromResponse(HttpURLConnection cnx) throws IOException {
         HttpMediaType returnedMediaType = mediaTypeFromResponse(cnx);
-        assertTrue(HttpMediaType.create(MediaTypes.APPLICATION_OPENAPI_YAML).test(returnedMediaType),
-                "Unexpected returned media type");
+        assertThat("Unexpected returned media type",
+                HttpMediaType.create(MediaTypes.APPLICATION_OPENAPI_YAML).test(returnedMediaType), is(true));
         return stringFromResponse(cnx, returnedMediaType);
     }
 


### PR DESCRIPTION
Part of #1749

[Original PR](https://github.com/helidon-io/helidon/pull/5028)