### PR TITLE
Support for unordered scope closings in JaegerScopeManager

### DIFF
--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerScopeManager.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerScopeManager.java
@@ -74,13 +74,14 @@ class JaegerScopeManager implements ScopeManager {
                     if (innermost == this) {
                         if (previousScope == null) {
                             SCOPES.remove(creatingThreadId);
+                            closed = true;
                         } else {
                             SCOPES.put(creatingThreadId, previousScope);
+                            closed = true;
                             if (closePreviousScope) {
                                 previousScope.close();
                             }
                         }
-                        closed = true;
                     } else {
                         // Delay closing to after we close all inner scopes
                         innermost.delayClose(this);


### PR DESCRIPTION
In combination with async processing (like the @Asynchronous annotation) it may be possible for tracing spans to be closed in an order other than innermost to outermost (i.e., the reverse order of activation). This can result in a memory leak in JaegerScopeManager. The new implementation of this manager now handles unordered closings. See issue #5633.