### PR TITLE
'Accept-Encoding' parser fix

### DIFF
--- a/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncodingSupportImpl.java
+++ b/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncodingSupportImpl.java
@@ -95,10 +95,10 @@ class ContentEncodingSupportImpl implements ContentEncodingContext {
             Accept-Encoding: gzip, compress, br
             Accept-Encoding: br;q=1.0, gzip;q=0.8, *;q=0.1
          */
-        String[] values = acceptEncoding.split(", ");
+        String[] values = acceptEncoding.split(",");
         List<EncodingWithQ> supported = new ArrayList<>(values.length);
         for (String value : values) {
-            supported.add(EncodingWithQ.parse(value));
+            supported.add(EncodingWithQ.parse(value.trim()));
         }
         Collections.sort(supported);
         for (EncodingWithQ encodingWithQ : supported) {


### PR DESCRIPTION
Fixed 'Accept-Encoding' parser for cases where comma delimiter is not followed by space symbol.
Current version fails with NumberFormatException for values like this `gzip;q=1.0,deflate;q=0.6,identity;q=0.3`