### PR TITLE
Support for different propagators for Jaeger OpenTelemetry

### DIFF
--- a/docs/config/io_helidon_tracing_jaeger_JaegerTracerBuilder.adoc
+++ b/docs/config/io_helidon_tracing_jaeger_JaegerTracerBuilder.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ This is a standalone configuration type, prefix from configuration root: `tracin
 |`port` |int |{nbsp} |Port to use to connect to tracing collector.
  Default is defined by each tracing integration.
 |`private-key-pem` |xref:{rootdir}/config/io_helidon_common_configurable_Resource.adoc[Resource] |{nbsp} |Private key in PEM format.
+|`propagation` |`JAEGER`    |addPropagation     |Propagation type (`jaeger`, `b3`, `b3_single`, `w3c`). Jaeger is the default, `b3` is for compatibility with Zipkin (using multiple headers), `b3_single` using a single header.
 |`protocol` |string |{nbsp} |Protocol to use (such as `http` or `https`) to connect to tracing collector.
  Default is defined by each tracing integration.
 |`sampler-param` |Number |`1` |The sampler parameter (number).

--- a/examples/microprofile/static-content/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/microprofile/static-content/src/main/resources/META-INF/microprofile-config.properties
@@ -16,7 +16,7 @@
 
 # web server configuration
 # Use a random free port
-server.port=0
+server.port=8080
 
 # location on classpath (e.g. src/main/resources/WEB in maven)
 server.static.classpath.location=/WEB

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerTracerBuilderTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerTracerBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,26 @@
 
 package io.helidon.tracing.jaeger;
 
+import java.util.List;
 import java.util.Map;
 
 import io.helidon.config.Config;
 import io.helidon.tracing.Tracer;
 import io.helidon.tracing.TracerBuilder;
 
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -105,5 +112,11 @@ class JaegerTracerBuilderTest {
                 "tag6", "741"
         )));
 
+        List<TextMapPropagator> propagators = jBuilder.createPropagators();
+        assertThat(propagators, hasSize(3));
+
+        assertThat(propagators.get(0), instanceOf(B3Propagator.class));
+        assertThat(propagators.get(1), instanceOf(JaegerPropagator.class));
+        assertThat(propagators.get(2), instanceOf(W3CBaggagePropagator.class));
     }
 }

--- a/tracing/jaeger/src/test/resources/application.yaml
+++ b/tracing/jaeger/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ tracing:
     path: "/api/traces/mine"   # JAEGER_ENDPOINT
     sampler-type: "ratio"
     sampler-param: 0.5
+    propagation: ["jaeger", "b3_single", "w3c"]
     tags:
       tag1: "tag1-value"  # JAEGER_TAGS
       tag2: "tag2-value"  # JAEGER_TAGS


### PR DESCRIPTION
Resolves #6587 

* Support for different propagators for Jaeger OpenTelemetry integration.
* Added tests to validate the correct propagators are added

(cherry picked from commit f5bf1ffec3358e91fc19020be038ce3ed72e134b)
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>