### PR TITLE
Add enum related config bean tests

### DIFF
--- a/builder/tests/configbean/src/main/java/io/helidon/builder/config/testsubjects/EnumRelatedConfig.java
+++ b/builder/tests/configbean/src/main/java/io/helidon/builder/config/testsubjects/EnumRelatedConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.config.testsubjects;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.builder.Singular;
+import io.helidon.builder.config.ConfigBean;
+import io.helidon.builder.config.testsubjects.fakes.FakeClientAuth;
+
+@ConfigBean
+public interface EnumRelatedConfig {
+
+    FakeClientAuth clientAuth();
+
+    Optional<FakeClientAuth> optionalClientAuth();
+
+    @Singular
+    List<InlinedEnum> list();
+
+    @Singular
+    Set<InlinedEnum> set();
+
+    @Singular
+    Map<String, InlinedEnum> map();
+
+
+    enum InlinedEnum {
+        TEST
+    }
+
+}

--- a/builder/tests/configbean/src/test/java/io/helidon/builder/config/test/EnumRelatedConfigBeanTest.java
+++ b/builder/tests/configbean/src/test/java/io/helidon/builder/config/test/EnumRelatedConfigBeanTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.config.test;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.builder.config.testsubjects.DefaultEnumRelatedConfig;
+import io.helidon.builder.config.testsubjects.EnumRelatedConfig;
+import io.helidon.builder.config.testsubjects.fakes.FakeClientAuth;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+
+class EnumRelatedConfigBeanTest {
+
+    @Test
+    void testIt() {
+        EnumRelatedConfig cfg = DefaultEnumRelatedConfig.builder()
+                .clientAuth(FakeClientAuth.OPTIONAL)
+                .list(List.of(EnumRelatedConfig.InlinedEnum.TEST))
+                .addSet(Set.of(EnumRelatedConfig.InlinedEnum.TEST))
+                .addMap("test", EnumRelatedConfig.InlinedEnum.TEST)
+                .build();
+
+        assertThat(cfg.clientAuth(),
+                   equalTo(FakeClientAuth.OPTIONAL));
+        assertThat(cfg.optionalClientAuth(),
+                   optionalEmpty());
+        assertThat(cfg.set(),
+                   contains(EnumRelatedConfig.InlinedEnum.TEST));
+        assertThat(cfg.list(),
+                   contains(EnumRelatedConfig.InlinedEnum.TEST));
+        assertThat(cfg.map(),
+                   hasEntry("test", EnumRelatedConfig.InlinedEnum.TEST));
+    }
+
+}


### PR DESCRIPTION
Add test coverage for enum-related config bean tests as mentioned on https://github.com/helidon-io/helidon/issues/6591