### PR TITLE
Fix parent handling in OpenTelemetry (#6092)

### DIFF
--- a/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/OpenTelemetrySpanBuilder.java
+++ b/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/OpenTelemetrySpanBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.helidon.tracing.SpanContext;
 
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
 
 class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder> {
     private final SpanBuilder spanBuilder;
@@ -89,7 +90,10 @@ class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder>
         return new OpenTelemetrySpan(span);
     }
 
-    SpanBuilder openTelemetry() {
-        return spanBuilder;
+    // used to set open telemetry context as parent, to be equivalent in function to
+    // #parent(SpanContext)
+    void parent(Context context) {
+        this.parentSet = true;
+        this.spanBuilder.setParent(context);
     }
 }

--- a/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/OpenTelemetrySpanContext.java
+++ b/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/OpenTelemetrySpanContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,11 +40,10 @@ class OpenTelemetrySpanContext implements SpanContext {
     @Override
     public void asParent(io.helidon.tracing.Span.Builder<?> spanBuilder) {
         spanBuilder.unwrap(OpenTelemetrySpanBuilder.class)
-                .openTelemetry()
-                .setParent(context);
+                .parent(context);
     }
 
-    public Context openTelemetry() {
+    Context openTelemetry() {
         return context;
     }
 }


### PR DESCRIPTION
(cherry picked from commit e36870fcf64959a81e77e5f31ce52333c5298c01)

Backport of #5968 

There is no backport for 2.x, as the tracing abstraction and OpenTelemetry support does not exist there