### PR TITLE
Use Hamcrest assertions instead of JUnit in tests/functional/jax-rs-multiple-apps - backport main (#1749)

### DIFF
--- a/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
+++ b/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,10 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasKey;
 
 @HelidonTest
 @Disabled("3.0.0-JAKARTA")
@@ -44,13 +45,13 @@ class MainTest {
                 .request()
                 .header("who", "World 1")
                 .get();
-        assertEquals(response.getStatus(), 200);
-        assertTrue(response.getHeaders().containsKey("sharedfilter"));
-        assertTrue(response.getHeaders().containsKey("filter1"));
-        assertFalse(response.getHeaders().containsKey("filter2"));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getHeaders(), hasKey("sharedfilter"));
+        assertThat(response.getHeaders(), hasKey("filter1"));
+        assertThat(response.getHeaders(), not(hasKey("filter2")));
         JsonObject jsonObject = response.readEntity(JsonObject.class);
-        assertEquals("Hello World 1!", jsonObject.getString("message"),
-                "default message");
+        assertThat("default message", jsonObject.getString("message"),
+                is("Hello World 1!"));
     }
 
     @Test
@@ -60,13 +61,13 @@ class MainTest {
                 .request()
                 .header("who", "World 2")
                 .get();
-        assertEquals(response.getStatus(), 200);
-        assertTrue(response.getHeaders().containsKey("sharedfilter"));
-        assertTrue(response.getHeaders().containsKey("filter2"));
-        assertTrue(response.getHeaders().containsKey("filter3"));       // MyFeature
-        assertFalse(response.getHeaders().containsKey("filter1"));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getHeaders(), hasKey("sharedfilter"));
+        assertThat(response.getHeaders(), hasKey("filter2"));
+        assertThat(response.getHeaders(), hasKey("filter3"));       // MyFeature
+        assertThat(response.getHeaders(), not(hasKey("filter1")));
         JsonObject jsonObject = response.readEntity(JsonObject.class);
-        assertEquals("Hello World 2!", jsonObject.getString("message"),
-                "default message");
+        assertThat("default message", jsonObject.getString("message"),
+                is("Hello World 2!"));
     }
 }


### PR DESCRIPTION
Part of #1749 

[Original PR](https://github.com/helidon-io/helidon/pull/5634)