### PR TITLE
LRA TCK failing randomly #6106

### DIFF
--- a/microprofile/tests/tck/tck-lra/pom.xml
+++ b/microprofile/tests/tck/tck-lra/pom.xml
@@ -108,10 +108,6 @@
                     <includes>
                         <include>**/*Test*.java</include>
                     </includes>
-                    <excludes>
-                        <!-- It fails randomly -->
-                        <exclude>org.eclipse.microprofile.lra.tck.TckRecoveryTests.java</exclude>
-                    </excludes>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
Relates to https://github.com/helidon-io/helidon/issues/6106

I am not able to make it to fail anymore. This issue was happening more or less the 50% of the time.

Then, I am enabling the test again.

In case it fails, we will take the stacktrace of the error and we can analyze it.