### PR TITLE
[Nima] Set running flag to false in shutdownhook

### DIFF
--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/LoomServer.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/LoomServer.java
@@ -243,6 +243,9 @@ class LoomServer implements WebServer {
             if (startFutures != null) {
                 startFutures.forEach(future -> future.future().cancel(true));
             }
+
+            running.set(false);
+
             LOGGER.log(System.Logger.Level.INFO, "Shutdown finished");
         }, "nima-shutdown-hook");
 


### PR DESCRIPTION
Currently shutdownhook doesn't set flag `running` to `false`.
Setting to `false` is useful because we can test that `WebServer.isRunning()`  in user `custom` hook