### PR TITLE
Make size of header buffer independent of payload size

### DIFF
--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -430,7 +430,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             if (!isChunked) {
                 if (firstByte) {
                     firstByte = false;
-                    BufferData growing = BufferData.growing(256 + buffer.available());
+                    BufferData growing = BufferData.growing(256);
                     nonEntityBytes(headers, status.get(), growing, keepAlive);
                     responseBytesTotal += growing.available();
                     dataWriter.write(growing);


### PR DESCRIPTION
Some old code required a larger buffer, but this is no longer needed. This change should reduce memory allocation in WebServer, especially for large payloads. Found while evaluating issue #6443.