### PR TITLE
Remove trailing empty line in copyright comment (part 26)

### DIFF
--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.microprofile.openapi;
 

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/other/TestApp2.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/other/TestApp2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.microprofile.openapi.other;
 

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicCancelSubscriber.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicCancelSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicCollectSubscriber.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicCollectSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicCompletionSubscriber.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicCompletionSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicFindFirstSubscriber.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicFindFirstSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicProcessor.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BasicProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BridgeProcessor.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/BridgeProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/DeferredProcessor.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/DeferredProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/DeferredViaProcessor.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/DeferredViaProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveCompletionRunner.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveCompletionRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveGraphCaptureEngine.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveGraphCaptureEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveProcessorBuilder.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveProcessorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.microprofile.reactive;
 

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactivePublisherBuilder.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactivePublisherBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactivePublisherFactory.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactivePublisherFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveStage.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngine.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveSubscriberBuilder.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveSubscriberBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/MultiCancelOnExecutor.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/MultiCancelOnExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/MultiNullGuard.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/MultiNullGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/SubscriptionHelper.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/SubscriptionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.reactive;

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/package-info.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 /**

--- a/microprofile/scheduling/src/main/java/io/helidon/microprofile/scheduling/FixedRate.java
+++ b/microprofile/scheduling/src/main/java/io/helidon/microprofile/scheduling/FixedRate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.scheduling;

--- a/microprofile/scheduling/src/main/java/io/helidon/microprofile/scheduling/package-info.java
+++ b/microprofile/scheduling/src/main/java/io/helidon/microprofile/scheduling/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 /**

--- a/microprofile/scheduling/src/test/java/io/helidon/microprofile/scheduling/InvalidStateTest.java
+++ b/microprofile/scheduling/src/test/java/io/helidon/microprofile/scheduling/InvalidStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.helidon.microprofile.scheduling;


### PR DESCRIPTION
The last part of https://github.com/helidon-io/helidon/pull/5324 .
<img width="1240" alt="Screenshot 2023-02-01 at 19 13 38" src="https://user-images.githubusercontent.com/4740207/216114014-635eae42-0e6e-4b64-8e35-11b12d94f244.png">
