### PR TITLE
Typo in metrics guide 3.x

### DIFF
--- a/docs/includes/guides/metrics.adoc
+++ b/docs/includes/guides/metrics.adoc
@@ -283,7 +283,7 @@ metrics:
     - type: base
       enabled: false
     - type: vendor
-      enables: false
+      enabled: false
 ----
 
 ===== Controlling Metrics by Metric Name


### PR DESCRIPTION
Fixes the 3.x version of the metrics guide. #5809 #5926 fixed the 2.x version