### PR TITLE
Use Hamcrest assertions instead of JUnit in examples/webserver/multiport - backport main (#1749)

### DIFF
--- a/examples/webserver/multiport/pom.xml
+++ b/examples/webserver/multiport/pom.xml
@@ -66,6 +66,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>

--- a/examples/webserver/multiport/src/test/java/io/helidon/examples/webserver/multiport/MainTest.java
+++ b/examples/webserver/multiport/src/test/java/io/helidon/examples/webserver/multiport/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,11 +28,13 @@ import io.helidon.reactive.webclient.WebClient;
 import io.helidon.reactive.webserver.WebServer;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MainTest {
 
@@ -96,7 +98,7 @@ public class MainTest {
                 .uri("http://localhost:" + params.port)
                 .path(params.path)
                 .request()
-                .thenAccept(response -> Assertions.assertEquals(params.httpStatus, response.status()))
+                .thenAccept(response -> assertThat(response.status(), is(params.httpStatus)))
                 .toCompletableFuture()
                 .get();
     }
@@ -108,7 +110,7 @@ public class MainTest {
                 .uri("http://localhost:" + publicPort)
                 .path("/hello")
                 .request(String.class)
-                .thenAccept(s -> Assertions.assertEquals("Public Hello!!", s))
+                .thenAccept(s -> assertThat(s, is("Public Hello!!")))
                 .toCompletableFuture()
                 .get();
 
@@ -116,7 +118,7 @@ public class MainTest {
                 .uri("http://localhost:" + privatePort)
                 .path("/private/hello")
                 .request(String.class)
-                .thenAccept(s -> Assertions.assertEquals("Private Hello!!", s))
+                .thenAccept(s -> assertThat(s, is("Private Hello!!")))
                 .toCompletableFuture()
                 .get();
     }


### PR DESCRIPTION
Part of #1749 

[Original PR](https://github.com/helidon-io/helidon/pull/5979)