### PR TITLE
Reactive Media Common deprecated cleanup

### DIFF
--- a/examples/webserver/tutorial/src/main/java/io/helidon/reactive/webserver/examples/tutorial/CommentService.java
+++ b/examples/webserver/tutorial/src/main/java/io/helidon/reactive/webserver/examples/tutorial/CommentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,8 +187,7 @@ public class CommentService implements Service {
             String str = comments.stream()
                     .map(Comment::toString)
                     .collect(Collectors.joining("\n"));
-            return ContentWriters.charSequenceWriter(StandardCharsets.UTF_8)
-                    .apply(str + "\n");
+            return ContentWriters.writeCharSequence(str + "\n", StandardCharsets.UTF_8);
         }
 
     }

--- a/reactive/media/common/src/main/java/io/helidon/reactive/media/common/ContentReaders.java
+++ b/reactive/media/common/src/main/java/io/helidon/reactive/media/common/ContentReaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,13 +81,7 @@ public final class ContentReaders {
      * Implementation of {@link Mapper} that converts a {@code byte[]} into
      * a {@link String} using a given {@link Charset}.
      */
-    private static final class BytesToString implements Mapper<byte[], String> {
-
-        private final Charset charset;
-
-        BytesToString(Charset charset) {
-            this.charset = charset;
-        }
+    private record BytesToString(Charset charset) implements Mapper<byte[], String> {
 
         @Override
         public String map(byte[] bytes) {
@@ -98,19 +92,14 @@ public final class ContentReaders {
     /**
      * Mapper that applies URL decoding to a {@code String}.
      */
-    private static final class StringToDecodedString implements Mapper<String, String> {
-
-        private final Charset charset;
-
-        StringToDecodedString(Charset charset) {
-            this.charset = charset;
-        }
+    private record StringToDecodedString(Charset charset) implements Mapper<String, String> {
 
         @Override
         public String map(String s) {
             return URLDecoder.decode(s, charset);
         }
     }
+
     /**
      * Implementation of {@link Collector} that collects chunks into a single
      * {@code byte[]}.

--- a/reactive/media/common/src/main/java/io/helidon/reactive/media/common/ContentWriters.java
+++ b/reactive/media/common/src/main/java/io/helidon/reactive/media/common/ContentWriters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,9 @@ package io.helidon.reactive.media.common;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
-import java.util.Objects;
-import java.util.concurrent.Flow.Publisher;
-import java.util.function.Function;
 
 import io.helidon.common.http.DataChunk;
-import io.helidon.common.reactive.IoMulti;
-import io.helidon.common.reactive.RetrySchema;
 import io.helidon.common.reactive.Single;
 
 /**
@@ -115,88 +109,4 @@ public final class ContentWriters {
         }
         return returnValue;
     }
-
-    /**
-     * Returns a writer function for {@code byte[]}.
-     * <p>
-     * The {@code copy} variant is by default registered in
-     * {@code ServerResponse}.
-     *
-     * @param copy a signal if byte array should be copied - set it {@code true}
-     * if {@code byte[]} will be immediately reused.
-     * @return a {@code byte[]} writer
-     *
-     * @deprecated since 2.0.0, use {@link #writeBytes(byte[], boolean)} instead
-     */
-    @Deprecated(since = "2.0.0")
-    public static Function<byte[], Publisher<DataChunk>> byteArrayWriter(boolean copy) {
-        return (bytes) -> writeBytes(bytes, copy);
-    }
-
-    /**
-     * Returns a writer function for {@link CharSequence} using provided
-     * standard {@code charset}.
-     * <p>
-     * An instance is by default registered in {@code ServerResponse} for all
-     * standard charsets.
-     *
-     * @param charset a standard charset to use
-     * @return a {@link String} writer
-     * @throws NullPointerException if parameter {@code charset} is {@code null}
-     * @deprecated since 2.0.0, use {@link #writeCharSequence(CharSequence, Charset)}
-     *  or {@link DefaultMediaSupport#charSequenceWriter()} instead
-     */
-    @Deprecated(since = "2.0.0")
-    public static Function<CharSequence, Publisher<DataChunk>> charSequenceWriter(Charset charset) {
-        return (cs) -> writeCharSequence(cs, charset);
-    }
-
-    /**
-     * Returns a writer function for {@link CharBuffer} using provided standard
-     * {@code charset}.
-     * <p>
-     * An instance is by default registered in {@code ServerResponse} for all
-     * standard charsets.
-     *
-     * @param charset a standard charset to use
-     * @return a {@link String} writer
-     * @throws NullPointerException if parameter {@code charset} is {@code null}
-     * @deprecated since 2.0.0, use {@link #writeCharBuffer(CharBuffer, Charset)} instead
-     */
-    @Deprecated(since = "2.0.0")
-    public static Function<CharBuffer, Publisher<DataChunk>> charBufferWriter(Charset charset) {
-        return (buffer) -> writeCharBuffer(buffer, charset);
-    }
-
-    /**
-     * Returns a writer function for {@link ReadableByteChannel}. Created
-     * publisher use provided {@link RetrySchema} to define delay between
-     * unsuccessful read attempts.
-     *
-     * @param retrySchema a retry schema to use in case when {@code read}
-     * operation reads {@code 0 bytes}
-     * @return a {@link ReadableByteChannel} writer
-     * @deprecated since 2.0.0, use {@link DefaultMediaSupport#byteChannelWriter(RetrySchema)}} instead
-     */
-    @Deprecated(since = "2.0.0")
-    public static Function<ReadableByteChannel, Publisher<DataChunk>> byteChannelWriter(RetrySchema retrySchema) {
-        Objects.requireNonNull(retrySchema);
-
-        return channel -> IoMulti.multiFromByteChannelBuilder(channel)
-                .retrySchema(retrySchema)
-                .build()
-                .map(DataChunk::create);
-    }
-
-    /**
-     * Returns a writer function for {@link ReadableByteChannel}.
-     *
-     * @return a {@link ReadableByteChannel} writer
-     * @deprecated since 2.0.0, use {@link DefaultMediaSupport#byteChannelWriter()}} instead
-     */
-    @Deprecated(since = "2.0.0")
-    public static Function<ReadableByteChannel, Publisher<DataChunk>> byteChannelWriter() {
-        return channel -> IoMulti.multiFromByteChannel(channel).map(DataChunk::create);
-    }
-
 }

--- a/reactive/media/common/src/main/java/io/helidon/reactive/media/common/MessageBodyReadableContent.java
+++ b/reactive/media/common/src/main/java/io/helidon/reactive/media/common/MessageBodyReadableContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import io.helidon.common.reactive.Single;
 /**
  * Readable {@link MessageBodyContent}.
  */
-@SuppressWarnings("deprecation")
 public final class MessageBodyReadableContent
         implements MessageBodyReaders, MessageBodyFilters, MessageBodyContent, Multi<DataChunk> {
 
@@ -44,16 +43,6 @@ public final class MessageBodyReadableContent
         Objects.requireNonNull(context, "context is null!");
         this.publisher = publisher;
         this.context = context;
-    }
-
-    /**
-     * Copy constructor.
-     * @param orig original context to be copied
-     */
-    private MessageBodyReadableContent(MessageBodyReadableContent orig) {
-        Objects.requireNonNull(orig, "orig is null!");
-        this.publisher = orig.publisher;
-        this.context = orig.context;
     }
 
     /**

--- a/reactive/media/common/src/main/java/io/helidon/reactive/media/common/PathBodyWriter.java
+++ b/reactive/media/common/src/main/java/io/helidon/reactive/media/common/PathBodyWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.mapper.Mapper;
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.common.reactive.IoMulti;
 import io.helidon.common.reactive.Single;
 
 /**
@@ -65,13 +66,7 @@ final class PathBodyWriter implements MessageBodyWriter<Path> {
      * Implementation of {@link Mapper} that converts a {@link Path} to a
      * publisher of {@link DataChunk}.
      */
-    private static final class PathToChunks implements Mapper<Path, Publisher<DataChunk>> {
-
-        private final MessageBodyWriterContext context;
-
-        PathToChunks(MessageBodyWriterContext context) {
-            this.context = context;
-        }
+    private record PathToChunks(MessageBodyWriterContext context) implements Mapper<Path, Publisher<DataChunk>> {
 
         @Override
         public Publisher<DataChunk> map(Path path) {
@@ -79,9 +74,9 @@ final class PathBodyWriter implements MessageBodyWriter<Path> {
                 context.contentType(MediaTypes.APPLICATION_OCTET_STREAM);
                 context.contentLength(Files.size(path));
                 FileChannel fc = FileChannel.open(path, StandardOpenOption.READ);
-                return ContentWriters.byteChannelWriter().apply(fc);
+                return IoMulti.multiFromByteChannel(fc).map(DataChunk::create);
             } catch (IOException ex) {
-                return Single.<DataChunk>error(ex);
+                return Single.error(ex);
             }
         }
     }

--- a/reactive/media/common/src/test/java/io/helidon/reactive/media/common/ContentReadersTest.java
+++ b/reactive/media/common/src/test/java/io/helidon/reactive/media/common/ContentReadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 class ContentReadersTest {
     @Test
-    void testByteArrayReader() {
+    void readBytes() {
         String original = "Popokatepetl";
         byte[] bytes = original.getBytes(StandardCharsets.UTF_8);
 
@@ -45,7 +45,7 @@ class ContentReadersTest {
     }
 
     @Test
-    void testURLDecodingReader() {
+    void readURLEncodedString() {
         String original = "myParam=\"Now@is'the/time";
         String encoded = URLEncoder.encode(original, StandardCharsets.UTF_8);
         Multi<DataChunk> chunks = Multi.singleton(DataChunk.create(encoded.getBytes(StandardCharsets.UTF_8)));

--- a/reactive/media/common/src/test/java/io/helidon/reactive/media/common/ContentWritersTest.java
+++ b/reactive/media/common/src/test/java/io/helidon/reactive/media/common/ContentWritersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ContentWritersTest {
 
     @Test
-    public void byteWriter() throws Exception {
+    public void writeBytesNoCopy() throws Exception {
         byte[] bytes = "abc".getBytes(StandardCharsets.ISO_8859_1);
         Publisher<DataChunk> publisher = ContentWriters.writeBytes(bytes, false);
         byte[] result = ContentReaders.readBytes(publisher).get(5, TimeUnit.SECONDS);
@@ -41,7 +41,7 @@ public class ContentWritersTest {
     }
 
     @Test
-    public void copyByteWriter() throws Exception {
+    public void writeBytesCopy() throws Exception {
         byte[] bytes = "abc".getBytes(StandardCharsets.ISO_8859_1);
         Publisher<DataChunk> publisher = ContentWriters.writeBytes(bytes, true);
         System.arraycopy("xxx".getBytes(StandardCharsets.ISO_8859_1), 0, bytes, 0, bytes.length);
@@ -50,7 +50,7 @@ public class ContentWritersTest {
     }
 
     @Test
-    public void byteWriterEmpty() throws Exception {
+    public void writeEmptyBytes() throws Exception {
         byte[] bytes = new byte[0];
         Publisher<DataChunk> publisher = ContentWriters.writeBytes(bytes, false);
         byte[] result = ContentReaders.readBytes(publisher).get(5, TimeUnit.SECONDS);
@@ -58,9 +58,9 @@ public class ContentWritersTest {
     }
 
     @Test
-    public void charSequenceWriter() throws Exception {
+    public void writeCharSequence() throws Exception {
         String data = "abc";
-        Publisher<DataChunk> publisher = ContentWriters.charSequenceWriter(StandardCharsets.UTF_8).apply(data);
+        Publisher<DataChunk> publisher = ContentWriters.writeCharSequence(data, StandardCharsets.UTF_8);
         byte[] result = ContentReaders.readBytes(publisher).get(5, TimeUnit.SECONDS);
         assertThat(new String(result, StandardCharsets.UTF_8), is(data));
     }


### PR DESCRIPTION
- Remove ContentWriters methods that are deprecated in 3.x
- Aligned test method names in ContentWriterTests and ContentReaderTests
- Removed unused private code in MessageBodyWriterContext and MessageBodyReadableContent
- Convert private inner classes to records

Fixes #4364