### PR TITLE
Register OciMetricsSupport service only when enable flag is set to true

### DIFF
--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>helidon-integrations-oci-metrics</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-metadata</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>
         </dependency>

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.inject.Singleton;
+
+import io.helidon.config.Config;
+import io.helidon.integrations.oci.metrics.OciMetricsSupport;
+import io.helidon.microprofile.server.RoutingBuilders;
+
+import com.oracle.bmc.monitoring.Monitoring;
+
+import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
+
+/**
+ * OCI metrics integration CDI extension.
+ */
+
+// This bean is added to handle injection on the ObserverMethod as it does not work on an Extension class.
+@Singleton
+public class OciMetricsBean {
+
+    // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
+    void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object ignore,
+                            Config config, Monitoring monitoringClient) {
+        Config ocimetrics = config.get("ocimetrics");
+        OciMetricsSupport.Builder builder = OciMetricsSupport.builder()
+                .config(ocimetrics)
+                .monitoringClient(monitoringClient);
+        if (builder.enabled()) {
+            activateOciMetricsSupport(ocimetrics, builder);
+        }
+    }
+
+    void activateOciMetricsSupport(Config ocimetrics, OciMetricsSupport.Builder builder) {
+        RoutingBuilders.create(ocimetrics)
+                .routingBuilder()
+                .register(builder.build());
+    }
+}

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,6 @@
  */
 package io.helidon.integrations.oci.metrics.cdi;
 
-import javax.annotation.Priority;
-import javax.enterprise.inject.Alternative;
-import static javax.interceptor.Interceptor.Priority.APPLICATION;
-
 import com.oracle.bmc.Region;
 import com.oracle.bmc.monitoring.Monitoring;
 import com.oracle.bmc.monitoring.MonitoringPaginators;
@@ -28,7 +24,10 @@ import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
 import com.oracle.bmc.monitoring.requests.*;
 import com.oracle.bmc.monitoring.responses.*;
 
+import io.helidon.config.Config;
+import io.helidon.integrations.oci.metrics.OciMetricsSupport;
 import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.microprofile.config.ConfigCdiExtension;
 import io.helidon.microprofile.server.ServerCdiExtension;
 import io.helidon.microprofile.server.JaxRsCdiExtension;
 import io.helidon.microprofile.tests.junit5.AddBean;
@@ -39,6 +38,7 @@ import io.helidon.microprofile.tests.junit5.HelidonTest;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -50,10 +50,12 @@ import static org.hamcrest.Matchers.is;
 
 @HelidonTest(resetPerTest = true)
 @AddBean(OciMetricsCdiExtensionTest.MockMonitoring.class)
+@AddBean(OciMetricsCdiExtensionTest.MockOciMetricsBean.class)
 @DisableDiscovery
 // Helidon MP Extensions
 @AddExtension(ServerCdiExtension.class)
 @AddExtension(JaxRsCdiExtension.class)
+@AddExtension(ConfigCdiExtension.class)
 // OciMetricsCdiExtension
 @AddExtension(OciMetricsCdiExtension.class)
 // ConfigSources
