### PR TITLE
2.x: Upgrade eclipselink to 2.7.12 and hibernate to 5.6.15

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -48,7 +48,7 @@
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
-        <version.lib.eclipselink>2.7.11</version.lib.eclipselink>
+        <version.lib.eclipselink>2.7.12</version.lib.eclipselink>
         <version.lib.el-api>3.0.3</version.lib.el-api>
         <version.lib.el-impl>3.0.4</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
@@ -65,7 +65,7 @@
         <version.lib.guava>31.1-jre</version.lib.guava>
         <version.lib.h2>1.4.200</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
-        <version.lib.hibernate>5.6.11.Final</version.lib.hibernate>
+        <version.lib.hibernate>5.6.15.Final</version.lib.hibernate>
         <version.lib.hikaricp>5.0.0</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
         <version.lib.inject>1.0</version.lib.inject>


### PR DESCRIPTION
Upgrade eclipselink to 2.7.12 and hibernate to 5.6.15

This enables use of Java 20 due to the upgrade of ASM to 9.4.0

See #6506