### PR TITLE
[2.x]: Use Hamcrest assertions instead of JUnit in tests/integration/jms (#1749)

### DIFF
--- a/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AbstractMPTest.java
+++ b/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AbstractMPTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import javax.jms.MessageProducer;
 import javax.jms.TextMessage;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.is;
 
 import org.hamcrest.Matchers;
 
@@ -53,8 +53,8 @@ public abstract class AbstractMPTest extends AbstractJmsTest {
         if (expected.size() > 0) {
             // Wait till records are delivered
             boolean done = consumingBean.await();
-            assertTrue(done, String.format("Timeout waiting for results.\nExpected: %s \nBut was: %s",
-                    expected.toString(), consumingBean.consumed().toString()));
+            assertThat(String.format("Timeout waiting for results.\nExpected: %s \nBut was: %s",
+                    expected.toString(), consumingBean.consumed().toString()), done, is(true));
         }
         if (!expected.isEmpty()) {
             assertThat(consumingBean.consumed(), Matchers.containsInAnyOrder(expected.toArray()));

--- a/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AbstractSampleBean.java
+++ b/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AbstractSampleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,7 +255,7 @@ abstract class AbstractSampleBean {
 
         public void await(long timeout) {
             try {
-                assertTrue(countDownLatch.await(timeout, TimeUnit.MILLISECONDS));
+                assertThat(countDownLatch.await(timeout, TimeUnit.MILLISECONDS), is(true));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -292,7 +292,7 @@ abstract class AbstractSampleBean {
 
         public void await(long timeout) {
             try {
-                assertTrue(countDownLatch.await(timeout, TimeUnit.MILLISECONDS));
+                assertThat(countDownLatch.await(timeout, TimeUnit.MILLISECONDS), is(true));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -337,7 +337,7 @@ abstract class AbstractSampleBean {
 
         public void await(long timeout) {
             try {
-                assertTrue(countDownLatch.await(timeout, TimeUnit.MILLISECONDS));
+                assertThat(countDownLatch.await(timeout, TimeUnit.MILLISECONDS), is(true));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -381,7 +381,7 @@ abstract class AbstractSampleBean {
 
         public void await(long timeout) {
             try {
-                assertTrue(countDownLatch.await(timeout, TimeUnit.MILLISECONDS));
+                assertThat(countDownLatch.await(timeout, TimeUnit.MILLISECONDS), is(true));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/JmsSeTest.java
+++ b/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/JmsSeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  2020 Oracle and/or its affiliates.
+ * Copyright (c)  2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ import io.helidon.messaging.Channel;
 import io.helidon.messaging.Messaging;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.activemq.jndi.ActiveMQInitialContextFactory;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -80,7 +80,7 @@ public class JmsSeTest extends AbstractJmsTest {
                 .build()
                 .start();
 
-        assertTrue(cdl.await(2, TimeUnit.SECONDS));
+        assertThat(cdl.await(2, TimeUnit.SECONDS), is(true));
         assertThat(result, containsInAnyOrder("1", "2", "3", "4"));
     }
 


### PR DESCRIPTION
Part of #1749 