### PR TITLE
Re-enables microprofile/metrics/.../TestMetricsOnOwnSocket.java

### DIFF
--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestMetricsOnOwnSocket.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestMetricsOnOwnSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,6 @@ import static org.hamcrest.Matchers.is;
 @AddConfig(key = "metrics.routing", value = "metrics")
 @AddConfig(key = "metrics.key-performance-indicators.extended", value = "true")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Disabled
 public class TestMetricsOnOwnSocket {
 
     private Invocation metricsInvocation= null;


### PR DESCRIPTION
Re-enables `microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestMetricsOnOwnSocket.java`. See #5407.