### PR TITLE
Re-enables microprofile/cors/.../AdapterTest.java

### DIFF
--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/AdapterTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/AdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,7 +41,6 @@ import static org.hamcrest.Matchers.is;
 
 @AddBean(AdapterTest.TestApp.class)
 @AddBean(AdapterTest.TestResource.class)
-@Disabled
 public class AdapterTest extends BaseCrossOriginTest {
 
     private static final String APP_PATH = "/adaptertestapp";


### PR DESCRIPTION
Re-enables `microprofile/cors/src/test/java/io/helidon/microprofile/cors/AdapterTest.java`. See #5407.  