### PR TITLE
Update grpc-java version to 1.54.1 and clean up grpc tests

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -59,7 +59,7 @@
         <version.lib.graphql-java>17.5</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>17.1</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
-        <version.lib.grpc>1.49.2</version.lib.grpc>
+        <version.lib.grpc>1.54.1</version.lib.grpc>
         <version.lib.guava>31.1-jre</version.lib.guava>
         <version.lib.h2>2.1.212</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/grpc/io.grpc/src/main/java/io/grpc/util/OutlierDetectionLoadBalancerProvider.java
+++ b/grpc/io.grpc/src/main/java/io/grpc/util/OutlierDetectionLoadBalancerProvider.java
@@ -1,0 +1,14 @@
+package io.grpc.util;
+
+import io.grpc.LoadBalancerProvider;
+
+/**
+ * A dummy class to allow the re-packaging of grpc-java
+ * with a module-info.java file to work.
+ * <p>
+ * This file will be replaced by the real implementation from grpc-java
+ * as part of the re-packaging process.
+ */
+public class OutlierDetectionLoadBalancerProvider
+        extends LoadBalancerProvider {
+}

--- a/grpc/io.grpc/src/main/java/io/grpc/util/OutlierDetectionLoadBalancerProvider.java
+++ b/grpc/io.grpc/src/main/java/io/grpc/util/OutlierDetectionLoadBalancerProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.grpc.util;
 
 import io.grpc.LoadBalancerProvider;

--- a/grpc/io.grpc/src/main/java/module-info.java
+++ b/grpc/io.grpc/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/io.grpc/src/main/java/module-info.java
+++ b/grpc/io.grpc/src/main/java/module-info.java
@@ -37,7 +37,8 @@ module io.grpc {
 
     provides io.grpc.LoadBalancerProvider
             with io.grpc.internal.PickFirstLoadBalancerProvider,
-                 io.grpc.util.SecretRoundRobinLoadBalancerProvider.Provider;
+                 io.grpc.util.SecretRoundRobinLoadBalancerProvider.Provider,
+                 io.grpc.util.OutlierDetectionLoadBalancerProvider;
 
     provides io.grpc.NameResolverProvider
             with io.grpc.internal.DnsNameResolverProvider;

--- a/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
@@ -33,7 +33,6 @@ import io.helidon.grpc.server.test.EchoServiceGrpc;
 
 import com.oracle.bedrock.runtime.LocalPlatform;
 import com.oracle.bedrock.runtime.network.AvailablePortIterator;
-import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
@@ -41,7 +40,7 @@ import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -86,7 +85,7 @@ public class SslIT {
     // ----- test lifecycle -------------------------------------------------
 
     @BeforeAll
-    public static void setup() throws Exception {
+    public static void setup() {
         LogConfig.configureRuntime();
 
         AvailablePortIterator ports = LocalPlatform.get().getAvailablePorts();
@@ -100,7 +99,7 @@ public class SslIT {
         grpcServer_2WaySSLConfig = startGrpcServer(port2WaySSLConfig, true/*mutual*/, true /*useConfig*/);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() throws Exception
     {
         CompletableFuture<?>[] futures =
@@ -120,7 +119,7 @@ public class SslIT {
         // client do not have to provide certs for 1way ssl
         SslContext sslContext = clientSslContext(tlsCaCert, null, null);
 
-        Channel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_1WaySSL.port())
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_1WaySSL.port())
                 .negotiationType(NegotiationType.TLS)
                 .sslContext(sslContext)
                 .build();
@@ -129,7 +128,7 @@ public class SslIT {
         Echo.EchoResponse response = EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build());
         assertThat(response.getMessage(), is("foo"));
 
-        ((ManagedChannel) channel).shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -137,7 +136,7 @@ public class SslIT {
         // client do not have to provide certs for 1way ssl
         SslContext sslContext = clientSslContext(null, null, null);
 
-        Channel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_1WaySSL.port())
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_1WaySSL.port())
                 .negotiationType(NegotiationType.TLS)
                 .sslContext(sslContext)
                 .build();
@@ -146,7 +145,7 @@ public class SslIT {
         Assertions.assertThrows(StatusRuntimeException.class,
                                 ()->EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build()));
 
-        ((ManagedChannel) channel).shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -157,7 +156,7 @@ public class SslIT {
 
         SslContext sslContext = clientSslContext(tlsCaCert, tlsClientCert, tlsClientKey);
 
-        Channel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSL.port())
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSL.port())
                     .negotiationType(NegotiationType.TLS)
                     .sslContext(sslContext)
                     .build();
@@ -166,7 +165,7 @@ public class SslIT {
         Echo.EchoResponse response = EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build());
         assertThat(response.getMessage(), is("foo"));
 
-        ((ManagedChannel) channel).shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -175,7 +174,7 @@ public class SslIT {
         Resource tlsClientKey = Resource.create(CLIENT_KEY);
         SslContext sslContext = clientSslContext(null, tlsClientCert, tlsClientKey);
 
-        Channel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSL.port())
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSL.port())
                 .negotiationType(NegotiationType.TLS)
                 .sslContext(sslContext)
                 .build();
@@ -184,7 +183,7 @@ public class SslIT {
         Assertions.assertThrows(StatusRuntimeException.class,
                                 ()->EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build()));
 
-        ((ManagedChannel) channel).shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -193,7 +192,7 @@ public class SslIT {
         Resource tlsClientKey = Resource.create(CLIENT_KEY);
         SslContext sslContext = clientSslContext(tlsCaCert, null, tlsClientKey);
 
-        Channel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSL.port())
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSL.port())
                 .negotiationType(NegotiationType.TLS)
                 .sslContext(sslContext)
                 .build();
@@ -202,7 +201,7 @@ public class SslIT {
         Assertions.assertThrows(StatusRuntimeException.class,
                                 ()->EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build()));
 
-        ((ManagedChannel) channel).shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -212,7 +211,7 @@ public class SslIT {
         Resource tlsClientKey = Resource.create(CLIENT_KEY);
         SslContext sslContext = clientSslContext(tlsCaCert, tlsClientCert, tlsClientKey);
 
-        Channel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSLConfig.port())
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSLConfig.port())
                 .negotiationType(NegotiationType.TLS)
                 .sslContext(sslContext)
                 .build();
