### PR TITLE
Register OciMetricsSupport service only when enable flag is set to true

### DIFF
--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -39,15 +39,18 @@ public class OciMetricsBean {
     // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
     void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object ignore,
                             Config config, Monitoring monitoringClient) {
-        Config helidonConfig =  config.get("ocimetrics");
-        if (helidonConfig.exists()) {
-            OciMetricsSupport.Builder builder = OciMetricsSupport.builder()
-                    .config(helidonConfig)
-                    .monitoringClient(monitoringClient);
-
-            RoutingBuilders.create(helidonConfig)
-                    .routingBuilder()
-                    .register(builder.build());
+        Config ocimetrics = config.get("ocimetrics");
+        OciMetricsSupport.Builder builder = OciMetricsSupport.builder()
+                .config(ocimetrics)
+                .monitoringClient(monitoringClient);
+        if (builder.enabled()) {
+            activateOciMetricsSupport(ocimetrics, builder);
         }
+    }
+
+    void activateOciMetricsSupport(Config ocimetrics, OciMetricsSupport.Builder builder) {
+        RoutingBuilders.create(ocimetrics)
+                .routingBuilder()
+                .register(builder.build());
     }
 }

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
@@ -15,10 +15,6 @@
  */
 package io.helidon.integrations.oci.metrics.cdi;
 
-import jakarta.annotation.Priority;
-import jakarta.enterprise.inject.Alternative;
-import static jakarta.interceptor.Interceptor.Priority.APPLICATION;
-
 import com.oracle.bmc.Region;
 import com.oracle.bmc.monitoring.Monitoring;
 import com.oracle.bmc.monitoring.MonitoringPaginators;
@@ -28,6 +24,8 @@ import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
 import com.oracle.bmc.monitoring.requests.*;
 import com.oracle.bmc.monitoring.responses.*;
 
+import io.helidon.config.Config;
+import io.helidon.integrations.oci.metrics.OciMetricsSupport;
 import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.microprofile.config.ConfigCdiExtension;
 import io.helidon.microprofile.server.ServerCdiExtension;
@@ -40,6 +38,7 @@ import io.helidon.microprofile.tests.junit5.HelidonTest;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -51,6 +50,7 @@ import static org.hamcrest.Matchers.is;
 
 @HelidonTest(resetPerTest = true)
 @AddBean(OciMetricsCdiExtensionTest.MockMonitoring.class)
+@AddBean(OciMetricsCdiExtensionTest.MockOciMetricsBean.class)
 @DisableDiscovery
 // Helidon MP Extensions
 @AddExtension(ServerCdiExtension.class)
