### PR TITLE
Wrap underlying output stream with a buffered one whose buffer size is configurable

### DIFF
--- a/examples/microprofile/http-status-count-mp/src/test/java/io/helidon/examples/mp/httpstatuscount/StatusResource.java
+++ b/examples/microprofile/http-status-count-mp/src/test/java/io/helidon/examples/mp/httpstatuscount/StatusResource.java
@@ -46,6 +46,6 @@ public class StatusResource {
             status = Http.Status.INTERNAL_SERVER_ERROR_500.code();
             msg = "Unsuccessful conversion";
         }
-        return Response.status(status).entity(msg).build();
+        return status == 204 ? Response.status(204).build() : Response.status(status).entity(msg).build();
     }
 }

--- a/nima/http/encoding/deflate/src/main/java/io/helidon/nima/http/encoding/deflate/DeflateEncodingProvider.java
+++ b/nima/http/encoding/deflate/src/main/java/io/helidon/nima/http/encoding/deflate/DeflateEncodingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/http/encoding/deflate/src/main/java/io/helidon/nima/http/encoding/deflate/DeflateEncodingProvider.java
+++ b/nima/http/encoding/deflate/src/main/java/io/helidon/nima/http/encoding/deflate/DeflateEncodingProvider.java
@@ -16,7 +16,6 @@
 
 package io.helidon.nima.http.encoding.deflate;
 
-import java.io.BufferedOutputStream;
 import java.io.OutputStream;
 import java.util.Set;
 import java.util.zip.DeflaterOutputStream;
