### PR TITLE
Use Hamcrest assertions instead of JUnit in  tests/integration/kafka - backport main (#1749)

### DIFF
--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/AbstractKafkaTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/AbstractKafkaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,9 @@ import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractKafkaTest {
@@ -98,13 +99,13 @@ public abstract class AbstractKafkaTest {
         if (requested > 0) {
             // Wait till records are delivered
             boolean done = kafkaConsumingBean.await();
-            assertTrue(done, String.format("Timeout waiting for results.\nExpected: %s \nBut was: %s",
-                    expected.toString(), kafkaConsumingBean.consumed().toString()));
+            assertThat(String.format("Timeout waiting for results.\nExpected: %s \nBut was: %s",
+                    expected.toString(), kafkaConsumingBean.consumed().toString()), done, is(true));
         }
         Collections.sort(kafkaConsumingBean.consumed());
         Collections.sort(expected);
         if (!expected.isEmpty()) {
-            assertEquals(expected, kafkaConsumingBean.consumed());
+            assertThat(kafkaConsumingBean.consumed(), contains(expected.toArray()));
         }
     }
 

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/EmittingPublisherTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/EmittingPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,11 @@ import org.reactivestreams.FlowAdapters;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EmittingPublisherTest {
 
@@ -57,14 +58,14 @@ public class EmittingPublisherTest {
 
         TEST_DATA.forEach(emitter::emit);
 
-        assertEquals(TEST_DATA, result);
+        assertThat(result, contains(TEST_DATA.toArray()));
     }
 
     @Test
     void notReady() {
         EmittingPublisher<String> emitter = EmittingPublisher.create();
         emitter.onRequest((n, d) -> LOGGER.fine(() -> Long.toString(n)));
-        assertFalse(emitter.emit(""));
+        assertThat(emitter.emit(""), is(false));
     }
 
     @Test
@@ -98,9 +99,9 @@ public class EmittingPublisherTest {
             }
         });
 
-        assertTrue(emitter.isCancelled());
-        assertFalse(emitter.emit("should false"));
-        assertEquals(List.of(), forbiddenSigns);
+        assertThat(emitter.isCancelled(), is(true));
+        assertThat(emitter.emit("should false"), is(false));
+        assertThat(forbiddenSigns, empty());
     }
 
     @Test
@@ -131,9 +132,9 @@ public class EmittingPublisherTest {
             }
         });
         emitter.complete();
-        assertTrue(onCompleteCalled.get());
-        assertTrue(emitter.isCompleted());
+        assertThat(onCompleteCalled.get(), is(true));
+        assertThat(emitter.isCompleted(), is(true));
         assertThrows(IllegalStateException.class, () -> emitter.emit("should false"));
