### PR TITLE
Update build-tools to 3.0.4

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -42,8 +42,8 @@
         <version.plugin.dependency>3.1.2</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
-        <version.plugin.helidon>3.0.3</version.plugin.helidon>
-        <version.plugin.helidon-cli>3.0.3</version.plugin.helidon-cli>
+        <version.plugin.helidon>3.0.4</version.plugin.helidon>
+        <version.plugin.helidon-cli>3.0.4</version.plugin.helidon-cli>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.nativeimage>0.9.16</version.plugin.nativeimage>
         <version.plugin.os>1.5.0.Final</version.plugin.os>

--- a/archetypes/helidon/src/main/archetype/flavor.xml
+++ b/archetypes/helidon/src/main/archetype/flavor.xml
@@ -21,8 +21,8 @@
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-2.0.xsd">
 
     <variables>
-        <text path="module-dir"><![CDATA[]]></text>
-        <boolean path="multi-module">false</boolean>
+        <text path="module-dir" transient="true"><![CDATA[]]></text>
+        <boolean path="multi-module" transient="true">false</boolean>
     </variables>
     <step name="Helidon Flavor" optional="true">
         <inputs>

--- a/archetypes/helidon/src/main/archetype/mp/oci/oci-mp.xml
+++ b/archetypes/helidon/src/main/archetype/mp/oci/oci-mp.xml
@@ -35,8 +35,8 @@ This will mount `~/.oci` as a volume in the running docker container.
         </method>
     </methods>
     <variables>
-        <text path="module-dir">server</text>
-        <boolean path="multi-module">true</boolean>
+        <text path="module-dir" transient="true">server</text>
+        <boolean path="multi-module" transient="true">true</boolean>
     </variables>
     <presets>
         <boolean path="db">false</boolean>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@
         <version.plugin.eclipselink>2.7.5.1</version.plugin.eclipselink>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
-        <version.plugin.helidon>3.0.3</version.plugin.helidon>
-        <version.plugin.helidon-cli>3.0.3</version.plugin.helidon-cli>
+        <version.plugin.helidon>3.0.4</version.plugin.helidon>
+        <version.plugin.helidon-cli>3.0.4</version.plugin.helidon-cli>
         <version.plugin.jandex>1.0.6</version.plugin.jandex>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.os>1.5.0.Final</version.plugin.os>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@
         <version.plugin.dependency>3.0.0</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
-        <version.plugin.helidon>3.0.3</version.plugin.helidon>
-        <version.plugin.helidon-cli>3.0.3</version.plugin.helidon-cli>
+        <version.plugin.helidon>3.0.4</version.plugin.helidon>
+        <version.plugin.helidon-cli>3.0.4</version.plugin.helidon-cli>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.os>1.5.0.Final</version.plugin.os>
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
         <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
-        <version.plugin.helidon-build-tools>3.0.3</version.plugin.helidon-build-tools>
+        <version.plugin.helidon-build-tools>3.0.4</version.plugin.helidon-build-tools>
         <version.plugin.hibernate-enhance>${version.lib.hibernate}</version.plugin.hibernate-enhance>
         <version.plugin.jacoco>0.8.5</version.plugin.jacoco>
         <version.plugin.jandex>1.1.0</version.plugin.jandex>


### PR DESCRIPTION
- Mark module-dir and multi-module variables as transient.
- Integrate build-tools 3.0.4

Fixes #6123 