### PR TITLE
[4.x] Kafka bump up 2.8.1 > 3.4.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -94,7 +94,7 @@
         <version.lib.jersey>3.1.1</version.lib.jersey>
         <version.lib.jgit>5.11.1.202105131744-r</version.lib.jgit>
         <version.lib.junit>5.7.0</version.lib.junit>
-        <version.lib.kafka>2.8.1</version.lib.kafka>
+        <version.lib.kafka>3.4.0</version.lib.kafka>
         <version.lib.log4j>2.18.0</version.lib.log4j>
         <version.lib.logback>1.4.0</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -58,27 +58,6 @@
    <cve>CVE-2023-28867</cve>
 </suppress>
 
-<!-- False Postive. This CVE is against the kafka server. This is the kafka client
--->
-<suppress>
-   <notes><![CDATA[
-   file name: kafka-clients-2.8.1.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka\-clients@.*$</packageUrl>
-   <cve>CVE-2022-34917</cve>
-</suppress>
-
-<!-- False Postive. This CVE is against the kafka connect server. We use the kafka client
--->
-<suppress>
-   <notes><![CDATA[
-   file name: kafka-clients-2.8.1.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka\-clients@.*$</packageUrl>
-   <cve>CVE-2023-25194</cve>
-</suppress>
-
-
 <!-- False Postives. CVE CVE-2022-45129 is against Payara not jakarta.resource-api nor microprofile
  -->
 <suppress>

--- a/messaging/connectors/kafka/src/main/resources/META-INF/native-image/io.helidon.messaging.connectors.kafka/jni-config.json
+++ b/messaging/connectors/kafka/src/main/resources/META-INF/native-image/io.helidon.messaging.connectors.kafka/jni-config.json
@@ -11,7 +11,7 @@
     ]
   },
   {
-    "name": "com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
+    "name": "com.github.luben.zstd.ZstdInputStreamNoFinalizer",
     "fields": [
       {
         "name": "dstPos"

--- a/messaging/connectors/kafka/src/main/resources/META-INF/native-image/io.helidon.messaging.connectors.kafka/native-image.properties
+++ b/messaging/connectors/kafka/src/main/resources/META-INF/native-image/io.helidon.messaging.connectors.kafka/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ Args=--initialize-at-build-time=org.slf4j \
   --initialize-at-build-time=com.github.luben.zstd.ZstdInputStream \
   --initialize-at-build-time=com.github.luben.zstd.ZstdOutputStream \
   --initialize-at-build-time=com.github.luben.zstd.util.Native \
+  --initialize-at-run-time=io.netty.handler.codec.compression.Lz4XXHash32 \
   --initialize-at-run-time=org.apache.kafka.common.security.authenticator.SaslClientAuthenticator \
   --initialize-at-run-time=org.apache.kafka.common.security.oauthbearer.internals.expiring.ExpiringCredentialRefreshingLogin \
   --initialize-at-run-time=org.apache.kafka.common.security.kerberos.KerberosLogin \


### PR DESCRIPTION
Fixes #6626

There is a known issue with OSS and older versions of Kafka [KIP-679](https://cwiki.apache.org/confluence/display/KAFKA/KIP-679%3A+Producer+will+enable+the+strongest+delivery+guarantee+by+default) which enabled backward incompatible feature by default, workaround is explicitly disabling producer idempotence with `enable.idempotence: false`