-        assertEquals(List.of(), forbiddenSigs);
+        assertThat(forbiddenSigs, empty());
     }
 }

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaMpTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaMpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,12 +61,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class KafkaMpTest extends AbstractKafkaTest{
@@ -244,9 +244,9 @@ class KafkaMpTest extends AbstractKafkaTest{
     static void cdiContainerDown() {
         KafkaConnector factory = getInstance(KafkaConnector.class, KAFKA_CONNECTOR_LITERAL).get();
         Collection<KafkaPublisher<?, ?>> resources = factory.resources();
-        assertFalse(resources.isEmpty());
+        assertThat(resources, not(empty()));
         cdiContainer.close();
-        assertTrue(resources.isEmpty());
+        assertThat(resources, empty());
         LOGGER.info("Container destroyed");
 
         kafkaResource.stopKafka();
@@ -267,7 +267,7 @@ class KafkaMpTest extends AbstractKafkaTest{
 
         Map<String, String> p = new HashMap<>(cdiConfig());
         cdiContainer = startCdiContainer(p, classes);
-        assertTrue(cdiContainer.isRunning());
+        assertThat(cdiContainer.isRunning(), is(true));
         List<String> topicsInKafka = new ArrayList<>(kafkaResource.getKafkaTestUtils().getTopicNames());
         topicsInKafka.remove(DLQ_TOPIC);
         //Wait till consumers are ready
@@ -281,7 +281,7 @@ class KafkaMpTest extends AbstractKafkaTest{
             }
             topicsInKafka.removeAll(c.topics());
         });
-        assertEquals(Collections.emptyList(), topicsInKafka);
+        assertThat(topicsInKafka, empty());
         LOGGER.info("Container setup");
     }
 
@@ -292,8 +292,7 @@ class KafkaMpTest extends AbstractKafkaTest{
         Config config = Config.builder().sources(ConfigSources.create(p)).build();
         KafkaConfig kafkaConfig = KafkaConfig.create(config);
         List<String> topics = kafkaConfig.topics();
-        assertEquals(2, topics.size());
-        assertTrue(topics.containsAll(Arrays.asList("topic1", "topic2")));
+        assertThat(topics, contains("topic1", "topic2"));
     }
 
     @Test
@@ -302,10 +301,10 @@ class KafkaMpTest extends AbstractKafkaTest{
         Map<String, String> p = Map.of("topic.pattern", "topic[1-2]");
         Config config = Config.builder().sources(ConfigSources.create(p)).build();
         KafkaConfig kafkaConfig = KafkaConfig.create(config);
-        assertTrue(kafkaConfig.topicPattern().isPresent());
-        assertTrue(kafkaConfig.topicPattern().get().matcher("topic1").matches());
-        assertTrue(kafkaConfig.topicPattern().get().matcher("topic2").matches());
-        assertFalse(kafkaConfig.topicPattern().get().matcher("topic3").matches());
+        assertThat(kafkaConfig.topicPattern().isPresent(), is(true));
+        assertThat(kafkaConfig.topicPattern().get().matcher("topic1").matches(), is(true));
+        assertThat(kafkaConfig.topicPattern().get().matcher("topic2").matches(), is(true));
+        assertThat(kafkaConfig.topicPattern().get().matcher("topic3").matches(), is(false));
     }
 
     @Test
@@ -404,7 +403,7 @@ class KafkaMpTest extends AbstractKafkaTest{
         produceAndCheck(kafkaConsumingBean, testData, TEST_TOPIC_10, Collections.emptyList(), 0);
         // As the channel is cancelled, we cannot wait till something happens. We need to explicitly wait some time.
         Thread.sleep(1000);
-        assertEquals(Collections.emptyList(), kafkaConsumingBean.consumed());
+        assertThat(kafkaConsumingBean.consumed(), empty());
         kafkaResource.getKafkaTestUtils().consumeAllRecordsFromTopic(TEST_TOPIC_10);
     }
 
@@ -413,7 +412,7 @@ class KafkaMpTest extends AbstractKafkaTest{
         LOGGER.fine(() -> "==========> test kafkaProduceWithNack()");
         AbstractSampleBean.Channel14 kafkaProdBean = cdiContainer.select(AbstractSampleBean.Channel14.class).get();
         Throwable t = kafkaProdBean.getNacked().get(5, TimeUnit.SECONDS);
-        assertNotNull(t);
+        assertThat(t, notNullValue());
         assertThat(t.getCause(), Matchers.instanceOf(org.apache.kafka.common.errors.TimeoutException.class));
     }
 
@@ -429,7 +428,7 @@ class KafkaMpTest extends AbstractKafkaTest{
         produceAndCheck(kafkaConsumingBean, testData, TEST_TOPIC_13, Collections.emptyList(), 0);
         // As the channel is cancelled, we cannot wait till something happens. We need to explicitly wait some time.
         Thread.sleep(1000);
-        assertEquals(Collections.emptyList(), kafkaConsumingBean.consumed());
+        assertThat(kafkaConsumingBean.consumed(), empty());
         kafkaResource.getKafkaTestUtils().consumeAllRecordsFromTopic(TEST_TOPIC_13);
     }
 
@@ -448,7 +447,7 @@ class KafkaMpTest extends AbstractKafkaTest{
                 .registerConfig(config,
                         Thread.currentThread().getContextClassLoader());
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance();
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         initializer.addBeanClasses(beanClasses.toArray(new Class<?>[0]));
         return initializer.initialize();
     }

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,10 +64,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaSeTest extends AbstractKafkaTest {
     private static final Logger LOGGER = Logger.getLogger(KafkaSeTest.class.getName());
@@ -501,7 +501,7 @@ public class KafkaSeTest extends AbstractKafkaTest {
         List<String> events = readTopic(TOPIC, uncommit.size(), GROUP);
         Collections.sort(events);
         Collections.sort(uncommit);
-        assertEquals(uncommit, events);
+        assertThat(events, contains(uncommit.toArray()));
     }
 
     @Test
@@ -544,10 +544,10 @@ public class KafkaSeTest extends AbstractKafkaTest {
         }
         int uncommited = kafkaConsumingBean.uncommitted();
         // At least one message was not committed
-        assertTrue(uncommited > 0);
+        assertThat(uncommited, greaterThan(0));
         LOGGER.fine(() -> "Uncommitted messages : " + uncommited);
         List<String> messages = readTopic(TOPIC, uncommited, GROUP);
-        assertEquals(uncommited, messages.size(), "Received messages are " + messages);
+        assertThat("Received messages are " + messages, messages, hasSize(uncommited));
     }
 
     @Test


### PR DESCRIPTION
Part of #1749 

[Original PR](https://github.com/helidon-io/helidon/pull/5235)