@@ -63,7 +62,7 @@ public class DeflateEncodingProvider implements ContentEncodingProvider {
         return new ContentEncoder() {
             @Override
             public OutputStream encode(OutputStream network) {
-                return new DeflaterOutputStream(new BufferedOutputStream(network, 512));
+                return new DeflaterOutputStream(network);
             }
 
             @Override

--- a/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/spi/ContentEncodingProvider.java
+++ b/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/spi/ContentEncodingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/http/encoding/gzip/src/main/java/io/helidon/nima/http/encoding/gzip/GzipEncodingProvider.java
+++ b/nima/http/encoding/gzip/src/main/java/io/helidon/nima/http/encoding/gzip/GzipEncodingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/http/encoding/gzip/src/main/java/io/helidon/nima/http/encoding/gzip/GzipEncodingProvider.java
+++ b/nima/http/encoding/gzip/src/main/java/io/helidon/nima/http/encoding/gzip/GzipEncodingProvider.java
@@ -16,7 +16,6 @@
 
 package io.helidon.nima.http.encoding.gzip;
 
-import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -75,7 +74,7 @@ public class GzipEncodingProvider implements ContentEncodingProvider, Weighted {
             @Override
             public OutputStream encode(OutputStream network) {
                 try {
-                    return new GZIPOutputStream(new BufferedOutputStream(network, 512));
+                    return new GZIPOutputStream(network);
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }

--- a/nima/tests/integration/webclient/webclient/src/test/java/io/helidon/nima/webclient/http1/ClientRequestImplTest.java
+++ b/nima/tests/integration/webclient/webclient/src/test/java/io/helidon/nima/webclient/http1/ClientRequestImplTest.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.ArrayList;
@@ -34,10 +33,8 @@ import io.helidon.nima.http.media.EntityWriter;
 import io.helidon.nima.http.media.MediaContext;
 import io.helidon.nima.testing.junit5.webserver.ServerTest;
 import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
-import io.helidon.nima.testing.junit5.webserver.SetUpServer;
 import io.helidon.nima.webclient.ClientConnection;
 import io.helidon.nima.webclient.WebClient;
-import io.helidon.nima.webclient.http1.ClientRequestImpl;
 import io.helidon.nima.webserver.WebServer;
 import io.helidon.nima.webserver.http.HttpRules;
 import io.helidon.nima.webserver.http.ServerRequest;
@@ -336,6 +333,7 @@ class ClientRequestImplTest {
                     byte[] chunk = new byte[chunkLen];
                     System.arraycopy(entity, i * regularChunkLen, chunk, 0, chunkLen);
                     outputStream.write(chunk);
+                    outputStream.flush();       // will force chunked
                 }
             }
         }

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ErrorHandlingWithOutputStreamTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ErrorHandlingWithOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,13 +62,6 @@ class ErrorHandlingWithOutputStreamTest {
                     os.write("writeOnceOnly".getBytes(StandardCharsets.UTF_8));
                     throw new CustomException();
                 })
-                .get("get-outputStream-writeTwiceThenError", (req, res) -> {
-                    res.header(MAIN_HEADER_NAME, "x");
-                    OutputStream os = res.outputStream();
-                    os.write("writeOnce".getBytes(StandardCharsets.UTF_8));
-                    os.write("|writeTwice".getBytes(StandardCharsets.UTF_8));
-                    throw new CustomException();
-                })
                 .get("get-outputStream-writeFlushThenError", (req, res) -> {
                     res.header(MAIN_HEADER_NAME, "x");
                     OutputStream os = res.outputStream();
@@ -111,16 +104,6 @@ class ErrorHandlingWithOutputStreamTest {
             assertThat(response.entity().as(String.class), is("CustomErrorContent"));
             assertThat(response.headers().contains(ERROR_HEADER_NAME), is(true));
             assertThat(response.headers().contains(MAIN_HEADER_NAME), is(false));
-        }
-    }
-
-    @Test
-    void testGetOutputStreamWriteTwiceThenError_expect_invalidResponse() {
-        try (Http1ClientResponse response = client.method(Http.Method.GET)
-                .uri("/get-outputStream-writeTwiceThenError")
-                .request()) {
-            assertThat(response.status(), is(Http.Status.OK_200));
-            assertThrows(DataReader.InsufficientDataAvailableException.class, () -> response.entity().as(String.class));
         }
     }
 

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ListenerConfiguration.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ListenerConfiguration.java
@@ -49,6 +49,7 @@ public final class ListenerConfiguration {
     private final SocketOptions connectionOptions;
     private final int writeQueueLength;
     private final long maxPayloadSize;
+    private final int writeBufferSize;
     private final ContentEncodingContext contentEncodingContext;
     private final MediaContext mediaContext;
     private final DirectHandlers directHandlers;
@@ -64,6 +65,7 @@ public final class ListenerConfiguration {
         this.connectionOptions = builder.connectionOptions;
         this.writeQueueLength = builder.writeQueueLength;
         this.maxPayloadSize = builder.maxPayloadSize;
+        this.writeBufferSize = builder.writeBufferSize;
         this.contentEncodingContext = builder.contentEncodingContext;
         this.mediaContext = builder.mediaContext;
         this.directHandlers = builder.directHandlers.build();
@@ -146,6 +148,15 @@ public final class ListenerConfiguration {
     }
 
     /**
+     * Initial buffer size of {@link java.io.BufferedOutputStream} created internally.
+     *
+     * @return initial buffer size for writing (in bytes)
+     */
+    public int writeBufferSize() {
+        return writeBufferSize;
+    }
+
+    /**
      * Configured direct handlers.
      *
      * @return direct handlers
@@ -224,6 +235,7 @@ public final class ListenerConfiguration {
         private SocketOptions connectionOptions;
         private int writeQueueLength = 0;
         private long maxPayloadSize = -1;
+        private int writeBufferSize = 512;
         private ContentEncodingContext contentEncodingContext;
         private MediaContext mediaContext;
         private Context context;
@@ -359,6 +371,18 @@ public final class ListenerConfiguration {
         }
 
         /**
+         * Initial buffer size in bytes of {@link java.io.BufferedOutputStream} created internally to
+         * write data to a socket connection. Default is {@code 512}.
+         *
+         * @param writeBufferSize initial buffer size used for writing
+         * @return updated builder
+         */
+        public Builder writeBufferSize(int writeBufferSize) {
+            this.writeBufferSize = writeBufferSize;
+            return this;
+        }
+
+        /**
          * Maximal number of bytes an entity may have.
          * If {@link io.helidon.common.http.Http.Header#CONTENT_LENGTH} is used, this is checked immediately,
          * if {@link io.helidon.common.http.Http.HeaderValues#TRANSFER_ENCODING_CHUNKED} is used, we will fail when the
@@ -366,9 +390,11 @@ public final class ListenerConfiguration {
          * Defaults to unlimited ({@code -1}).
          *
          * @param maxPayloadSize maximal number of bytes of entity
+         * @return updated builder
          */
-        public void maxPayloadSize(long maxPayloadSize) {
+        public Builder maxPayloadSize(long maxPayloadSize) {
             this.maxPayloadSize = maxPayloadSize;
+            return this;
         }
 
         /**

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
@@ -236,6 +236,7 @@ public interface WebServer {
                         listenerConfig.get("backlog").asInt().ifPresent(listener::backlog);
                         listenerConfig.get("receive-buffer-size").asInt().ifPresent(listener::receiveBufferSize);
                         listenerConfig.get("write-queue-length").asInt().ifPresent(listener::writeQueueLength);
+                        listenerConfig.get("write-buffer-size").asInt().ifPresent(listener::writeBufferSize);
 
                         listenerConfig.get("tls").as(Tls::create).ifPresent(listener::tls);
 
@@ -523,7 +524,7 @@ public interface WebServer {
                     .toList();
         }
 
-        private ListenerConfiguration.Builder socket(String socketName) {
+        ListenerConfiguration.Builder socket(String socketName) {
             return socketBuilder.computeIfAbsent(socketName, ListenerConfiguration::builder);
         }
 

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -16,6 +16,7 @@
 
 package io.helidon.nima.webserver.http1;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -177,7 +178,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                                                      request,
                                                      keepAlive);
 
-        return contentEncode(outputStream);
+        return new BufferedOutputStream(contentEncode(outputStream));
     }
 
     @Override

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -590,7 +590,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
 
         private final BlockingOutputStream delegate;
 
-        public ClosingBufferedOutputStream(BlockingOutputStream out, int size) {
+        ClosingBufferedOutputStream(BlockingOutputStream out, int size) {
             super(out, size);
             this.delegate = out;
         }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -178,7 +178,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                                                      request,
                                                      keepAlive);
 
-        return new BufferedOutputStream(contentEncode(outputStream));
+        int writeBufferSize = ctx.listenerContext().config().writeBufferSize();
+        return contentEncode(new BufferedOutputStream(outputStream, writeBufferSize));
     }
 
     @Override

--- a/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/ListenerConfigTest.java
+++ b/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/ListenerConfigTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webserver;
+
+import io.helidon.config.Config;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.nima.webserver.WebServer.DEFAULT_SOCKET_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class ListenerConfigTest {
+
+    @Test
+    void testListenerConfig() {
+        Config config = Config.create();
+        WebServer.Builder webServerBuilder = WebServer.builder().config(config.get("server"));
+        ListenerConfiguration.Builder listenerBuilder1 = webServerBuilder.socket(DEFAULT_SOCKET_NAME);
+        assertThat(listenerBuilder1.build().writeQueueLength(), is(0));         // default
+        assertThat(listenerBuilder1.build().writeBufferSize(), is(512));        // default
+        ListenerConfiguration.Builder listenerBuilder2 = webServerBuilder.socket("other");
+        assertThat(listenerBuilder2.build().writeQueueLength(), is(64));
+        assertThat(listenerBuilder2.build().writeBufferSize(), is(1024));
+    }
+}

--- a/nima/webserver/webserver/src/test/resources/application.yaml
+++ b/nima/webserver/webserver/src/test/resources/application.yaml
@@ -18,6 +18,11 @@ server:
   port: 8079
   host: 127.0.0.1
 
+  sockets:
+    - name: "other"
+      write-buffer-size: 1024
+      write-queue-length: 64
+
   connection-providers:
     http_1_1:
       max-prologue-length: 4096


### PR DESCRIPTION
Wrap underlying output stream with a buffered one whose buffer size is configurable. Using a buffered stream prevents bad interactions between Nagle's algorithm and delayed ACKs in TCP. Drop extra buffering in encoders to avoid double buffering. Minor fix in the ListenerConfiguration class and new test.

Summary of additional changes:

- `StatusResource` updated to not return an entity on a 204 status
- Gzip and Deflate codecs modified to not use an additional buffer (to avoid double buffering)
- `ClientRequestImplTest` now calls `flush()` explicitly
- New call to `flush()` in `ErrorHandlingWihtOutpuStreamTest`
- Method `maxPayloadsize(long)` did not return the `Builder` as required and was fixed
- New test for `write-buffer-size` property