### PR TITLE
Support for different propagators for Jaeger OpenTelemetry integration.

### DIFF
--- a/docs/config/io_helidon_tracing_jaeger_JaegerTracerBuilder.adoc
+++ b/docs/config/io_helidon_tracing_jaeger_JaegerTracerBuilder.adoc
@@ -60,7 +60,7 @@ This is a standalone configuration type, prefix from configuration root: `tracin
 |`port` |int |{nbsp} |Port to use to connect to tracing collector.
  Default is defined by each tracing integration.
 |`private-key-pem` |xref:{rootdir}/config/io_helidon_common_configurable_Resource.adoc[Resource] |{nbsp} |Private key in PEM format.
-|`propagation` |`JAEGER`    |addPropagation     |Propagation type (`jaeger`, `b3`, `w3c`). Jaeger is the default, `b3` is for compatibility with Zipkin.
+|`propagation` |`JAEGER`    |addPropagation     |Propagation type (`jaeger`, `b3`, `b3_single`, `w3c`). Jaeger is the default, `b3` is for compatibility with Zipkin (using multiple headers), `b3_single` using a single header.
 |`protocol` |string |{nbsp} |Protocol to use (such as `http` or `https`) to connect to tracing collector.
  Default is defined by each tracing integration.
 |`sampler-param` |Number |`1` |The sampler parameter (number).

--- a/docs/config/io_helidon_tracing_jaeger_JaegerTracerBuilder.adoc
+++ b/docs/config/io_helidon_tracing_jaeger_JaegerTracerBuilder.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ This is a standalone configuration type, prefix from configuration root: `tracin
 |`port` |int |{nbsp} |Port to use to connect to tracing collector.
  Default is defined by each tracing integration.
 |`private-key-pem` |xref:{rootdir}/config/io_helidon_common_configurable_Resource.adoc[Resource] |{nbsp} |Private key in PEM format.
+|`propagation` |`JAEGER`    |addPropagation     |Propagation type (`jaeger`, `b3`, `w3c`). Jaeger is the default, `b3` is for compatibility with Zipkin.
 |`protocol` |string |{nbsp} |Protocol to use (such as `http` or `https`) to connect to tracing collector.
  Default is defined by each tracing integration.
 |`sampler-param` |Number |`1` |The sampler parameter (number).

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -395,6 +395,13 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         return this;
     }
 
