### PR TITLE
Fix TODO to handle close call on entity

### DIFF
--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
@@ -246,12 +246,6 @@ public abstract class ReadableEntityBase implements ReadableEntity {
 
         @Override
         public void close() throws IOException {
-            while (!finished) {
-                ensureBuffer(512);
-                if (currentBuffer != null) {
-                    currentBuffer.skip(currentBuffer.available());
-                }
-            }
             super.close();
         }
 

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
@@ -248,7 +248,9 @@ public abstract class ReadableEntityBase implements ReadableEntity {
         public void close() throws IOException {
             while (!finished) {
                 ensureBuffer(512);
-                currentBuffer.skip(currentBuffer.available());
+                if (currentBuffer != null) {
+                    currentBuffer.skip(currentBuffer.available());
+                }
             }
             super.close();
         }

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
@@ -246,8 +246,9 @@ public abstract class ReadableEntityBase implements ReadableEntity {
 
         @Override
         public void close() throws IOException {
-            if (!finished) {
-                // TODO we need to close the connection!
+            while (!finished) {
+                ensureBuffer(512);
+                currentBuffer.skip(currentBuffer.available());
             }
             super.close();
         }

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
@@ -244,11 +244,6 @@ public abstract class ReadableEntityBase implements ReadableEntity {
             return currentBuffer.read(b, off, len);
         }
 
-        @Override
-        public void close() throws IOException {
-            super.close();
-        }
-
         private void ensureBuffer(int estimate) {
             if (currentBuffer != null && currentBuffer.consumed()) {
                 currentBuffer = null;


### PR DESCRIPTION
Addresses #5388 

There is already an auto drain in place in Http1Connection.consumeEntity. See https://github.com/helidon-io/helidon/blob/main/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Connection.java#L341. So just removing the method as we don’t need to do anything is this case.

For http2, it will be handled #6545 