### PR TITLE
Fix intermittent issue on OciMetricsSupportTest

### DIFF
--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
@@ -15,38 +15,61 @@
  */
 package io.helidon.integrations.oci.metrics.cdi;
 
-import com.oracle.bmc.Region;
-import com.oracle.bmc.monitoring.Monitoring;
-import com.oracle.bmc.monitoring.MonitoringPaginators;
-import com.oracle.bmc.monitoring.MonitoringWaiters;
-import com.oracle.bmc.monitoring.model.MetricDataDetails;
-import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
-import com.oracle.bmc.monitoring.requests.*;
-import com.oracle.bmc.monitoring.responses.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import io.helidon.config.Config;
 import io.helidon.integrations.oci.metrics.OciMetricsSupport;
 import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.microprofile.config.ConfigCdiExtension;
-import io.helidon.microprofile.server.ServerCdiExtension;
 import io.helidon.microprofile.server.JaxRsCdiExtension;
+import io.helidon.microprofile.server.ServerCdiExtension;
 import io.helidon.microprofile.tests.junit5.AddBean;
 import io.helidon.microprofile.tests.junit5.AddConfig;
 import io.helidon.microprofile.tests.junit5.AddExtension;
 import io.helidon.microprofile.tests.junit5.DisableDiscovery;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
 
+import com.oracle.bmc.Region;
+import com.oracle.bmc.monitoring.Monitoring;
+import com.oracle.bmc.monitoring.MonitoringPaginators;
+import com.oracle.bmc.monitoring.MonitoringWaiters;
+import com.oracle.bmc.monitoring.model.MetricDataDetails;
+import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
+import com.oracle.bmc.monitoring.requests.ChangeAlarmCompartmentRequest;
+import com.oracle.bmc.monitoring.requests.CreateAlarmRequest;
+import com.oracle.bmc.monitoring.requests.DeleteAlarmRequest;
+import com.oracle.bmc.monitoring.requests.GetAlarmHistoryRequest;
+import com.oracle.bmc.monitoring.requests.GetAlarmRequest;
+import com.oracle.bmc.monitoring.requests.ListAlarmsRequest;
+import com.oracle.bmc.monitoring.requests.ListAlarmsStatusRequest;
+import com.oracle.bmc.monitoring.requests.ListMetricsRequest;
+import com.oracle.bmc.monitoring.requests.PostMetricDataRequest;
+import com.oracle.bmc.monitoring.requests.RemoveAlarmSuppressionRequest;
+import com.oracle.bmc.monitoring.requests.SummarizeMetricsDataRequest;
+import com.oracle.bmc.monitoring.requests.UpdateAlarmRequest;
+import com.oracle.bmc.monitoring.responses.ChangeAlarmCompartmentResponse;
+import com.oracle.bmc.monitoring.responses.CreateAlarmResponse;
+import com.oracle.bmc.monitoring.responses.DeleteAlarmResponse;
+import com.oracle.bmc.monitoring.responses.GetAlarmHistoryResponse;
+import com.oracle.bmc.monitoring.responses.GetAlarmResponse;
+import com.oracle.bmc.monitoring.responses.ListAlarmsResponse;
+import com.oracle.bmc.monitoring.responses.ListAlarmsStatusResponse;
+import com.oracle.bmc.monitoring.responses.ListMetricsResponse;
+import com.oracle.bmc.monitoring.responses.PostMetricDataResponse;
+import com.oracle.bmc.monitoring.responses.RemoveAlarmSuppressionResponse;
+import com.oracle.bmc.monitoring.responses.SummarizeMetricsDataResponse;
+import com.oracle.bmc.monitoring.responses.UpdateAlarmResponse;
+
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @HelidonTest(resetPerTest = true)
 @AddBean(OciMetricsCdiExtensionTest.MockMonitoring.class)
