### PR TITLE
[3.x] - OpenTelemetry version upgrade

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -129,9 +129,9 @@
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.okhttp3>3.14.9</version.lib.okhttp3>
         <version.lib.okio>1.17.5</version.lib.okio>
-        <version.lib.opentelemetry>1.15.0</version.lib.opentelemetry>
-        <version.lib.opentelemetry.semconv>1.15.0-alpha</version.lib.opentelemetry.semconv>
-        <version.lib.opentelemetry.opentracing.shim>1.15.0-alpha</version.lib.opentelemetry.opentracing.shim>
+        <version.lib.opentelemetry>1.22.0</version.lib.opentelemetry>
+        <version.lib.opentelemetry.semconv>1.22.0-alpha</version.lib.opentelemetry.semconv>
+        <version.lib.opentelemetry.opentracing.shim>1.22.0-alpha</version.lib.opentelemetry.opentracing.shim>
         <version.lib.opentracing>0.33.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>


### PR DESCRIPTION
Fixes #6476 

*NOTE: OpenTelemetry currently should be upgraded to 1.22.0. Version 1.23.0 brakes MP Telemetry TCK.