### PR TITLE
Use Hamcrest assertions instead of JUnit in lra/coordinator/server - backport main (#1749)

### DIFF
--- a/lra/coordinator/server/pom.xml
+++ b/lra/coordinator/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -102,6 +102,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lra/coordinator/server/src/test/java/io/helidon/lra/coordinator/CoordinatorTest.java
+++ b/lra/coordinator/server/src/test/java/io/helidon/lra/coordinator/CoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,11 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonValue;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CoordinatorTest {
 
@@ -93,26 +95,26 @@ public class CoordinatorTest {
     void startAndClose() {
         String lraId = start();
 
-        Assertions.assertEquals(LRAStatus.Active, getParsedStatusOfLra(lraId));
-        Assertions.assertEquals(LRAStatus.Active, status(lraId));
+        assertThat(getParsedStatusOfLra(lraId), is(LRAStatus.Active));
+        assertThat(status(lraId), is(LRAStatus.Active));
 
         close(lraId);
 
-        Assertions.assertEquals(LRAStatus.Closed, getParsedStatusOfLra(lraId));
-        Assertions.assertEquals(LRAStatus.Closed, status(lraId));
+        assertThat(getParsedStatusOfLra(lraId), is(LRAStatus.Closed));
+        assertThat(status(lraId), is(LRAStatus.Closed));
     }
 
     @Test
     void startAndCancel() {
         String lraId = start();
 
-        Assertions.assertEquals(LRAStatus.Active, getParsedStatusOfLra(lraId));
-        Assertions.assertEquals(LRAStatus.Active, status(lraId));
+        assertThat(getParsedStatusOfLra(lraId), is(LRAStatus.Active));
+        assertThat(status(lraId), is(LRAStatus.Active));
 
         close(lraId);
 
-        Assertions.assertEquals(LRAStatus.Closed, getParsedStatusOfLra(lraId));
-        Assertions.assertEquals(LRAStatus.Closed, status(lraId));
+        assertThat(getParsedStatusOfLra(lraId), is(LRAStatus.Closed));
+        assertThat(status(lraId), is(LRAStatus.Closed));
     }
 
     private String start() {


### PR DESCRIPTION
Part of #1749 

[Original PR](https://github.com/helidon-io/helidon/pull/5933)