### PR TITLE
Convenient flushing on response commit

### DIFF
--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/OutputStreamTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/OutputStreamTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.server;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.common.http.Http;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webclient.http1.Http1Client;
+import io.helidon.nima.webclient.http1.Http1ClientResponse;
+import io.helidon.nima.webserver.http.HttpRouting;
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.http.Http.Method.GET;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class OutputStreamTest {
+
+    private final Http1Client client;
+
+    OutputStreamTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder router) {
+        router.route(GET, "/outputStream", Service::outputStream);
+    }
+
+    @Test
+    void verifyAutoFlush() {
+        try (Http1ClientResponse response = client.get("/outputStream").request()) {
+            assertThat(response.status(), is(Http.Status.OK_200));
+            String entity = response.entity().as(String.class);
+            assertThat(entity, is("Hello World"));
+        }
+    }
+
+    private static class Service {
+
+        public static void outputStream(ServerRequest req, ServerResponse res) throws IOException {
+            InputStream in = new ByteArrayInputStream("Hello World".getBytes(StandardCharsets.UTF_8));
+            in.transferTo(res.outputStream());      // no explicit flush
+        }
+    }
+}

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -615,7 +615,12 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         }
 
         void commit() {
-            delegate.commit();
+            try {
+                flush();
+                delegate.commit();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 }


### PR DESCRIPTION
Convenient flushing on response commit when handler writes directly to output stream. See issue #6651.