### PR TITLE
Handle zero or more spaces after commas when parsing Accept-Encoding

### DIFF
--- a/nima/http/encoding/encoding/pom.xml
+++ b/nima/http/encoding/encoding/pom.xml
@@ -46,6 +46,16 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nima/http/encoding/encoding/src/test/java/io/helidon/nima/http/encoding/ContentEncodingSupportTest.java
+++ b/nima/http/encoding/encoding/src/test/java/io/helidon/nima/http/encoding/ContentEncodingSupportTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.http.encoding;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import io.helidon.nima.http.encoding.ContentEncodingSupportImpl.EncodingWithQ;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static io.helidon.nima.http.encoding.ContentEncodingSupportImpl.encodings;
+
+class ContentEncodingSupportTest {
+
+    @Test
+    void testEncodingsParserOne() {
+        List<EncodingWithQ> encodings = encodings("gzip");
+        assertThat(encodings.size(), is(1));
+        assertThat(encodings.get(0).toString(), is("gzip;q=1.0"));
+    }
+
+    @Test
+    void testEncodingsParserMany() {
+        List<EncodingWithQ> encodings = encodings("gzip,compress,  br  ");
+        assertThat(encodings.size(), is(3));
+        assertThat(encodings.get(0).toString(), is("gzip;q=1.0"));
+        assertThat(encodings.get(1).toString(), is("compress;q=1.0"));
+        assertThat(encodings.get(2).toString(), is("br;q=1.0"));
+
+    }
+
+    @Test
+    void testEncodingsParserWithQs() {
+        List<EncodingWithQ> encodings = encodings("gzip;q=1.0, deflate;q=0.6,  identity;q=0.3");
+        assertThat(encodings.size(), is(3));
+        assertThat(encodings.get(0).toString(), is("gzip;q=1.0"));
+        assertThat(encodings.get(1).toString(), is("deflate;q=0.6"));
+        assertThat(encodings.get(2).toString(), is("identity;q=0.3"));
+    }
+}

--- a/nima/http/encoding/encoding/src/test/java/io/helidon/nima/http/encoding/ContentEncodingSupportTest.java
+++ b/nima/http/encoding/encoding/src/test/java/io/helidon/nima/http/encoding/ContentEncodingSupportTest.java
@@ -41,7 +41,6 @@ class ContentEncodingSupportTest {
         assertThat(encodings.get(0).toString(), is("gzip;q=1.0"));
         assertThat(encodings.get(1).toString(), is("compress;q=1.0"));
         assertThat(encodings.get(2).toString(), is("br;q=1.0"));
-
     }
 
     @Test


### PR DESCRIPTION
Handle zero or more spaces after commas when parsing Accept-Encoding header. Minor refactoring to add some unit tests. Issue #6352.