### PR TITLE
2.x: Configuration fixes

### DIFF
--- a/config/config/src/main/java/io/helidon/config/BuilderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/BuilderImpl.java
@@ -90,7 +90,9 @@ class BuilderImpl implements Config.Builder {
      */
     private boolean cachingEnabled;
     private boolean keyResolving;
+    private boolean keyResolvingFailOnMissing;
     private boolean valueResolving;
+    private boolean valueResolvingFailOnMissing;
     private boolean systemPropertiesSourceEnabled;
     private boolean environmentVariablesSourceEnabled;
     private boolean envVarAliasGeneratorEnabled;
@@ -262,8 +264,20 @@ class BuilderImpl implements Config.Builder {
     }
 
     @Override
+    public Config.Builder failOnMissingKeyReference(boolean shouldFail) {
+        this.keyResolvingFailOnMissing = shouldFail;
+        return this;
+    }
+
+    @Override
     public Config.Builder disableValueResolving() {
         this.valueResolving = false;
+        return this;
+    }
+
+    @Override
+    public Config.Builder failOnMissingValueReference(boolean shouldFail) {
+        this.valueResolvingFailOnMissing = shouldFail;
         return this;
     }
 
@@ -282,7 +296,7 @@ class BuilderImpl implements Config.Builder {
     @Override
     public AbstractConfigImpl build() {
         if (valueResolving) {
-            addFilter(ConfigFilters.valueResolving());
+            addFilter(ConfigFilters.valueResolving().failOnMissingReference(valueResolvingFailOnMissing));
         }
         if (null == changesExecutor) {
             changesExecutor = Executors.newCachedThreadPool(new ConfigThreadFactory("config-changes"));
@@ -329,6 +343,7 @@ class BuilderImpl implements Config.Builder {
                               cachingEnabled,
                               changesExecutor,
                               keyResolving,
+                              keyResolvingFailOnMissing,
                               aliasGenerator)
                 .newConfig();
     }
@@ -439,6 +454,7 @@ class BuilderImpl implements Config.Builder {
                                 boolean cachingEnabled,
                                 Executor changesExecutor,
                                 boolean keyResolving,
+                                boolean keyResolvingFailOnMissing,
                                 Function<String, List<String>> aliasGenerator) {
         return new ProviderImpl(configMapperManager,
                                 targetConfigSource,
@@ -447,6 +463,7 @@ class BuilderImpl implements Config.Builder {
                                 cachingEnabled,
                                 changesExecutor,
                                 keyResolving,
+                                keyResolvingFailOnMissing,
                                 aliasGenerator);
     }
 

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ import io.helidon.config.spi.MergingStrategy;
 import io.helidon.config.spi.OverrideSource;
 
 /**
- * <h1>Configuration</h1>
+ * <h2>Configuration</h2>
  * Immutable tree-structured configuration.
- * <h2>Loading Configuration</h2>
+ * <h3>Loading Configuration</h3>
  * Load the default configuration using the {@link Config#create} method.
  * <pre>{@code
  * Config config = Config.create();
@@ -95,7 +95,7 @@ import io.helidon.config.spi.OverrideSource;
  * </tr>
  * </table>
  *
- * <h2>Navigating in a Configuration Tree</h2>
+ * <h3>Navigating in a Configuration Tree</h3>
  * Each loaded configuration is a tree of {@code Config} objects. The
  * application can access an arbitrary node in the tree by passing its
  * fully-qualified name to {@link Config#get}:
@@ -146,8 +146,8 @@ import io.helidon.config.spi.OverrideSource;
  * <p>
  * To get node value, use {@link #as(Class)} to access this config node as a {@link ConfigValue}
  *
- * <h2>Converting Configuration Values to Types</h2>
- * <h3>Explicit Conversion by the Application</h3>
+ * <h3>Converting Configuration Values to Types</h3>
+ * <h4>Explicit Conversion by the Application</h4>
  * The interpretation of a configuration node, including what datatype to use,
  * is up to the application. To interpret a node's value as a type other than
  * {@code String} the application can invoke one of these convenience methods:
@@ -231,14 +231,19 @@ import io.helidon.config.spi.OverrideSource;
  * that can handle classes that fulfill some requirements (see documentation), such as a public constructor,
  * static "create(Config)" method etc.
  *
- * <h2><a id="multipleSources">Handling Multiple Configuration
- * Sources</a></h2>
+ * <h3><a id="multipleSources">Handling Multiple Configuration
+ * Sources</a></h3>
  * A {@code Config} instance, including the default {@code Config} returned by
  * {@link Config#create}, might be associated with multiple {@link ConfigSource}s. The
  * config system merges these together so that values from config sources with higher priority have
  * precedence over values from config sources with lower priority.
  */
 public interface Config {
+    /**
+     * Generic type of configuration.
+     */
+    GenericType<Config> GENERIC_TYPE = GenericType.create(Config.class);
+
     /**
      * Returns empty instance of {@code Config}.
      *
@@ -922,6 +927,12 @@ public interface Config {
         @Override
         String toString();
 
+        /**
+         * Create a child key to the current key.
+         *
+         * @param key child key (relative to current key)
+         * @return a new resolved key
+         */
         Key child(Key key);
 
         /**
@@ -1138,7 +1149,7 @@ public interface Config {
      * @see ConfigParser
      * @see ConfigFilter
      */
-    interface Builder {
+    interface Builder extends io.helidon.common.Builder<Config> {
         /**
          * Sets ordered list of {@link ConfigSource} instance to be used as single source of configuration
          * to be wrapped into {@link Config} API.
@@ -1298,6 +1309,16 @@ public interface Config {
         Builder disableKeyResolving();
 
         /**
+         * When key resolving is enabled and a reference cannot be resolved, should we fail, or use the key verbatim.
+         * Defaults to {@code false}, so key resolving does not fail when a reference is missing.
+         *
+         * @param shouldFail whether to fail when key reference cannot be resolved
+         * @return updated builder
+         * @see #disableKeyResolving()
+         */
+        Builder failOnMissingKeyReference(boolean shouldFail);
+
+        /**
          * Disables an usage of resolving value tokens.
          * <p>
          * A value can contain tokens enclosed in {@code ${}} (i.e. ${name}), that are resolved by default and tokens are replaced
@@ -1308,6 +1329,16 @@ public interface Config {
          * @return an updated builder instance
          */
         Builder disableValueResolving();
+
+        /**
+         * When value resolving is enabled and a reference cannot be resolved, should we fail, or use the value verbatim.
+         * Defaults to {@code false}, so value resolving does not fail when a reference is missing.
+         *
+         * @param shouldFail whether to fail when value reference cannot be resolved
+         * @return updated builder
+         * @see #disableValueResolving()
+         */
+        Builder failOnMissingValueReference(boolean shouldFail);
 
         /**
          * Disables use of {@link ConfigSources#environmentVariables() environment variables config source}.

--- a/config/config/src/main/java/io/helidon/config/ConfigSources.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public final class ConfigSources {
      * @return {@code ConfigSource} for the same {@code Config} as the original
      */
     public static ConfigSource create(Config config) {
-        return ConfigSources.create(config.asMap().get()).get();
+        return create(ObjectNodeImpl.create(config));
     }
 
     /**

--- a/config/config/src/main/java/io/helidon/config/ObjectNodeImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ObjectNodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,14 @@ public class ObjectNodeImpl extends AbstractMap<String, ConfigNode> implements O
         return members.entrySet();
     }
 
+    static ObjectNode create(Config config) {
+        ObjectNode.Builder root = ObjectNode.builder();
+
+        addObjectNode(root, config);
+
+        return root.build();
+    }
+
     static void initDescription(ConfigNode node, String description) {
         switch (node.nodeType()) {
         case OBJECT:
@@ -103,6 +111,56 @@ public class ObjectNodeImpl extends AbstractMap<String, ConfigNode> implements O
         default:
             throw new IllegalArgumentException("Unsupported node type: " + node.getClass().getName());
         }
+    }
+
+    private static void addObjectNode(Builder parentBuilder, Config parent) {
+        parent.asNodeList().ifPresent(it -> {
+            for (Config child : it) {
+                switch (child.type()) {
+                case OBJECT -> {
+                    Builder childBuilder = ObjectNode.builder();
+                    addObjectNode(childBuilder, child);
+                    parentBuilder.addObject(child.name(), childBuilder.build());
+                }
+                case LIST -> {
+                    ListNode.Builder childBuilder = ListNode.builder();
+                    addListNode(childBuilder, child);
+                    parentBuilder.addList(child.name(), childBuilder.build());
+                }
+                case VALUE -> {
+                    parentBuilder.addValue(child.name(), child.asString().get());
+                }
+                default -> {
+                    // do nothing
+                }
+                }
+            }
+        });
+    }
+
+    private static void addListNode(ListNode.Builder parentBuilder, Config parent) {
+        parent.asNodeList().ifPresent(it -> {
+            for (Config child : it) {
+                switch (child.type()) {
+                case OBJECT -> {
+                    Builder childBuilder = ObjectNode.builder();
+                    addObjectNode(childBuilder, child);
+                    parentBuilder.addObject(childBuilder.build());
+                }
+                case LIST -> {
+                    ListNode.Builder childBuilder = ListNode.builder();
+                    addListNode(childBuilder, child);
+                    parentBuilder.addList(childBuilder.build());
+                }
+                case VALUE -> {
+                    parentBuilder.addValue(child.asString().get());
+                }
+                default -> {
+                    // do nothing
+                }
+                }
+            }
+        });
     }
 
     private MergeableNode mergeWithValueNode(ValueNodeImpl node) {

--- a/config/config/src/main/java/io/helidon/config/ObjectNodeImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ObjectNodeImpl.java
@@ -117,22 +117,22 @@ public class ObjectNodeImpl extends AbstractMap<String, ConfigNode> implements O
         parent.asNodeList().ifPresent(it -> {
             for (Config child : it) {
                 switch (child.type()) {
-                case OBJECT -> {
-                    Builder childBuilder = ObjectNode.builder();
-                    addObjectNode(childBuilder, child);
-                    parentBuilder.addObject(child.name(), childBuilder.build());
-                }
-                case LIST -> {
-                    ListNode.Builder childBuilder = ListNode.builder();
-                    addListNode(childBuilder, child);
-                    parentBuilder.addList(child.name(), childBuilder.build());
-                }
-                case VALUE -> {
-                    parentBuilder.addValue(child.name(), child.asString().get());
-                }
-                default -> {
-                    // do nothing
-                }
+                    case OBJECT:
+                        Builder objectChildBuilder = ObjectNode.builder();
+                        addObjectNode(objectChildBuilder, child);
+                        parentBuilder.addObject(child.name(), objectChildBuilder.build());
+                        break;
+                    case LIST:
+                        ListNode.Builder listChildBuilder = ListNode.builder();
+                        addListNode(listChildBuilder, child);
+                        parentBuilder.addList(child.name(), listChildBuilder.build());
+                        break;
+                    case VALUE:
+                        parentBuilder.addValue(child.name(), child.asString().get());
+                        break;
+                    default:
+                        // do nothing
+                        break;
                 }
             }
         });
@@ -142,22 +142,22 @@ public class ObjectNodeImpl extends AbstractMap<String, ConfigNode> implements O
         parent.asNodeList().ifPresent(it -> {
             for (Config child : it) {
                 switch (child.type()) {
-                case OBJECT -> {
-                    Builder childBuilder = ObjectNode.builder();
-                    addObjectNode(childBuilder, child);
-                    parentBuilder.addObject(childBuilder.build());
-                }
-                case LIST -> {
-                    ListNode.Builder childBuilder = ListNode.builder();
-                    addListNode(childBuilder, child);
-                    parentBuilder.addList(childBuilder.build());
-                }
-                case VALUE -> {
-                    parentBuilder.addValue(child.asString().get());
-                }
-                default -> {
-                    // do nothing
-                }
+                    case OBJECT:
+                        Builder objectChildBuilder = ObjectNode.builder();
+                        addObjectNode(objectChildBuilder, child);
+                        parentBuilder.addObject(objectChildBuilder.build());
+                        break;
+                    case LIST:
+                        ListNode.Builder listChildBuilder = ListNode.builder();
+                        addListNode(listChildBuilder, child);
+                        parentBuilder.addList(listChildBuilder.build());
+                        break;
+                    case VALUE:
+                        parentBuilder.addValue(child.asString().get());
+                        break;
+                    default:
+                        // do nothing
+                        break;
                 }
             }
         });

--- a/config/config/src/test/java/io/helidon/config/BuilderImplTest.java
+++ b/config/config/src/test/java/io/helidon/config/BuilderImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ public class BuilderImplTest {
                                           eq(true), //cachingEnabled
                                           notNull(), //changesExecutor
                                           eq(true), //keyResolving
+                                          eq(false), // fail when key resolving cannot find ref
                                           isNull() //aliasGenerator
         );
     }
@@ -91,6 +92,7 @@ public class BuilderImplTest {
                                           eq(true), //cachingEnabled
                                           eq(myExecutor), //changesExecutor
                                           eq(true), //keyResolving
+                                          eq(false), // fail when key resolving cannot find ref
                                           isNull() //aliasGenerator
         );
     }
@@ -116,6 +118,7 @@ public class BuilderImplTest {
                                           eq(true), //cachingEnabled
                                           eq(myExecutor), //changesExecutor
                                           eq(false), //keyResolving
+                                          eq(false), // fail when key resolving cannot find ref
                                           isNull() //aliasGenerator
         );
     }

--- a/config/config/src/test/java/io/helidon/config/ConfigCopyTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigCopyTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+import io.helidon.config.spi.ConfigNode;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/*
+ * Make sure that when we copy a config that uses list nodes, the list nodes are honored in the copy as well.
+ */
+class ConfigCopyTest {
+    @Test
+    void testCopyWithArray() {
+        ConfigNode.ListNode listNode = ConfigNode.ListNode.builder()
+                .addValue("bbb")
+                .addValue("ccc")
+                .addValue("ddd")
+                .build();
+
+        ConfigNode.ObjectNode otherObject = ConfigNode.ObjectNode.builder()
+                .addValue("first", "firstValue")
+                .addValue("second", "secondValue")
+                .build();
+
+        ConfigNode.ObjectNode rootNode = ConfigNode.ObjectNode.builder()
+                .addList("aaa", listNode)
+                .addValue("value", "some value")
+                .addObject("object", otherObject)
+                .build();
+
+        Config original = Config.builder()
+                .disableSystemPropertiesSource()
+                .disableEnvironmentVariablesSource()
+                .addSource(io.helidon.config.ConfigSources.create(rootNode))
+                .build();
+
+        assertThat("Node type of original aaa",
+                   original.get("aaa").type(),
+                   is(Config.Type.LIST));
+
+        Config copy = Config.builder()
+                .disableSystemPropertiesSource()
+                .disableEnvironmentVariablesSource()
+                .addSource(ConfigSources.create(original))
+                .build();
+
+        assertThat("Node type of copied aaa",
+                   copy.get("aaa").type(),
+                   is(Config.Type.LIST));
+
+        // now also assert that all values were correctly copied
+        assertThat(copy.get("value").asString(), is(ConfigValues.simpleValue("some value")));
+        assertThat(copy.get("object.first").asString(), is(ConfigValues.simpleValue("firstValue")));
+        assertThat(copy.get("object.second").asString(), is(ConfigValues.simpleValue("secondValue")));
+        assertThat(copy.get("aaa.0").asString(), is(ConfigValues.simpleValue("bbb")));
+    }
+}

--- a/config/config/src/test/java/io/helidon/config/KeyTokenResolvingTest.java
+++ b/config/config/src/test/java/io/helidon/config/KeyTokenResolvingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,11 +182,12 @@ public class KeyTokenResolvingTest {
                                                         .build()))
                     .disableSystemPropertiesSource()
                     .disableEnvironmentVariablesSource()
+                    .failOnMissingKeyReference(true)
                     .build();
 
             config.traverse().forEach(System.out::println);
         });
-        assertThat(ex.getMessage(), startsWith("Missing value in token 'region' definition"));
+        assertThat(ex.getMessage(), startsWith("Missing token 'region' to resolve a key reference"));
     }
 
     @Test
@@ -199,6 +200,7 @@ public class KeyTokenResolvingTest {
                                                     .build()))
                 .disableSystemPropertiesSource()
                 .disableEnvironmentVariablesSource()
+                .failOnMissingKeyReference(true)
                 .build();
         });
         assertThat(ex.getMessage(), startsWith("Missing token 'ad' to resolve"));

