### PR TITLE
RestClient and FT intergration changes

### DIFF
--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResource.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.tests.integration.restclient;
 
+import java.util.Collections;
+
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
@@ -23,7 +25,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import java.util.Collections;
 
 /**
  * A typical greet resource that only handles a single GET for a default message.
@@ -36,6 +37,13 @@ public class GreetResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public JsonObject getDefaultMessage() {
+        return createResponse("World");
+    }
+
+    @GET
+    @Path("async")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject getDefaultMessageAsync() {
         return createResponse("World");
     }
 

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceClient.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 package io.helidon.tests.integration.restclient;
 
+import java.util.concurrent.CompletionStage;
+
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -40,4 +42,10 @@ public interface GreetResourceClient {
     @Timeout(value = 3000)
     @Produces(MediaType.APPLICATION_JSON)
     JsonObject getDefaultMessage();
+
+    @GET
+    @Path("async")
+    @Asynchronous
+    @Produces(MediaType.APPLICATION_JSON)
+    CompletionStage<JsonObject> getDefaultMessageAsync();
 }

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceProxy.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
 
 package io.helidon.tests.integration.restclient;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.json.JsonObject;
@@ -25,7 +29,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriInfo;
-
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -70,6 +73,25 @@ public class GreetResourceProxy {
     public JsonObject getDefaultMessage() {
         JsonObject msg1 = injectedClient.getDefaultMessage();
         JsonObject msg2 = builderClient.getDefaultMessage();
+        if (!msg1.getString("message").equals(msg2.getString("message"))) {
+            throw new IllegalStateException("Oops");
+        }
+        return msg1;
+    }
+
+    /**
+     * Test both clients and compares responses before returning one. Async version.
+     *
+     * @return JSON response.
+     */
+    @GET
+    @Path("async")
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject getDefaultMessageAsync() throws ExecutionException, InterruptedException, TimeoutException {
+        JsonObject msg1 = injectedClient.getDefaultMessageAsync()
+                .toCompletableFuture().get(5, TimeUnit.SECONDS);
+        JsonObject msg2 = builderClient.getDefaultMessageAsync()
+                .toCompletableFuture().get(5, TimeUnit.SECONDS);
         if (!msg1.getString("message").equals(msg2.getString("message"))) {
             throw new IllegalStateException("Oops");
         }

--- a/tests/integration/restclient/src/test/java/io/helidon/tests/integration/restclient/MainTest.java
+++ b/tests/integration/restclient/src/test/java/io/helidon/tests/integration/restclient/MainTest.java
@@ -16,16 +16,16 @@
 
 package io.helidon.tests.integration.restclient;
 
+import io.helidon.microprofile.tests.junit5.HelidonTest;
 import jakarta.inject.Inject;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.WebTarget;
-
-import io.helidon.microprofile.tests.junit5.HelidonTest;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -66,5 +66,16 @@ class MainTest {
         // Verify that @Retry code was executed by looking at counter
         counter = registry.getCounters().get(metricID);
         assertThat(counter.getCount(), is(2L));
+    }
+
+    @Test
+    @Disabled
+    void testHelloWorldAsync() {
+        JsonObject jsonObject = target
+                .path("proxy")
+                .path("async")
+                .request()
+                .get(JsonObject.class);
+        assertThat(jsonObject.getString("message"), is("Hello World!"));
     }
 }


### PR DESCRIPTION
Updated CommandInterceptor with special code to handle async calls coming from the RestClient implementation in Jersey due to an issue with the default invocation context in Weld. New integration test that is currently disabled until the next integration with Jersey. See issue #6580. 