### PR TITLE
Use checkNested(Throwable) for req.next(Throwable)

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -416,7 +416,7 @@ class RequestRouting implements Routing {
 
         @Override
         public void next(Throwable t) {
-            checkNexted();
+            checkNexted(t);
 
             nextNoCheck(t);
         }


### PR DESCRIPTION
This allows to propagate the exception even if req.next() was already called.

Fixes #6550