### PR TITLE
Update MP OpenAPI to 3.1

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/common/common-mp.xml
+++ b/archetypes/helidon/src/main/archetype/mp/common/common-mp.xml
@@ -28,7 +28,7 @@
             <value key="parent-artifactId">helidon-mp</value>
             <list key="dependencies">
                 <map>
-                    <value key="groupId">org.jboss</value>
+                    <value key="groupId">io.smallrye</value>
                     <value key="artifactId">jandex</value>
                     <value key="scope">runtime</value>
                 </map>

--- a/archetypes/helidon/src/main/archetype/mp/oci/oci-mp.xml
+++ b/archetypes/helidon/src/main/archetype/mp/oci/oci-mp.xml
@@ -193,7 +193,7 @@ ocimetrics:
                     <value key="scope">runtime</value>
                 </map>
                 <map>
-                    <value key="groupId">org.jboss</value>
+                    <value key="groupId">io.smallrye</value>
                     <value key="artifactId">jandex</value>
                     <value key="scope">runtime</value>
                 </map>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -61,7 +61,7 @@
         <version.lib.h2>2.1.212</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.handlebars>4.3.1</version.lib.handlebars>
-        <version.lib.hibernate>6.1.7.Final</version.lib.hibernate>
+        <version.lib.hibernate>6.2.0.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>7.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -111,7 +111,7 @@
         <version.lib.microprofile-health>4.0</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>2.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics-api>4.0</version.lib.microprofile-metrics-api>
-        <version.lib.microprofile-openapi-api>3.0</version.lib.microprofile-openapi-api>
+        <version.lib.microprofile-openapi-api>3.1</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-reactive-messaging-api>3.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>3.0</version.lib.microprofile-reactive-streams-operators-api>
         <version.lib.microprofile-reactive-streams-operators-core>3.0</version.lib.microprofile-reactive-streams-operators-core>
@@ -142,7 +142,7 @@
         <version.lib.postgresql>42.4.3</version.lib.postgresql>
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>2.0.0</version.lib.slf4j>
-        <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>
+        <version.lib.smallrye-openapi>3.3.1</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>2.0</version.lib.snakeyaml>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>
         <version.lib.tyrus>2.0.4</version.lib.tyrus>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -82,7 +82,7 @@
         <version.lib.jakarta.validation-api>3.0.0</version.lib.jakarta.validation-api>
         <version.lib.jakarta.websockets-api>2.0.0</version.lib.jakarta.websockets-api>
         <version.lib.jakarta.xml.bind-api>4.0.0</version.lib.jakarta.xml.bind-api>
-        <version.lib.jandex>2.4.3.Final</version.lib.jandex>
+        <version.lib.jandex>3.0.5</version.lib.jandex>
         <version.lib.jaxb-core>3.0.2</version.lib.jaxb-core>
         <version.lib.jaxb-impl>3.0.2</version.lib.jaxb-impl>
         <version.lib.jboss.classfilewriter>1.2.5.Final</version.lib.jboss.classfilewriter>
@@ -142,7 +142,7 @@
         <version.lib.postgresql>42.4.3</version.lib.postgresql>
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>2.0.0</version.lib.slf4j>
-        <version.lib.smallrye-openapi>3.3.1</version.lib.smallrye-openapi>
+        <version.lib.smallrye-openapi>3.1.0</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>2.0</version.lib.snakeyaml>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>
         <version.lib.tyrus>2.0.4</version.lib.tyrus>
@@ -737,7 +737,7 @@
                 <version>${version.lib.microprofile-lra-api}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex</artifactId>
                 <version>${version.lib.jandex}</version>
             </dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -77,7 +77,7 @@
         <version.lib.jakarta.jms-api>3.0.0</version.lib.jakarta.jms-api>
         <version.lib.jakarta.jsonb-api>2.0.0</version.lib.jakarta.jsonb-api>
         <version.lib.jakarta.jsonp-api>2.0.1</version.lib.jakarta.jsonp-api>
