### PR TITLE
[4.x] Switch metrics API jar scope to compile from provided

### DIFF
--- a/microprofile/fault-tolerance/pom.xml
+++ b/microprofile/fault-tolerance/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>


### PR DESCRIPTION
Switch metrics API jar scope to compile from provided. Metrics is not included in a core MP app, so it is not always provided as such.