### PR TITLE
4.x: Fix duplicate maven-failsafe-plugin declaration in dbclient integration test

### DIFF
--- a/tests/integration/dbclient/jdbc/pom.xml
+++ b/tests/integration/dbclient/jdbc/pom.xml
@@ -534,15 +534,6 @@
             </dependencies>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <io.helidon.tests.integration.dbclient.config>mssql.yaml</io.helidon.tests.integration.dbclient.config>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
@@ -581,6 +572,9 @@
                        <groupId>org.apache.maven.plugins</groupId>
                        <artifactId>maven-failsafe-plugin</artifactId>
                        <configuration>
+                           <systemPropertyVariables>
+                               <io.helidon.tests.integration.dbclient.config>mssql.yaml</io.helidon.tests.integration.dbclient.config>
+                           </systemPropertyVariables>
                            <parallel>methods</parallel>
                            <threadCount>10</threadCount>
                        </configuration>


### PR DESCRIPTION
Fixes #6233 

