### PR TITLE
native-image configuration for Jackson in Helidon MP.

### DIFF
--- a/integrations/graal/native-image-extension/src/main/resources/META-INF/native-image/io.helidon.integrations.graal/helidon-graal-native-image-extension/native-image.properties
+++ b/integrations/graal/native-image-extension/src/main/resources/META-INF/native-image/io.helidon.integrations.graal/helidon-graal-native-image-extension/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ Args=--no-fallback \
       --initialize-at-build-time=org.yaml.snakeyaml \
       --initialize-at-build-time=org.reactivestreams \
       --initialize-at-build-time=org.glassfish.json \
+      --initialize-at-build-time=com.fasterxml.jackson \
       --initialize-at-build-time=org.eclipse.microprofile \
       --initialize-at-build-time=io.opentracing \
       --initialize-at-build-time=jakarta.json \

--- a/integrations/graal/native-image-extension/src/main/resources/META-INF/native-image/io.helidon.integrations.graal/helidon-graal-native-image-extension/reflect-config.json
+++ b/integrations/graal/native-image-extension/src/main/resources/META-INF/native-image/io.helidon.integrations.graal/helidon-graal-native-image-extension/reflect-config.json
@@ -13,5 +13,10 @@
         "name": "java.util.logging.FileHandler",
         "allDeclaredConstructors": true,
         "allPublicMethods": true
+    },
+    {
+      "name": "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
     }
 ]


### PR DESCRIPTION
Update helidon-graal-native-image-extension:
- Add `--initialize-at-build-time=com.fasterxm.jackson`
- Add a `reflect-config.json` to enable reflection done by `org.glassfish.jersey.jackson.internal.JacksonMapperConfigurator`

Fixes #6538