### PR TITLE
Use Hamcrest assertions instead of JUnit in  microprofile/messaging/core - backport main (#1749)

### DIFF
--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/EmitterTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/EmitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
 
 import jakarta.inject.Inject;
 
@@ -69,7 +69,7 @@ class EmitterTest {
         emitter.send("Test2");
         emitter.send(Message.of("Test3"));
         emitter.complete();
-        assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
+        assertThat(countDownLatch.await(10, TimeUnit.SECONDS), is(true));
         assertThat(payloads, contains("Test1", "Test2", "Test3"));
     }
 }

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/UnwrapProcessorTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/UnwrapProcessorTest.java
@@ -24,11 +24,11 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.CoreMatchers.is;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.reactivestreams.Subscriber;
@@ -63,7 +63,7 @@ class UnwrapProcessorTest {
         unwrapProcessor.setMethod(method);
         Object unwrappedValue = unwrapProcessor.unwrap(Message.of("test"));
         if (method.getName().endsWith("Message")) {
-            Assertions.assertTrue(MessageUtils.isMessageType(method));
+            assertThat(MessageUtils.isMessageType(method), is(true));
             assertThat(unwrappedValue, instanceOf(Message.class));
         } else {
             assertThat("Expected method param to be a Message type.",

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/connector/Processor2ConnectorTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/connector/Processor2ConnectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ import org.reactivestreams.FlowAdapters;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @HelidonTest
@@ -89,7 +89,7 @@ public class Processor2ConnectorTest {
         emitter.emit(Message.of("test2"));
         emitter.complete();
         connector.awaitComplete("to-connector-" + channelPostfix);
-        assertEquals(4, resultList.size());
+        assertThat(resultList, hasSize(4));
         assertThat(resultList.stream()
                         .map(Message::getPayload)
                         .collect(Collectors.toList()),


### PR DESCRIPTION
Part of #1749

[Original PR](https://github.com/helidon-io/helidon/pull/5043)