@@ -76,26 +76,56 @@ public class OciMetricsCdiExtensionTest {
     // Use countDownLatch1 to signal the test that results to be asserted has been retrieved
     private static CountDownLatch countDownLatch1 = new CountDownLatch(1);
     private static PostMetricDataDetails postMetricDataDetails;
+    private static boolean activateOciMetricsSupportIsInvoked;
+
+    @AfterEach
+    private void resetState() {
+        postMetricDataDetails = null;
+        activateOciMetricsSupportIsInvoked = false;
+        countDownLatch1 = new CountDownLatch(1);
+    }
 
     @Test
-    public void testRegisterOciMetrics() throws InterruptedException {
+    @AddConfig(key = "ocimetrics.enabled", value = "true")
+    public void testEnableOciMetrics() throws InterruptedException {
+        validateOciMetricsSupport(true);
+    }
+
+    @Test
+    public void testEnableOciMetricsWithoutConfig() throws InterruptedException {
+        validateOciMetricsSupport(true);
+    }
+
+    @Test
+    @AddConfig(key = "ocimetrics.enabled", value = "false")
+    public void testDisableOciMetrics() throws InterruptedException {
+        validateOciMetricsSupport(false);
+    }
+
+    private void validateOciMetricsSupport(boolean enabled) throws InterruptedException {
         baseMetricRegistry.counter("baseDummyCounter").inc();
         vendorMetricRegistry.counter("vendorDummyCounter").inc();
         appMetricRegistry.counter("appDummyCounter").inc();
         // Wait for signal from metric update that testMetricCount has been retrieved
-        countDownLatch1.await(10, TimeUnit.SECONDS);
+        countDownLatch1.await(3, TimeUnit.SECONDS);
 
-        assertThat(testMetricCount, is(equalTo(3)));
+        if (enabled) {
+            assertThat(activateOciMetricsSupportIsInvoked, is(true));
+            assertThat(testMetricCount, is(3));
 
-        MetricDataDetails metricDataDetails = postMetricDataDetails.getMetricData().get(0);
-        assertThat(metricDataDetails.getCompartmentId(),
-                   is(equalTo(OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.compartmentId)));
-        assertThat(metricDataDetails.getNamespace(), is(equalTo(MetricDataDetailsOCIParams.namespace)));
-        assertThat(metricDataDetails.getResourceGroup(), is(equalTo(MetricDataDetailsOCIParams.resourceGroup)));
+            MetricDataDetails metricDataDetails = postMetricDataDetails.getMetricData().get(0);
+            assertThat(metricDataDetails.getCompartmentId(),
+                       is(MetricDataDetailsOCIParams.compartmentId));
+            assertThat(metricDataDetails.getNamespace(), is(MetricDataDetailsOCIParams.namespace));
+            assertThat(metricDataDetails.getResourceGroup(), is(MetricDataDetailsOCIParams.resourceGroup));
+        } else {
+            assertThat(activateOciMetricsSupportIsInvoked, is(false));
+            assertThat(testMetricCount, is(0));
+            // validate that OCI post metric is never called
+            assertThat(postMetricDataDetails, is(equalTo(null)));
+        }
     }
 
-    @Alternative
-    @Priority(APPLICATION + 1)
     static class MockMonitoring implements Monitoring {
         @Override
         public void setEndpoint(String s) {}
@@ -177,6 +207,15 @@ public class OciMetricsCdiExtensionTest {
 
         @Override
         public void close() throws Exception {}
+    }
+
+    static class MockOciMetricsBean extends OciMetricsBean {
+        // Override so we can test if this is invoked when enabled or skipped when disabled
+        @Override
+        void activateOciMetricsSupport(Config config, OciMetricsSupport.Builder builder) {
+            activateOciMetricsSupportIsInvoked = true;
+            super.activateOciMetricsSupport(config, builder);
+        }
     }
 
     public interface MetricDataDetailsOCIParams {

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
@@ -525,6 +525,16 @@ public class OciMetricsSupport implements HttpService {
             return this;
         }
 
+        /**
+         * Returns boolean value to indicate whether OciMetricsSupport service will be activated or not.
+         *
+         * @return {@code true} if OciMetricsSupport service will be activated or
+         *         {@code false} if it not
+         */
+        public boolean enabled() {
+            return this.enabled;
+        }
+
         private static Type[] getAllMetricScopes() {
             return new ArrayList<>(SCOPE_TYPES.values()).toArray(new Type[SCOPE_TYPES.size()]);
         }

--- a/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsSupportTest.java
+++ b/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsSupportTest.java
@@ -132,7 +132,8 @@ public class OciMetricsSupportTest {
                 .initialDelay(1L)
                 .delay(2L)
                 .descriptionEnabled(false)
-                .monitoringClient(monitoringClient);
+                .monitoringClient(monitoringClient)
+                .enabled(true);
 
         HttpRouting routing = createRouting(ociMetricsSupportBuilder);
 
@@ -143,6 +144,7 @@ public class OciMetricsSupportTest {
         countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
 
         // Test the 1st and 2nd metric counter updates
+        assertThat(ociMetricsSupportBuilder.enabled(), is(true));
         assertThat(testMetricUpdateCounterValue[0].intValue(), is(equalTo(1)));
         assertThat(testMetricUpdateCounterValue[1].intValue(), is(equalTo(2)));
 
@@ -187,6 +189,7 @@ public class OciMetricsSupportTest {
         // Wait for metrics to be posted
         countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
 
+        assertThat(ociMetricsSupportBuilder.enabled(), is(true));
         // Verify that telemetry-ingestion endpoint is properly set during postin
         assertThat(postingEndPoint, startsWith("https://telemetry-ingestion."));
         // Verify that original endpoint is restored after metric posting
@@ -349,6 +352,7 @@ public class OciMetricsSupportTest {
         delay(1000L);
 
         webServer.stop();
+        assertThat(ociMetricsSupportBuilder.enabled(), is(false));
         // metric count should remain 0 as metrics is disabled
         assertThat(testMetricCount, is(equalTo(0)));
     }


### PR DESCRIPTION
Changes include:
1. Add a getter enabled method in OciMetricsSupport.Builder to provide boolean value indicating whether OciMetricsSupport service will be activated or not.
2. In OciMetricsBean, use the new enabled method to determine whether OciMetricsSupport service will be registered in the default routing or not.
3. Refactor routing registration of OciMetricsSupport, so it can be properly unit tested to verify if it is skipped when disabled or invoked when enabled.
4. Add unit test validation when enable flag is set to true, false, or not set (which defaults to true).