### PR TITLE
Register injected metrics during start-up

### DIFF
--- a/docs/mp/guides/05_metrics.adoc
+++ b/docs/mp/guides/05_metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ include::{metrics-common}[tag=built-in-metrics-discussion]
 
 include::{metrics-common}[tag=controlling-intro-part-1]
 * <<controlling-rest-request-metrics,Control `REST.request` metrics.>>
+* <<controlling-registration-of-injected-metrics,Control Registration of Injected Metrics>>
 include::{metrics-common}[tag=controlling-intro-part-2]
 [[controlling-rest-request-metrics]]
 
@@ -95,6 +96,32 @@ Enable it by editing your application configuration to set `metrics.rest-request
 Note that the applications you generate using the full Helidon archetype _do_ enable this feature in the
 generated config file.
 You can see the results in the sample output shown in earlier example runs.
+
+[[controlling-registration-of-injected-metrics]]
+==== Controlling Registration of Injected Metrics
+Normally, the Helidon MP metrics subsystem relies on CDI to trigger the registration of metrics which are injected into beans.
+For example, your JAX-RS resource class might inject a metric into a field or method parameter declared by that class.
+Because you typically declare a JAX-RS resource classe as `@Dependent` scoped, CDI does not create an instance of the JAX-RS resource class until a client accesses an endpoint served by that resource class.
+At that time CDI also processes any injections into the resource class, including metrics.
+If your code only injects a metric and does not otherwise declare it, then only when a client first accesses that resource will CDI resolve the injection and thereby trigger the registration of the injected metric.
+
+One side effect of this behavior is that, after your service starts but before any client accesses a resource, the output from the `/metrics` endpoint will _not_ include metrics which are only injected, even though Helidon does register such metrics correctly--just in time--and updates them appropriately.
+
+[CAUTION]
+====
+_Do not_ use this feature if your application includes any CDI `@Produces` fields or methods for any of the injected metrics. To register injected-only metrics during start-up, Helidon MP 2 must bypass CDI producers and register the metrics directly itself.
+====
+You can configure the Helidon MP metrics system so it _does_ register injected-only metrics during start-up as follows:
+
+[source,properties]
+.Configuration properties file to select start-up (instead of just-in-time) injected-only metrics registration
+----
+mp.metrics.startup-registration.enabled = true
+----
+
+
+
+
 
 include::{metrics-common}[tags=controlling-by-component;controlling-by-registry]
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonMetadataBuilder.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonMetadataBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import org.eclipse.microprofile.metrics.MetadataBuilder;
+
+/**
+ * Helidon-MP-specific builder for {@link org.eclipse.microprofile.metrics.Metadata}.
+ *
+ * <p>
+ *     This implementation normalizes the description and display, mapping empty strings to nulls for consistency.
+ * </p>
+ */
+class HelidonMetadataBuilder extends MetadataBuilder {
+
+    /**
+     * Creates a new builder for metadata, one which supports normalized description and display name values.
+     *
+     * @return new {@code HelidonMetadataBuilder}
+     */
+    static MetadataBuilder create() {
+        return new HelidonMetadataBuilder();
+    }
+
+    private HelidonMetadataBuilder() {
+    }
+
+    @Override
+    public MetadataBuilder withOptionalDescription(String description) {
+        super.withOptionalDescription(MetricUtil.normalize(description));
+        return this;
+    }
+
+    @Override
+    public MetadataBuilder withOptionalDisplayName(String displayName) {
+        return super.withOptionalDisplayName(MetricUtil.normalize(displayName));
+    }
+}

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -133,6 +133,7 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
 
     static final String SYNTHETIC_SIMPLE_TIMER_METRIC_NAME = "REST.request";
 
+    static final String STARTUP_REGISTRATION_OF_INJECTED_ENABLED = "startup-registration.enabled";
     static final Metadata SYNTHETIC_SIMPLE_TIMER_METADATA = Metadata.builder()
             .withName(SYNTHETIC_SIMPLE_TIMER_METRIC_NAME)
             .withDisplayName(SYNTHETIC_SIMPLE_TIMER_METRIC_NAME + " for all REST endpoints")
@@ -711,12 +712,16 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
         }
 
         registerProducers(bm);
-        registerMetricsForInjectSites();
+
+        Config config = MpConfig.toHelidonConfig(ConfigProvider.getConfig()).get(MetricsSettings.Builder.METRICS_CONFIG_KEY);
+        if (config.get(STARTUP_REGISTRATION_OF_INJECTED_ENABLED)
+                .asBoolean()
+                .isPresent()) {
+            registerMetricsForInjectSites();
+        }
 
         Set<String> vendorMetricsAdded = new HashSet<>();
         vendorMetricsAdded.add("@default");
-
-        Config config = MpConfig.toHelidonConfig(ConfigProvider.getConfig()).get(MetricsSettings.Builder.METRICS_CONFIG_KEY);
 
         // now we may have additional sockets we want to add vendor metrics to
         config.get("vendor-metrics-routings")

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistrationPrep.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistrationPrep.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Member;
+import java.util.Optional;
+
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedParameter;
+
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetadataBuilder;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.Tag;
+
+/**
+ * Encapsulates information for a pending metric registration based on an annotation and an annotated element.
+ * <p>
+ *     We need several concrete implementations because we need to get information from different AnnotatedXXX classes
+ *     which share no common ancestry.
+ * </p>
+ */
+abstract class RegistrationPrep {
+
+    /**
+     * Creates a pending registration for an intercepted executable (constructor or method annotated with one of the
+     * metrics annotations in force: @Counted, etc.). The annotation might appear at the containing type level.
+     *
+     * @param annotation the metrics annotation which applies to the executable
+     * @param annotatedElement the element annotated (constructor, method, type)
+     * @param clazz the class of the metric (e.g., Counter)
+     * @param matchingType which type of matching located the annotation (class, method, etc.)
+     * @param executable the annotated constructor or method
+     * @return the new intercept deferred registration
+     * @param <A> the type of the annotation
+     * @param <E> the type of the annotated element
+     */
+    static <A extends Annotation, E extends Member & AnnotatedElement>
+    InterceptRegistrationPrep<A, E> create(A annotation,
+                                     E annotatedElement,
+                                     Class<?> clazz,
+                                     MetricUtil.MatchingType matchingType,
+                                     Executable executable) {
+
+        MetricAnnotationInfo<?, ?> info = MetricAnnotationInfo.infoFromAnnotationType(annotation.annotationType());
+
+        return new InterceptRegistrationPrep<>(info,
+                                               annotation,
+                                               annotatedElement,
+                                               clazz,
+                                               matchingType,
+                                               executable);
+    }
+
+    /**
+     * Creates am {@code Optional} around a deferred registration for an injected field, provided the injected field's type
+     * is a metric; an empty {@code Optional} otherwise.
+     *
+     * @param annotatedField the injected field
+     * @return {@optional} of the new deferred registration or {@code empty} if none
+     */
+    static Optional<InjectRegistrationPrep> create(AnnotatedField<?> annotatedField) {
+
+        MetricAnnotationInfo<?, ?> info = MetricAnnotationInfo.info(annotatedField.getJavaMember().getType());
+        if (info == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new InjectRegistrationPrep(info,
+                  MetricUtil.metricName(annotatedField),
+                  MetricUtil.tags(annotatedField.getAnnotation(org.eclipse.microprofile.metrics.annotation.Metric.class)),
+                  annotatedField));
+    }
+
+    /**
+     * Creates am {@code Optional} around a deferred registration for an annotated parameter, provided the parameter's type
+     * is a metric; an empty {@code Optional} otherwise.
+     *
+     * @param annotatedParameter the annotated field
+     * @return {@optional} of the new deferred registration or {@code empty} if none
+     */static Optional<InjectRegistrationPrep> create(AnnotatedParameter<?> annotatedParameter) {
+        MetricAnnotationInfo<?, ?> info = MetricAnnotationInfo.info(annotatedParameter.getJavaParameter().getType());
+        if (info == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new InjectRegistrationPrep(info,
+                  MetricUtil.metricName(annotatedParameter),
+                  MetricUtil.tags(annotatedParameter.getAnnotation(org.eclipse.microprofile.metrics.annotation.Metric.class)),
+                  annotatedParameter));
+    }
+
+    private final MetricAnnotationInfo<?, ?> info;
+    private final String metricName;
+    private final Tag[] tags;
+
+    /**
+     * Common constructor for all concrete implementations of deferred registrations.
+     *
+     * @param info the metric annotation info object describing the annotation
+     * @param metricName name of the metric derived from the annotated item
+     * @param tags tags derived from the annotated item
+     */
+    protected RegistrationPrep(MetricAnnotationInfo<?, ?> info,
+                               String metricName,
+                               Tag[] tags) {
+        this.info = info;
+        this.metricName = metricName;
+        this.tags = tags;
+    }
+
+    /**
+     *
+     * @return the metric name for the deferred registration
+     */
+    String metricName() {
+        return metricName;
+    }
+
+    /**
+     *
+     * @return the tags for the deferred registration (non-null)
+     */
+    Tag[] tags() {
+        return tags;
+    }
+
+    /**
+     *
+     * @return the metric annotation info for the deferred registration
+     */
+    MetricAnnotationInfo<?, ?> info() {
+        return info;
+    }
+
+    /**
+     * Returns the previously-registered metric with the same name and tags or a new metric derived from the injected
+     * or annotated site.
+     *
+     * @param registry the metric registry in which to register the metric
+     * @return the registered or pre-existing metric
+     */
+    abstract Metric register(MetricRegistry registry);
+
+    /**
+     * Deferred registration for metrics inferred from metrics annotations (e.g., {@code Counted}).
+     *
+     * @param <A> type of the annotation
+     * @param <E> type of the annotated item
+     */
+    static class InterceptRegistrationPrep<A extends Annotation, E extends Member & AnnotatedElement>
+            extends RegistrationPrep {
+
+        private final A annotation;
+        private final E annotatedElement;
+        private final Class<?> clazz;
+        private final MetricUtil.MatchingType matchingType;
+        private final Executable executable;
+
+        private InterceptRegistrationPrep(MetricAnnotationInfo<?, ?> info,
+                                          A annotation,
+                                          E annotatedElement,
+                                          Class<?> clazz,
+                                          MetricUtil.MatchingType matchingType,
+                                          Executable executable) {
+            super(info,
+                  MetricUtil.getMetricName(annotatedElement,
+                                           clazz,
+                                           matchingType,
+                                           info.name(annotation),
+                                           info.absolute(annotation)),
+                  info.tags(annotation));
+
+            this.annotation = annotation;
+            this.annotatedElement = annotatedElement;
+            this.clazz = clazz;
+            this.matchingType = matchingType;
+            this.executable = executable;
+        }
+
+        /**
+         *
+         * @return the {@code Executable} corresponding to the metric
+         */
+        Executable executable() {
+            return executable;
+        }
+
+        /**
+         *
+         * @return the type for the annotation applied to the executable triggering the deferred registration
+         */
+        Class<? extends Annotation> annotationType() {
+            return annotation.annotationType();
+        }
+
+        @Override
+        Metric register(MetricRegistry registry) {
+            // Registrations via annotated sites must be fully compatible with any prior registration of the same metric,
+            // including consistency of metadata including reuse settings. All that checking occurs in the registry's logic,
+            // so this code simply attempts the registration without redoing that checking here.
+
+            String metricName = MetricUtil.getMetricName(annotatedElement, clazz, matchingType, info().name(annotation),
+                                                         info().absolute(annotation));
+            MetadataBuilder metadataBuilder = HelidonMetadataBuilder.create()
+                    .withName(metricName)
+                    .withType(info().metricType())
+                    .withUnit(info().unit(annotation)
+                                      .trim())
+                    .reusable(info().reusable(annotation))
+                    .withOptionalDescription(info().description(annotation))
+                    .withOptionalDisplayName(info().displayName(annotation));
+
+            return info().registerFunction().register(registry, metadataBuilder.build(), tags());
+        }
+    }
+
+    /**
+     * Common behavior of deferred registrations inferred from injection (fields or parameters).
+     */
+    static class InjectRegistrationPrep extends RegistrationPrep {
+
+        private final Annotated annotated;
+
+        /**
+         * Creates a new deferred registration for an injected parameter or field.
+         *
+         * @param info metric annotation information for the injected site
+         * @param metricName name of the metric
+         * @param tags tags for the metric implied by the injected site
+         */
+        protected InjectRegistrationPrep(MetricAnnotationInfo<?, ?> info,
+                                         String metricName,
+                                         Tag[] tags,
+                                         Annotated annotated) {
+            super(info, metricName, tags);
+            this.annotated = annotated;
+        }
+
+        @Override
+        Metric register(MetricRegistry registry) {
+            // For injected registrations, the consistency check between a previously-registered metric with the same name and
+            // tags vs. this new registration is "softer" than for intercept registrations.
+            //
+            // That is, if the field or parameter bears a @Metric annotation, then any non-default string element (name, tags,
+            // (etc.) must match the previously-registered metadata but any empty string matches any previous value.
+
+            org.eclipse.microprofile.metrics.annotation.Metric metricAnno =
+                    annotated.getAnnotation(org.eclipse.microprofile.metrics.annotation.Metric.class);
+
+            Metadata previouslyRegisteredMetadata = registry.getMetadata().get(metricName());
+            if (previouslyRegisteredMetadata != null) {
+                if (!MetricUtil.checkConsistentMetadata(metricName(),
+                                                        previouslyRegisteredMetadata,
+                                                        info().metricType(),
+                                                        metricAnno)) {
+                    throw new IllegalArgumentException(String.format(
+                            "Attempt to inject previously-registered metric %s with metadata %s using "
+                            + "inconsistent settings %s",
+                            metricName(),
+                            previouslyRegisteredMetadata,
+                            annotated.getAnnotation(org.eclipse.microprofile.metrics.annotation.Metric.class)));
+                }
+            }
+
+
+            MetadataBuilder metadataBuilder = HelidonMetadataBuilder.create()
+                    .withName(metricName())
+                    .withType(info().metricType());
+            if (metricAnno != null) {
+                metadataBuilder.withOptionalDisplayName(metricAnno.displayName());
+                metadataBuilder.withOptionalDescription(metricAnno.description());
+                if (metricAnno.unit() != null) {
+                    // If the @Metric annotation 'unit' setting is NONE, then that's the default so use
+                    // the value from the existing metadata.
+                    String annoUnit = metricAnno.unit();
+                    Optional<String> previouslyRegisteredUnit = previouslyRegisteredMetadata != null
+                            ? previouslyRegisteredMetadata.getUnit()
+                            : Optional.empty();
+                    if (!annoUnit.equals(MetricUnits.NONE)) {
+                        metadataBuilder.withUnit(annoUnit);
+                    } else {
+                        metadataBuilder.withUnit(previouslyRegisteredUnit.orElse(annoUnit));
+                    }
+                } else {
+                    metadataBuilder.withUnit(MetricUtil.chooseDefaultUnit(info().metricType()));
+                }
+            }
+            if (previouslyRegisteredMetadata != null) {
+                metadataBuilder.reusable(previouslyRegisteredMetadata.isReusable());
+            }
+
+            return info().registerFunction().register(registry, metadataBuilder.build(), tags());
+        }
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldResource.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 package io.helidon.microprofile.metrics;
 
 import io.helidon.webserver.ServerResponse;
+
+import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 import org.eclipse.microprofile.metrics.annotation.Timed;
@@ -52,6 +55,9 @@ import java.util.logging.Logger;
 @Counted
 public class HelloWorldResource {
 
+    static final String CLASS_INJECTED_METRIC_NAME = "class-injected";
+    static final String PARAMETER_INJECTED_METRIC_NAME = "param-injected";
+    static final String PARAMETER_INJECTED_METRIC_NAME_2 = "param-injected-2";
     private static final Logger LOGGER = Logger.getLogger(HelloWorldResource.class.getName());
 
     static final String SLOW_RESPONSE = "At last";
@@ -106,6 +112,25 @@ public class HelloWorldResource {
     @Inject
     @RegistryType(type = MetricRegistry.Type.VENDOR)
     private MetricRegistry vendorRegistry;
+
+    @Inject
+    @Metric(name = CLASS_INJECTED_METRIC_NAME,
+            description = "explicitly-named absolute class-injected metric",
+            displayName = "class-injected metric",
+            absolute = true)
+    Counter classInjectedCounter;
+
+    @Inject
+    @Metric(description = "automatically-named absolute class-injected metric",
+            absolute = true)
+    Counter autoNamedAbsoluteClassInjectedCounter;
+
+    @Inject
+    @Metric(description = "automatically-named relative class-injected metric")
+    Counter autoNamedRelativeClassInjectedCounter;
+
+    @Inject
+    private Counter bareCounter;
 
     public HelloWorldResource() {
 
@@ -201,6 +226,19 @@ public class HelloWorldResource {
             }
         });
     }
+
+    @Inject
+    public void useInjectedParameter(@Metric(name = PARAMETER_INJECTED_METRIC_NAME,
+                                      absolute = true,
+                                      description = "explicitly-named absolute parameter-injected metric")
+                              Counter explicitParamInjectedCounter,
+                              @Metric(name = PARAMETER_INJECTED_METRIC_NAME_2,
+                                      description = "automatically-named relative parameter-injected metric",
+                                      tags = {"t1=v1", "t2=v2"})
+                                     Counter autoNamedParamInjectedCounter) {
+
+    }
+
 
     private long inflightRequestsCount() {
         return inflightRequestsCount(vendorRegistry);

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
@@ -62,6 +62,7 @@ import static org.hamcrest.Matchers.nullValue;
  */
 @HelidonTest
 @AddConfig(key = "metrics." + MetricsCdiExtension.REST_ENDPOINTS_METRIC_ENABLED_PROPERTY_NAME, value = "true")
+@AddConfig(key = "metrics." + MetricsCdiExtension.STARTUP_REGISTRATION_OF_INJECTED_ENABLED, value = "true")
 public class HelloWorldTest {
 
     @Inject

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,41 +16,46 @@
 
 package io.helidon.microprofile.metrics;
 
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 
 import javax.inject.Inject;
 import javax.json.JsonObject;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
-import io.helidon.common.http.Http;
+import io.helidon.config.testing.OptionalMatcher;
 import io.helidon.microprofile.tests.junit5.AddConfig;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
 
 import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.SimpleTimer;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.microprofile.metrics.HelloWorldResource.MESSAGE_SIMPLE_TIMER;
-import static org.hamcrest.Matchers.greaterThan;
+import static io.helidon.microprofile.metrics.HelloWorldResource.PARAMETER_INJECTED_METRIC_NAME;
+import static io.helidon.microprofile.metrics.HelloWorldResource.PARAMETER_INJECTED_METRIC_NAME_2;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Class HelloWorldTest.
@@ -82,6 +87,112 @@ public class HelloWorldTest {
     @BeforeEach
     public void registerCounter() {
         MetricsMpServiceTest.registerCounter(registry, "helloCounter");
+    }
+
+    @Test
+    @Order(1)
+    void checkExplicitlyNamedAbsoluteClassInjection() {
+        checkInjectedRegistration(HelloWorldResource.CLASS_INJECTED_METRIC_NAME,
+                                  null,
+                                  "explicitly-named absolute class-injected");
+    }
+
+    @Test
+    @Order(1)
+    void checkAutomaticallylNamedAbsoluteClassInjection() throws NoSuchFieldException {
+        checkInjectedRegistration("autoNamedAbsoluteClassInjectedCounter",
+                                  null,
+                                  "automatically-named absolute class-injected");
+    }
+
+    @Test
+    @Order(1)
+    void checkAutomaticallyNamedRelativeClassInjection() {
+        checkInjectedRegistration(HelloWorldResource.class.getName() + ".autoNamedRelativeClassInjectedCounter",
+                                          null,
+                                  "automatically-named relative class-injected");
+    }
+
+    @Test
+    @Order(1)
+    void checkExplicitlyNamedAbsoluteParameterInjection() {
+        checkInjectedRegistration(PARAMETER_INJECTED_METRIC_NAME,
+                                  null,
+                                  "explicitly-named absolute parameter-injected");
+    }
+
+    @Test
+    @Order(1)
+    void checkAutomaticallyNamedRelativeParameterInjection() {
+        checkInjectedRegistration(HelloWorldResource.class.getName()
+                                      + "."
+                                      + PARAMETER_INJECTED_METRIC_NAME_2,
+                                  new Tag[] {new Tag("t1", "v1"), new Tag("t2", "v2")},
+                                  "automatically-named relative parameter-injected");
+    }
+
+    @Test
+    @Order(1) // Run before all others so no resource classes are realized (which can trigger metrics registration from producers)
+    void checkInjectedMetricRegistration() {
+
+        checkInjectedRegistration(HelloWorldResource.CLASS_INJECTED_METRIC_NAME,
+                                  null,
+                                  "explicitly-named absolute class-injected");
+    }
+
+    @Test
+    @Order(1)
+    void checkInjectedMetricRegistrationWithoutMetricAnno() {
+        checkInjectedRegistration(HelloWorldResource.class.getName() + ".bareCounter",
+                                  null,
+                                  null);
+    }
+
+    private Counter checkInjectedRegistration(String metricName,
+                                           Tag[] tags,
+                                           String expectedDesc) {
+        return checkInjectedRegistration(metricName, tags, expectedDesc, 0);
+    }
+
+    private Counter checkInjectedRegistration(String metricName,
+                                              Tag[] tags,
+                                              String expectedDesc,
+                                              long expectedValue) {
+
+        if (tags == null) {
+            tags = new Tag[0];
+        }
+
+        Metadata metadataForClassInjectedExplicitlyNamedCounter = registry.getMetadata()
+                .get(metricName);
+        assertThat("Metadata for " + metricName,
+                   metadataForClassInjectedExplicitlyNamedCounter, is(notNullValue()));
+        if (expectedDesc != null) {
+            assertThat("Description for " + metricName,
+                       metadataForClassInjectedExplicitlyNamedCounter.getDescription(),
+                       OptionalMatcher.value(containsString(expectedDesc)));
+        } else {
+            assertThat("Description for " + metricName,
+                       metadataForClassInjectedExplicitlyNamedCounter.getDescription(),
+                       OptionalMatcher.empty());
+        }
+        // Look for the counter based on only the name. Save matching metric IDs to make sure
+        // they (it) match the expected tags.
+
+        Map<MetricID, Counter> sameNamedCounters = registry.getCounters((id, metric) ->
+                                                       id.getName().equals(metricName));
+        // We expect only one match because of the way we set up the test annotations, and
+        // its tags should match what we expect.
+        assertThat("Number of counters matching " + metricName,
+                   sameNamedCounters.size(), is(1));
+        Map.Entry<MetricID, Counter> matchedEntry = sameNamedCounters.entrySet().iterator().next();
+        assertThat("Tags for " + metricName,
+                   matchedEntry.getKey().getTagsAsArray(),
+                   is(tags));
+        assertThat("Value for " + metricName,
+                   matchedEntry.getValue().getCount(),
+                   is(expectedValue));
+        return matchedEntry.getValue();
     }
 
     @Test

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestMetricTypeCoverage.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestMetricTypeCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,10 +41,8 @@ public class TestMetricTypeCoverage {
 
 
         for (MetricType type : typesToCheck) {
-            for (MetricAnnotationInfo<?, ?> info : MetricAnnotationInfo.ANNOTATION_TYPE_TO_INFO.values()) {
-                if (info.metricType().equals(type)) {
-                    found.add(type);
-                }
+            if (MetricAnnotationInfo.info(type) != null) {
+                found.add(type);
             }
         }
         typesToCheck.removeAll(found);


### PR DESCRIPTION
Resolves #6122 

# Background
MP Metrics permits developers to use annotations to refer to metrics in two ways:

## "Metric-declaring" annotations
`@Counted`, `@Timed`, etc. _declare_ metrics. In 2.x, there can be only one such metric-declaring annotation for a given metric _unless_ that metric's metadata allows reuse. In that case, we permit multiple registrations of the same metric provided that the metadata (description, display name, units, reusability) supplied by all the metric's metric-declaring annotations are consistent. 

In addition, developers can declare `@Produces` methods and fields to serve as sources for injecting metrics elsewhere. Such producers can have the `@Metric` annotation to provide additional metadata information for the produced metric.

## `@Inject` sites
The developer can `@Inject` a metric as well, either as fields or as parameters to methods and constructors. Again, such references can use the `@Metric` annotation to specify metadata information for the metric to be injected. 
Helidon's MP implementation injects the correct metrics either using developer-provided producers (if any) or, failing that, its own built-in producers for the various kind of metrics.

If the referenced metric has not yet been registered, the producer (either the developers or ours) creates and registers the metric. If the metric _has_ been previously registered, the producer simply returns that one to CDI for injection.

The `@Metric` annotation on an injection site _can_ only identify the metric to be injected: give the name and any relevant tags. The parameter's or field's Java type determines the metric type to be injected. The ID and type are enough for Helidon to locate and inject the correct metric. If the metric has not already been registered, Helidon registers it automatically before injecting it. 

If the `@Metric` annotation appears on multiple injection sites for the same metric, the metadata declared in the annotations must be consistent across all appearances.

# What behavior does this PR change?
## Former behavior
Helidon at start-up would automatically register only those metrics triggered by metric-_declaring_ annotations and producers. Metrics that appeared only at injection sites would be registered just-in-time, when they were first needed. For a JAX-RS resource, for example, that translates to the first access to an endpoint exposed by the resource. So, after start-up but before any endpoint accesses, the output from `/metrics` would _not_ include metrics which appear only at injection sites in beans which CDI had not yet had to create.

This was odd and, potentially, contrary to the MicroProfile Metrics spec (although no TCK tests exercise this).

## New behavior
Users can configure Helidon to register, during _start-up_, all metrics implied by metric-declaring sites, producers, _and injection sites_.

To work, though, in 2.x these changes must bypass any user-provided producers for metrics. That is why this feature is off by default. Users must explicitly enable it:
```properties
mp.metrics.startup-registration.enabled = true
```

This PR requires injected meter parameters to have a `@Metric` annotation with at least the `name` specified. (If tags are important to identify the metric they should be supplied as well but we have no way of knowing if we should require tags.) At runtime the Java parameter names are not always available, in which case they are named `arg<n>` based on the position in the parameter list. What should be the same injected metric could appear in different places in two different method signatures. It is much safer to require the developer to be explicit about the name (and, if relevant, tags).

## How the MP metrics CDI extension works (unchanged at a high level)
The MP metrics CDI extension follows this high-level life cycle:
1. Observes `ProcessAnnotatedType` for any type bearing any metric-declaring or metric-referring annotation and records each type.
2. Observes `ProcessManagedBean`. Ignores any bean not previously recorded by the `PAT` observer. For each declared or referenced metric in the type, creates and saves a deferred registration object. We cannot register the metrics at this point because runtime config can affect the behavior of the metric registry we will use, so instead we save the registration work to be done later.
3. Observes `@Initialized(ApplicationScoped.class)`. At this point the runtime config is available so we can obtain the correct metric registry and perform the deferred registration work saved during `PMB`.

# Overview of the changes
Two main categories:
1. Because we now potentially attempt to register the same metric from multiple sites (declaring and referring), we need to make sure the metadata we use from all those sites is consistent. In particular, we now normalize the description and display name to null if the original value is an empty string (as can happen easily from a `@Metric` annotation).
2. During start-up we now have to gather information about every metric injection site (formerly just the metric-declaring ones) and record the deferred registration work to register the metrics for those sites. This resulted in quite a few changes.

## `MetricAnnotationInfo`
The metric-declaring annotations have identical elements (`name`, `tags`, `absolute`, `displayName`, `description`, `units`, `reusable`). 
Because annotations cannot extend a common superclass, the metric-declaring annotations have to be handled individually despite the fact they have common methods. The `MetricAnnotationInfo` class abstracts all those details to simplify code elsewhere in MP metrics. This package-private class now supports some new functionality useful from other changed code. It also used to expose the maps it populates; now it exposes look-up methods and the maps are private. 

## `RegistrationPrep` class
This class represents deferred registrations of metrics. It used to be an inner class of `MetricAnnotationInfo` but it became complicated enough to warrant being a separate class on its own. It now has two subtypes, one for intercepted sites (metric-declaring annotations) and one for injected sites. The rules for consistency checking and the info needed to register metrics are a little different for the two.

## `MetricUtil`
Some refactoring of utility methods among classes.

## `MetricProducer`
Acts as a CDI producer of metrics. No substantive changes; removed unused parameters and code and rearranged some code.

## `MetricsCdiExtension`
Previously it recorded deferred registrations only for metric-_defining_ annotations (intercept sites). Now it also records deferred registrations for injection sites. We want to register the metrics based on referring sites last, so the extension maintains two separate lists for deferred registrations of the two types.

The extension has CDI produce the injected metrics, thus ensuring that developer-provided producers, if any, are properly invoked.


## Tests
Added tests to make sure injected metrics are registered with the correct metadataand before the system starts.