-        <version.lib.jakarta.persistence-api>3.0.0</version.lib.jakarta.persistence-api>
+        <version.lib.jakarta.persistence-api>3.1.0</version.lib.jakarta.persistence-api>
         <version.lib.jakarta.transaction-api>2.0.0</version.lib.jakarta.transaction-api>
         <version.lib.jakarta.validation-api>3.0.0</version.lib.jakarta.validation-api>
         <version.lib.jakarta.websockets-api>2.0.0</version.lib.jakarta.websockets-api>

--- a/examples/grpc/microprofile/basic-client/pom.xml
+++ b/examples/grpc/microprofile/basic-client/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>helidon-microprofile-grpc-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/grpc/microprofile/basic-server-implicit/pom.xml
+++ b/examples/grpc/microprofile/basic-server-implicit/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>helidon-microprofile-grpc-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/grpc/microprofile/metrics/pom.xml
+++ b/examples/grpc/microprofile/metrics/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>helidon-microprofile-grpc-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
@@ -61,7 +61,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
@@ -62,7 +62,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp/pom.xml
@@ -67,7 +67,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/cdi/jedis/pom.xml
+++ b/examples/integrations/cdi/jedis/pom.xml
@@ -60,7 +60,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/cdi/jpa/pom.xml
+++ b/examples/integrations/cdi/jpa/pom.xml
@@ -92,7 +92,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/cdi/pokemons/pom.xml
+++ b/examples/integrations/cdi/pokemons/pom.xml
@@ -90,7 +90,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/micronaut/data/pom.xml
+++ b/examples/integrations/micronaut/data/pom.xml
@@ -79,7 +79,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/neo4j/neo4j-mp/pom.xml
+++ b/examples/integrations/neo4j/neo4j-mp/pom.xml
@@ -55,7 +55,7 @@
 
 
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/integrations/oci/atp-cdi/pom.xml
+++ b/examples/integrations/oci/atp-cdi/pom.xml
@@ -61,7 +61,7 @@
             <artifactId>helidon-config-yaml-mp</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/examples/integrations/oci/objectstorage-cdi/pom.xml
+++ b/examples/integrations/oci/objectstorage-cdi/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>helidon-config-yaml-mp</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/examples/jbatch/pom.xml
+++ b/examples/jbatch/pom.xml
@@ -68,7 +68,7 @@
 
 
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/messaging/jms-websocket-mp/pom.xml
+++ b/examples/messaging/jms-websocket-mp/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-microprofile-websocket</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/messaging/kafka-websocket-mp/pom.xml
+++ b/examples/messaging/kafka-websocket-mp/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>helidon-microprofile-websocket</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/messaging/oracle-aq-websocket-mp/pom.xml
+++ b/examples/messaging/oracle-aq-websocket-mp/pom.xml
@@ -54,7 +54,7 @@
             <artifactId>helidon-microprofile-websocket</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/messaging/weblogic-jms-mp/pom.xml
