### PR TITLE
4.x supress graphql-data-loader and maven-artifact-manager false positives. OCI SDK upgrade.

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -126,7 +126,7 @@
         <version.lib.neo4j>4.4.11</version.lib.neo4j>
         <version.lib.netty>4.1.86.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.8.Final</version.lib.netty-io_uring>
-        <version.lib.oci>3.2.1</version.lib.oci>
+        <version.lib.oci>3.8.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.okhttp3>3.14.9</version.lib.okhttp3>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -37,37 +37,6 @@
    <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
 </suppress>
 
-<!-- False Positive. This is a CVE again Payara. This is generating a number of false positives.
-     See  https://github.com/jeremylong/DependencyCheck/issues/4781 for one example
--->
-<suppress>
-   <notes><![CDATA[
-   file name: jakarta.resource-api-2.0.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/jakarta\.resource/jakarta\.resource\-api@.*$</packageUrl>
-   <cve>CVE-2022-37422</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: microprofile-jwt-auth-api-2.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.jwt/microprofile\-jwt\-auth\-api@.*$</packageUrl>
-   <cve>CVE-2022-37422</cve>
-</suppress>
-
-<!-- 
-     We use SafeConstructor() or an even more limited custom constructor so this CVE does not apply.
-     SnakeYaml maintainer has closed their issue as "will not fix".
-     https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in
--->
-<suppress>
-   <notes><![CDATA[
-   file name: snakeyaml-1.32.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-   <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
-</suppress>
-
 <!-- False Positive. This CVE is against graphql-java, not the microprofile-graphql-api
 -->
 <suppress>
@@ -76,6 +45,17 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.graphql/microprofile\-graphql\-api@.*$</packageUrl>
    <cve>CVE-2022-37734</cve>
+</suppress>
+
+<!-- False Positive. This CVE is against graphql-java, not graphql-java-dataloader
+     See https://github.com/jeremylong/DependencyCheck/issues/5641
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: java-dataloader-3.1.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/com\.graphql\-java/java\-dataloader@.*$</packageUrl>
+   <cve>CVE-2023-28867</cve>
 </suppress>
 
 <!-- False Postive. This CVE is against the kafka server. This is the kafka client
@@ -144,5 +124,16 @@
    <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
 </suppress>
 
+<!-- False Positive. This CVE is against the Maven plugins listed here:
+     https://maven.apache.org/security.html
+     Our dependency is on  maven-artifact-manager which is not in this list.
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: maven-artifact-manager-2.2.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.apache\.maven/maven\-artifact\-manager@.*$</packageUrl>
+   <vulnerabilityName>CVE-2021-26291</vulnerabilityName>
+</suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>8.1.1</version.plugin.dependency-check>
+        <version.plugin.dependency-check>8.2.1</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0-M5</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION

* upgrade owasp dependency check to 8.2.1
* upgrade oci sdk to 3.8.0
* Suppress graphql-data-loader false postive
* Suppress maven-artifact-manager  false postive
* Remove old suppressions that are no longer needed

