### PR TITLE
Re-enables grpc/metrics/src/test/java/.../*.java

### DIFF
--- a/grpc/metrics/pom.xml
+++ b/grpc/metrics/pom.xml
@@ -52,6 +52,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.reactive.metrics</groupId>
             <artifactId>helidon-reactive-metrics</artifactId>
             <scope>test</scope>

--- a/grpc/metrics/src/test/java/io/helidon/grpc/metrics/GrpcMetricsInterceptorIT.java
+++ b/grpc/metrics/src/test/java/io/helidon/grpc/metrics/GrpcMetricsInterceptorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.Timer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -72,7 +71,6 @@ import static org.mockito.Mockito.when;
  * to be initialised which may impact other tests that rely on metrics being
  * configured a specific way.
  */
-@Disabled
 @SuppressWarnings("unchecked")
 public class GrpcMetricsInterceptorIT {
 

--- a/grpc/metrics/src/test/java/io/helidon/grpc/metrics/MetricsIT.java
+++ b/grpc/metrics/src/test/java/io/helidon/grpc/metrics/MetricsIT.java
@@ -39,7 +39,6 @@ import jakarta.json.JsonStructure;
 import jakarta.json.JsonValue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import services.EchoService;
 
@@ -50,7 +49,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Integration tests for gRPC server with metrics.
  */
-@Disabled
 public class MetricsIT {
 
     // ----- data members ---------------------------------------------------


### PR DESCRIPTION
Re-enables `grpc/metrics/src/test/java/io/helidon/grpc/metrics/*.java`. See #5407. 