### PR TITLE
Move SnakeYAML log suppression to slightly earlier in the code path

### DIFF
--- a/openapi/src/main/java/io/helidon/openapi/ParserHelper.java
+++ b/openapi/src/main/java/io/helidon/openapi/ParserHelper.java
@@ -46,10 +46,6 @@ public class ParserHelper {
 
     private ParserHelper(SnakeYAMLParserHelper<ExpandedTypeDescription> generatedHelper) {
         this.generatedHelper = generatedHelper;
-        boolean warningsEnabled = Boolean.getBoolean("openapi.parsing.warnings.enabled");
-        if (SNAKE_YAML_INTROSPECTOR_LOGGER.isLoggable(java.util.logging.Level.WARNING) && !warningsEnabled) {
-            SNAKE_YAML_INTROSPECTOR_LOGGER.setLevel(java.util.logging.Level.SEVERE);
-        }
     }
 
     /**
@@ -58,6 +54,10 @@ public class ParserHelper {
      * @return a new parser helper
      */
     public static ParserHelper create() {
+        boolean warningsEnabled = Boolean.getBoolean("openapi.parsing.warnings.enabled");
+        if (SNAKE_YAML_INTROSPECTOR_LOGGER.isLoggable(java.util.logging.Level.WARNING) && !warningsEnabled) {
+            SNAKE_YAML_INTROSPECTOR_LOGGER.setLevel(java.util.logging.Level.SEVERE);
+        }
         ParserHelper helper = new ParserHelper(SnakeYAMLParserHelper.create(ExpandedTypeDescription::create));
         adjustTypeDescriptions(helper.types());
         return helper;


### PR DESCRIPTION
Resolves #6624 

See this PR for an explanation of the messages from SnakeYAML https://github.com/helidon-io/helidon/pull/5793

The Helidon code to suppress the SnakeYAML 2.0 warning messages needed to execute before instantiating the (generated) `SnakeYAMLParserHelper` class to be effective. There is a slight difference between the code in 3.x and 4.x where this happens, which is why the earlier fix for this in 4.x was not effective.