### PR TITLE
Need to use a ConcurrentHashMap in DefaultDnsResolver

### DIFF
--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/DefaultDnsResolver.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/DefaultDnsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,14 @@ package io.helidon.nima.webclient;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.helidon.nima.webclient.spi.DnsResolver;
 
 final class DefaultDnsResolver implements DnsResolver {
 
-    private final Map<String, InetAddress> hostnameAddresses = new HashMap<>();
+    private final Map<String, InetAddress> hostnameAddresses = new ConcurrentHashMap<>();
 
     @Override
     public InetAddress resolveAddress(String hostname, DnsAddressLookup dnsAddressLookup) {

--- a/nima/webclient/webclient/src/test/java/io/helidon/nima/webclient/DefaultDnsResolverTest.java
+++ b/nima/webclient/webclient/src/test/java/io/helidon/nima/webclient/DefaultDnsResolverTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webclient;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class DefaultDnsResolverTest {
+
+    private static final int THREADS = 100;
+
+    /**
+     * Test that {@link DefaultDnsResolver} can be exercised concurrently. A
+     * {@link WebClient} used concurrently will use a single resolver.
+     *
+     * @throws Exception on unexpected condition
+     */
+    @Test
+    void testConcurrency() throws Exception {
+        DefaultDnsResolver dns = new DefaultDnsResolver();
+        try (var exec = Executors.newVirtualThreadPerTaskExecutor()) {
+            Set<Future<?>> futures = new HashSet<>();
+            for (int i = 0; i < THREADS; i++) {
+                futures.add(exec.submit(() -> dns.resolveAddress("localhost", DnsAddressLookup.IPV4)));
+            }
+            for (Future<?> f : futures) {
+                f.get(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Need to use a ConcurrentHashMap in resolver given that a single instance is used in WebClient. New test that easily fails using a normal HashMap. See Issue #6206.