--- a/config/yaml/src/test/java/io/helidon/config/yaml/IgnoreRefsTest.java
+++ b/config/yaml/src/test/java/io/helidon/config/yaml/IgnoreRefsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.yaml;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigException;
+import io.helidon.config.ConfigSources;
+import io.helidon.config.ConfigValues;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/*
+ * This test could be done in main config module, but the problem was reported for yaml,
+ *  and I wanted to make sure we use the exact YAML from the issue.
+ */
+class IgnoreRefsTest {
+    @Test
+    void testKeyRefsAreIgnored() {
+        Config config = Config.builder()
+                .addSource(ConfigSources.classpath("ignore-refs.yaml"))
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .build();
+
+        assertThat(config.get("server.port").as(Integer.class), is(ConfigValues.simpleValue(8080)));
+        assertThat(config.get("openapi.schemas.Pet.content.application/json.schema.$ref").asString(),
+                   is(ConfigValues.simpleValue("#/components/schemas/Pet")));
+    }
+
+    @Test
+    void testKeyRefsAreNotIgnored() {
+        Config.Builder configBuilder = Config.builder()
+                .addSource(ConfigSources.classpath("ignore-refs-2.yaml"))
+                .failOnMissingKeyReference(true)
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource();
+
+        ConfigException e = assertThrows(ConfigException.class, configBuilder::build);
+        assertThat(e.getMessage(), is("Missing token 'ref' to resolve a key reference."));
+    }
+
+    @Test
+    void testKeyRefsAreIgnoredFromBuilder() {
+        Config config = Config.builder()
+                .addSource(ConfigSources.classpath("ignore-refs-2.yaml"))
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .build();
+        assertThat(config.get("server.port").as(Integer.class), is(ConfigValues.simpleValue(8080)));
+        assertThat(config.get("openapi.schemas.Pet.content.application/json.schema.$ref").asString(),
+                   is(ConfigValues.simpleValue("#/components/schemas/Pet")));
+    }
+}

--- a/config/yaml/src/test/resources/ignore-refs-2.yaml
+++ b/config/yaml/src/test/resources/ignore-refs-2.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 8080
+openapi:
+  schemas:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true

--- a/config/yaml/src/test/resources/ignore-refs.yaml
+++ b/config/yaml/src/test/resources/ignore-refs.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+config:
+  key-resolving:
+    fail-on-missing-reference: false
+server:
+  port: 8080
+openapi:
+  schemas:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true


### PR DESCRIPTION
Resolves #6149 

- allow unresolved key references (configurable)
- config created from another config honors node types
- Key resolving does not fail by default when reference cannot be found - aligned with value resolving filter
- Config.Builder methods added for key resolving and value resolving "fail on missing reference"

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>