### PR TITLE
Fix `{h1-prefix}` unreplaced token in SE metrics guide preamble

### DIFF
--- a/docs/se/guides/metrics.adoc
+++ b/docs/se/guides/metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@
 = Helidon SE Metrics Guide
 :description: Helidon metrics
 :keywords: helidon, metrics, microprofile, guide
-:intro-project-name: {h1-prefix}
 :rootdir: {docdir}/../..
+include::{rootdir}/includes/se.adoc[]
+:intro-project-name: {h1-prefix}
 
 include::{rootdir}/includes/se.adoc[]
 


### PR DESCRIPTION
Resolves #6408 

Assign `h1-prefix` from `se.doc` earlier in the file.