+
+    /**
+     * Add propagation format to use.
+     *
+     * @param propagationFormat propagation value
+     * @return updated builder instance
+     */
     @ConfiguredOption(key = "propagation", kind = ConfiguredOption.Kind.LIST, type = PropagationFormat.class, value = "JAEGER")
     public JaegerTracerBuilder addPropagation(PropagationFormat propagationFormat) {
         Objects.requireNonNull(propagationFormat);

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -18,8 +18,13 @@ package io.helidon.tracing.jaeger;
 
 import java.lang.System.Logger.Level;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import io.helidon.common.config.Config;
 import io.helidon.config.metadata.Configured;
@@ -31,11 +36,14 @@ import io.helidon.tracing.opentelemetry.OpenTelemetryTracerProvider;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporterBuilder;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -49,7 +57,7 @@ import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
  * <p>
  * <b>Unless You want to explicitly depend on Jaeger in Your code, please
  * use {@link io.helidon.tracing.TracerBuilder#create(String)} or
- * {@link io.helidon.tracing.TracerBuilder#create(io.helidon.config.Config)} that is abstracted.</b>
+ * {@link io.helidon.tracing.TracerBuilder#create(io.helidon.common.config.Config)} that is abstracted.</b>
  * <p>
  * The Jaeger tracer uses environment variables and system properties to override the defaults.
  * Except for {@code protocol} and {@code service} these are honored, unless overridden in configuration
@@ -147,6 +155,8 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     static final int DEFAULT_HTTP_PORT = 14250;
 
     private final Map<String, String> tags = new HashMap<>();
+    // this is a backward incompatible change, but the correct choice is Jaeger, not B3
+    private final Set<PropagationFormat> propagationFormats = EnumSet.of(PropagationFormat.JAEGER);
     private String serviceName;
     private String protocol = "http";
     private String host = DEFAULT_HTTP_HOST;
@@ -184,7 +194,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      *
      * @param config configuration to load this builder from
      * @return a new builder instance.
-     * @see io.helidon.tracing.jaeger.JaegerTracerBuilder#config(io.helidon.config.Config)
+     * @see io.helidon.tracing.jaeger.JaegerTracerBuilder#config(io.helidon.common.config.Config)
      */
     public static JaegerTracerBuilder create(Config config) {
         return create().config(config);
@@ -256,6 +266,13 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         config.get("private-key-pem").map(io.helidon.common.configurable.Resource::create).ifPresent(this::privateKey);
         config.get("client-cert-pem").map(io.helidon.common.configurable.Resource::create).ifPresent(this::clientCertificate);
         config.get("trusted-cert-pem").map(io.helidon.common.configurable.Resource::create).ifPresent(this::trustedCertificates);
+        config.get("propagation").asList(String.class)
+                        .ifPresent(propagationStrings -> {
+                            propagationStrings.stream()
+                                    .map(String::toUpperCase)
+                                    .map(PropagationFormat::valueOf)
+                                    .forEach(this::addPropagation);
+                        });
 
         config.get("tags").detach()
                 .asMap()
@@ -378,6 +395,13 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         return this;
     }
 
+    @ConfiguredOption(key = "propagation", kind = ConfiguredOption.Kind.LIST, type = PropagationFormat.class, value = "JAEGER")
+    public JaegerTracerBuilder addPropagation(PropagationFormat propagationFormat) {
+        Objects.requireNonNull(propagationFormat);
+        this.propagationFormats.add(propagationFormat);
+        return this;
+    }
+
     /**
      * Builds the {@link io.helidon.tracing.Tracer} for Jaeger based on the configured parameters.
      *
@@ -421,7 +445,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
                                                .setSampler(sampler)
                                                .setResource(serviceName)
                                                .build())
-                    .setPropagators(ContextPropagators.create(B3Propagator.injectingMultiHeaders()))
+                    .setPropagators(createPropagators(propagationFormats))
                     .build();
 
             result = HelidonOpenTelemetry.create(ot, ot.getTracer(this.serviceName), tags);
@@ -480,6 +504,22 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         return enabled;
     }
 
+    private static ContextPropagators createPropagators(Set<PropagationFormat> propagatorFormats) {
+        List<TextMapPropagator> propagators = new ArrayList<>();
+
+        for (PropagationFormat propagatorFormat : propagatorFormats) {
+            switch (propagatorFormat) {
+
+            case B3 -> propagators.add(B3Propagator.injectingMultiHeaders());
+            case W3C -> propagators.add(W3CBaggagePropagator.getInstance());
+            // jaeger and unknown are jaeger
+            default -> propagators.add(JaegerPropagator.getInstance());
+            }
+        }
+
+        return ContextPropagators.create(TextMapPropagator.composite(propagators));
+    }
+
     /**
      * Sampler type definition.
      * Available options are "const", "probabilistic", "ratelimiting" and "remote".
@@ -512,5 +552,23 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         String config() {
             return config;
         }
+    }
+
+    /**
+     * Supported Jaeger trace context propagation formats.
+     */
+    public enum PropagationFormat {
+        /**
+         * The Zipkin B3 trace context propagation format.
+         */
+        B3,
+        /**
+         * The Jaeger trace context propagation format.
+         */
+        JAEGER,
+        /**
+         * The W3C trace context propagation format.
+         */
+        W3C
     }
 }

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -20,6 +20,7 @@ import java.lang.System.Logger.Level;
 import java.time.Duration;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -449,7 +450,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
                                                .setSampler(sampler)
                                                .setResource(serviceName)
                                                .build())
-                    .setPropagators(createPropagators(propagationFormats))
+                    .setPropagators(ContextPropagators.create(TextMapPropagator.composite(createPropagators())))
                     .build();
 
             result = HelidonOpenTelemetry.create(ot, ot.getTracer(this.serviceName), tags);
@@ -508,12 +509,10 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         return enabled;
     }
 
-    private static ContextPropagators createPropagators(Set<PropagationFormat> propagatorFormats) {
-        var propagators = propagatorFormats.stream()
+    List<TextMapPropagator> createPropagators() {
+        return propagationFormats.stream()
                 .map(JaegerTracerBuilder::mapFormatToPropagator)
                 .toList();
-
-        return ContextPropagators.create(TextMapPropagator.composite(propagators));
     }
 
     private static TextMapPropagator mapFormatToPropagator(PropagationFormat propagationFormat) {

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerTracerBuilderTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerTracerBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 package io.helidon.tracing.jaeger;
 
+import java.util.List;
 import java.util.Map;
 
 import io.helidon.config.Config;
 import io.helidon.tracing.Tracer;
 import io.helidon.tracing.TracerBuilder;
 
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -105,5 +108,7 @@ class JaegerTracerBuilderTest {
                 "tag6", "741"
         )));
 
+        List<TextMapPropagator> propagators = jBuilder.createPropagators();
+        assertThat(propagators, hasSize(3));
     }
 }

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerTracerBuilderTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerTracerBuilderTest.java
@@ -23,10 +23,14 @@ import io.helidon.config.Config;
 import io.helidon.tracing.Tracer;
 import io.helidon.tracing.TracerBuilder;
 
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
@@ -110,5 +114,9 @@ class JaegerTracerBuilderTest {
 
         List<TextMapPropagator> propagators = jBuilder.createPropagators();
         assertThat(propagators, hasSize(3));
+
+        assertThat(propagators.get(0), instanceOf(B3Propagator.class));
+        assertThat(propagators.get(1), instanceOf(JaegerPropagator.class));
+        assertThat(propagators.get(2), instanceOf(W3CBaggagePropagator.class));
     }
 }

--- a/tracing/jaeger/src/test/resources/application.yaml
+++ b/tracing/jaeger/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ tracing:
     path: "/api/traces/mine"   # JAEGER_ENDPOINT
     sampler-type: "ratio"
     sampler-param: 0.5
+    propagation: ["jaeger", "b3_single", "w3c"]
     tags:
       tag1: "tag1-value"  # JAEGER_TAGS
       tag2: "tag2-value"  # JAEGER_TAGS


### PR DESCRIPTION
Resolves #6574 

A support for compatibilty with 2.x - we now support Jaeger, B3, and W3C propagators, Jaeger is the default.

Backport issue for 3.x: #6587
There is no need to backport to 2.x, as it is based on OpenTracing