### PR TITLE
[2.x]: Use Hamcrest assertions instead of JUnit in examples/todo-app (#1749)

### DIFF
--- a/examples/todo-app/backend/src/test/java/io/helidon/demo/todos/backend/BackendTests.java
+++ b/examples/todo-app/backend/src/test/java/io/helidon/demo/todos/backend/BackendTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @HelidonTest
 @Configuration(useExisting = true)
@@ -113,8 +114,8 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .post(Entity.json(todo), JsonObject.class);
 
-        assertEquals("john", returnedTodo.getString("user"));
-        assertEquals(todo.getString("title"), returnedTodo.getString("title"));
+        assertThat(returnedTodo.getString("user"), is("john"));
+        assertThat(returnedTodo.getString("title"), is(todo.getString("title")));
 
         // Get the todo created earlier
         JsonObject fromServer = webTarget.path("/api/backend/" + returnedTodo.getString("id"))
@@ -122,7 +123,7 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .get(JsonObject.class);
 
-        assertEquals(returnedTodo, fromServer);
+        assertThat(fromServer, is(returnedTodo));
 
         // Update the todo created earlier
         JsonObject updatedTodo = Json.createObjectBuilder()
@@ -135,7 +136,7 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .put(Entity.json(updatedTodo), JsonObject.class);
 
-        assertEquals(updatedTodo.getString("title"), fromServer.getString("title"));
+        assertThat(fromServer.getString("title"), is(updatedTodo.getString("title")));
 
         // Delete the todo created earlier
         fromServer = webTarget.path("/api/backend/" + returnedTodo.getString("id"))
@@ -143,7 +144,7 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .delete(JsonObject.class);
 
-        assertEquals(returnedTodo.getString("id"), fromServer.getString("id"));
+        assertThat(fromServer.getString("id"), is(returnedTodo.getString("id")));
 
         // Get list of todos
         JsonArray jsonValues = webTarget.path("/api/backend")
@@ -151,7 +152,7 @@ class BackendTests {
                 .header(Http.Header.AUTHORIZATION, basicAuth)
                 .get(JsonArray.class);
 
-        assertEquals(0, jsonValues.size(), "There should be no todos on server");
+        assertThat("There should be no todos on server", jsonValues.size(), is(0));
     }
 
 }

--- a/examples/todo-app/frontend/pom.xml
+++ b/examples/todo-app/frontend/pom.xml
@@ -136,6 +136,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-jersey</artifactId>
             <scope>test</scope>

--- a/examples/todo-app/frontend/src/test/java/io/helidon/demo/todos/frontend/FrontendTest.java
+++ b/examples/todo-app/frontend/src/test/java/io/helidon/demo/todos/frontend/FrontendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.jersey.JerseySupport;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +51,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static io.helidon.config.ConfigSources.classpath;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FrontendTest {
 
@@ -183,7 +185,7 @@ public class FrontendTest {
                 })
                 .request(JsonArray.class)
                 .thenAccept(jsonValues -> {
-                    Assertions.assertEquals(TODO, jsonValues.getJsonObject(0));
+                    assertThat(jsonValues.getJsonObject(0), is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -199,7 +201,7 @@ public class FrontendTest {
                 })
                 .submit(TODO, JsonObject.class)
                 .thenAccept(jsonObject -> {
-                    Assertions.assertEquals(TODO, jsonObject);
+                    assertThat(jsonObject, is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -215,7 +217,7 @@ public class FrontendTest {
                 })
                 .request(JsonObject.class)
                 .thenAccept(jsonObject -> {
-                    Assertions.assertEquals(TODO, jsonObject);
+                    assertThat(jsonObject, is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -231,7 +233,7 @@ public class FrontendTest {
                 })
                 .request(JsonObject.class)
                 .thenAccept(jsonObject -> {
-                    Assertions.assertEquals(TODO, jsonObject);
+                    assertThat(jsonObject, is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -247,7 +249,7 @@ public class FrontendTest {
                 })
                 .submit(TODO, JsonObject.class)
                 .thenAccept(jsonObject -> {
-                    Assertions.assertEquals(TODO, jsonObject);
+                    assertThat(jsonObject, is(TODO));
                 })
                 .toCompletableFuture()
                 .get();
@@ -259,7 +261,7 @@ public class FrontendTest {
                 .path("/env")
                 .request(String.class)
                 .thenAccept(s -> {
-                    Assertions.assertEquals("docker", s);
+                    assertThat(s, is("docker"));
                 })
                 .toCompletableFuture()
                 .get();


### PR DESCRIPTION
Part of #1749