### PR TITLE
3.x upgrade netty to 4.1.90.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -351,31 +351,6 @@
                 <version>${version.lib.parsson}</version>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler-proxy</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http2</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-buffer</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${version.lib.yasson}</version>
@@ -1220,39 +1195,6 @@
 
             <!-- Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-dns</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver-dns</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>${version.lib.netty}</version>
-                <classifier>linux-x86_64</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>${version.lib.netty}</version>
-                <classifier>linux-aarch64</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-kqueue</artifactId>
-                <version>${version.lib.netty}</version>
-                <classifier>osx-x86_64</classifier>
-            </dependency>
-            <dependency>
                 <groupId>io.netty.incubator</groupId>
                 <artifactId>netty-incubator-transport-native-io_uring</artifactId>
                 <version>${version.lib.netty-io_uring}</version>
@@ -1262,11 +1204,6 @@
                 <groupId>io.netty.incubator</groupId>
                 <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
                 <version>${version.lib.netty-io_uring}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>${version.lib.netty}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -1442,6 +1379,13 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
                 <version>${version.lib.google-protobuf}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${version.lib.netty}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -123,7 +123,7 @@
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>4.4.11</version.lib.neo4j>
         <version.lib.netty>4.1.90.Final</version.lib.netty>
-        <version.lib.netty-io_uring>0.0.17.Final</version.lib.netty-io_uring>
+        <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.8.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1259,6 +1259,11 @@
                 <classifier>linux-x86_64</classifier>
             </dependency>
             <dependency>
+                <groupId>io.netty.incubator</groupId>
+                <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+                <version>${version.lib.netty-io_uring}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
                 <version>${version.lib.netty}</version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -122,8 +122,8 @@
         <version.lib.mysql-connector-java>8.0.28</version.lib.mysql-connector-java>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>4.4.11</version.lib.neo4j>
-        <version.lib.netty>4.1.86.Final</version.lib.netty>
-        <version.lib.netty-io_uring>0.0.8.Final</version.lib.netty-io_uring>
+        <version.lib.netty>4.1.88.Final</version.lib.netty>
+        <version.lib.netty-io_uring>0.0.17.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.8.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -122,7 +122,7 @@
         <version.lib.mysql-connector-java>8.0.28</version.lib.mysql-connector-java>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>4.4.11</version.lib.neo4j>
-        <version.lib.netty>4.1.89.Final</version.lib.netty>
+        <version.lib.netty>4.1.90.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.17.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.8.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -122,7 +122,7 @@
         <version.lib.mysql-connector-java>8.0.28</version.lib.mysql-connector-java>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>4.4.11</version.lib.neo4j>
-        <version.lib.netty>4.1.88.Final</version.lib.netty>
+        <version.lib.netty>4.1.89.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.17.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.8.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.lib.junit4>4.13.1</version.lib.junit4>
         <version.lib.kafka-junit5>3.2.3</version.lib.kafka-junit5>
         <version.lib.mockito>2.23.4</version.lib.mockito>
-        <version.lib.netty.tcnative>2.0.54.Final</version.lib.netty.tcnative>
+        <version.lib.netty.tcnative>2.0.56.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.2.10</version.lib.rxjava>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.lib.junit4>4.13.1</version.lib.junit4>
         <version.lib.kafka-junit5>3.2.3</version.lib.kafka-junit5>
         <version.lib.mockito>2.23.4</version.lib.mockito>
-        <version.lib.netty.tcnative>2.0.56.Final</version.lib.netty.tcnative>
+        <version.lib.netty.tcnative>2.0.59.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.2.10</version.lib.rxjava>

--- a/webserver/transport/netty/iouring/pom.xml
+++ b/webserver/transport/netty/iouring/pom.xml
@@ -39,7 +39,9 @@
             <artifactId>netty-incubator-transport-native-io_uring</artifactId>
             <classifier>linux-x86_64</classifier>
         </dependency>
-
+        <dependency>
+            <groupId>io.netty.incubator</groupId>
+            <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+        </dependency>
     </dependencies>
-
 </project>

--- a/webserver/transport/netty/iouring/src/main/java/module-info.java
+++ b/webserver/transport/netty/iouring/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ module io.helidon.webserver.transport.netty.iouring {
 
     requires io.netty.transport;
 
-    requires io.netty.incubator.transport.io_uring;
+    requires io.netty.incubator.transport.classes.io_uring;
 
     exports io.helidon.webserver.transport.netty.iouring;
 }


### PR DESCRIPTION
Upgrades Netty to 4.1.90.Final
Uses `netty-bom` for dependency management instead of individual dependencies