### PR TITLE
Fix native-image build-time initialization

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -26,7 +26,6 @@
         <version>3.1.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>io.helidon.applications</groupId>
     <artifactId>helidon-applications</artifactId>
     <packaging>pom</packaging>
     <name>Helidon Applications Parent</name>
@@ -201,7 +200,6 @@
                                 <buildArgs>
                                     <!-- Some native image features use the svm dependencies which require additional exports -->
                                     <arg>--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED</arg>
-                                    <arg>--static</arg>
                                 </buildArgs>
                             </configuration>
                         </execution>
@@ -211,6 +209,27 @@
         </pluginManagement>
     </build>
     <profiles>
+        <profile>
+            <id>static</id>
+            <activation>
+                <os>
+                    <family>Linux</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArgs>
+                                <arg>--static</arg>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>helidon-cli</id>
             <activation>

--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -210,7 +210,7 @@
     </build>
     <profiles>
         <profile>
-            <id>static</id>
+            <id>linux-native</id>
             <activation>
                 <os>
                     <family>Linux</family>
@@ -221,11 +221,16 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <configuration>
-                            <buildArgs>
-                                <arg>--static</arg>
-                            </buildArgs>
-                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build-native-image</id>
+                                <configuration>
+                                    <buildArgs combine.children="append">
+                                        <arg>--static</arg>
+                                    </buildArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/archetypes/helidon/src/main/archetype/common/files/src/main/resources/META-INF/native-image/__dir__/native-image.properties.mustache
+++ b/archetypes/helidon/src/main/archetype/common/files/src/main/resources/META-INF/native-image/__dir__/native-image.properties.mustache
@@ -1,0 +1,1 @@
+Args=--initialize-at-build-time={{package}}

--- a/archetypes/helidon/src/main/archetype/common/native-image.xml
+++ b/archetypes/helidon/src/main/archetype/common/native-image.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<archetype-script xmlns="https://helidon.io/archetype/2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-2.0.xsd">
+
+    <output>
+        <transformation id="native-image">
+            <replace regex="__dir__" replacement="${groupId}/${artifactId}"/>
+        </transformation>
+
+        <templates engine="mustache" transformations="native-image,mustache">
+            <directory>files</directory>
+            <includes>
+                <include>**/native-image/**</include>
+            </includes>
+        </templates>
+    </output>
+</archetype-script>

--- a/archetypes/helidon/src/main/archetype/common/packaging.xml
+++ b/archetypes/helidon/src/main/archetype/common/packaging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-2.0.xsd">
 
+    <exec src="native-image.xml"/>
     <step name="Packaging and Deployment" optional="true">
         <exec src="docker.xml"/>
         <inputs>

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Isolate the use of --static to Linux only.
- Add a native-image.properties file in archetypes for all generated project

Fixes #6284