### PR TITLE
3.x: Cleanup Helidon BOM by removing obsolete and internal artifacts

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -678,12 +678,6 @@
                 <artifactId>helidon-dbclient-tracing</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
-            <!-- db client examples -->
-            <dependency>
-                <groupId>io.helidon.examples.dbclient</groupId>
-                <artifactId>helidon-examples-dbclient-common</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
 
             <!-- tracing -->
             <dependency>
@@ -1035,11 +1029,6 @@
             <dependency>
                 <groupId>io.helidon.microprofile.tests</groupId>
                 <artifactId>helidon-microprofile-tests-junit5</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.microprofile.tests</groupId>
-                <artifactId>helidon-microprofile-tests-testng</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -470,11 +470,6 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.helidon.microprofile.bundles</groupId>
-                <artifactId>internal-test-libs</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.helidon.microprofile</groupId>
                 <artifactId>helidon-microprofile-security</artifactId>
                 <version>${helidon.version}</version>
@@ -806,11 +801,6 @@
                 <artifactId>helidon-lra-coordinator-narayana-client</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.helidon.lra</groupId>
-                <artifactId>helidon-lra-coordinator-server</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
 
             <!-- integrations -->
             <dependency>
@@ -821,56 +811,6 @@
             <dependency>
                 <groupId>io.helidon.integrations.db</groupId>
                 <artifactId>h2</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-api</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-config-source</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-system-kubernetes</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-system-oracle-accs</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-ucp-accs</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-ucp-localhost</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.serviceconfiguration</groupId>
-                <artifactId>helidon-serviceconfiguration-ucp</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
@@ -1060,12 +1000,6 @@
                 <artifactId>helidon-integrations-openapi-ui</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
-            <!-- CORS support -->
-            <dependency>
-                <groupId>io.helidon.webserver.cors</groupId>
-                <artifactId>helidon-cors</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
             <!-- Messaging -->
             <dependency>
                 <groupId>io.helidon.messaging</groupId>
@@ -1155,17 +1089,6 @@
                 <groupId>io.helidon.microprofile.bean-validation</groupId>
                 <artifactId>helidon-microprofile-bean-validation</artifactId>
                 <version>${helidon.version}</version>
-            </dependency>
-            <!-- Helidon tests tools -->
-            <dependency>
-                <groupId>io.helidon.tests.integration.tools</groupId>
-                <artifactId>helidon-tests-integration-tools-service</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.tests.integration.tools</groupId>
-                <artifactId>helidon-tests-integration-tools-client</artifactId>
-                <version>${project.version}</version>
             </dependency>
             <!-- Microstream -->
             <dependency>

--- a/examples/dbclient/jdbc/pom.xml
+++ b/examples/dbclient/jdbc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -107,6 +107,7 @@
         <dependency>
             <groupId>io.helidon.examples.dbclient</groupId>
             <artifactId>helidon-examples-dbclient-common</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>

--- a/examples/dbclient/mongodb/pom.xml
+++ b/examples/dbclient/mongodb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -89,6 +89,7 @@
         <dependency>
             <groupId>io.helidon.examples.dbclient</groupId>
             <artifactId>helidon-examples-dbclient-common</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>

--- a/microprofile/lra/jax-rs/pom.xml
+++ b/microprofile/lra/jax-rs/pom.xml
@@ -71,6 +71,7 @@
         <dependency>
             <groupId>io.helidon.lra</groupId>
             <artifactId>helidon-lra-coordinator-server</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/microprofile/tests/testng-tests/pom.xml
+++ b/microprofile/tests/testng-tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2022, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>io.helidon.microprofile.tests</groupId>
             <artifactId>helidon-microprofile-tests-testng</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/integration/dbclient/appl/pom.xml
+++ b/tests/integration/dbclient/appl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -85,10 +85,12 @@
         <dependency>
             <groupId>io.helidon.tests.integration.tools</groupId>
             <artifactId>helidon-tests-integration-tools-service</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.tests.integration.tools</groupId>
             <artifactId>helidon-tests-integration-tools-client</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/integration/tools/example/pom.xml
+++ b/tests/integration/tools/example/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -75,10 +75,12 @@
         <dependency>
             <groupId>io.helidon.tests.integration.tools</groupId>
             <artifactId>helidon-tests-integration-tools-service</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.tests.integration.tools</groupId>
             <artifactId>helidon-tests-integration-tools-client</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes #6015

The rule I'm following is: The Helidon BOM that is published to maven central should not manage versions of things not published to maven central.