@@ -74,26 +76,56 @@ public class OciMetricsCdiExtensionTest {
     // Use countDownLatch1 to signal the test that results to be asserted has been retrieved
     private static CountDownLatch countDownLatch1 = new CountDownLatch(1);
     private static PostMetricDataDetails postMetricDataDetails;
+    private static boolean activateOciMetricsSupportIsInvoked;
+
+    @AfterEach
+    private void resetState() {
+        postMetricDataDetails = null;
+        activateOciMetricsSupportIsInvoked = false;
+        countDownLatch1 = new CountDownLatch(1);
+    }
 
     @Test
-    public void testRegisterOciMetrics() throws InterruptedException {
+    @AddConfig(key = "ocimetrics.enabled", value = "true")
+    public void testEnableOciMetrics() throws InterruptedException {
+        validateOciMetricsSupport(true);
+    }
+
+    @Test
+    public void testEnableOciMetricsWithoutConfig() throws InterruptedException {
+        validateOciMetricsSupport(true);
+    }
+
+    @Test
+    @AddConfig(key = "ocimetrics.enabled", value = "false")
+    public void testDisableOciMetrics() throws InterruptedException {
+        validateOciMetricsSupport(false);
+    }
+
+    private void validateOciMetricsSupport(boolean enabled) throws InterruptedException {
         baseMetricRegistry.counter("baseDummyCounter").inc();
         vendorMetricRegistry.counter("vendorDummyCounter").inc();
         appMetricRegistry.counter("appDummyCounter").inc();
         // Wait for signal from metric update that testMetricCount has been retrieved
-        countDownLatch1.await(10, TimeUnit.SECONDS);
+        countDownLatch1.await(3, TimeUnit.SECONDS);
 
-        assertThat(testMetricCount, is(equalTo(3)));
+        if (enabled) {
+            assertThat(activateOciMetricsSupportIsInvoked, is(true));
+            assertThat(testMetricCount, is(3));
 
-        MetricDataDetails metricDataDetails = postMetricDataDetails.getMetricData().get(0);
-        assertThat(metricDataDetails.getCompartmentId(),
-                is(equalTo(OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.compartmentId)));
-        assertThat(metricDataDetails.getNamespace(), is(equalTo(MetricDataDetailsOCIParams.namespace)));
-        assertThat(metricDataDetails.getResourceGroup(), is(equalTo(MetricDataDetailsOCIParams.resourceGroup)));
+            MetricDataDetails metricDataDetails = postMetricDataDetails.getMetricData().get(0);
+            assertThat(metricDataDetails.getCompartmentId(),
+                       is(MetricDataDetailsOCIParams.compartmentId));
+            assertThat(metricDataDetails.getNamespace(), is(MetricDataDetailsOCIParams.namespace));
+            assertThat(metricDataDetails.getResourceGroup(), is(MetricDataDetailsOCIParams.resourceGroup));
+        } else {
+            assertThat(activateOciMetricsSupportIsInvoked, is(false));
+            assertThat(testMetricCount, is(0));
+            // validate that OCI post metric is never called
+            assertThat(postMetricDataDetails, is(equalTo(null)));
+        }
     }
 
-    @Alternative
-    @Priority(APPLICATION + 1)
     static class MockMonitoring implements Monitoring {
         @Override
         public void setEndpoint(String s) {}
@@ -170,6 +202,15 @@ public class OciMetricsCdiExtensionTest {
 
         @Override
         public void close() throws Exception {}
+    }
+
+    static class MockOciMetricsBean extends OciMetricsBean {
+        // Override so we can test if this is invoked when enabled or skipped when disabled
+        @Override
+        void activateOciMetricsSupport(Config config, OciMetricsSupport.Builder builder) {
+            activateOciMetricsSupportIsInvoked = true;
+            super.activateOciMetricsSupport(config, builder);
+        }
     }
 
     public interface MetricDataDetailsOCIParams {

--- a/integrations/oci/metrics/metrics/pom.xml
+++ b/integrations/oci/metrics/metrics/pom.xml
@@ -48,6 +48,14 @@
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-metadata</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-metadata-processor</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsSupportTest.java
+++ b/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package io.helidon.integrations.oci.metrics;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -26,7 +28,7 @@ import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 
-import com.oracle.bmc.monitoring.MonitoringClient;
+import com.oracle.bmc.monitoring.Monitoring;
 import com.oracle.bmc.monitoring.model.MetricDataDetails;
 import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
 import com.oracle.bmc.monitoring.requests.PostMetricDataRequest;
@@ -44,13 +46,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class OciMetricsSupportTest {
     private final OciMetricsSupport.NameFormatter nameFormatter = new OciMetricsSupport.NameFormatter() { };
-    private static final MonitoringClient monitoringClient = mock(MonitoringClient.class);
+    private static final Monitoring monitoringClient = mock(Monitoring.class);
     private final Type[] types = {Type.BASE, Type.VENDOR, Type.APPLICATION};
 
     private static volatile Double[] testMetricUpdateCounterValue = new Double[2];
@@ -58,6 +61,7 @@ public class OciMetricsSupportTest {
     // Use CountDownLatch to signal when to start testing, for example, test only after results has been retrieved.
     private static CountDownLatch countDownLatch1;
     private static int noOfExecutions;
+    private static int noOfMetrics;
 
     private final RegistryFactory rf = RegistryFactory.getInstance();
     private final MetricRegistry baseMetricRegistry = rf.getRegistry(Type.BASE);
@@ -113,7 +117,8 @@ public class OciMetricsSupportTest {
                 .initialDelay(1L)
                 .delay(2L)
                 .descriptionEnabled(false)
-                .monitoringClient(monitoringClient);
+                .monitoringClient(monitoringClient)
+                .enabled(true);
 
         Routing routing = createRouting(ociMetricsSupportBuilder);
 
@@ -123,9 +128,94 @@ public class OciMetricsSupportTest {
         // Wait for metric updates to complete
         countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
 
+        assertThat(ociMetricsSupportBuilder.enabled(), is(true));
         // Test the 1st and 2nd metric counter updates
         assertThat(testMetricUpdateCounterValue[0].intValue(), is(equalTo(1)));
         assertThat(testMetricUpdateCounterValue[1].intValue(), is(equalTo(2)));
+
+        webServer.shutdown().await(10, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testBatchSize() throws InterruptedException {
+        baseMetricRegistry.counter("baseDummyCounter1").inc();
+        baseMetricRegistry.counter("baseDummyCounter2").inc();
+        baseMetricRegistry.counter("baseDummyCounter3").inc();
+
+        vendorMetricRegistry.counter("vendorDummyCounter1").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter2").inc();
+        vendorMetricRegistry.counter("vendorDummyCounter3").inc();
+
+        appMetricRegistry.counter("appDummyCounter1").inc();
+        appMetricRegistry.counter("appDummyCounter2").inc();
+        appMetricRegistry.counter("appDummyCounter3").inc();
+        appMetricRegistry.counter("appDummyCounter4").inc();
+
+        // Should be 10 metrics
+        int totalMetrics =
+                baseMetricRegistry.getMetrics().size() +
+                        vendorMetricRegistry.getMetrics().size() +
+                        appMetricRegistry.getMetrics().size();
+
+        int batchSize = 3;
+        long batchDelay = 100L;
+        // Should be 1
+        int remainder = totalMetrics % batchSize;
+        // Should be 4
+        int noOfBatches = Math.round(totalMetrics / batchSize) + (remainder > 0 ? 1 : 0);
+
+        countDownLatch1 = new CountDownLatch(1);
+        noOfExecutions = 0;
+        noOfMetrics = 0;
+
+        doAnswer(invocationOnMock -> {
+            noOfExecutions++;
+            PostMetricDataRequest postMetricDataRequest = invocationOnMock.getArgument(0);
+            PostMetricDataDetails postMetricDataDetails = postMetricDataRequest.getPostMetricDataDetails();
+            int metricSizeToPost = postMetricDataDetails.getMetricData().size();
+            noOfMetrics += metricSizeToPost;
+            // Give signal that the last remaining metric in the last batch has been posted
+            if (metricSizeToPost == remainder) {
+                countDownLatch1.countDown();
+            }
+            return PostMetricDataResponse.builder()
+                    .__httpStatusCode__(200)
+                    .build();
+        }).when(monitoringClient).postMetricData(any());
+
+        OciMetricsSupport.Builder ociMetricsSupportBuilder = OciMetricsSupport.builder()
+                .compartmentId("compartmentId")
+                .namespace("namespace")
+                .resourceGroup("resourceGroup")
+                .initialDelay(0L)
+                .delay(20000L)
+                .batchDelay(batchDelay)
+                .schedulingTimeUnit(TimeUnit.MILLISECONDS)
+                .descriptionEnabled(false)
+                .batchSize(batchSize)
+                .monitoringClient(monitoringClient);
+
+
+        Instant start = Instant.now();
+
+        Routing routing = createRouting(ociMetricsSupportBuilder);
+
+        WebServer webServer = createWebServer(routing);
+
+        // Wait for last batch to be completed
+        countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
+        Instant finish = Instant.now();
+
+        // Batch size of 3 for 10 metrics should yield 4 batches to post
+        assertThat(totalMetrics, is(10));
+        assertThat(noOfBatches, is(4));
+        assertThat(noOfExecutions, is(noOfBatches));
+        assertThat(noOfMetrics, is(totalMetrics));
+
+        // Last batch is not delayed so compute only the delays for prior batches
+        long estimatedTotalBatchDelay = batchDelay * (noOfBatches - 1);
+        // Test total batch delay
+        assertThat(Duration.between(start, finish).toMillis(), is(greaterThanOrEqualTo(estimatedTotalBatchDelay)));
 
         webServer.shutdown().await(10, java.util.concurrent.TimeUnit.SECONDS);
     }
@@ -200,6 +290,7 @@ public class OciMetricsSupportTest {
         delay(1000L);
 
         webServer.shutdown().await(10, java.util.concurrent.TimeUnit.SECONDS);
+        assertThat(ociMetricsSupportBuilder.enabled(), is(false));
         // metric count should remain 0 as metrics is disabled
         assertThat(testMetricCount, is(equalTo(0)));
 


### PR DESCRIPTION
Changes include:
1. Add a getter enabled method in OciMetricsSupport.Builder to provide boolean value indicating whether OciMetricsSupport service will be activated or not.
2. In OciMetricsBean, use the new enabled method to determine whether OciMetricsSupport service will be registered in the default routing or not.
3. Refactor routing registration of OciMetricsSupport, so it can be properly unit tested to verify if it is skipped when disabled or invoked when enabled.
4. Add unit test validation when enable flag is set to true, false, or not set (which defaults to true).

Additional relevant changes backported from 3.x/4.x
1. Change MonitoringClient.class to Monitoring.class for mocking using Mockito in the unit test as the OCI Java SDK v3 converted some of the methods in MonitoringClient as Final making them difficult to mock.
2. Trim the OCI Metadata value which contains the metric description if the value exceeds 256 characters, or otherwise it will fail.
3. OCI Monitoring service only allows a maximum of 50 metrics per posting, hence additional configuration parameters were added to control sending metrics in batches. The configuration parameters are: (a.) batchSize - Maximum no. of metrics to send in a batch. Defaults to 50 which is what OCI allows. (b.) batchDelay - Interval between batch posting For example if there are 51 metrics and batchSize is set to 25 and batchDelay to 5 seconds, the Helidon metric integration module will divide the posting to 3 batches sending 25 metrics on the 1st and 2nd batches and 1 metric on the 3rd batch with 5 seconds interval between batch posting.
4. Refactor OciMetricsCdiExtension to add a new bean (OciMetricsBean) to handle the Observer method which will inject Monitoring. Previous code of OciMetricsCdiExtension cannot independently handle instantiation of Monitoring client via CDI.
5. Add unit tests to verify batch posting feature.
6. Move shutdown hook init rules.onNewWebServer(this::prepareShutdown) only after enabled config is verified to be true.
7. Add non null check on builder methods where appropriate.
8. Update builder method ConfiguredOption annotation to reflect default values.