### PR TITLE
Renamed receive() method to onMessage() in WsListener

### DIFF
--- a/examples/nima/protocols/src/main/java/io/helidon/examples/nima/protocols/ProtocolsMain.java
+++ b/examples/nima/protocols/src/main/java/io/helidon/examples/nima/protocols/ProtocolsMain.java
@@ -96,7 +96,7 @@ public class ProtocolsMain {
     private static WsListener wsEcho() {
         return new WsListener() {
             @Override
-            public void receive(WsSession session, String text, boolean last) {
+            public void onMessage(WsSession session, String text, boolean last) {
                 session.send(text, last);
                 System.out.println("websocket request " + text);
             }

--- a/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusConnection.java
+++ b/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusConnection.java
@@ -62,7 +62,7 @@ class TyrusConnection implements ServerConnection, WsSession {
         while (true) {
             try {
                 BufferData buffer = dataReader.readBuffer();
-                listener.receive(this, buffer, true);
+                listener.onMessage(this, buffer, true);
             } catch (Exception e) {
                 listener.onError(this, e);
                 listener.onClose(this, WsCloseCodes.UNEXPECTED_CONDITION, e.getMessage());
@@ -112,12 +112,12 @@ class TyrusConnection implements ServerConnection, WsSession {
         private Connection connection;
 
         @Override
-        public void receive(WsSession session, String text, boolean last) {
+        public void onMessage(WsSession session, String text, boolean last) {
             // Should never be called!
         }
 
         @Override
-        public void receive(WsSession session, BufferData buffer, boolean last) {
+        public void onMessage(WsSession session, BufferData buffer, boolean last) {
             byte[] b = new byte[buffer.available()];
             buffer.read(b);         // buffer copy!
             writeToTyrus(session, ByteBuffer.wrap(b));

--- a/nima/testing/junit5/websocket/src/test/java/io/helidon/nima/testing/junit5/websocket/WsSocketAbstractTestingTest.java
+++ b/nima/testing/junit5/websocket/src/test/java/io/helidon/nima/testing/junit5/websocket/WsSocketAbstractTestingTest.java
@@ -104,7 +104,7 @@ abstract class WsSocketAbstractTestingTest {
         }
 
         @Override
-        public void receive(WsSession session, String text, boolean last) {
+        public void onMessage(WsSession session, String text, boolean last) {
             this.message = text;
             session.close(WsCloseCodes.NORMAL_CLOSE, "End");
         }
@@ -140,7 +140,7 @@ abstract class WsSocketAbstractTestingTest {
         String message;
 
         @Override
-        public void receive(WsSession session, String text, boolean last) {
+        public void onMessage(WsSession session, String text, boolean last) {
             message = text;
             session.send("ws", true);
         }

--- a/nima/tests/integration/websocket/server/src/main/java/io/helidon/nima/tests/integration/websocket/webserver/EchoService.java
+++ b/nima/tests/integration/websocket/server/src/main/java/io/helidon/nima/tests/integration/websocket/webserver/EchoService.java
@@ -42,7 +42,7 @@ class EchoService implements WsListener {
     }
 
     @Override
-    public void receive(WsSession session, String text, boolean last) {
+    public void onMessage(WsSession session, String text, boolean last) {
         session.send(text, last);
     }
 

--- a/nima/tests/integration/websocket/server/src/main/java/io/helidon/nima/tests/integration/websocket/webserver/WsConversationService.java
+++ b/nima/tests/integration/websocket/server/src/main/java/io/helidon/nima/tests/integration/websocket/webserver/WsConversationService.java
@@ -85,12 +85,12 @@ class WsConversationService implements WsListener {
     }
 
     @Override
-    public void receive(WsSession session, String text, boolean last) {
+    public void onMessage(WsSession session, String text, boolean last) {
         received.add(new WsAction(RCV, TEXT, text));
     }
 
     @Override
-    public void receive(WsSession session, BufferData buffer, boolean last) {
+    public void onMessage(WsSession session, BufferData buffer, boolean last) {
         int n = buffer.available();
         received.add(new WsAction(RCV, BINARY, buffer.readString(n, UTF_8)));
     }

--- a/nima/tests/integration/websocket/server/src/test/java/io/helidon/nima/tests/integration/websocket/webserver/WebSocketOriginTest.java
+++ b/nima/tests/integration/websocket/server/src/test/java/io/helidon/nima/tests/integration/websocket/webserver/WebSocketOriginTest.java
@@ -102,7 +102,7 @@ class WebSocketOriginTest {
     private static WsListener single() {
         return new WsListener() {
             @Override
-            public void receive(WsSession session, String text, boolean last) {
+            public void onMessage(WsSession session, String text, boolean last) {
                 session.send(text.toUpperCase(Locale.ROOT), true);
             }
         };

--- a/nima/websocket/client/src/main/java/io/helidon/nima/websocket/client/ClientWsConnection.java
+++ b/nima/websocket/client/src/main/java/io/helidon/nima/websocket/client/ClientWsConnection.java
@@ -228,8 +228,8 @@ public class ClientWsConnection implements WsSession, Runnable {
                 recvContinuation = ContinuationType.NONE;
             }
             switch (ct) {
-            case TEXT -> listener.receive(this, payload.readString(payload.available(), StandardCharsets.UTF_8), finalFrame);
-            case BINARY -> listener.receive(this, payload, finalFrame);
+            case TEXT -> listener.onMessage(this, payload.readString(payload.available(), StandardCharsets.UTF_8), finalFrame);
+            case BINARY -> listener.onMessage(this, payload, finalFrame);
             default -> {
                 close(WsCloseCodes.PROTOCOL_ERROR, "Unexpected continuation received");
                 throw new WsClientException("Unexpected continuation received");
@@ -238,11 +238,11 @@ public class ClientWsConnection implements WsSession, Runnable {
         }
         case TEXT -> {
             recvContinuation = ContinuationType.TEXT;
-            listener.receive(this, payload.readString(payload.available(), StandardCharsets.UTF_8), frame.fin());
+            listener.onMessage(this, payload.readString(payload.available(), StandardCharsets.UTF_8), frame.fin());
         }
         case BINARY -> {
             recvContinuation = ContinuationType.BINARY;
-            listener.receive(this, payload, frame.fin());
+            listener.onMessage(this, payload, frame.fin());
         }
         case CLOSE -> {
             int status = payload.readInt16();

--- a/nima/websocket/webserver/src/main/java/io/helidon/nima/websocket/webserver/WsConnection.java
+++ b/nima/websocket/webserver/src/main/java/io/helidon/nima/websocket/webserver/WsConnection.java
@@ -158,8 +158,8 @@ public class WsConnection implements ServerConnection, WsSession {
                 recvContinuation = ContinuationType.NONE;
             }
             switch (ct) {
-            case TEXT -> listener.receive(this, payload.readString(payload.available(), StandardCharsets.UTF_8), finalFrame);
-            case BINARY -> listener.receive(this, payload, finalFrame);
+            case TEXT -> listener.onMessage(this, payload.readString(payload.available(), StandardCharsets.UTF_8), finalFrame);
+            case BINARY -> listener.onMessage(this, payload, finalFrame);
             default -> {
                 close(WsCloseCodes.PROTOCOL_ERROR, "Unexpected continuation received");
                 throw new CloseConnectionException("Websocket unexpected continuation");
@@ -168,11 +168,11 @@ public class WsConnection implements ServerConnection, WsSession {
         }
         case TEXT -> {
             recvContinuation = ContinuationType.TEXT;
-            listener.receive(this, payload.readString(payload.available(), StandardCharsets.UTF_8), frame.fin());
+            listener.onMessage(this, payload.readString(payload.available(), StandardCharsets.UTF_8), frame.fin());
         }
         case BINARY -> {
             recvContinuation = ContinuationType.BINARY;
-            listener.receive(this, payload, frame.fin());
+            listener.onMessage(this, payload, frame.fin());
         }
         case CLOSE -> {
             int status = payload.readInt16();

--- a/nima/websocket/websocket/src/main/java/io/helidon/nima/websocket/WsListener.java
+++ b/nima/websocket/websocket/src/main/java/io/helidon/nima/websocket/WsListener.java
@@ -27,23 +27,23 @@ import io.helidon.common.http.HttpPrologue;
  */
 public interface WsListener {
     /**
-     * Receive text fragment.
+     * Received text fragment.
      *
      * @param session WebSocket session
      * @param text    text received
      * @param last    is this last fragment
      */
-    default void receive(WsSession session, String text, boolean last) {
+    default void onMessage(WsSession session, String text, boolean last) {
     }
 
     /**
-     * Receive binary fragment.
+     * Received binary fragment.
      *
      * @param session WebSocket session
      * @param buffer  buffer with data
      * @param last    is this last fragment
      */
-    default void receive(WsSession session, BufferData buffer, boolean last) {
+    default void onMessage(WsSession session, BufferData buffer, boolean last) {
     }
 
     /**

--- a/tests/integration/native-image/nima-1/src/main/java/io/helidon/tests/integration/nativeimage/nima1/WebSocketEndpoint.java
+++ b/tests/integration/native-image/nima-1/src/main/java/io/helidon/tests/integration/nativeimage/nima1/WebSocketEndpoint.java
@@ -34,7 +34,7 @@ class WebSocketEndpoint implements WsListener {
     }
 
     @Override
-    public void receive(WsSession session, String message, boolean last) {
+    public void onMessage(WsSession session, String message, boolean last) {
         LOGGER.log(Level.INFO, "WS Receiving " + message);
         if (message.contains("SEND")) {
             session.send(message, false);


### PR DESCRIPTION
Renamed receive() method to onMessage() to make it consistent with the other methods in the interface, all of which use "on" as prefix. Part of doc issue #6467.