### PR TITLE
Fix OpenAPI UI options processing

### DIFF
--- a/integrations/openapi-ui/src/test/java/io/helidon/integrations/openapi/ui/TestConfig.java
+++ b/integrations/openapi-ui/src/test/java/io/helidon/integrations/openapi/ui/TestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,20 +34,23 @@ class TestConfig {
     void checkOptionsConfig() {
         String newTitle = "New Title";
         String newContext = "/overThere";
+        String newFooter = "New Footer";
         Map<String, String> settings = Map.of("openapi.ui.options.title", newTitle,
+                                              "openapi.ui.options.footer", newFooter,
                                               "openapi.ui.options.notThere", "anything",
                                               "openapi.web-context", newContext);
 
-        Config config = Config.create(ConfigSources.create(settings));
+        Config config = Config.just(ConfigSources.create(settings));
         Config openApiConfig = config.get(OpenAPISupport.Builder.CONFIG_KEY);
         OpenApiUiFull.Builder uiSupportBuilder = OpenApiUiFull.builder()
                 .config(openApiConfig.get(OpenApiUi.Builder.OPENAPI_UI_CONFIG_KEY));
-        OpenAPISupport openAPISupportBuilder = OpenAPISupport.builder()
+        OpenAPISupport.builder() // Side effect: trigger conversion of string options to SmallRye Options options.
                 .config(openApiConfig)
                 .ui(uiSupportBuilder)
                 .build();
 
         // Check a simple option setting.
         assertThat("Overridden title value", uiSupportBuilder.uiOptions().get(Option.title), is(newTitle));
+        assertThat("Overridden footer value", uiSupportBuilder.uiOptions().get(Option.footer), is(newFooter));
     }
 }

--- a/openapi/src/main/java/io/helidon/openapi/OpenApiUi.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenApiUi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,9 +100,9 @@ public interface OpenApiUi extends Service {
         String WEB_CONTEXT_CONFIG_KEY = "web-context";
 
         /**
-         * Sets implementation-specific UI options.
+         * Merges implementation-specific UI options.
          *
-         * @param options the options to set for the UI
+         * @param options the options to for the UI to merge
          * @return updated builder
          */
         @ConfiguredOption(kind = ConfiguredOption.Kind.MAP)
@@ -136,7 +136,7 @@ public interface OpenApiUi extends Service {
         default B config(Config uiConfig) {
             uiConfig.get(ENABLED_CONFIG_KEY).asBoolean().ifPresent(this::isEnabled);
             uiConfig.get(WEB_CONTEXT_CONFIG_KEY).asString().ifPresent(this::webContext);
-            uiConfig.get(OPTIONS_CONFIG_KEY).asMap().ifPresent(this::options);
+            uiConfig.get(OPTIONS_CONFIG_KEY).detach().asMap().ifPresent(this::options);
             return identity();
         }
 

--- a/openapi/src/main/java/io/helidon/openapi/OpenApiUiBase.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenApiUiBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,7 +192,6 @@ public abstract class OpenApiUiBase implements OpenApiUi {
 
         @Override
         public B options(Map<String, String> options) {
-            this.options.clear();
             this.options.putAll(options);
             return identity();
         }
@@ -235,6 +234,10 @@ public abstract class OpenApiUiBase implements OpenApiUi {
          */
         public Function<MediaType, String> documentPreparer() {
             return documentPreparer;
+        }
+
+        protected Map<String, String> options() {
+            return options;
         }
     }
 }


### PR DESCRIPTION
Resolves #5998 

Changes:

1. The original `OpenApiUiFull.Builder#convertOptions` method (now renamed to `uiOptions`) prematurely exited a loop when processing UI options.
2. Originally `OpenApiUiFull.Builder` kept its own `Map<Options, String>`. It now reuses the `Map<String, String>` kept by its abstract superclass `OpenApiUIBase.Builder` to avoid confusion and converts when needed. The change in the type of the key in the map also involves two slight changes in retrieving the `url` entry from the map for a sanity check warning.
3. There was redundant and confusing config logic in the abstract builder superclass and the builder in `OpenApiUiFull`. 
4. Expand the UI config test to make sure multiple overridden values are applied correctly.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>