+++ b/examples/messaging/weblogic-jms-mp/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/bean-validation/pom.xml
+++ b/examples/microprofile/bean-validation/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/cors/pom.xml
+++ b/examples/microprofile/cors/pom.xml
@@ -50,7 +50,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/http-status-count-mp/pom.xml
+++ b/examples/microprofile/http-status-count-mp/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>helidon-microprofile-health</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/examples/microprofile/idcs/pom.xml
+++ b/examples/microprofile/idcs/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>helidon-security-providers-idcs-mapper</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/lra/pom.xml
+++ b/examples/microprofile/lra/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>helidon-lra-coordinator-narayana-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/messaging-sse/pom.xml
+++ b/examples/microprofile/messaging-sse/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>jersey-media-sse</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/multipart/pom.xml
+++ b/examples/microprofile/multipart/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>jersey-media-multipart</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/oidc/pom.xml
+++ b/examples/microprofile/oidc/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-microprofile-oidc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -50,7 +50,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/security/pom.xml
+++ b/examples/microprofile/security/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/static-content/pom.xml
+++ b/examples/microprofile/static-content/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/tls/pom.xml
+++ b/examples/microprofile/tls/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/microprofile/websocket/pom.xml
+++ b/examples/microprofile/websocket/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>helidon-microprofile-websocket</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -69,7 +69,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/security/attribute-based-access-control/pom.xml
+++ b/examples/security/attribute-based-access-control/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/examples/security/idcs-login/pom.xml
+++ b/examples/security/idcs-login/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/integrations/cdi/common-cdi/delegates/pom.xml
+++ b/integrations/cdi/common-cdi/delegates/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/integrations/cdi/common-cdi/reference-counted-context/pom.xml
+++ b/integrations/cdi/common-cdi/reference-counted-context/pom.xml
@@ -54,7 +54,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -76,7 +76,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -71,7 +71,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/integrations/cdi/datasource/pom.xml
+++ b/integrations/cdi/datasource/pom.xml
@@ -60,7 +60,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/integrations/cdi/eclipselink-cdi/pom.xml
+++ b/integrations/cdi/eclipselink-cdi/pom.xml
@@ -72,7 +72,7 @@
         
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -44,7 +44,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/integrations/cdi/jedis-cdi/pom.xml
+++ b/integrations/cdi/jedis-cdi/pom.xml
@@ -60,7 +60,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -77,7 +77,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/integrations/cdi/jta-cdi/pom.xml
+++ b/integrations/cdi/jta-cdi/pom.xml
@@ -54,7 +54,7 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/integrations/oci/sdk/cdi/pom.xml
+++ b/integrations/oci/sdk/cdi/pom.xml
@@ -88,7 +88,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/microprofile/graphql/server/pom.xml
+++ b/microprofile/graphql/server/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>helidon-microprofile-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/microprofile/lra/jax-rs/pom.xml
+++ b/microprofile/lra/jax-rs/pom.xml
@@ -36,7 +36,7 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/InspectionService.java
+++ b/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/InspectionService.java
@@ -158,7 +158,7 @@ class InspectionService {
                 methodInfo.declaringClass(),
                 annotations,
                 methodInfo.name(),
-                methodInfo.parameters().toArray(new Type[0])
+                methodInfo.parameterTypes().toArray(new Type[0])
         );
         HashSet<AnnotationInstance> result = new HashSet<>(annotations.values());
 