@@ -60,45 +83,44 @@ import static org.hamcrest.Matchers.is;
 @AddExtension(OciMetricsCdiExtension.class)
 // ConfigSources
 @AddConfig(key = "ocimetrics.compartmentId",
-        value = OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.compartmentId)
+           value = OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.compartmentId)
 @AddConfig(key = "ocimetrics.namespace",
-        value = OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.namespace)
+           value = OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.namespace)
 @AddConfig(key = "ocimetrics.resourceGroup",
-        value =  OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.resourceGroup)
+           value = OciMetricsCdiExtensionTest.MetricDataDetailsOCIParams.resourceGroup)
 @AddConfig(key = "ocimetrics.initialDelay", value = "1")
 @AddConfig(key = "ocimetrics.delay", value = "2")
-public class OciMetricsCdiExtensionTest {
-    private final RegistryFactory rf = RegistryFactory.getInstance();
-    private final MetricRegistry baseMetricRegistry = rf.getRegistry(MetricRegistry.Type.BASE);
-    private final MetricRegistry vendorMetricRegistry = rf.getRegistry(MetricRegistry.Type.VENDOR);
-    private final MetricRegistry appMetricRegistry = rf.getRegistry(MetricRegistry.Type.APPLICATION);
+class OciMetricsCdiExtensionTest {
     private static volatile int testMetricCount = 0;
-    // Use countDownLatch1 to signal the test that results to be asserted has been retrieved
-    private static CountDownLatch countDownLatch1 = new CountDownLatch(1);
+    private static CountDownLatch countDownLatch = new CountDownLatch(1);
     private static PostMetricDataDetails postMetricDataDetails;
     private static boolean activateOciMetricsSupportIsInvoked;
+    private final RegistryFactory rf = RegistryFactory.getInstance();
+    private final MetricRegistry appMetricRegistry = rf.getRegistry(MetricRegistry.Type.APPLICATION);
+    private final MetricRegistry baseMetricRegistry = rf.getRegistry(MetricRegistry.Type.BASE);
+    private final MetricRegistry vendorMetricRegistry = rf.getRegistry(MetricRegistry.Type.VENDOR);
 
     @AfterEach
-    private void resetState() {
+    void resetState() {
         postMetricDataDetails = null;
         activateOciMetricsSupportIsInvoked = false;
-        countDownLatch1 = new CountDownLatch(1);
+        countDownLatch = new CountDownLatch(1);
     }
 
     @Test
     @AddConfig(key = "ocimetrics.enabled", value = "true")
-    public void testEnableOciMetrics() throws InterruptedException {
+    void testEnableOciMetrics() throws InterruptedException {
         validateOciMetricsSupport(true);
     }
 
     @Test
-    public void testEnableOciMetricsWithoutConfig() throws InterruptedException {
+    void testEnableOciMetricsWithoutConfig() throws InterruptedException {
         validateOciMetricsSupport(true);
     }
 
     @Test
     @AddConfig(key = "ocimetrics.enabled", value = "false")
-    public void testDisableOciMetrics() throws InterruptedException {
+    void testDisableOciMetrics() throws InterruptedException {
         validateOciMetricsSupport(false);
     }
 
@@ -107,7 +129,12 @@ public class OciMetricsCdiExtensionTest {
         vendorMetricRegistry.counter("vendorDummyCounter").inc();
         appMetricRegistry.counter("appDummyCounter").inc();
         // Wait for signal from metric update that testMetricCount has been retrieved
-        countDownLatch1.await(3, TimeUnit.SECONDS);
+        if (!countDownLatch.await(3, TimeUnit.SECONDS)) {
+            // If Oci Metrics is enabled, this means that countdown() of CountDownLatch was never triggered, and hence should fail
+            if (enabled) {
+                fail("CountDownLatch timed out");
+            }
+        }
 
         if (enabled) {
             assertThat(activateOciMetricsSupportIsInvoked, is(true));
@@ -126,21 +153,33 @@ public class OciMetricsCdiExtensionTest {
         }
     }
 
+    interface MetricDataDetailsOCIParams {
+        String compartmentId = "dummy.compartmentId";
+        String namespace = "dummy-namespace";
+        String resourceGroup = "dummy_resourceGroup";
+    }
+
     static class MockMonitoring implements Monitoring {
         @Override
-        public void setEndpoint(String s) {}
+        public String getEndpoint() {
+            return "http://www.DummyEndpoint.com";
+        }
 
         @Override
-        public String getEndpoint() {return "http://www.DummyEndpoint.com";}
+        public void setEndpoint(String s) {
+        }
 
         @Override
-        public void setRegion(Region region) {}
+        public void setRegion(Region region) {
+        }
 
         @Override
-        public void setRegion(String s) {}
+        public void setRegion(String s) {
+        }
 
         @Override
-        public void refreshClient() {}
+        public void refreshClient() {
+        }
 
         @Override
         public ChangeAlarmCompartmentResponse changeAlarmCompartment(ChangeAlarmCompartmentRequest changeAlarmCompartmentRequest) {
@@ -148,19 +187,29 @@ public class OciMetricsCdiExtensionTest {
         }
 
         @Override
-        public CreateAlarmResponse createAlarm(CreateAlarmRequest createAlarmRequest) {return null;}
+        public CreateAlarmResponse createAlarm(CreateAlarmRequest createAlarmRequest) {
+            return null;
+        }
 
         @Override
-        public DeleteAlarmResponse deleteAlarm(DeleteAlarmRequest deleteAlarmRequest) {return null;}
+        public DeleteAlarmResponse deleteAlarm(DeleteAlarmRequest deleteAlarmRequest) {
+            return null;
+        }
 
         @Override
-        public GetAlarmResponse getAlarm(GetAlarmRequest getAlarmRequest) {return null;}
+        public GetAlarmResponse getAlarm(GetAlarmRequest getAlarmRequest) {
+            return null;
+        }
 
         @Override
-        public GetAlarmHistoryResponse getAlarmHistory(GetAlarmHistoryRequest getAlarmHistoryRequest) {return null;}
+        public GetAlarmHistoryResponse getAlarmHistory(GetAlarmHistoryRequest getAlarmHistoryRequest) {
+            return null;
+        }
 
         @Override
-        public ListAlarmsResponse listAlarms(ListAlarmsRequest listAlarmsRequest) {return null;}
+        public ListAlarmsResponse listAlarms(ListAlarmsRequest listAlarmsRequest) {
+            return null;
+        }
 
         @Override
         public ListAlarmsStatusResponse listAlarmsStatus(ListAlarmsStatusRequest listAlarmsStatusRequest) {
@@ -168,14 +217,16 @@ public class OciMetricsCdiExtensionTest {
         }
 
         @Override
-        public ListMetricsResponse listMetrics(ListMetricsRequest listMetricsRequest) {return null;}
+        public ListMetricsResponse listMetrics(ListMetricsRequest listMetricsRequest) {
+            return null;
+        }
 
         @Override
         public PostMetricDataResponse postMetricData(PostMetricDataRequest postMetricDataRequest) {
             postMetricDataDetails = postMetricDataRequest.getPostMetricDataDetails();
             testMetricCount = postMetricDataDetails.getMetricData().size();
             // Give signal that testMetricCount was retrieved
-            countDownLatch1.countDown();
+            countDownLatch.countDown();
             return PostMetricDataResponse.builder()
                     .__httpStatusCode__(200)
                     .build();
@@ -192,16 +243,23 @@ public class OciMetricsCdiExtensionTest {
         }
 
         @Override
-        public UpdateAlarmResponse updateAlarm(UpdateAlarmRequest updateAlarmRequest) {return null;}
+        public UpdateAlarmResponse updateAlarm(UpdateAlarmRequest updateAlarmRequest) {
+            return null;
+        }
 
         @Override
-        public MonitoringWaiters getWaiters() {return null;}
+        public MonitoringWaiters getWaiters() {
+            return null;
+        }
 
         @Override
-        public MonitoringPaginators getPaginators() {return null;}
+        public MonitoringPaginators getPaginators() {
+            return null;
+        }
 
         @Override
-        public void close() throws Exception {}
+        public void close() throws Exception {
+        }
     }
 
     static class MockOciMetricsBean extends OciMetricsBean {
@@ -210,19 +268,6 @@ public class OciMetricsCdiExtensionTest {
         void activateOciMetricsSupport(Config config, OciMetricsSupport.Builder builder) {
             activateOciMetricsSupportIsInvoked = true;
             super.activateOciMetricsSupport(config, builder);
-        }
-    }
-
-    public interface MetricDataDetailsOCIParams {
-        String compartmentId = "dummy.compartmentId";
-        String namespace = "dummy-namespace";
-        String resourceGroup = "dummy_resourceGroup";
-    }
-
-    private static void delay(long millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException ignore) {
         }
     }
 }

--- a/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsSupportTest.java
+++ b/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsSupportTest.java
@@ -49,29 +49,26 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
-public class OciMetricsSupportTest {
-    private final OciMetricsSupport.NameFormatter nameFormatter = new OciMetricsSupport.NameFormatter() { };
+class OciMetricsSupportTest {
     private static final Monitoring monitoringClient = mock(Monitoring.class);
-    private final Type[] types = {Type.BASE, Type.VENDOR, Type.APPLICATION};
-
     private static volatile Double[] testMetricUpdateCounterValue = new Double[2];
     private static volatile int testMetricCount = 0;
-    // Use CountDownLatch to signal when to start testing, for example, test only after results has been retrieved.
-    private static CountDownLatch countDownLatch1;
     private static int noOfExecutions;
     private static int noOfMetrics;
-
+    private final Type[] types = {Type.BASE, Type.VENDOR, Type.APPLICATION};
     private final RegistryFactory rf = RegistryFactory.getInstance();
     private final MetricRegistry baseMetricRegistry = rf.getRegistry(Type.BASE);
     private final MetricRegistry vendorMetricRegistry = rf.getRegistry(Type.VENDOR);
     private final MetricRegistry appMetricRegistry = rf.getRegistry(Type.APPLICATION);
 
     @BeforeEach
-    private void beforeEach() {
+    void resetState() {
         // clear all registry
-        for (Type type: types) {
+        for (Type type : types) {
             MetricRegistry metricRegistry = rf.getRegistry(type);
             metricRegistry.removeMatching(new MetricFilter() {
                 @Override
@@ -83,10 +80,10 @@ public class OciMetricsSupportTest {
     }
 
     @Test
-    public void testMetricUpdate() throws InterruptedException {
+    void testMetricUpdate() throws InterruptedException {
         Counter counter = baseMetricRegistry.counter("DummyCounter");
 
-        countDownLatch1 = new CountDownLatch(1);
+        CountDownLatch countDownLatch = new CountDownLatch(1);
         noOfExecutions = 0;
 
         doAnswer(invocationOnMock -> {
@@ -103,7 +100,7 @@ public class OciMetricsSupportTest {
                 counter.inc();
             } else {
                 // Give signal that multiple metric updates have been triggered
-                countDownLatch1.countDown();
+                countDownLatch.countDown();
             }
             return PostMetricDataResponse.builder()
                     .__httpStatusCode__(200)
@@ -126,7 +123,7 @@ public class OciMetricsSupportTest {
         WebServer webServer = createWebServer(routing);
 
         // Wait for metric updates to complete
-        countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
+        countDownLatchWait(countDownLatch);
 
         assertThat(ociMetricsSupportBuilder.enabled(), is(true));
         // Test the 1st and 2nd metric counter updates
@@ -137,7 +134,7 @@ public class OciMetricsSupportTest {
     }
 
     @Test
-    public void testBatchSize() throws InterruptedException {
+    void testBatchSize() throws InterruptedException {
         baseMetricRegistry.counter("baseDummyCounter1").inc();
         baseMetricRegistry.counter("baseDummyCounter2").inc();
         baseMetricRegistry.counter("baseDummyCounter3").inc();
@@ -164,7 +161,7 @@ public class OciMetricsSupportTest {
         // Should be 4
         int noOfBatches = Math.round(totalMetrics / batchSize) + (remainder > 0 ? 1 : 0);
 
-        countDownLatch1 = new CountDownLatch(1);
+        CountDownLatch countDownLatch = new CountDownLatch(1);
         noOfExecutions = 0;
         noOfMetrics = 0;
 
@@ -176,7 +173,7 @@ public class OciMetricsSupportTest {
             noOfMetrics += metricSizeToPost;
             // Give signal that the last remaining metric in the last batch has been posted
             if (metricSizeToPost == remainder) {
-                countDownLatch1.countDown();
+                countDownLatch.countDown();
             }
             return PostMetricDataResponse.builder()
                     .__httpStatusCode__(200)
@@ -195,7 +192,6 @@ public class OciMetricsSupportTest {
                 .batchSize(batchSize)
                 .monitoringClient(monitoringClient);
 
-
         Instant start = Instant.now();
 
         Routing routing = createRouting(ociMetricsSupportBuilder);
@@ -203,7 +199,7 @@ public class OciMetricsSupportTest {
         WebServer webServer = createWebServer(routing);
 
         // Wait for last batch to be completed
-        countDownLatch1.await(10, java.util.concurrent.TimeUnit.SECONDS);
+        countDownLatchWait(countDownLatch);
         Instant finish = Instant.now();
 
         // Batch size of 3 for 10 metrics should yield 4 batches to post
@@ -221,9 +217,7 @@ public class OciMetricsSupportTest {
     }
 
     @Test
-    public void testConfigSources() {
-        mockPostMetricDataAndGetTestMetricCount();
-
+    void testConfigSources() {
         baseMetricRegistry.counter("baseDummyCounter1").inc();
 
         vendorMetricRegistry.counter("vendorDummyCounter1").inc();
@@ -241,9 +235,7 @@ public class OciMetricsSupportTest {
     }
 
     @Test
-    public void testMetricScope() {
-        mockPostMetricDataAndGetTestMetricCount();
-
+    void testMetricScope() {
         baseMetricRegistry.counter("baseDummyCounter1").inc();
 
         vendorMetricRegistry.counter("vendorDummyCounter1").inc();
@@ -253,21 +245,19 @@ public class OciMetricsSupportTest {
         appMetricRegistry.counter("appDummyCounter2").inc();
         appMetricRegistry.counter("appDummyCounter3").inc();
 
-        validateMetricCount(new String[]{}, 6);
-        validateMetricCount(new String[]{Type.BASE.getName(), Type.VENDOR.getName(), Type.APPLICATION.getName()}, 6);
-        validateMetricCount(new String[]{Type.BASE.getName()}, 1);
-        validateMetricCount(new String[]{Type.VENDOR.getName()}, 2);
-        validateMetricCount(new String[]{Type.APPLICATION.getName()}, 3);
-        validateMetricCount(new String[]{"base", "vendor", "application"}, 6);
-        validateMetricCount(new String[]{"base"}, 1);
-        validateMetricCount(new String[]{"vendor"}, 2);
-        validateMetricCount(new String[]{"application"}, 3);
+        validateMetricCount(new String[] {}, 6);
+        validateMetricCount(new String[] {Type.BASE.getName(), Type.VENDOR.getName(), Type.APPLICATION.getName()}, 6);
+        validateMetricCount(new String[] {Type.BASE.getName()}, 1);
+        validateMetricCount(new String[] {Type.VENDOR.getName()}, 2);
+        validateMetricCount(new String[] {Type.APPLICATION.getName()}, 3);
+        validateMetricCount(new String[] {"base", "vendor", "application"}, 6);
+        validateMetricCount(new String[] {"base"}, 1);
+        validateMetricCount(new String[] {"vendor"}, 2);
+        validateMetricCount(new String[] {"application"}, 3);
     }
 
     @Test
-    public void testDisableMetrics() {
-        mockPostMetricDataAndGetTestMetricCount();
-
+    void testDisableMetrics() {
         baseMetricRegistry.counter("baseDummyCounter1").inc();
         vendorMetricRegistry.counter("vendorDummyCounter1").inc();
         appMetricRegistry.counter("appDummyCounter1").inc();
@@ -293,17 +283,16 @@ public class OciMetricsSupportTest {
         assertThat(ociMetricsSupportBuilder.enabled(), is(false));
         // metric count should remain 0 as metrics is disabled
         assertThat(testMetricCount, is(equalTo(0)));
-
     }
 
-    private void mockPostMetricDataAndGetTestMetricCount() {
+    private void mockPostMetricDataAndGetTestMetricCount(CountDownLatch countDownLatch) {
         // mock monitoringClient.postMetricData()
         doAnswer(invocationOnMock -> {
             PostMetricDataRequest postMetricDataRequest = invocationOnMock.getArgument(0);
             PostMetricDataDetails postMetricDataDetails = postMetricDataRequest.getPostMetricDataDetails();
             testMetricCount = postMetricDataDetails.getMetricData().size();
             // Give signal that testMetricCount was retrieved
-            countDownLatch1.countDown();
+            countDownLatch.countDown();
             return PostMetricDataResponse.builder()
                     .__httpStatusCode__(200)
                     .build();
@@ -313,7 +302,6 @@ public class OciMetricsSupportTest {
     private WebServer createWebServer(Routing routing) {
         WebServer webServer = WebServer.builder()
                 .host("localhost")
-                .port(8888)
                 .routing(routing)
                 .build();
         webServer.start().await(10L, TimeUnit.SECONDS);
@@ -364,21 +352,28 @@ public class OciMetricsSupportTest {
 
     private void validateMetricCount(OciMetricsSupport.Builder ociMetricsSupportBuilder, int expectedMetricCount) {
         testMetricCount = 0;
-        countDownLatch1 = new CountDownLatch(1);
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        mockPostMetricDataAndGetTestMetricCount(countDownLatch);
         Routing routing = createRouting(ociMetricsSupportBuilder);
         WebServer webServer = createWebServer(routing);
 
         try {
             // Wait for signal from metric update that testMetricCount has been retrieved
-            countDownLatch1.await(10, TimeUnit.SECONDS);
-        } catch(InterruptedException e) {
+            countDownLatchWait(countDownLatch);
+        } catch (InterruptedException e) {
             fail("Error while waiting for testMetricCount: " + e.getMessage());
         }
         webServer.shutdown().await(10, java.util.concurrent.TimeUnit.SECONDS);
         assertThat(testMetricCount, is(equalTo(expectedMetricCount)));
     }
 
-    private static void delay(long millis) {
+    private void countDownLatchWait(CountDownLatch countDownLatch) throws InterruptedException {
+        if (!countDownLatch.await(10, TimeUnit.SECONDS)) {
+            fail("CountDownLatch timed out");
+        }
+    }
+
+    private void delay(long millis) {
         try {
             Thread.sleep(millis);
         } catch (InterruptedException ie) {


### PR DESCRIPTION
RCA is described here: https://github.com/helidon-io/helidon/issues/6112#issuecomment-1426213497, but in this version, OciMetricsSupportTest.testEndpoint is not applicable. Hence, only peripheral changes outside of the ociMetricsSupportTest.testEndpoint race condition issue will be included.

Changes include the following:
1. Modify all countdownLatch to be locally defined in the test methods rather than being a static variable, which is causing chain reaction failure to other tests if a previous test fails because they share the same countdownLatch.
2. Always check that countDownLatch.await() is verified to have completed or otherwise, assert a failure.
3. Remove the use of fixed port when starting a WebServer.
4. Reset postingEndPoint to its original value before each test, so @RepeatedTest can be used in the future for debugging purposes.
5. Apply Helidon Code Style on both OciMetricsSupportTest and OciMetricsCdiExtensionTest. This would include making the tests's class and methods package local  rather than public, rearranging variable fields order based on whether they are static, final, etc.
6. Note that OciMetricsCdiExtensionTest only involves Code Style change and removal of delay method which is never used, so logic in that test class will be the same as before. Only OciMetricsSupportTest contain significant change to resolve the issue reported.
7. Fail the OciMetricsCdiExtensionTest if enabled OCI Metrics validation times out on countDownLatch.await()