### PR TITLE
Use Hamcrest assertions instead of JUnit in examples/microprofile/bean-validation - backport main (#1749)

### DIFF
--- a/examples/microprofile/bean-validation/pom.xml
+++ b/examples/microprofile/bean-validation/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/microprofile/bean-validation/src/test/java/io/helidon/tests/integration/bean/validation/TestValidationEndpoint.java
+++ b/examples/microprofile/bean-validation/src/test/java/io/helidon/tests/integration/bean/validation/TestValidationEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * When enabled, endpoints with bean validation should return response with BAD REQUEST status.
@@ -46,7 +47,7 @@ public class TestValidationEndpoint {
                 .get()
                 .getStatusInfo();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), statusInfo.getStatusCode(), "Endpoint should return BAD REQUEST");
+        assertThat("Endpoint should return BAD REQUEST", statusInfo.getStatusCode(), is(Response.Status.BAD_REQUEST.getStatusCode()));
 
     }
 
@@ -61,7 +62,7 @@ public class TestValidationEndpoint {
                 .request()
                 .get()
                 .getStatusInfo();
-        assertEquals(Response.Status.OK.getStatusCode(), statusInfo.getStatusCode(), "Endpoint should return OK");
+        assertThat("Endpoint should return OK", statusInfo.getStatusCode(), is(Response.Status.OK.getStatusCode()));
 
     }
 }


### PR DESCRIPTION
Part of #1749 

[Original PR](https://github.com/helidon-io/helidon/pull/5922)