### PR TITLE
Fix multiple registration of Jaeger-related gauges

### DIFF
--- a/metrics/jaeger/pom.xml
+++ b/metrics/jaeger/pom.xml
@@ -54,7 +54,22 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.tracing</groupId>
+            <artifactId>helidon-tracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing</groupId>
             <artifactId>helidon-tracing-jaeger</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.grpc</groupId>
+            <artifactId>helidon-grpc-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/metrics/jaeger/src/test/java/io/helidon/metrics/jaeger/TestMultipleJaegerClients.java
+++ b/metrics/jaeger/src/test/java/io/helidon/metrics/jaeger/TestMultipleJaegerClients.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.jaeger;
+
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.config.Config;
+import io.helidon.grpc.server.GrpcRouting;
+import io.helidon.grpc.server.GrpcServer;
+import io.helidon.grpc.server.GrpcServerConfiguration;
+import io.helidon.grpc.server.GrpcTracingConfig;
+import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.tracing.TracerBuilder;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+import io.opentracing.Tracer;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class TestMultipleJaegerClients {
+
+    @BeforeEach
+    @AfterEach
+    void clearVendorRegistry() {
+        RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.VENDOR).removeMatching((metricId, Metric) -> true);
+    }
+
+    @Test
+    void checkMultipleJaegerClientsReuseMetric() {
+
+        Config config = Config.create();
+        Tracer tracer = TracerBuilder.create(config.get("tracing")).build();
+
+        WebServer webServer = WebServer.builder(createRouting(config))
+                .tracer(tracer)
+                .config(config.get("server"))
+                .build();
+
+        GrpcTracingConfig grpcTracingConfig = GrpcTracingConfig.create();
+        GrpcServerConfiguration grpcServerconfig = GrpcServerConfiguration.builder(config.get("grpc"))
+                .tracer(tracer)
+                .tracingConfig(grpcTracingConfig)
+                .build();
+
+        GrpcServer grpcServer = GrpcServer.create(grpcServerconfig, GrpcRouting.builder().build());
+
+        webServer.start()
+                .thenAccept(ws -> ws.whenShutdown().thenRun(() -> System.err.println("Web server has stopped.")))
+                .exceptionallyAccept(t -> fail("WebServer failed to start: " + t.getMessage()));
+
+        grpcServer.start()
+                .thenAccept(gs -> gs.whenShutdown().thenRun(() -> System.err.println("gRPC server has stopped.")))
+                .exceptionally(t -> {
+                    fail("gRPC server failed to start: " + t.getMessage());
+                    return null;
+                });
+
+        try {
+            TimeUnit.SECONDS.sleep(4);
+        } catch (InterruptedException e) {
+            fail("Error waiting for servers to warm up: ", e);
+        }
+    }
+
+    private Routing createRouting(Config config) {
+        return Routing.builder()
+                .get((req, resp) -> req.next())
+                .build();
+    }
+}

--- a/metrics/jaeger/src/test/resources/application.yaml
+++ b/metrics/jaeger/src/test/resources/application.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+tracing:
+  service: twoClients
+
+app:
+  greeting: Hello


### PR DESCRIPTION
Resolves #5811 

The Helidon Jaeger tracing integration registers metrics on behalf of Jaeger by acting as a Jaeger `MetricsFactory`. In doing so, Helidon defines the metrics metadata to be reusable so if multiple components and/or the developer's own app use Jaeger tracing we don't define duplicate metrics.

But, Helidon gauges (consistent with MicroProfile metrics) are _never_ reusable, regardless of what the metadata says. Jaeger requests the creation of gauges, and with multiple traceable components present the second attempt to  register the same gauge fails, as reported in the issue.

This fix explicitly checks for the existence of a gauge (metric name and tags) before registering it to avoid this problem. 

Because of the Jaeger SPI we implement, we need to be able to find the Jaeger-typed `Gauge` which corresponds to each Helidon `Gauge` so the PR adds a map. (The way we implement gauges internally does not allow us to simply store a reference to the Jaeger gauge in our own gauge and then retrieve the Jaeger gauge from it; hence the need for the map.)

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>