@@ -221,7 +220,7 @@ public class SslIT {
         Echo.EchoResponse response = EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build());
         assertThat(response.getMessage(), is("foo"));
 
-        ((ManagedChannel) channel).shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -230,7 +229,7 @@ public class SslIT {
         Resource tlsClientKey = Resource.create(CLIENT_KEY);
         SslContext sslContext = clientSslContext(tlsCaCert, null, tlsClientKey);
 
-        Channel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSLConfig.port())
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", grpcServer_2WaySSLConfig.port())
                 .negotiationType(NegotiationType.TLS)
                 .sslContext(sslContext)
                 .build();
@@ -239,7 +238,7 @@ public class SslIT {
         Assertions.assertThrows(StatusRuntimeException.class,
                                 ()->EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build()));
 
-        ((ManagedChannel) channel).shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     }
 
     // ----- helper methods -------------------------------------------------
@@ -260,10 +259,8 @@ public class SslIT {
 
     /**
      * Start the gRPC Server listening on the specified nPort.
-     *
-     * @throws Exception in case of an error
      */
-    private static GrpcServer startGrpcServer(int nPort, boolean mutual, boolean useConfig ) throws Exception {
+    private static GrpcServer startGrpcServer(int nPort, boolean mutual, boolean useConfig ) {
         Resource tlsCert = Resource.create(SERVER_CERT);
         Resource tlsKey = Resource.create(SERVER_KEY);
         Resource tlsCaCert = Resource.create(CA_CERT);

--- a/grpc/server/src/test/java/io/helidon/grpc/server/TracingIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/TracingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/server/src/test/java/io/helidon/grpc/server/TracingIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/TracingIT.java
@@ -46,7 +46,6 @@ import services.EchoService;
 import zipkin2.Span;
 import zipkin2.junit.ZipkinRule;
 
-import static com.oracle.bedrock.deferred.DeferredHelper.invoking;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -110,7 +109,7 @@ public class TracingIT {
         // call the gRPC Echo service so that there should be tracing span sent to zipkin server
         EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build());
 
-        Eventually.assertThat(invoking(this).getSpanCount(), is(not(0)));
+        Eventually.assertDeferred(() -> zipkin.collectorMetrics().spans(), is(not(0)));
 
         List<List<Span>> listTraces = zipkin.getTraces();
         assertThat(listTraces, is(notNullValue()));
@@ -181,13 +180,6 @@ public class TracingIT {
                         .get(10, TimeUnit.SECONDS);
 
        LOGGER.info("Started gRPC server at: localhost:" + grpcServer.port());
-    }
-
-    /**
-     * Return the span count collect.
-     */
-    public int getSpanCount() {
-        return zipkin.collectorMetrics().spans();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <version.lib.test.containers.keycloak>2.3.0</version.lib.test.containers.keycloak>
         <version.lib.testng>7.7.0</version.lib.testng>
         <version.lib.zipkin.junit>2.12.5</version.lib.zipkin.junit>
-        <version.lib.bedrock>5.0.11</version.lib.bedrock>
+        <version.lib.bedrock>7.0.1</version.lib.bedrock>
         <version.lib.awaitility>3.1.6</version.lib.awaitility>
         <version.lib.weld-junit>3.0.0.Final</version.lib.weld-junit>
         <version.lib.jmh>1.23</version.lib.jmh>


### PR DESCRIPTION
This PR is to update grpc-java to the latest version, which depends on a version of Netty closer to the one Helidon now depends on.