### PR TITLE
3.x: Upgrade opentelemetry to 1.22.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -127,9 +127,10 @@
         <version.lib.oci>3.2.1</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
-        <version.lib.okhttp3>3.14.9</version.lib.okhttp3>
-        <version.lib.okio>1.17.5</version.lib.okio>
-        <version.lib.opentelemetry>1.15.0</version.lib.opentelemetry>
+        <version.lib.okhttp3>4.10.0</version.lib.okhttp3>
+        <version.lib.okio>3.0.0</version.lib.okio>
+        <version.lib.kotlin>1.6.20</version.lib.kotlin>
+        <version.lib.opentelemetry>1.22.0</version.lib.opentelemetry>
         <version.lib.opentelemetry.semconv>1.15.0-alpha</version.lib.opentelemetry.semconv>
         <version.lib.opentelemetry.opentracing.shim>1.15.0-alpha</version.lib.opentelemetry.opentracing.shim>
         <version.lib.opentracing>0.33.0</version.lib.opentracing>
@@ -1320,24 +1321,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!-- 4.x versions cause problems with native-image This is used by jaeger-client -->
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${version.lib.okhttp3}</version>
-            </dependency>
-            <dependency>
-                <!-- required for dependency convergence
-                used from both
-                com.squareup.okhttp3:mockwebserver:3.13.1
-                com.squareup.moshi:moshi:1.8.0
-                both referenced by
-                io.zipkin.zipkin2:zipkin-junit:2.12.5
-                -->
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
-                <version>${version.lib.okio}</version>
-            </dependency>
             <!-- END OF Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
 
             <!-- Section 4: Testing -->
@@ -1437,6 +1420,28 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
                 <version>${version.lib.google-protobuf}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Dependency convergence: okhttp, okio-jvm as used by opentelemetry, grpc -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${version.lib.kotlin}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-bom</artifactId>
+                <version>${version.lib.okio}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-bom</artifactId>
+                <version>${version.lib.okhttp3}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2016, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -114,6 +114,18 @@
             <artifactId>zipkin-junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Dependency convergence for junit:junit from io.zipkin.zipkin2:zipkin-junit -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>com.oracle.bedrock</groupId>
             <artifactId>bedrock-testing-support</artifactId>


### PR DESCRIPTION
This upgrades OpenTelemetry to 1.22.0 and makes some changes for dependency convergence. There is a bit of a tangle between okio, okhttp3 and kotlin.  Reviewers should confirm that we want to make this upgrade.

Also, we had a note about okhttp 4.x and issues with native-image. I did a test by adding Jaeger and Zipkin tracing support to the MP quickstart and I was able to build/run native-image. 