### PR TITLE
[3.x]: Use Hamcrest assertions instead of JUnit in tests/integration/jms (#1749)

### DIFF
--- a/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AbstractMPTest.java
+++ b/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AbstractMPTest.java
@@ -30,7 +30,7 @@ import jakarta.jms.TextMessage;
 import org.hamcrest.Matchers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.is;
 
 public abstract class AbstractMPTest extends AbstractJmsTest {
 
@@ -52,8 +52,8 @@ public abstract class AbstractMPTest extends AbstractJmsTest {
         if (expected.size() > 0) {
             // Wait till records are delivered
             boolean done = consumingBean.await();
-            assertTrue(done, String.format("Timeout waiting for results.\nExpected: %s \nBut was: %s",
-                    expected.toString(), consumingBean.consumed().toString()));
+            assertThat(String.format("Timeout waiting for results.\nExpected: %s \nBut was: %s",
+                    expected.toString(), consumingBean.consumed().toString()), done, is(true));
         }
         if (!expected.isEmpty()) {
             assertThat(consumingBean.consumed(), Matchers.containsInAnyOrder(expected.toArray()));

--- a/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AbstractSampleBean.java
+++ b/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AbstractSampleBean.java
@@ -48,7 +48,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class contains the outputs of the tests. In order to avoid that one test mess up in the results
@@ -249,7 +248,7 @@ abstract class AbstractSampleBean {
 
         public void await(long timeout) {
             try {
-                assertTrue(countDownLatch.await(timeout, TimeUnit.MILLISECONDS));
+                assertThat(countDownLatch.await(timeout, TimeUnit.MILLISECONDS), is(true));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -286,7 +285,7 @@ abstract class AbstractSampleBean {
 
         public void await(long timeout) {
             try {
-                assertTrue(countDownLatch.await(timeout, TimeUnit.MILLISECONDS));
+                assertThat(countDownLatch.await(timeout, TimeUnit.MILLISECONDS), is(true));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -331,7 +330,7 @@ abstract class AbstractSampleBean {
 
         public void await(long timeout) {
             try {
-                assertTrue(countDownLatch.await(timeout, TimeUnit.MILLISECONDS));
+                assertThat(countDownLatch.await(timeout, TimeUnit.MILLISECONDS), is(true));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -375,7 +374,7 @@ abstract class AbstractSampleBean {
 
         public void await(long timeout) {
             try {
-                assertTrue(countDownLatch.await(timeout, TimeUnit.MILLISECONDS));
+                assertThat(countDownLatch.await(timeout, TimeUnit.MILLISECONDS), is(true));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/JmsSeTest.java
+++ b/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/JmsSeTest.java
@@ -34,9 +34,9 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JmsSeTest extends AbstractJmsTest {
 
@@ -81,7 +81,7 @@ public class JmsSeTest extends AbstractJmsTest {
                 .build()
                 .start();
 
-        assertTrue(cdl.await(2, TimeUnit.SECONDS));
+        assertThat(cdl.await(2, TimeUnit.SECONDS), is(true));
         assertThat(result, containsInAnyOrder("1", "2", "3", "4"));
     }
 


### PR DESCRIPTION
Part of #1749 

- [ ] Create backport 2.x
- [ ] Create backport 4.x