### PR TITLE
[3.x]: Use Hamcrest assertions instead of JUnit in examples/todo-app (#1749)

### DIFF
--- a/examples/todo-app/backend/src/test/java/io/helidon/demo/todos/backend/BackendTests.java
+++ b/examples/todo-app/backend/src/test/java/io/helidon/demo/todos/backend/BackendTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @HelidonTest
 @Configuration(useExisting = true)
@@ -115,8 +116,8 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .post(Entity.json(todo), JsonObject.class);
 
-        assertEquals("john", returnedTodo.getString("user"));
-        assertEquals(todo.getString("title"), returnedTodo.getString("title"));
+        assertThat(returnedTodo.getString("user"), is("john"));
+        assertThat(returnedTodo.getString("title"), is(todo.getString("title")));
 
         // Get the todo created earlier
         JsonObject fromServer = webTarget.path("/api/backend/" + returnedTodo.getString("id"))
@@ -124,7 +125,7 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .get(JsonObject.class);
 
-        assertEquals(returnedTodo, fromServer);
+        assertThat(fromServer, is(returnedTodo));
 
         // Update the todo created earlier
         JsonObject updatedTodo = Json.createObjectBuilder()
@@ -137,7 +138,7 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .put(Entity.json(updatedTodo), JsonObject.class);
 
-        assertEquals(updatedTodo.getString("title"), fromServer.getString("title"));
+        assertThat(fromServer.getString("title"), is(updatedTodo.getString("title")));
 
         // Delete the todo created earlier
         fromServer = webTarget.path("/api/backend/" + returnedTodo.getString("id"))
@@ -145,7 +146,7 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .delete(JsonObject.class);
 
-        assertEquals(returnedTodo.getString("id"), fromServer.getString("id"));
+        assertThat(fromServer.getString("id"), is(returnedTodo.getString("id")));
 
         // Get list of todos
         JsonArray jsonValues = webTarget.path("/api/backend")
@@ -153,7 +154,7 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .get(JsonArray.class);
 
-        assertEquals(0, jsonValues.size(), "There should be no todos on server");
+        assertThat("There should be no todos on server", jsonValues.size(), is(0));
     }
 
 }

--- a/examples/todo-app/frontend/pom.xml
+++ b/examples/todo-app/frontend/pom.xml
@@ -137,6 +137,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-jersey</artifactId>
             <scope>test</scope>

--- a/examples/todo-app/frontend/src/test/java/io/helidon/demo/todos/frontend/FrontendTest.java
+++ b/examples/todo-app/frontend/src/test/java/io/helidon/demo/todos/frontend/FrontendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,11 +48,13 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.config.ConfigSources.classpath;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FrontendTest {
 
@@ -184,7 +186,7 @@ public class FrontendTest {
                 })
                 .request(JsonArray.class)
                 .thenAccept(jsonValues -> {
-                    Assertions.assertEquals(TODO, jsonValues.getJsonObject(0));
+                    assertThat(jsonValues.getJsonObject(0), is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -200,7 +202,7 @@ public class FrontendTest {
                 })
                 .submit(TODO, JsonObject.class)
                 .thenAccept(jsonObject -> {
-                    Assertions.assertEquals(TODO, jsonObject);
+                    assertThat(jsonObject, is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -216,7 +218,7 @@ public class FrontendTest {
                 })
                 .request(JsonObject.class)
                 .thenAccept(jsonObject -> {
-                    Assertions.assertEquals(TODO, jsonObject);
+                    assertThat(jsonObject, is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -232,7 +234,7 @@ public class FrontendTest {
                 })
                 .request(JsonObject.class)
                 .thenAccept(jsonObject -> {
-                    Assertions.assertEquals(TODO, jsonObject);
+                    assertThat(jsonObject, is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -248,7 +250,7 @@ public class FrontendTest {
                 })
                 .submit(TODO, JsonObject.class)
                 .thenAccept(jsonObject -> {
-                    Assertions.assertEquals(TODO, jsonObject);
+                    assertThat(jsonObject, is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -260,7 +262,7 @@ public class FrontendTest {
                 .path("/env")
                 .request(String.class)
                 .thenAccept(s -> {
-                    Assertions.assertEquals("docker", s);
+                    assertThat(s, is("docker"));
                 })
                 .toCompletableFuture()
                 .get();


### PR DESCRIPTION
Part of #1749 

- [x] Create backport 2.x