### PR TITLE
Use Hamcrest assertions instead of JUnit in  integrations/cdi/jpa-cdi- backport main (#1749)

### DIFF
--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAnnotationRewriting.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAnnotationRewriting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ApplicationScoped
@@ -78,7 +79,7 @@ class TestAnnotationRewriting {
         System.setProperty("jpaAnnotationRewritingEnabled", "true");
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
   
@@ -109,24 +110,24 @@ class TestAnnotationRewriting {
     @PersistenceContext(unitName = "test")
     private void observerMethod(@Observes final TestIsRunning event,
                                 final EntityManager emParameter) {
-        assertNotNull(event);
+        assertThat(event, notNullValue());
 
-        assertNotNull(emParameter);
-        assertTrue(emParameter.isOpen());
-        assertFalse(emParameter.isJoinedToTransaction());
+        assertThat(emParameter, notNullValue());
+        assertThat(emParameter.isOpen(), is(true));
+        assertThat(emParameter.isJoinedToTransaction(), is(false));
 
-        assertNotNull(this.em);
-        assertTrue(this.em.isOpen());
-        assertFalse(this.em.isJoinedToTransaction());
+        assertThat(this.em, notNullValue());
+        assertThat(this.em.isOpen(), is(true));
+        assertThat(this.em.isJoinedToTransaction(), is(false));
 
-        assertNotNull(this.emf);
-        assertTrue(this.emf.isOpen());
+        assertThat(this.emf, notNullValue());
+        assertThat(this.emf.isOpen(), is(true));
         EntityManager em = null;
         try {
           em = this.emf.createEntityManager();
-          assertNotNull(em);
-          assertTrue(em.isOpen());
-          assertFalse(em.isJoinedToTransaction());
+          assertThat(em, notNullValue());
+          assertThat(em.isOpen(), is(true));
+          assertThat(em.isJoinedToTransaction(), is(false));
         } finally {
           if (em != null && !em.isOpen()) {
             em.close();
@@ -162,9 +163,9 @@ class TestAnnotationRewriting {
         qualifiers.add(ContainerManaged.Literal.INSTANCE);
         qualifiers.add(JpaTransactionScoped.Literal.INSTANCE);
         final EntityManager entityManager = this.cdiContainer.select(EntityManager.class, qualifiers.toArray(new Annotation[qualifiers.size()])).get();
-        assertTrue(entityManager instanceof DelegatingEntityManager);
-        assertTrue(entityManager.isOpen());
-        assertFalse(entityManager.isJoinedToTransaction());
+        assertThat(entityManager, instanceOf(DelegatingEntityManager.class));
+        assertThat(entityManager.isOpen(), is(true));
+        assertThat(entityManager.isJoinedToTransaction(), is(false));
         try {
             entityManager.persist(new Object());
             fail("A TransactionRequiredException should have been thrown");
@@ -187,14 +188,14 @@ class TestAnnotationRewriting {
             .fire(new TestIsRunning("testTransactionalEntityManager"));
         final Instance<TestAnnotationRewriting> instance = this.cdiContainer.select(TestAnnotationRewriting.class);
         final TestAnnotationRewriting test = instance.get();
-        assertNotNull(test);
+        assertThat(test, notNullValue());
         test.testEntityManagerIsJoinedToTransactionInTransactionalAnnotatedMethod();
     }
     
     @Transactional
     void testEntityManagerIsJoinedToTransactionInTransactionalAnnotatedMethod() {
-        assertNotNull(this.em);
-        assertTrue(this.em.isJoinedToTransaction());
+        assertThat(this.em, notNullValue());
+        assertThat(this.em.isJoinedToTransaction(), is(true));
         try {
             this.em.close();
             fail("Closed EntityManager; should not have been able to");

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestMessages.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,17 @@ package io.helidon.integrations.cdi.jpa;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 final class TestMessages {
 
     @Test
     final void testMessages() {
         final String message = Messages.format("resourceLocalPersistenceUnitWarning");
-        assertNotNull(message);
-        assertTrue(message.startsWith("The persistence unit "));
+        assertThat(message, notNullValue());
+        assertThat(message, startsWith("The persistence unit "));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestMultiplePersistenceUnits.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestMultiplePersistenceUnits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 @DataSourceDefinition(
@@ -70,7 +71,7 @@ class TestMultiplePersistenceUnits {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -109,15 +110,15 @@ class TestMultiplePersistenceUnits {
     @Test
     void testMultiplePersistenceUnits() {
         TestMultiplePersistenceUnits self = this.cdiContainer.select(TestMultiplePersistenceUnits.class).get();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         EntityManager testEm = self.getTestEntityManager();
-        assertNotNull(testEm);
-        assertTrue(testEm.isOpen());
+        assertThat(testEm, notNullValue());
+        assertThat(testEm.isOpen(), is(true));
 
         EntityManager test2Em = self.getTest2EntityManager();
-        assertNotNull(test2Em);
-        assertTrue(test2Em.isOpen());
+        assertThat(test2Em, notNullValue());
+        assertThat(test2Em.isOpen(), is(true));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestCascadePersist.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestCascadePersist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,12 +44,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ApplicationScoped
@@ -96,13 +95,13 @@ class TestCascadePersist {
     void startCdiContainerAndRunDDL() throws SQLException {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
         final DataSource ds = this.cdiContainer.select(DataSource.class).get();
-        assertNotNull(ds);
+        assertThat(ds, notNullValue());
         try (final Connection connection = ds.getConnection();
              final Statement statement = connection.createStatement()) {
-            assertNotNull(statement);
+            assertThat(statement, notNullValue());
             statement.executeUpdate("RUNSCRIPT FROM 'classpath:chirp.ddl'");
         }
     }
@@ -169,83 +168,83 @@ class TestCascadePersist {
         // Get a CDI contextual reference to this test instance.  It
         // is important to use "self" in this test instead of "this".
         final TestCascadePersist self = self();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         // Get the EntityManager that is synchronized with and scoped
         // to a JTA transaction.
         final EntityManager em = self.getEntityManager();
-        assertNotNull(em);
-        assertTrue(em.isOpen());
+        assertThat(em, notNullValue());
+        assertThat(em.isOpen(), is(true));
 
         // We haven't started any kind of transaction yet and we
         // aren't testing anything using
         // the @jakarta.transaction.Transactional annotation so there is
         // no transaction in effect so the EntityManager cannot be
         // joined to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Get the TransactionManager that normally is behind the
         // scenes and use it to start a Transaction.  This simulates
         // entering a method annotated
         // with @Transactional(TxType.REQUIRES_NEW) or similar.
         final TransactionManager tm = self.getTransactionManager();
-        assertNotNull(tm);
+        assertThat(tm, notNullValue());
         tm.begin();
-        assertEquals(Status.STATUS_ACTIVE, tm.getStatus());
+        assertThat(tm.getStatus(), is(Status.STATUS_ACTIVE));
 
         // Now magically our EntityManager should be joined to it.
-        assertTrue(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(true));
 
         // Create an author but don't persist him explicitly.
         Author author = new Author("Abraham Lincoln");
 
         // No trip to the database has happened yet, so the author's
         // identifier isn't set yet.
-        assertNull(author.getId());
+        assertThat(author.getId(), nullValue());
 
         // Set up a blog for that Author.
         Microblog blog = new Microblog(author, "Gettysburg Address Draft 1");
 
         // Persist the blog.  The Author should be persisted too.
         em.persist(blog);
-        assertTrue(em.contains(blog));
-        assertTrue(em.contains(author));
+        assertThat(em.contains(blog), is(true));
+        assertThat(em.contains(author), is(true));
 
         // Commit the transaction.  Because we're relying on the
         // default flush mode, this will cause a flush to the
         // database, which, in turn, will result in identifier
         // generation.
         tm.commit();
-        assertEquals(Status.STATUS_NO_TRANSACTION, tm.getStatus());
-        assertEquals(Integer.valueOf(1), author.getId());
-        assertEquals(Integer.valueOf(1), blog.getId());
+        assertThat(tm.getStatus(), is(Status.STATUS_NO_TRANSACTION));
+        assertThat(author.getId(), is(1));
+        assertThat(blog.getId(), is(1));
 
         // We're no longer in a transaction.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // The persistence context should be cleared.
-        assertFalse(em.contains(blog));
-        assertFalse(em.contains(author));
+        assertThat(em.contains(blog), is(false));
+        assertThat(em.contains(author), is(false));
 
         // Let's check the database directly.
         final DataSource ds = this.cdiContainer.select(DataSource.class).get();
-        assertNotNull(ds);
+        assertThat(ds, notNullValue());
         try (final Connection connection = ds.getConnection();
              final Statement statement = connection.createStatement()) {
-            assertNotNull(statement);
+            assertThat(statement, notNullValue());
             ResultSet rs = statement.executeQuery("SELECT COUNT(1) FROM MICROBLOG");
-            assertNotNull(rs);
+            assertThat(rs, notNullValue());
             try {
-                assertTrue(rs.next());
-                assertEquals(1, rs.getInt(1));
+                assertThat(rs.next(), is(true));
+                assertThat(rs.getInt(1), is(1));
             } finally {
                 rs.close();
             }
             rs = statement.executeQuery("SELECT COUNT(1) FROM AUTHOR");
-            assertNotNull(rs);
+            assertThat(rs, notNullValue());
             try {
-                assertTrue(rs.next());
-                assertEquals(1, rs.getInt(1));
+                assertThat(rs.next(), is(true));
+                assertThat(rs.getInt(1), is(1));
             } finally {
                 rs.close();
             }
@@ -254,12 +253,12 @@ class TestCascadePersist {
         // Start a new transaction.
         tm.begin();
 
-        assertFalse(em.contains(blog));
+        assertThat(em.contains(blog), is(false));
         final Microblog newBlog = em.find(Microblog.class, Integer.valueOf(1));
-        assertNotNull(newBlog);
-        assertTrue(em.contains(newBlog));
+        assertThat(newBlog, notNullValue());
+        assertThat(em.contains(newBlog), is(true));
 
-        assertEquals(blog.getId(), newBlog.getId());
+        assertThat(newBlog.getId(), is(blog.getId()));
         blog = newBlog;
 
         // Now let's have our author write some stuff.
@@ -271,11 +270,11 @@ class TestCascadePersist {
                                        + "whether that nation, or any nation so conceived and so "
                                        + "dedicated, can long endure.");
         blog.addChirp(chirp1);
-        assertSame(blog, chirp1.getMicroblog());
+        assertThat(chirp1.getMicroblog(), sameInstance(blog));
         blog.addChirp(chirp2);
-        assertSame(blog, chirp2.getMicroblog());
+        assertThat(chirp2.getMicroblog(), sameInstance(blog));
         blog.addChirp(chirp3);
-        assertSame(blog, chirp3.getMicroblog());
+        assertThat(chirp3.getMicroblog(), sameInstance(blog));
 
         // Commit the transaction.  The changes should be propagated.
         // However, this will fail, because the third chirp above is
@@ -292,12 +291,12 @@ class TestCascadePersist {
         // functioned properly.  Let's make sure.
         try (final Connection connection = ds.getConnection();
              final Statement statement = connection.createStatement()) {
-            assertNotNull(statement);
+            assertThat(statement, notNullValue());
             ResultSet rs = statement.executeQuery("SELECT COUNT(1) FROM CHIRP");
-            assertNotNull(rs);
+            assertThat(rs, notNullValue());
             try {
-                assertTrue(rs.next());
-                assertEquals(0, rs.getInt(1));
+                assertThat(rs.next(), is(true));
+                assertThat(rs.getInt(1), is(0));
             } finally {
                 rs.close();
             }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedSynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedSynchronizedEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,9 +37,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 @DataSourceDefinition(
@@ -89,7 +89,7 @@ class TestExtendedSynchronizedEntityManager {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -157,20 +157,20 @@ class TestExtendedSynchronizedEntityManager {
         // is important to use "self" in this test instead of "this".
         final TestExtendedSynchronizedEntityManager self =
             this.cdiContainer.select(TestExtendedSynchronizedEntityManager.class).get();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         // Get the EntityManager that is synchronized with but whose
         // persistence context extends past a single JTA transaction.
         final EntityManager em = self.getExtendedSynchronizedEntityManager();
-        assertNotNull(em);
-        assertTrue(em.isOpen());
+        assertThat(em, notNullValue());
+        assertThat(em.isOpen(), is(true));
 
         // We haven't started any kind of transaction yet and we
         // aren't testing anything using
         // the @jakarta.transaction.Transactional annotation so there is
         // no transaction in effect so the EntityManager cannot be
         // joined to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Create a JPA entity and try to insert it.  Should be just
         // fine.
@@ -183,30 +183,30 @@ class TestExtendedSynchronizedEntityManager {
         // Get the TransactionManager that normally is behind the
         // scenes and use it to start a Transaction.
         final TransactionManager tm = self.getTransactionManager();
-        assertNotNull(tm);
+        assertThat(tm, notNullValue());
         tm.begin();
 
         // Now magically our EntityManager should be joined to it.
-        assertTrue(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(true));
 
         // Roll the transaction back and note that our EntityManager
         // is no longer joined to it.
         tm.rollback();
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Start another transaction and persist our Author.
         tm.begin();
         em.persist(author);
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
         tm.commit();
 
         // The transaction is over, so our EntityManager is not joined
         // to one anymore.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Our PersistenceContextType is EXTENDED, not TRANSACTION, so
         // the underlying persistence context spans transactions.
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedUnsynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedUnsynchronizedEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,9 +37,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 @DataSourceDefinition(
@@ -89,7 +89,7 @@ class TestExtendedUnsynchronizedEntityManager {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -156,21 +156,21 @@ class TestExtendedUnsynchronizedEntityManager {
         // is important to use "self" in this test instead of "this".
         final TestExtendedUnsynchronizedEntityManager self =
             this.cdiContainer.select(TestExtendedUnsynchronizedEntityManager.class).get();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         // Get the EntityManager that is not synchronized with and
         // whose persistence context extends past a single JTA
         // transaction.
         final EntityManager em = self.getExtendedUnsynchronizedEntityManager();
-        assertNotNull(em);
-        assertTrue(em.isOpen());
+        assertThat(em, notNullValue());
+        assertThat(em.isOpen(), is(true));
 
         // We haven't started any kind of transaction yet and we
         // aren't testing anything using
         // the @jakarta.transaction.Transactional annotation so there is
         // no transaction in effect so the EntityManager cannot be
         // joined to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Create a JPA entity and try to insert it.  Should be just
         // fine.
@@ -183,41 +183,41 @@ class TestExtendedUnsynchronizedEntityManager {
         // Get the TransactionManager that normally is behind the
         // scenes and use it to start a Transaction.
         final TransactionManager tm = self.getTransactionManager();
-        assertNotNull(tm);
+        assertThat(tm, notNullValue());
         tm.begin();
 
         // Because we're UNSYNCHRONIZED, no automatic joining takes place.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // We can join manually.
         em.joinTransaction();
 
         // Now we should be joined to it.
-        assertTrue(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(true));
 
         // Roll the transaction back and note that our EntityManager
         // is no longer joined to it.
         tm.rollback();
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Start another transaction and persist our Author.  But note
         // that joining the transaction must be manual.
         tm.begin();
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
         em.persist(author);
-        assertFalse(em.isJoinedToTransaction());
-        assertTrue(em.contains(author));
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(em.contains(author), is(true));
 
         // (Remember, we weren't ever joined to this transaction.)
         tm.commit();
 
         // The transaction is over, and our EntityManager is STILL not joined
         // to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Our PersistenceContextType is EXTENDED, not TRANSACTION, so
         // the underlying persistence context spans transactions.
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedSynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedSynchronizedEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,11 +49,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ApplicationScoped
@@ -110,7 +109,7 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -181,30 +180,30 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
 
         // Get a BeanManager for later use.
         final BeanManager beanManager = this.cdiContainer.getBeanManager();
-        assertNotNull(beanManager);
+        assertThat(beanManager, notNullValue());
 
         // Get a CDI contextual reference to this test instance.  It
         // is important to use "self" in this test instead of "this".
         final TestJpaTransactionScopedSynchronizedEntityManager self =
             this.cdiContainer.select(TestJpaTransactionScopedSynchronizedEntityManager.class).get();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         // Get the EntityManager that is synchronized with and scoped
         // to a JTA transaction.
         final EntityManager em = self.getJpaTransactionScopedSynchronizedEntityManager();
-        assertNotNull(em);
-        assertTrue(em.isOpen());
+        assertThat(em, notNullValue());
+        assertThat(em.isOpen(), is(true));
 
         // Get a DataSource for JPA-independent testing and assertions.
         final DataSource dataSource = self.getDataSource();
-        assertNotNull(dataSource);
+        assertThat(dataSource, notNullValue());
 
         // We haven't started any kind of transaction yet and we
         // aren't testing anything using
         // the @jakarta.transaction.Transactional annotation so there is
         // no transaction in effect so the EntityManager cannot be
         // joined to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Create a JPA entity and try to insert it.  This should fail
         // because according to JPA a TransactionRequiredException
@@ -216,13 +215,13 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
         } catch (final TransactionRequiredException expected) {
 
         }
-        assertFalse(em.contains(author1));
-        assertNull(author1.getId());
+        assertThat(em.contains(author1), is(false));
+        assertThat(author1.getId(), nullValue());
 
         // Get the TransactionManager that normally is behind the
         // scenes and use it to start a Transaction.
         final TransactionManager tm = self.getTransactionManager();
-        assertNotNull(tm);
+        assertThat(tm, notNullValue());
         tm.setTransactionTimeout(60 * 20); // TODO: set to 20 minutes for debugging purposes only
 
         // New transaction.
@@ -232,28 +231,28 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
         // active.  We want to make sure it's active at various
         // points.
         final Context transactionScopedContext = beanManager.getContext(TransactionScoped.class);
-        assertNotNull(transactionScopedContext);
-        assertTrue(transactionScopedContext.isActive());
+        assertThat(transactionScopedContext, notNullValue());
+        assertThat(transactionScopedContext.isActive(), is(true));
 
         // Now magically our EntityManager should be joined to it.
-        assertTrue(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(true));
 
         // Roll the transaction back and note that our EntityManager
         // is no longer joined to it.
         tm.rollback();
-        assertFalse(em.isJoinedToTransaction());
-        assertFalse(transactionScopedContext.isActive());
-        assertFalse(em.contains(author1));
-        assertNull(author1.getId());
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(transactionScopedContext.isActive(), is(false));
+        assertThat(em.contains(author1), is(false));
+        assertThat(author1.getId(), nullValue());
 
         // Start another transaction.
         tm.begin();
-        assertTrue(transactionScopedContext.isActive());
+        assertThat(transactionScopedContext.isActive(), is(true));
 
         // Persist our Author.
-        assertNull(author1.getId());
+        assertThat(author1.getId(), nullValue());
         em.persist(author1);
-        assertTrue(em.contains(author1));
+        assertThat(em.contains(author1), is(true));
 
         // A persist() doesn't flush(), so no ID should have been
         // generated yet.
@@ -264,51 +263,51 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
 
         // After the transaction commits, a flush should happen, and
         // the Author is managed, so we should see his ID.
-        assertEquals(Integer.valueOf(1), author1.getId());
+        assertThat(author1.getId(), is(1));
 
         // Make sure the database contains the changes.
         try (final Connection connection = dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT ID, NAME FROM AUTHOR WHERE ID = 1");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(1, resultSet.getInt(1));
-            assertEquals("Abraham Lincoln", resultSet.getString(2));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(1));
+            assertThat(resultSet.getString(2), is("Abraham Lincoln"));
+            assertThat(resultSet.next(), is(false));
         }
 
         // The Author, however, is detached, because the transaction
         // is over, and because our PersistenceContextType is
         // TRANSACTION, not EXTENDED, the underlying persistence
         // context dies with the transaction.
-        assertFalse(em.contains(author1));
+        assertThat(em.contains(author1), is(false));
 
         // The transaction is over, so our EntityManager is not joined
         // to one anymore.
-        assertFalse(em.isJoinedToTransaction());
-        assertFalse(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(transactionScopedContext.isActive(), is(false));
 
         // Start a new transaction.
         tm.begin();
-        assertTrue(transactionScopedContext.isActive());
+        assertThat(transactionScopedContext.isActive(), is(true));
 
         // Remove the Author we successfully committed before.  We
         // have to merge because author1 became detached a few lines
         // above.
         author1 = em.merge(author1);
-        assertNotNull(author1);
-        assertTrue(em.contains(author1));
+        assertThat(author1, notNullValue());
+        assertThat(em.contains(author1), is(true));
         em.remove(author1);
-        assertFalse(em.contains(author1));
+        assertThat(em.contains(author1), is(false));
 
         // Commit and flush the removal.
         tm.commit();
 
-        assertFalse(em.isJoinedToTransaction());
-        assertFalse(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(transactionScopedContext.isActive(), is(false));
 
         // Note that its ID is still 1.
-        assertEquals(Integer.valueOf(1), author1.getId());
+        assertThat(author1.getId(), is(1));
 
         // After all this activity we should have no rows in any
         // tables.
@@ -318,27 +317,27 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
         // commit.  This will bump the author's ID and put a row in
         // the database.
         tm.begin();
-        assertTrue(em.isJoinedToTransaction());
-        assertTrue(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(true));
+        assertThat(transactionScopedContext.isActive(), is(true));
         author1 = em.merge(author1);
         tm.commit();
-        assertFalse(em.isJoinedToTransaction());
-        assertFalse(em.contains(author1));
-        assertFalse(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(em.contains(author1), is(false));
+        assertThat(transactionScopedContext.isActive(), is(false));
 
         // Now that the commit and accompanying flush have
         // happened, our author's ID has changed.
-        assertEquals(Integer.valueOf(2), author1.getId());
+        assertThat(author1.getId(), is(2));
 
         // Make sure the database contains the changes.
         try (final Connection connection = dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT ID, NAME FROM AUTHOR");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(2, resultSet.getInt(1));
-            assertEquals("Abraham Lincoln", resultSet.getString(2));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(2));
+            assertThat(resultSet.getString(2), is("Abraham Lincoln"));
+            assertThat(resultSet.next(), is(false));
         }
 
         // Discard author1 in this unit test so we'll get a
@@ -349,74 +348,74 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
         // Let's find the new author that got merged in.  We'll use a
         // transaction just for kicks.
         tm.begin();
-        assertTrue(em.isJoinedToTransaction());
-        assertTrue(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(true));
+        assertThat(transactionScopedContext.isActive(), is(true));
 
         Author author2 = em.find(Author.class, Integer.valueOf(2));
-        assertNotNull(author2);
-        assertTrue(em.contains(author2));
-        assertEquals(Integer.valueOf(2), author2.getId());
-        assertEquals("Abraham Lincoln", author2.getName());
+        assertThat(author2, notNullValue());
+        assertThat(em.contains(author2), is(true));
+        assertThat(author2.getId(), is(2));
+        assertThat(author2.getName(), is("Abraham Lincoln"));
 
         // No need, really, but it's what a @Transactional method
         // would do.
         tm.commit();
-        assertFalse(em.isJoinedToTransaction());
-        assertFalse(em.contains(author2));
-        assertFalse(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(em.contains(author2), is(false));
+        assertThat(transactionScopedContext.isActive(), is(false));
 
         // New transaction.  Let's change the name.
         tm.begin();
-        assertTrue(em.isJoinedToTransaction());
-        assertTrue(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(true));
+        assertThat(transactionScopedContext.isActive(), is(true));
 
         author2 = em.find(Author.class, Integer.valueOf(2));
-        assertNotNull(author2);
+        assertThat(author2, notNullValue());
 
         // Remember that finding an entity causes it to become
         // managed.
-        assertTrue(em.contains(author2));
+        assertThat(em.contains(author2), is(true));
 
-        assertEquals(Integer.valueOf(2), author2.getId());
-        assertEquals("Abraham Lincoln", author2.getName());
+        assertThat(author2.getId(), is(2));
+        assertThat(author2.getName(), is("Abraham Lincoln"));
 
         author2.setName("Abe Lincoln");
-        assertEquals(Integer.valueOf(2), author2.getId());
-        assertEquals("Abe Lincoln", author2.getName());
+        assertThat(author2.getId(), is(2));
+        assertThat(author2.getName(), is("Abe Lincoln"));
 
         tm.commit();
-        assertFalse(em.isJoinedToTransaction());
-        assertFalse(em.contains(author2));
-        assertFalse(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(em.contains(author2), is(false));
+        assertThat(transactionScopedContext.isActive(), is(false));
 
         // Make sure the database contains the changes.
         try (final Connection connection = dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT ID, NAME FROM AUTHOR");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(2, resultSet.getInt(1));
-            assertEquals("Abe Lincoln", resultSet.getString(2));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(2));
+            assertThat(resultSet.getString(2), is("Abe Lincoln"));
+            assertThat(resultSet.next(), is(false));
         }
 
         // Let's go find him again.
         tm.begin();
-        assertTrue(em.isJoinedToTransaction());
-        assertTrue(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(true));
+        assertThat(transactionScopedContext.isActive(), is(true));
 
         author2 = em.find(Author.class, Integer.valueOf(2));
-        assertNotNull(author2);
-        assertTrue(em.contains(author2));
-        assertEquals(Integer.valueOf(2), author2.getId());
-        assertEquals("Abe Lincoln", author2.getName());
+        assertThat(author2, notNullValue());
+        assertThat(em.contains(author2), is(true));
+        assertThat(author2.getId(), is(2));
+        assertThat(author2.getName(), is("Abe Lincoln"));
 
         // No need, really, but it's what a @Transactional method
         // would do.
         tm.commit();
-        assertFalse(em.isJoinedToTransaction());
-        assertFalse(em.contains(author2));
-        assertFalse(transactionScopedContext.isActive());
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(em.contains(author2), is(false));
+        assertThat(transactionScopedContext.isActive(), is(false));
 
     }
 
@@ -427,9 +426,9 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
         try (final Connection connection = dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM " + upperCaseTableName);) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(expectedCount, resultSet.getInt(1));
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(expectedCount));
         }
     }
 

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedUnsynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedUnsynchronizedEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ApplicationScoped
@@ -93,7 +93,7 @@ class TestJpaTransactionScopedUnsynchronizedEntityManager {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -161,20 +161,20 @@ class TestJpaTransactionScopedUnsynchronizedEntityManager {
         // is important to use "self" in this test instead of "this".
         final TestJpaTransactionScopedUnsynchronizedEntityManager self =
             this.cdiContainer.select(TestJpaTransactionScopedUnsynchronizedEntityManager.class).get();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         // Get the EntityManager that is not synchronized with but is
         // scoped to a JTA transaction.
         final EntityManager em = self.getJpaTransactionScopedUnsynchronizedEntityManager();
-        assertNotNull(em);
-        assertTrue(em.isOpen());
+        assertThat(em, notNullValue());
+        assertThat(em.isOpen(), is(true));
 
         // We haven't started any kind of transaction yet and we
         // aren't testing anything using
         // the @jakarta.transaction.Transactional annotation so there is
         // no transaction in effect so the EntityManager cannot be
         // joined to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Create a JPA entity and try to insert it.  This should fail
         // because according to JPA a TransactionRequiredException
@@ -190,44 +190,44 @@ class TestJpaTransactionScopedUnsynchronizedEntityManager {
         // Get the TransactionManager that normally is behind the
         // scenes and use it to start a Transaction.
         final TransactionManager tm = self.getTransactionManager();
-        assertNotNull(tm);
+        assertThat(tm, notNullValue());
         tm.begin();
 
         // Because we're UNSYNCHRONIZED, no automatic joining takes place.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // We can join manually.
         em.joinTransaction();
 
         // Now we should be joined to it.
-        assertTrue(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(true));
 
         // Roll the transaction back and note that our EntityManager
         // is no longer joined to it.
         tm.rollback();
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Start another transaction and persist our Author.  But note
         // that joining the transaction must be manual.
         tm.begin();
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
         em.persist(author);
-        assertFalse(em.isJoinedToTransaction());
-        assertTrue(em.contains(author));
+        assertThat(em.isJoinedToTransaction(), is(false));
+        assertThat(em.contains(author), is(true));
 
         // (Remember, we weren't ever joined to this transaction.)
         tm.commit();
 
         // The transaction is over, and our EntityManager is STILL not joined
         // to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Now the weird part.  Our EntityManager was of type
         // PersistenceContextType.TRANSACTION, but
         // SynchronizationType.UNSYNCHRONIZED.  So it never joins
         // transactions automatically, but its backing persistence
         // context does NOT span transactions.
-        assertFalse(em.contains(author));
+        assertThat(em.contains(author), is(false));
     }
 
 }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestRollbackScenarios.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestRollbackScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ApplicationScoped
@@ -88,7 +87,7 @@ class TestRollbackScenarios {
     void startCdiContainer() {
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
     }
 
@@ -160,30 +159,30 @@ class TestRollbackScenarios {
         // Get a CDI contextual reference to this test instance.  It
         // is important to use "self" in this test instead of "this".
         final TestRollbackScenarios self = self();
-        assertNotNull(self);
+        assertThat(self, notNullValue());
 
         // Get the EntityManager that is synchronized with and scoped
         // to a JTA transaction.
         final EntityManager em = self.getJpaTransactionScopedSynchronizedEntityManager();
-        assertNotNull(em);
-        assertTrue(em.isOpen());
+        assertThat(em, notNullValue());
+        assertThat(em.isOpen(), is(true));
 
         // We haven't started any kind of transaction yet and we
         // aren't testing anything using
         // the @jakarta.transaction.Transactional annotation so there is
         // no transaction in effect so the EntityManager cannot be
         // joined to one.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // Get the TransactionManager that normally is behind the
         // scenes and use it to start a Transaction.
         final TransactionManager tm = self.getTransactionManager();
-        assertNotNull(tm);
+        assertThat(tm, notNullValue());
         tm.begin();
-        assertEquals(Status.STATUS_ACTIVE, tm.getStatus());
+        assertThat(tm.getStatus(), is(Status.STATUS_ACTIVE));
 
         // Now magically our EntityManager should be joined to it.
-        assertTrue(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(true));
 
         // Create a JPA entity and insert it.
         Author author = new Author("Abraham Lincoln");
@@ -194,43 +193,43 @@ class TestRollbackScenarios {
         // database, which, in turn, will result in author identifier
         // generation.
         tm.commit();
-        assertEquals(Status.STATUS_NO_TRANSACTION, tm.getStatus());
-        assertEquals(Integer.valueOf(1), author.getId());
+        assertThat(tm.getStatus(), is(Status.STATUS_NO_TRANSACTION));
+        assertThat(author.getId(), is(1));
 
         // We're no longer in a transaction.
-        assertFalse(em.isJoinedToTransaction());
+        assertThat(em.isJoinedToTransaction(), is(false));
 
         // The persistence context should be cleared.
-        assertFalse(em.contains(author));
+        assertThat(em.contains(author), is(false));
 
         // Ensure transaction statuses are what we think they are.
         tm.begin();
         tm.setRollbackOnly();
         try {
-          assertEquals(Status.STATUS_MARKED_ROLLBACK, tm.getStatus());
+          assertThat(tm.getStatus(), is(Status.STATUS_MARKED_ROLLBACK));
         } finally {
           tm.rollback();
         }
-        assertEquals(Status.STATUS_NO_TRANSACTION, tm.getStatus());
+        assertThat(tm.getStatus(), is(Status.STATUS_NO_TRANSACTION));
 
         // We can do non-transactional things.
-        assertTrue(em.isOpen());
+        assertThat(em.isOpen(), is(true));
         author = em.find(Author.class, Integer.valueOf(1));
-        assertNotNull(author);
+        assertThat(author, notNullValue());
 
         // Note that because we've invoked this somehow outside of a
         // transaction everything it touches is detached, per section
         // 7.6.2 of the JPA 2.2 specification.
-        assertFalse(em.contains(author));
+        assertThat(em.contains(author), is(false));
 
         // Remove everything.
         tm.begin();
         author = em.merge(author);
-        assertNotNull(author);
-        assertTrue(em.contains(author));
+        assertThat(author, notNullValue());
+        assertThat(em.contains(author), is(true));
         em.remove(author);
         tm.commit();
-        assertFalse(em.contains(author));
+        assertThat(em.contains(author), is(false));
 
         // Perform a rollback "in the middle" of a sequence of
         // operations and observe that the EntityManager is in the
@@ -238,10 +237,10 @@ class TestRollbackScenarios {
         author = new Author("John Kennedy");
         tm.begin();
         em.persist(author);
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
         tm.rollback();
-        assertEquals(Status.STATUS_NO_TRANSACTION, tm.getStatus());
-        assertFalse(em.contains(author));
+        assertThat(tm.getStatus(), is(Status.STATUS_NO_TRANSACTION));
+        assertThat(em.contains(author), is(false));
         try {
           em.remove(author);
           fail("remove() was allowed to complete without a transaction");
@@ -257,11 +256,11 @@ class TestRollbackScenarios {
 
         // author is detached; prove it.
         tm.begin();
-        assertEquals(Status.STATUS_ACTIVE, tm.getStatus());
-        assertTrue(em.isJoinedToTransaction());
-        assertFalse(em.contains(author));
+        assertThat(tm.getStatus(), is(Status.STATUS_ACTIVE));
+        assertThat(em.isJoinedToTransaction(), is(true));
+        assertThat(em.contains(author), is(false));
         em.detach(author); // redundant; just making a point
-        assertFalse(em.contains(author));
+        assertThat(em.contains(author), is(false));
         try {
           em.remove(author);
           // We shouldn't get here because author is detached but with
@@ -274,21 +273,21 @@ class TestRollbackScenarios {
 
         // Remove the author properly.
         tm.begin();
-        assertEquals(Status.STATUS_ACTIVE, tm.getStatus());
-        assertTrue(em.isJoinedToTransaction());
-        assertFalse(em.contains(author));
+        assertThat(tm.getStatus(), is(Status.STATUS_ACTIVE));
+        assertThat(em.isJoinedToTransaction(), is(true));
+        assertThat(em.contains(author), is(false));
         author = em.merge(author);
         em.remove(author);
         tm.commit();
-        assertFalse(em.contains(author));
+        assertThat(em.contains(author), is(false));
 
         // Cause a timeout-tripped rollback.
         tm.setTransactionTimeout(1); // 1 second
         author = new Author("Woodrow Wilson");
         tm.begin();
-        assertEquals(Status.STATUS_ACTIVE, tm.getStatus());
+        assertThat(tm.getStatus(), is(Status.STATUS_ACTIVE));
         Thread.sleep(1500L); // 1.5 seconds (arbitrarily greater than 1 second)
-        assertEquals(Status.STATUS_ROLLEDBACK, tm.getStatus());
+        assertThat(tm.getStatus(), is(Status.STATUS_ROLLEDBACK));
         try {
           em.persist(author);
           fail("Transaction rolled back but persist still happened");
@@ -296,7 +295,7 @@ class TestRollbackScenarios {
 
         }
         tm.rollback();
-        assertEquals(Status.STATUS_NO_TRANSACTION, tm.getStatus());
+        assertThat(tm.getStatus(), is(Status.STATUS_NO_TRANSACTION));
 
         tm.setTransactionTimeout(60); // 60 seconds; the usual default
 

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestWithTransactionalInterceptors.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestWithTransactionalInterceptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,11 +42,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ApplicationScoped
 @DataSourceDefinition(
@@ -98,28 +97,28 @@ class TestWithTransactionalInterceptors {
 
     @BeforeEach
     void startCdiContainer() throws SQLException, SystemException {
-        assertNull(this.dataSource);
-        assertNull(this.em);
-        assertNull(this.tm);
-        assertNull(this.self);
+        assertThat(this.dataSource, nullValue());
+        assertThat(this.em, nullValue());
+        assertThat(this.tm, nullValue());
+        assertThat(this.self, nullValue());
 
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
-        assertNotNull(initializer);
+        assertThat(initializer, notNullValue());
         this.cdiContainer = initializer.initialize();
-        assertNotNull(this.cdiContainer);
+        assertThat(this.cdiContainer, notNullValue());
 
         this.self = this.cdiContainer.select(this.getClass()).get();
-        assertNotNull(this.self);
+        assertThat(this.self, notNullValue());
 
         this.em = this.self.getEntityManager();
-        assertNotNull(this.em);
+        assertThat(this.em, notNullValue());
 
         this.tm = this.self.getTransactionManager();
-        assertNotNull(this.tm);
+        assertThat(this.tm, notNullValue());
 
         this.dataSource = this.self.getDataSource();
-        assertNotNull(this.dataSource);
+        assertThat(this.dataSource, notNullValue());
 
         assertAuthorTableIsEmpty();
         assertNoTransaction();
@@ -189,10 +188,10 @@ class TestWithTransactionalInterceptors {
         try (final Connection connection = this.dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT ID FROM AUTHOR");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(1, resultSet.getInt(1));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(1));
+            assertThat(resultSet.next(), is(false));
         }
 
     }
@@ -217,11 +216,11 @@ class TestWithTransactionalInterceptors {
         try (final Connection connection = this.dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT ID, NAME FROM AUTHOR");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(1, resultSet.getInt(1));
-            assertEquals("Abe Lincoln", resultSet.getString(2));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(1));
+            assertThat(resultSet.getString(2), is("Abe Lincoln"));
+            assertThat(resultSet.next(), is(false));
         }
     }
 
@@ -241,17 +240,17 @@ class TestWithTransactionalInterceptors {
         // Persist an Author.
         final Author author = new Author("Abraham Lincoln");
         em.persist(author);
-        assertTrue(em.contains(author));
+        assertThat(em.contains(author), is(true));
     }
 
     @Transactional
     public void testFindAndUpdate() throws Exception {
         assertActiveTransaction();
         final Author author = this.em.find(Author.class, Integer.valueOf(1));
-        assertNotNull(author);
-        assertEquals(Integer.valueOf(1), author.getId());
-        assertEquals("Abraham Lincoln", author.getName());
-        assertTrue(this.em.contains(author));
+        assertThat(author, notNullValue());
+        assertThat(author.getId(), is(1));
+        assertThat(author.getName(), is("Abraham Lincoln"));
+        assertThat(this.em.contains(author), is(true));
         author.setName("Abe Lincoln");
     }
 
@@ -262,29 +261,29 @@ class TestWithTransactionalInterceptors {
 
 
     private void assertAuthorTableIsEmpty() throws SQLException {
-        assertNotNull(this.dataSource);
+        assertThat(this.dataSource, notNullValue());
         try (final Connection connection = this.dataSource.getConnection();
              final Statement statement = connection.createStatement();
              final ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM AUTHOR");) {
-            assertNotNull(resultSet);
-            assertTrue(resultSet.next());
-            assertEquals(0, resultSet.getInt(1));
-            assertFalse(resultSet.next());
+            assertThat(resultSet, notNullValue());
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(0));
+            assertThat(resultSet.next(), is(false));
         }
     }
 
     private void assertActiveTransaction() throws SystemException {
-        assertNotNull(this.tm);
-        assertEquals(Status.STATUS_ACTIVE, this.tm.getStatus());
-        assertNotNull(this.em);
-        assertTrue(this.em.isJoinedToTransaction());
+        assertThat(this.tm, notNullValue());
+        assertThat(this.tm.getStatus(), is(Status.STATUS_ACTIVE));
+        assertThat(this.em, notNullValue());
+        assertThat(this.em.isJoinedToTransaction(), is(true));
     }
 
     private void assertNoTransaction() throws SystemException {
-        assertNotNull(this.tm);
-        assertNotNull(this.em);
-        assertEquals(Status.STATUS_NO_TRANSACTION, this.tm.getStatus());
-        assertFalse(this.em.isJoinedToTransaction());
+        assertThat(this.tm, notNullValue());
+        assertThat(this.em, notNullValue());
+        assertThat(this.tm.getStatus(), is(Status.STATUS_NO_TRANSACTION));
+        assertThat(this.em.isJoinedToTransaction(), is(false));
     }
 
 }


### PR DESCRIPTION
Part of #1749 

[Original PR](https://github.com/helidon-io/helidon/pull/5251)