### PR TITLE
Some minor tweaks to the REST documentation

### DIFF
--- a/docs/mp/jaxrs/application-configuration.adoc
+++ b/docs/mp/jaxrs/application-configuration.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ You can inject values that the application can access from both MicroProfile Con
 Helidon Config.
 
 [source,java]
-.JAX-RS - inject a single config property
+.Jakarta REST - inject a single config property
 ----
 @Inject
 public MyResource(@ConfigProperty(name="app.name") String appName) {
@@ -46,7 +46,7 @@ You can also inject the whole configuration instance,
 either `io.helidon.config.Config` or
  `org.eclipse.microprofile.config.Config`.
 [source,java]
-.JAX-RS - inject config
+.Jakarta REST - inject config
 ----
 @Inject
 public MyResource(Config config) {

--- a/docs/mp/jaxrs/jaxrs-applications.adoc
+++ b/docs/mp/jaxrs/jaxrs-applications.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,42 +16,39 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-= JAX-RS Applications
-:description: Helidon MicroProfile JAX-RS applications
+= Jakarta REST
+:description: Helidon MicroProfile Jakarta REST
 :keywords: helidon, microprofile, micro-profile, jax-rs, applications, jakarta, rest
 :rootdir: {docdir}/../..
 
 include::{rootdir}/includes/mp.adoc[]
 
-== JAX-RS Applications
+== Jakarta REST Applications
 
-NOTE: In this section we shall distinguish the notion of a JAX-RS `Application` subclass
-from a Helidon application. As we shall learn shortly, the latter may include zero or more
-of the former.
-
-The JAX-RS specification defines the notion of an `Application` subclass whose methods return
-resource and provider classes, singletons and properties. This is the mechanism developers
-can use to define what comprises a JAX-RS application. Unless otherwise stated by the runtime
-environment in which the JAX-RS application runs, every JAX-RS application must include
+The Jakarta REST specification (formerly JAX-RS) defines the notion of an `Application`
+subclass whose methods return resource and provider classes, singletons and properties. This is the
+mechanism developers can use to define what comprises a REST application. Unless otherwise stated by
+the runtime  environment in which the application runs, every REST application must include
 exactly one `Application` subclass.
 
-Helidon provides an extension to JAX-RS in which 0 or more `Application` subclasses are allowed.
+Helidon provides an extension to Jakarta REST in which 0 or more `Application` subclasses are allowed.
 If no `Application` subclasses are provided, then a so-called _synthetic_ subclass will be
 created automatically. This _synthetic_ subclass shall include all resource and provider
 classes discovered by Helidon. Most Helidon applications should simply rely on this mechanism
 in accordance to convention over configuration practices.
 
-== Discovery of JAX-RS Beans
+== Discovery of REST Beans
 
 CDI scanning is controlled by the `bean-discovery-mode` attribute in `beans.xml` files &mdash;
 the default value for this attribute is `annotated`. In the default mode, CDI scans for beans
 decorated by bean-defining annotations such as `@ApplicationScoped`, `@RequestScoped`, etc.
 
-With the help of CDI, Helidon looks for JAX-RS `Application` subclasses in your
+With the help of CDI, Helidon looks for REST `Application` subclasses in your
 Helidon application. If none are found, a synthetic application will be created by gathering all
-resources and providers found during the discovery phase. Note that if your `Application`
-subclass has no bean-defining annotations, and bean discovery is set to the default `annotated`
-value, it will be ignored.
+resources and providers found during the discovery phase.
+
+NOTE: If an `Application` subclass has no bean-defining annotations, and bean discovery is
+set to the default `annotated` value, it will be ignored.
 
 The discovery phase is carried out as follows (in no particular order):
 
@@ -71,8 +68,8 @@ NOTE: Helidon treats `@Path` and `@Provided` as bean-defining annotations but, a
 
 == Access to Application Instances
 
-JAX-RS provides access to the `Application` subclass instance via injection using `@Context`. This form
-of access is still supported in Helidon but is insufficient if two or more subclasses are present.
+Jakarta REST provides access to the `Application` subclass instance via injection using `@Context`. This form
+of access is still supported in Helidon but this is not enough if two or more subclasses are present.
 Given that support for two or more `Application` subclasses is a Helidon extension, a new mechanism
 is provided via the `ServerRequest` 's context object as shown next.
 
@@ -96,7 +93,8 @@ executed.
 
 == Injection Managers in Helidon
 
-Jersey does not currently provide support for multiple `Application` subclasses.
+The Oracle implementation of Jakarta REST, known as Jersey, does not
+currently provide support for multiple `Application` subclasses.
 As a result, it creates a single internal _injection manager_ for your entire application,
 but this is insufficient when multiple `Application` subclasses are present.
 Helidon creates a separate injection manager

--- a/docs/mp/jaxrs/jaxrs-client.adoc
+++ b/docs/mp/jaxrs/jaxrs-client.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-= Jakarta REST (JAX-RS) Client
+= Jakarta REST Client
 :feature-name: Jakarta REST Client
-:description: Jakarta REST (JAX-RS) Client
+:description: Jakarta REST Client
 :keywords: helidon, rest, jax-rs, client, microprofile, micro-profile
 :rootdir: {docdir}/../..
 
@@ -72,7 +72,7 @@ Response res = client
 
 In the snippet above, the call to `target` returns a `WebTarget`, and the call to
 `request` returns an `Invocation.Builder`; finally, the call to `get` returns the `Response`
-that results from accessing the service resource.
+that results from accessing the remote resource.
 
 Given that this API is fully integrated with message body readers and writers, it is
 possible to request the response body be provided after conversion to a Java type
@@ -91,8 +91,8 @@ Alternatively, there are also methods in `Response` that can trigger similar con
 
 Configuration can be specified at the `Client` or `WebTarget` level, as both types implement
 `Configurable<T>`. This enables common configuration to be inherited by a `WebTarget` created
-from a `Client` instance. In either case, methods such as `register` can be used to
-register providers such as filters and exception mappers.
+from a `Client` instance. In either case, several `register` methods can be used to
+configure providers such as filters and exception mappers.
 
 [source,java]
 ----


### PR DESCRIPTION
Some minor tweaks to the REST documentation, including the use of "Jakarta REST" in preference of "JAX-RS". MP applications in 4.x that use Jakarta REST are compatible with 3.x applications. Issue #6486.