### PR TITLE
3.x Upgrade hibernate to 6.1.7.Final and eclipselink asm to 9.4.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -45,7 +45,8 @@
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
         <version.lib.eclipselink>3.0.3</version.lib.eclipselink>
-        <!-- Needed only to force upgrade to ASM 9.4.0. Once eclipselink is upgraded this can be removed -->
+        <!-- Force upgrade to ASM 9.4.0. Once eclipselink is upgraded this can be removed -->
+        <!-- Needed to support Java 20 -->
         <version.lib.eclipselink.asm>9.4.0</version.lib.eclipselink.asm>
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
@@ -883,7 +884,8 @@
                 <artifactId>org.eclipse.persistence.jpa</artifactId>
                 <version>${version.lib.eclipselink}</version>
             </dependency>
-            <!-- Needed only to force upgrade to ASM 9.4.0. Once eclipselink is upgraded this can be removed -->
+            <!-- Force upgrade to ASM 9.4.0. Once eclipselink is upgraded this can be removed -->
+            <!-- Needed to support Java 20 -->
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.asm</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -45,6 +45,8 @@
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
         <version.lib.eclipselink>3.0.3</version.lib.eclipselink>
+        <!-- Needed only to force upgrade to ASM 9.4.0. Once eclipselink is upgraded this can be removed -->
+        <version.lib.eclipselink.asm>9.4.0</version.lib.eclipselink.asm>
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>
@@ -60,7 +62,7 @@
         <version.lib.guava>31.1-jre</version.lib.guava>
         <version.lib.h2>2.1.212</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
-        <version.lib.hibernate>6.1.4.Final</version.lib.hibernate>
+        <version.lib.hibernate>6.1.7.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>7.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
@@ -880,6 +882,12 @@
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.jpa</artifactId>
                 <version>${version.lib.eclipselink}</version>
+            </dependency>
+            <!-- Needed only to force upgrade to ASM 9.4.0. Once eclipselink is upgraded this can be removed -->
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.asm</artifactId>
+                <version>${version.lib.eclipselink.asm}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.orm</groupId>


### PR DESCRIPTION
Upgrade eclipselink asm to 9.4.0 and hibernate to 6.1.7

Note that there does not appear to be a 3.x eclipselink release with ASM 9.4.0 -- so we force upgrade of eclipselink asm instead. Once eclipselink 3.0.4 (or whatever) comes out we can remove the forced eclipselink ASM upgrade.

This enables use of Java 20 due to the upgrade of ASM to 9.4.0

See https://github.com/helidon-io/helidon/issues/6506