### PR TITLE
[4.x]: Change provided and optional to just optional - iteration 1 (#6495)

### DIFF
--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -69,7 +69,6 @@
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-processor</artifactId>
             <optional>true</optional>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.testing</groupId>


### PR DESCRIPTION
Part of #6495 

First PR for this issue. The next PR will be bigger. Should be something like that? The same for `helidon-common-features` and other annotation-modules. Right?