### PR TITLE
Support for non-GET HTTP/2 upgrades

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/HelidonConnectionHandler.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/HelidonConnectionHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
@@ -68,6 +69,10 @@ class HelidonConnectionHandler extends HttpToHttp2ConnectionHandler implements H
                     .method(request.method().asciiName())
                     .path(request.uri())
                     .scheme(HttpScheme.HTTP.name());
+            CharSequence host = request.headers().get(HttpHeaderNames.HOST);
+            if (host != null) {
+                headers.authority(host);
+            }
             for (Map.Entry<String, String> e : request.headers()) {
                 headers.add(e.getKey().toLowerCase(), e.getValue());
             }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/HelidonConnectionHandler.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/HelidonConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package io.helidon.webserver.http2;
 
+import java.util.Map;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
@@ -61,20 +61,25 @@ class HelidonConnectionHandler extends HttpToHttp2ConnectionHandler implements H
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent upgradeEvent) {
-
-            // Map initial request headers to HTTP2
             FullHttpRequest request = upgradeEvent.upgradeRequest();
+
+            // Create HTTP/2 headers from HTTP upgrade request
             Http2Headers headers = new DefaultHttp2Headers()
-                    .method(HttpMethod.GET.asciiName())
+                    .method(request.method().asciiName())
                     .path(request.uri())
                     .scheme(HttpScheme.HTTP.name());
-            CharSequence host = request.headers().get(HttpHeaderNames.HOST);
-            if (host != null) {
-                headers.authority(host);
+            for (Map.Entry<String, String> e : request.headers()) {
+                headers.add(e.getKey().toLowerCase(), e.getValue());
             }
 
-            // Process mapped headers
-            onHeadersRead(ctx, 1, headers, 0, true);
+            // Support non-GET upgrade requests possibly with non-empty payloads
+            ByteBuf payload = request.content();
+            if (payload.readableBytes() > 0) {
+                onHeadersRead(ctx, 1, headers, 0, false);
+                onDataRead(ctx, 1, payload, 0, true);
+            } else {
+                onHeadersRead(ctx, 1, headers, 0, true);
+            }
         }
         super.userEventTriggered(ctx, evt);
     }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/test/H2UpgradeTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/test/H2UpgradeTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http2.test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import io.helidon.common.LogConfig;
+import io.helidon.webserver.WebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class H2UpgradeTest {
+
+    private static WebServer webServer;
+    private static HttpClient httpClient;
+
+    @BeforeAll
+    public static void startServer() {
+        LogConfig.configureRuntime();
+        webServer = WebServer.builder()
+                .defaultSocket(s -> s
+                        .bindAddress("localhost")
+                        .port(0)
+                )
+                .routing(r -> r
+                        .get("/", (req, res) ->
+                                res.send("GET " + req.version()))
+                        .post("/", (req, res) ->
+                                req.content().as(String.class).thenAccept(s ->
+                                        res.send("POST " + req.version() + " " + s)))
+                        .put("/", (req, res) ->
+                                req.content().as(String.class).thenAccept(s ->
+                                        res.send("PUT " + req.version() + " " + s)))
+                )
+                .build()
+                .start()
+                .await(Duration.ofSeconds(10));
+
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        webServer.shutdown().await(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void testGetUpgrade() throws IOException, InterruptedException {
+        HttpResponse<String> r = httpClientGet("GET", "/", BodyPublishers.noBody());
+        assertThat(r.body(), is("GET V2_0"));
+    }
+
+    @Test
+    void testPostUpgrade() throws IOException, InterruptedException {
+        HttpResponse<String> r = httpClientGet("POST", "/", BodyPublishers.ofString("Hello World"));
+        assertThat(r.body(), is("POST V2_0 Hello World"));
+    }
+
+    @Test
+    void testPutUpgrade() throws IOException, InterruptedException {
+        HttpResponse<String> r = httpClientGet("PUT", "/", BodyPublishers.ofString("Hello World"));
+        assertThat(r.body(), is("PUT V2_0 Hello World"));
+    }
+
+    private HttpResponse<String> httpClientGet(String method, String path, HttpRequest.BodyPublisher publisher)
+            throws IOException, InterruptedException {
+        return httpClient.send(HttpRequest.newBuilder()
+                .version(HttpClient.Version.HTTP_2)     // always upgrade, no prior knowledge support
+                .uri(URI.create("http://localhost:" + webServer.port() + path))
+                .method(method, publisher)
+                .build(), HttpResponse.BodyHandlers.ofString());
+    }
+}


### PR DESCRIPTION
Support for non-GET HTTP/2 upgrades. Improved mapping of HTTP/1 request to HTTP/2 to support non-GET upgrades with payloads. Issue #6353.