### PR TITLE
Switch (back) to a single version of Java

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Checkstyle
         run: etc/scripts/checkstyle.sh
   spotbugs:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/HELIDON-CLI.md
+++ b/HELIDON-CLI.md
@@ -8,7 +8,7 @@ It also supports a developer loop that performs continuous compilation and
 
 ## Prerequisites
 
-Helidon requires Java 11 (or newer) and Maven 3.6.1 or newer.
+Helidon requires Java 21 (or newer) and Maven 3.6.1 or newer.
 
 * [Java SE](https://www.oracle.com/technetwork/java/javase/downloads)
 * [Maven](https://maven.apache.org/download.cgi)

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -36,11 +36,6 @@
     <name>Helidon Builder Project</name>
     <packaging>pom</packaging>
 
-    <properties>
-        <!-- Helidon Builder should be backward compatible with Java 11 -->
-        <version.java>11</version.java>
-    </properties>
-
     <modules>
         <module>builder</module>
         <module>processor-spi</module>
@@ -50,20 +45,4 @@
         <module>builder-config-processor</module>
         <module>tests</module>
     </modules>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <!-- This module is Java 11, we must remove enable-preview from parent project -->
-                        <additionalOptions combine.self="override"/>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-
 </project>

--- a/common/common/pom.xml
+++ b/common/common/pom.xml
@@ -28,11 +28,6 @@
     <artifactId>helidon-common</artifactId>
     <name>Helidon Common</name>
 
-    <properties>
-        <!-- Helidon common should be backward compatible with Java 11 -->
-        <version.java>11</version.java>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -86,14 +81,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <!-- This module is Java 11, we must remove enable-preview from parent project -->
-                    <additionalOptions combine.self="override"/>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/common/config/pom.xml
+++ b/common/config/pom.xml
@@ -28,21 +28,4 @@
     <artifactId>helidon-common-config</artifactId>
     <name>Helidon Common Config</name>
 
-    <properties>
-        <!-- Helidon common should be backward compatible with Java 11 -->
-        <version.java>11</version.java>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <!-- This module is Java 11, we must remove enable-preview from parent project -->
-                    <additionalOptions combine.self="override"/>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/common/features/api/pom.xml
+++ b/common/features/api/pom.xml
@@ -30,16 +30,4 @@
     <artifactId>helidon-common-features-api</artifactId>
     <name>Helidon Common Features API</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <!-- This module is Java 11, we must remove enable-preview from parent project -->
-                    <additionalOptions combine.self="override"/>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/common/features/features/pom.xml
+++ b/common/features/features/pom.xml
@@ -40,17 +40,4 @@
             <artifactId>helidon-common-features-api</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <!-- This module is Java 11, we must remove enable-preview from parent project -->
-                    <additionalOptions combine.self="override"/>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/common/features/pom.xml
+++ b/common/features/pom.xml
@@ -31,11 +31,6 @@
     <artifactId>helidon-common-features-project</artifactId>
     <name>Helidon Common Features Project</name>
 
-    <properties>
-        <!-- Helidon features should be backward compatible with Java 11 -->
-        <version.java>11</version.java>
-    </properties>
-
     <packaging>pom</packaging>
 
     <modules>

--- a/common/features/processor/pom.xml
+++ b/common/features/processor/pom.xml
@@ -38,14 +38,6 @@
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <!-- This module is Java 11, we must remove enable-preview from parent project -->
-                    <additionalOptions combine.self="override"/>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/common/types/pom.xml
+++ b/common/types/pom.xml
@@ -32,11 +32,6 @@
         Abstraction of language types, that can be used during annotation processing and at runtime instead of reflection.
     </description>
 
-    <properties>
-        <!-- Used by modules that are backward compatible with Java 11 -->
-        <version.java>11</version.java>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
@@ -58,20 +53,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <!-- This module is Java 11, we must remove enable-preview from parent project -->
-                        <additionalOptions combine.self="override"/>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 
 </project>

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ git checkout tags/2.0.0
 ```
 
 Our examples are Maven projects and can be built and run with
-Java 11 or newer -- so make sure you have those:
+Java 21 or newer -- so make sure you have those:
 
 ```
 java -version

--- a/examples/pico/book/pom.xml
+++ b/examples/pico/book/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples.pico</groupId>
         <artifactId>helidon-examples-pico-project</artifactId>

--- a/examples/pico/car/dagger2/pom.xml
+++ b/examples/pico/car/dagger2/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples.pico.car</groupId>
         <artifactId>helidon-examples-pico-car-project</artifactId>

--- a/examples/pico/car/pico/pom.xml
+++ b/examples/pico/car/pico/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples.pico.car</groupId>
         <artifactId>helidon-examples-pico-car-project</artifactId>

--- a/examples/pico/car/pom.xml
+++ b/examples/pico/car/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples.pico</groupId>
         <artifactId>helidon-examples-pico-project</artifactId>

--- a/examples/pico/logger/common/pom.xml
+++ b/examples/pico/logger/common/pom.xml
@@ -18,7 +18,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples.pico.logger</groupId>
         <artifactId>helidon-examples-pico-logger-project</artifactId>

--- a/examples/pico/logger/guice/pom.xml
+++ b/examples/pico/logger/guice/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples.pico.logger</groupId>
         <artifactId>helidon-examples-pico-logger-project</artifactId>

--- a/examples/pico/logger/pico/pom.xml
+++ b/examples/pico/logger/pico/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples.pico.logger</groupId>
         <artifactId>helidon-examples-pico-logger-project</artifactId>

--- a/examples/pico/logger/pom.xml
+++ b/examples/pico/logger/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples.pico</groupId>
         <artifactId>helidon-examples-pico-project</artifactId>

--- a/examples/pico/pom.xml
+++ b/examples/pico/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
@@ -32,15 +32,6 @@
     <name>Helidon Examples Pico Project</name>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
-
-    <properties>
-<!--        <maven.deploy.skip>true</maven.deploy.skip>-->
-<!--        <maven.sources.skip>true</maven.sources.skip>-->
-<!--        <maven.javadoc.skip>true</maven.javadoc.skip>-->
-<!--        <spotbugs.skip>true</spotbugs.skip>-->
-<!--        <dependency-check.skip>true</dependency-check.skip>-->
-<!--        <helidon.services.skip>true</helidon.services.skip>-->
-    </properties>
 
     <modules>
         <module>book</module>

--- a/examples/pico/pom.xml
+++ b/examples/pico/pom.xml
@@ -34,9 +34,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
 <!--        <maven.deploy.skip>true</maven.deploy.skip>-->
 <!--        <maven.sources.skip>true</maven.sources.skip>-->
 <!--        <maven.javadoc.skip>true</maven.javadoc.skip>-->

--- a/messaging/connectors/kafka/src/main/java/io/helidon/messaging/connectors/kafka/Crc32CSubstitution.java
+++ b/messaging/connectors/kafka/src/main/java/io/helidon/messaging/connectors/kafka/Crc32CSubstitution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ import org.apache.kafka.common.utils.Checksums;
 /**
  * Method handles are not supported by native-image,
  * invoke {@link java.util.zip.CRC32C CRC32C} directly.
- *
- * Helidon runs only on Java 11 and newer, {@link java.util.zip.CRC32C CRC32C}
+ * <p/>
+ * Helidon (since version 2) runs only on Java 11 and newer, {@link java.util.zip.CRC32C CRC32C}
  * doesn't have to be instantiated by method handles.
  */
 @TargetClass(org.apache.kafka.common.utils.Crc32C.class)

--- a/microprofile/cdi/src/test/java/io/helidon/microprofile/cdi/TestExtension.java
+++ b/microprofile/cdi/src/test/java/io/helidon/microprofile/cdi/TestExtension.java
@@ -42,7 +42,7 @@ public class TestExtension implements Extension {
     private final List<String> events = new LinkedList<>();
     private Config runtimeConfig;
 
-    // must be public so it works with java 11 (do not want to open this module to weld)
+    // must be public so it works with never versions of Java (do not want to open this module to weld)
     public void registerBeans(@Observes BeforeBeanDiscovery bbd) {
         bbd.addAnnotatedType(TestBean.class, "unit-test-bean");
         bbd.addAnnotatedType(TestBean2.class, "unit-test-bean2");

--- a/microprofile/jwt-auth/etc/spotbugs/exclude.xml
+++ b/microprofile/jwt-auth/etc/spotbugs/exclude.xml
@@ -23,7 +23,7 @@
         xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
     <Match>
         <!--
-        Caused by Java 11 generating a null check on try with resources.
+        Caused by Java 11+ generating a null check on try with resources.
         This passed on Java 8
          See https://github.com/spotbugs/spotbugs/issues/756
          -->

--- a/pico/api/pom.xml
+++ b/pico/api/pom.xml
@@ -29,11 +29,6 @@
     <artifactId>helidon-pico-api</artifactId>
     <name>Helidon Pico API / SPI</name>
 
-    <properties>
-        <!-- Pico uses a lower level of Java language -->
-        <version.java>11</version.java>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/pico/pom.xml
+++ b/pico/pom.xml
@@ -36,9 +36,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!-- all pico modules should be backward compatible with 11 -->
-        <version.java>11</version.java>
-
         <!-- pico supports a universal debug flag -->
         <pico.debug>true</pico.debug>
     </properties>
@@ -54,20 +51,5 @@
         <module>services</module>
         <module>tests</module>
     </modules>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <!-- This module is Java 11, we must remove enable-preview from parent project -->
-                        <additionalOptions combine.self="override"/>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 
 </project>


### PR DESCRIPTION
Resolves #6523 

As decided, Helidon uses a single version of java