--- a/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/LraCdiExtension.java
+++ b/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/LraCdiExtension.java
@@ -256,7 +256,9 @@ public class LraCdiExtension implements Extension {
         LOGGER.log(Level.DEBUG, "Indexing " + fqdn);
         ClassInfo classInfo;
         try {
-            classInfo = indexer.index(classLoader.getResourceAsStream(fqdn.toString().replace('.', '/') + ".class"));
+            indexer.index(classLoader.getResourceAsStream(fqdn.toString().replace('.', '/') + ".class"));
+            classInfo = indexer.complete().getClassByName(fqdn.toString());
+
             // look also for extended classes
             runtimeIndex(classInfo.superName());
             // and implemented interfaces

--- a/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/LraCdiExtension.java
+++ b/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/LraCdiExtension.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.microprofile.lra;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.System.Logger.Level;
@@ -68,6 +70,7 @@ import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexReader;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
@@ -255,9 +258,18 @@ public class LraCdiExtension implements Extension {
         if (fqdn == null) return;
         LOGGER.log(Level.DEBUG, "Indexing " + fqdn);
         ClassInfo classInfo;
-        try {
-            indexer.index(classLoader.getResourceAsStream(fqdn.toString().replace('.', '/') + ".class"));
-            classInfo = indexer.complete().getClassByName(fqdn.toString());
+        try (InputStream classStream = classLoader.getResourceAsStream(fqdn.toString().replace('.', '/') + ".class")) {
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            int bytesRead;
+            byte[] buffer = new byte[512];
+            while ((bytesRead = classStream.read(buffer)) != -1) {
+                baos.write(buffer, 0, bytesRead);
+            }
+            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+
+            indexer.index(new ByteArrayInputStream(baos.toByteArray()));
+            classInfo = Index.singleClass(new ByteArrayInputStream(baos.toByteArray()));
 
             // look also for extended classes
             runtimeIndex(classInfo.superName());

--- a/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/ParticipantValidationModel.java
+++ b/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/ParticipantValidationModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.Type;
+import org.jboss.jandex.MethodParameterInfo;
 
 class ParticipantValidationModel {
 
@@ -155,8 +155,7 @@ class ParticipantValidationModel {
 
         String nameWithParams() {
             return methodInfo.name() + methodInfo.parameters().stream()
-                    .map(Type::name)
-                    .map(DotName::toString)
+                    .map(MethodParameterInfo::name)
                     .collect(Collectors.joining());
         }
 

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ import org.glassfish.jersey.server.spi.Container;
 import org.glassfish.jersey.server.spi.ContainerResponseWriter;
 
 import static org.glassfish.jersey.CommonProperties.PROVIDER_DEFAULT_DISABLE;
+import static org.glassfish.jersey.server.ServerProperties.RESOURCE_VALIDATION_IGNORE_ERRORS;
 import static org.glassfish.jersey.server.ServerProperties.WADL_FEATURE_DISABLE;
 
 class JaxRsService implements HttpService {
@@ -96,6 +97,12 @@ class JaxRsService implements HttpService {
     static JaxRsService create(ResourceConfig resourceConfig, InjectionManager injectionManager) {
         resourceConfig.property(PROVIDER_DEFAULT_DISABLE, "ALL");
         resourceConfig.property(WADL_FEATURE_DISABLE, "true");
+
+        // At least a temporary workaround for TCK bug https://github.com/eclipse/microprofile-open-api/issues/557.
+        String resourceValidationIgnoreErrors = System.getProperty(RESOURCE_VALIDATION_IGNORE_ERRORS);
+        if (resourceValidationIgnoreErrors != null) {
+            resourceConfig.property(RESOURCE_VALIDATION_IGNORE_ERRORS, Boolean.parseBoolean(resourceValidationIgnoreErrors));
+        }
 
         InjectionManager ij = injectionManager == null ? null : new InjectionManagerWrapper(injectionManager, resourceConfig);
         ApplicationHandler appHandler = new ApplicationHandler(resourceConfig,

--- a/microprofile/tests/tck/tck-openapi/pom.xml
+++ b/microprofile/tests/tck/tck-openapi/pom.xml
@@ -109,9 +109,12 @@
                         <dependency>org.eclipse.microprofile.openapi:microprofile-openapi-tck</dependency>
                     </dependenciesToScan>
                     <trimStackTrace>false</trimStackTrace>
-                    <!-- Following works around TCK test error when Application.getSingletons returns a non-empty set -->
                     <systemPropertyVariables>
+                        <!-- Following works around TCK test error when Application.getSingletons returns a non-empty set -->
                         <mp.openapi.extensions.helidon.use-jaxrs-semantics>false</mp.openapi.extensions.helidon.use-jaxrs-semantics>
+
+                        <!-- Following works around TCK bug https://github.com/eclipse/microprofile-open-api/issues/557 -->
+                        <jersey.config.server.resource.validation.ignoreErrors>true</jersey.config.server.resource.validation.ignoreErrors>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/nima/openapi/pom.xml
+++ b/nima/openapi/pom.xml
@@ -75,6 +75,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -99,6 +104,16 @@
                             <version>${helidon.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Allows test client to set restricted headers Origin and Host -->
+                    <systemPropertyVariables>
+                        <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/nima/openapi/src/main/java/io/helidon/nima/openapi/OpenApiService.java
+++ b/nima/openapi/src/main/java/io/helidon/nima/openapi/OpenApiService.java
@@ -556,6 +556,7 @@ public class OpenApiService implements HttpService {
             config.get(CORS_CONFIG_KEY)
                     .as(CrossOriginConfig::create)
                     .ifPresent(this::crossOriginConfig);
+            apiConfigBuilder.config(config);
             return identity();
         }
 

--- a/nima/openapi/src/test/java/io/helidon/nima/openapi/ServerModelReaderTest.java
+++ b/nima/openapi/src/test/java/io/helidon/nima/openapi/ServerModelReaderTest.java
@@ -29,7 +29,6 @@ import jakarta.json.JsonStructure;
 import jakarta.json.JsonValue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,7 +60,6 @@ public class ServerModelReaderTest {
     }
 
     @Test
-    @Disabled
     public void checkCustomModelReader() throws Exception {
         HttpURLConnection cnx = TestUtil.getURLConnection(
                 webServer.port(),

--- a/nima/openapi/src/test/java/io/helidon/nima/openapi/ServerTest.java
+++ b/nima/openapi/src/test/java/io/helidon/nima/openapi/ServerTest.java
@@ -28,7 +28,6 @@ import io.helidon.nima.webserver.WebServer;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Starts a server with the default OpenAPI endpoint to test a static OpenAPI
  * document file in various ways.
  */
-@Disabled
 class ServerTest {
 
     private static WebServer greetingWebServer;

--- a/nima/openapi/src/test/java/io/helidon/nima/openapi/TestCors.java
+++ b/nima/openapi/src/test/java/io/helidon/nima/openapi/TestCors.java
@@ -23,14 +23,12 @@ import io.helidon.config.Config;
 import io.helidon.nima.webserver.WebServer;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.nima.openapi.ServerTest.GREETING_OPENAPI_SUPPORT_BUILDER;
 import static io.helidon.nima.openapi.ServerTest.TIME_OPENAPI_SUPPORT_BUILDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled
 class TestCors {
 
     private static WebServer greetingWebServer;

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -82,6 +82,10 @@
             <artifactId>helidon-common-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-media-type</artifactId>
         </dependency>

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -116,7 +116,7 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>

--- a/openapi/src/main/java/io/helidon/openapi/Serializer.java
+++ b/openapi/src/main/java/io/helidon/openapi/Serializer.java
@@ -141,6 +141,28 @@ public class Serializer {
             return result;
         }
 
+        @Override
+        protected Node representMapping(Tag tag, Map<?, ?> mapping, DumperOptions.FlowStyle flowStyle) {
+            Node result = super.representMapping(tag, mapping, flowStyle);
+            if (mapping instanceof Extensible<?> extensible) {
+                List<NodeTuple> tuples = ((MappingNode) result).getValue();
+                if (extensible.getExtensions() != null) {
+                    extensible.getExtensions().forEach((k, v) -> {
+                        NodeTuple extensionTuple = new NodeTuple(new ScalarNode(Tag.STR, k, null, null, stringStyle),
+                                                                 represent(v));
+                        tuples.add(extensionTuple);
+                    });
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public Node represent(Object data) {
+            Node result = super.represent(data);
+            return result;
+        }
+
         private boolean isExemptedFromQuotes(Tag tag) {
             return tag.equals(Tag.BINARY) || tag.equals(Tag.BOOL) || tag.equals(Tag.FLOAT)
                     || tag.equals(Tag.INT);
@@ -206,8 +228,19 @@ public class Serializer {
 
         @Override
         protected MappingNode representJavaBean(Set<Property> properties, Object javaBean) {
+            /*
+             * First, let SnakeYAML prepare the node normally. If the JavaBean is Extensible and has extension properties, the
+             * will contain a subnode called "extensions" which itself has one or more subnodes, one for each extension
+             * property assigned.
+             */
             MappingNode result = super.representJavaBean(properties, javaBean);
+
+            /*
+             * Now promote the individual subnodes for each extension property (if any) up one level so that they are peers of the
+             * other properties. Also remove the "extensions" node.
+             */
             processExtensions(result, javaBean);
+
             /*
              * Clearing representedObjects is an awkward but effective way of preventing SnakeYAML from using anchors and
              * aliases, which apparently the Jackson parser used in the TCK (as of this writing) does not handle properly.
@@ -221,31 +254,50 @@ public class Serializer {
                 return;
             }
 
-            List<NodeTuple> tuples = new ArrayList<>(node.getValue());
+            List<NodeTuple> tuples = node.getValue();
 
             if (tuples.isEmpty()) {
                 return;
             }
+            List<NodeTuple> updatedTuples = processExtensions(tuples);
+            node.setValue(updatedTuples);
+        }
+
+        /**
+         * Returns a (possibly) updated list of {@code NodeTuple} objects, promoting any node under the node {@code extensions}
+         * one level higher and removing the {@code extensions} node itself.
+         *
+         * @param tuples {@code NodeTuple} objects to process
+         * @return possibly updated list of node tuples
+         */
+        private List<NodeTuple> processExtensions(List<NodeTuple> tuples) {
             List<NodeTuple> updatedTuples = new ArrayList<>();
 
             tuples.forEach(tuple -> {
-                Node keyNode = tuple.getKeyNode();
-                if (keyNode.getTag().equals(Tag.STR)) {
-                    String key = ((ScalarNode) keyNode).getValue();
-                    if (key.equals(EXTENSIONS)) {
-                        Node valueNode = tuple.getValueNode();
-                        if (valueNode.getNodeId().equals(NodeId.mapping)) {
-                            MappingNode extensions = MappingNode.class.cast(valueNode);
-                            updatedTuples.addAll(extensions.getValue());
-                        }
-                    } else {
-                        updatedTuples.add(tuple);
-                    }
-                } else {
+                // Returns either null (if the tuple is not for "extensions") or a list of tuples for each extension property.
+                List<NodeTuple> extensionTuples = processExtensions(tuple);
+                if (extensionTuples == null) {
                     updatedTuples.add(tuple);
+                } else {
+                    updatedTuples.addAll(extensionTuples);
                 }
             });
-            node.setValue(updatedTuples);
+            return updatedTuples;
+        }
+
+        private List<NodeTuple> processExtensions(NodeTuple tuple) {
+            Node keyNode = tuple.getKeyNode();
+            if (keyNode.getTag().equals(Tag.STR)) {
+                String key = ((ScalarNode) keyNode).getValue();
+                if (key.equals(EXTENSIONS)) {
+                    Node valueNode = tuple.getValueNode();
+                    if (valueNode.getNodeId().equals(NodeId.mapping)) {
+                        MappingNode extensions = MappingNode.class.cast(valueNode);
+                        return extensions.getValue();
+                    }
+                }
+            }
+            return null;
         }
 
         /**

--- a/openapi/src/main/java/io/helidon/openapi/internal/OpenAPIConfigImpl.java
+++ b/openapi/src/main/java/io/helidon/openapi/internal/OpenAPIConfigImpl.java
@@ -15,11 +15,9 @@
  */
 package io.helidon.openapi.internal;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -59,7 +57,7 @@ public class OpenAPIConfigImpl implements OpenApiConfig {
     private final Map<String, String> schemas;
 
     // Cannot be final because the interface we implement requires this to be settable after it is built.
-    private Optional<Boolean> allowNakedPathParameter;
+    private Optional<Boolean> allowNakedPathParameter = Optional.empty();
 
     private OpenAPIConfigImpl(Builder builder) {
         modelReader = builder.modelReader;
@@ -113,12 +111,12 @@ public class OpenAPIConfigImpl implements OpenApiConfig {
 
     @Override
     public Set<String> scanExcludePackages() {
-        return NEVER_SCAN_PACKAGES;
+        return scanExcludePackages;
     }
 
     @Override
     public Set<String> scanExcludeClasses() {
-        return NEVER_SCAN_CLASSES;
+        return scanExcludeClasses;
     }
 
     @Override

--- a/openapi/src/main/java/module-info.java
+++ b/openapi/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module io.helidon.openapi {
     requires io.helidon.common;
     requires io.helidon.common.config;
     requires io.helidon.common.media.type;
+    requires io.helidon.config;
 
     requires org.jboss.jandex;
 

--- a/openapi/src/test/java/io/helidon/openapi/ParserTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,9 @@ class ParserTest {
     @Test
     public void testExtensions() throws IOException {
         OpenAPI openAPI = parse(helper, "/openapi-greeting.yml");
+        Object xMyString = openAPI.getExtensions().get("x-my-string");
+        assertThat(xMyString, is(instanceOf(String.class)));
+        assertThat(xMyString, is("hello"));
         Object xMyPersonalMap = openAPI.getExtensions().get("x-my-personal-map");
         assertThat(xMyPersonalMap, is(instanceOf(Map.class)));
         Map<?,?> map = (Map<?,?>) xMyPersonalMap;

--- a/openapi/src/test/java/io/helidon/openapi/SerializerTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/SerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,15 @@ class SerializerTest {
         Serializer.serialize(helper.types(), implsToTypes, openAPI, Format.JSON, writer);
         JsonStructure json = jsonFromReader(new StringReader(writer.toString()));
 
+        String greetGreetingPut = "/paths/~1greet~1greeting/put";
+        assertThat(json.getValue(greetGreetingPut + "/x-put-ext-0").toString(), is("\"put-ext-0-value\""));
+        assertThat(json.getValue(greetGreetingPut + "/x-put-ext-1").toString(), is("\"put-ext-1-value\""));
+        assertThat(json.getValue(greetGreetingPut + "/responses/x-responses-ext").toString(),
+                   is("\"responses-ext-0-value\""));
+        assertThat(json.getValue(greetGreetingPut + "/responses/204/x-204-ext").toString(),
+                   is("\"204-ext-value\""));
         assertThat(json.getValue("/x-my-personal-map/owner/last").toString(), is("\"Myself\""));
+
         JsonValue otherItem = json.getValue("/x-other-item");
         assertThat(otherItem.getValueType(), is(JsonValue.ValueType.NUMBER));
         assertThat(Double.valueOf(otherItem.toString()), is(10.0));

--- a/openapi/src/test/resources/openapi-greeting.yml
+++ b/openapi/src/test/resources/openapi-greeting.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,8 @@
 # limitations under the License.
 # 
 ---
-openapi: 3.0.0
+openapi: 3.0.3
+x-my-string: hello
 x-my-personal-map:
   owner:
     first: Me
@@ -49,6 +50,8 @@ servers:
 paths:
   /greet/greeting:
     put:
+      x-put-ext-0: put-ext-0-value
+      x-put-ext-1: put-ext-1-value
       summary: Sets the greeting prefix
       description: Permits the client to set the prefix part of the greeting ("Hello")
       requestBody:
@@ -65,8 +68,19 @@ paths:
                   type: string
 
       responses:
+        x-responses-ext: responses-ext-0-value
         '204':
+          x-204-ext: 204-ext-value
           description: Greeting set
+        '200':
+          x-200-ext: 200-ext-value
+          description: Just for YAML testing
+          content:
+            x-200-content-ext: 200-content-ext-value
+            text/plain:
+              schema:
+                type: string
+
 
   /greet/:
     get:

--- a/reactive/webserver/jersey/src/main/java/io/helidon/reactive/webserver/jersey/JerseySupport.java
+++ b/reactive/webserver/jersey/src/main/java/io/helidon/reactive/webserver/jersey/JerseySupport.java
@@ -71,6 +71,7 @@ import org.glassfish.jersey.server.spi.Container;
 
 import static java.util.Objects.requireNonNull;
 import static org.glassfish.jersey.CommonProperties.PROVIDER_DEFAULT_DISABLE;
+import static org.glassfish.jersey.server.ServerProperties.RESOURCE_VALIDATION_IGNORE_ERRORS;
 import static org.glassfish.jersey.server.ServerProperties.WADL_FEATURE_DISABLE;
 
 /**
@@ -508,6 +509,12 @@ public class JerseySupport implements Service {
                 LOGGER.log(Level.DEBUG, "Disabling Jersey WADL feature, you can enable it by setting system property "
                                     + WADL_FEATURE_DISABLE + " to false");
                 resourceConfig.property(WADL_FEATURE_DISABLE, "true");
+            }
+
+            // At least a temporary workaround for TCK bug https://github.com/eclipse/microprofile-open-api/issues/557.
+            String resourceValidationIgnoreErrors = System.getProperty(RESOURCE_VALIDATION_IGNORE_ERRORS);
+            if (resourceValidationIgnoreErrors != null) {
+                resourceConfig.property(RESOURCE_VALIDATION_IGNORE_ERRORS, Boolean.parseBoolean(resourceValidationIgnoreErrors));
             }
         }
 

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -60,7 +60,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/functional/jax-rs-multiple-apps/pom.xml
+++ b/tests/functional/jax-rs-multiple-apps/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/functional/param-converter-provider/pom.xml
+++ b/tests/functional/param-converter-provider/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/functional/request-scope-cdi/pom.xml
+++ b/tests/functional/request-scope-cdi/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/functional/request-scope/pom.xml
+++ b/tests/functional/request-scope/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/integration/dbclient/appl/pom.xml
+++ b/tests/integration/dbclient/appl/pom.xml
@@ -123,7 +123,7 @@
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/integration/jpa/appl/pom.xml
+++ b/tests/integration/jpa/appl/pom.xml
@@ -101,7 +101,7 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/tests/integration/jpa/simple/pom.xml
+++ b/tests/integration/jpa/simple/pom.xml
@@ -109,7 +109,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/tests/integration/mp-bean-validation/pom.xml
+++ b/tests/integration/mp-bean-validation/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-microprofile-bean-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/integration/native-image/mp-1/pom.xml
+++ b/tests/integration/native-image/mp-1/pom.xml
@@ -67,7 +67,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/tests/integration/native-image/mp-2/pom.xml
+++ b/tests/integration/native-image/mp-2/pom.xml
@@ -52,7 +52,7 @@
             <artifactId>helidon-microprofile-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>
         <!--

--- a/tests/integration/native-image/mp-3/pom.xml
+++ b/tests/integration/native-image/mp-3/pom.xml
@@ -44,7 +44,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/integration/oidc/pom.xml
+++ b/tests/integration/oidc/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/integration/restclient/pom.xml
+++ b/tests/integration/restclient/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>helidon-microprofile-rest-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/integration/security/gh1487/pom.xml
+++ b/tests/integration/security/gh1487/pom.xml
@@ -47,7 +47,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/integration/security/security-response-mapper/pom.xml
+++ b/tests/integration/security/security-response-mapper/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/tests/integration/zipkin-mp-2.2/pom.xml
+++ b/tests/integration/zipkin-mp-2.2/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>helidon-microprofile-tracing</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>


### PR DESCRIPTION
Resolves #5820 

Brief summary of the changes:

* Update Jandex version and references - The updated SmallRye OpenAPI code now uses 3.0.5 which now has the group ID `io.smallrye` instead of the former `org.jboss`. No change seems to be needed to the version of the Jandex maven plug-in.
* Several additional model objects in the MP OpenAPI API now implement `Extensible` which requires special handling when converting to and from YAML via SnakeYAML. 
* Include/exclude for scanning packages and classes changed from `Pattern` to strings. 
* Some adaptation to changes in SmallRye's `OpenApiConfig` interface and its implementation.
* Setting a Jersey server property based on a system property to (temporarily at least) work around a bug in the MP OpenAPI TCK. Some sub-resources are ambiguous in the TCK and Jersey fails by default. Our MP OpenAPI TCK driver `pom.xml` now sets a system property which `JaxRsService` and `JerseySupport` detect and set to suppress the failures.
* Update `hibernate-core` version to 6.2.0 (because it also uses Jandex and 6.2.0 works with Jandex 3)
