### PR TITLE
3.x supress graphql-data-loader false positive

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -50,37 +50,6 @@
    <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
 </suppress>
 
-<!-- False Positive. This is a CVE again Payara. This is generating a number of false positives.
-     See  https://github.com/jeremylong/DependencyCheck/issues/4781 for one example
--->
-<suppress>
-   <notes><![CDATA[
-   file name: jakarta.resource-api-2.0.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/jakarta\.resource/jakarta\.resource\-api@.*$</packageUrl>
-   <cve>CVE-2022-37422</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: microprofile-jwt-auth-api-2.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.jwt/microprofile\-jwt\-auth\-api@.*$</packageUrl>
-   <cve>CVE-2022-37422</cve>
-</suppress>
-
-<!-- 
-     We use SafeConstructor() or an even more limited custom constructor so this CVE does not apply.
-     SnakeYaml maintainer has closed their issue as "will not fix".
-     https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in
--->
-<suppress>
-   <notes><![CDATA[
-   file name: snakeyaml-1.32.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-   <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
-</suppress>
-
 <!-- False Positive. This CVE is against graphql-java, not the microprofile-graphql-api
 -->
 <suppress>
@@ -91,6 +60,17 @@
    <cve>CVE-2022-37734</cve>
 </suppress>
 
+<!-- False Positive. This CVE is against graphql-java, not graphql-java-dataloader
+     See https://github.com/jeremylong/DependencyCheck/issues/5641
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: java-dataloader-3.1.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/com\.graphql\-java/java\-dataloader@.*$</packageUrl>
+   <cve>CVE-2023-28867</cve>
+</suppress>
+
 <!-- False Postive. This CVE is against the kafka server. This is the kafka client
 -->
 <suppress>
@@ -99,30 +79,6 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka\-clients@.*$</packageUrl>
    <cve>CVE-2022-34917</cve>
-</suppress>
-
-<!-- False Postives. CVE CVE-2022-45129 is against Payara not jakarta.resource-api nor microprofile
- -->
-<suppress>
-   <notes><![CDATA[
-   file name: jakarta.resource-api-2.0.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/jakarta\.resource/jakarta\.resource\-api@.*$</packageUrl>
-   <cve>CVE-2022-45129</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: microprofile-config-api-3.0.1.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.config/microprofile\-config\-api@.*$</packageUrl>
-   <cve>CVE-2022-45129</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: microprofile-jwt-auth-api-2.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.jwt/microprofile\-jwt\-auth\-api@.*$</packageUrl>
-   <cve>CVE-2022-45129</cve>
 </suppress>
 
 <!-- False Positive. CVE-2023-25194 is against Kafka Connect, not the client -->

--- a/integrations/vault/README.md
+++ b/integrations/vault/README.md
@@ -36,6 +36,6 @@ Example of obtaining vault instance using a token:
 ```java
  Vault vault = Vault.builder()
                 .address("http://localhost:8200")
-                .token("s.oZZcsMzbasmwNqfAxPZOs8jw")
+                .token("<put-token-here>")
                 .build();
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>8.1.1</version.plugin.dependency-check>
+        <version.plugin.dependency-check>8.2.1</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0-M5</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
- upgrade owasp dependency check to 8.2.1
- Suppress graphql-data-loader false postive
- Remove old suppressions that are no longer needed