### PR TITLE
support -Dnative.image.skip and -Dnative.image.buildStatic

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -89,9 +89,15 @@
                         <executions>
                             <execution>
                                 <id>resource-config</id>
+                                <goals>
+                                    <goal>generateResourceConfig</goal>
+                                </goals>
                             </execution>
                             <execution>
                                 <id>build-native-image</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -89,17 +89,9 @@
                         <executions>
                             <execution>
                                 <id>resource-config</id>
-                                <goals>
-                                    <goal>generateResourceConfig</goal>
-                                </goals>
-                                <phase>package</phase>
                             </execution>
                             <execution>
                                 <id>build-native-image</id>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                                <phase>package</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -179,6 +179,10 @@
                     <executions>
                         <execution>
                             <id>resource-config</id>
+                            <goals>
+                                <goal>generateResourceConfig</goal>
+                            </goals>
+                            <phase>package</phase>
                             <configuration>
                                 <!-- generate records for all module's resources -->
                                 <isDetectionEnabled>true</isDetectionEnabled>
@@ -186,6 +190,10 @@
                         </execution>
                         <execution>
                             <id>build-native-image</id>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <phase>package</phase>
                             <configuration>
                                 <!-- generate an argument file for native image - great for troubleshooting -->
                                 <useArgFile>true</useArgFile>
@@ -210,11 +218,37 @@
     </build>
     <profiles>
         <profile>
-            <id>linux-native</id>
+            <id>native-image-skip</id>
             <activation>
-                <os>
-                    <family>Linux</family>
-                </os>
+                <property>
+                    <name>native.image.skip</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>resource-config</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>build-native-image</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>native-image-static</id>
+            <activation>
+                <property>
+                    <name>native.image.buildStatic</name>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -179,9 +179,6 @@
                     <executions>
                         <execution>
                             <id>resource-config</id>
-                            <goals>
-                                <goal>generateResourceConfig</goal>
-                            </goals>
                             <phase>package</phase>
                             <configuration>
                                 <!-- generate records for all module's resources -->
@@ -190,9 +187,6 @@
                         </execution>
                         <execution>
                             <id>build-native-image</id>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
                             <phase>package</phase>
                             <configuration>
                                 <!-- generate an argument file for native image - great for troubleshooting -->

--- a/applications/se/pom.xml
+++ b/applications/se/pom.xml
@@ -42,17 +42,9 @@
                         <executions>
                             <execution>
                                 <id>resource-config</id>
-                                <goals>
-                                    <goal>generateResourceConfig</goal>
-                                </goals>
-                                <phase>package</phase>
                             </execution>
                             <execution>
                                 <id>build-native-image</id>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                                <phase>package</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/applications/se/pom.xml
+++ b/applications/se/pom.xml
@@ -42,9 +42,15 @@
                         <executions>
                             <execution>
                                 <id>resource-config</id>
+                                <goals>
+                                    <goal>generateResourceConfig</goal>
+                                </goals>
                             </execution>
                             <execution>
                                 <id>build-native-image</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/archetypes/helidon/src/main/archetype/common/files/Dockerfile.native.mustache
+++ b/archetypes/helidon/src/main/archetype/common/files/Dockerfile.native.mustache
@@ -21,12 +21,12 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip -Declipselink.weave.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn package -Pnative-image -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 

--- a/examples/integrations/neo4j/neo4j-mp/Dockerfile.native
+++ b/examples/integrations/neo4j/neo4j-mp/Dockerfile.native
@@ -36,12 +36,12 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip -Declipselink.weave.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn package -Pnative-image -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 

--- a/examples/integrations/neo4j/neo4j-se/Dockerfile.native
+++ b/examples/integrations/neo4j/neo4j-se/Dockerfile.native
@@ -36,12 +36,12 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip -Declipselink.weave.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn package -Pnative-image -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.native
@@ -36,12 +36,12 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip -Declipselink.weave.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn package -Pnative-image -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -36,12 +36,12 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip -Declipselink.weave.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn package -Pnative-image -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.native
@@ -36,12 +36,12 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip -Declipselink.weave.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn package -Pnative-image -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
@@ -36,12 +36,12 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Dmaven.test.skip -Declipselink.weave.skip
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip -Declipselink.weave.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn package -Pnative-image -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 


### PR DESCRIPTION
Update application parent poms to support -Dnative.image.skip and -Dnative.image.buildStatic

This makes the Dockerfiles backward compatible.

Fixes #6307
Fixes #6283