### PR TITLE
[3.x]: Fix params of @ExampleObject annotations in examples (#6040)

### DIFF
--- a/docs/mp/openapi.adoc
+++ b/docs/mp/openapi.adoc
@@ -118,7 +118,7 @@ Helidon MP QuickStart, enhanced with OpenAPI support.
                 examples = @ExampleObject(
                     name = "greeting",
                     summary = "Example greeting message to update",
-                    value = "{\"greeting\": \"New greeting message\"")))
+                    value = "{\"greeting\": \"New greeting message\"}")))
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public Response updateGreeting(JsonObject jsonObject) {

--- a/docs/mp/openapi.adoc
+++ b/docs/mp/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -114,11 +114,11 @@ Helidon MP QuickStart, enhanced with OpenAPI support.
     description = "Conveys the new greeting prefix to use in building greetings",
     content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(implementation = GreetingMessage.class),
+                schema = @Schema(implementation = GreetingUpdateMessage.class),
                 examples = @ExampleObject(
                     name = "greeting",
                     summary = "Example greeting message to update",
-                    value = "New greeting message")))
+                    value = "{\"greeting\": \"New greeting message\"")))
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public Response updateGreeting(JsonObject jsonObject) {

--- a/docs/mp/openapi/openapi.adoc
+++ b/docs/mp/openapi/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -111,11 +111,11 @@ Helidon MP QuickStart, enhanced with OpenAPI support.
     description = "Conveys the new greeting prefix to use in building greetings",
     content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(implementation = GreetingMessage.class),
+                schema = @Schema(implementation = GreetingUpdateMessage.class),
                 examples = @ExampleObject(
                     name = "greeting",
                     summary = "Example greeting message to update",
-                    value = "New greeting message")))
+                    value = "{\"greeting\": \"New greeting message\"")))
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public Response updateGreeting(JsonObject jsonObject) {

--- a/docs/mp/openapi/openapi.adoc
+++ b/docs/mp/openapi/openapi.adoc
@@ -115,7 +115,7 @@ Helidon MP QuickStart, enhanced with OpenAPI support.
                 examples = @ExampleObject(
                     name = "greeting",
                     summary = "Example greeting message to update",
-                    value = "{\"greeting\": \"New greeting message\"")))
+                    value = "{\"greeting\": \"New greeting message\"}")))
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public Response updateGreeting(JsonObject jsonObject) {

--- a/examples/microprofile/openapi-basic/src/main/java/io/helidon/microprofile/examples/openapi/basic/GreetResource.java
+++ b/examples/microprofile/openapi-basic/src/main/java/io/helidon/microprofile/examples/openapi/basic/GreetResource.java
@@ -132,7 +132,7 @@ public class GreetResource {
                     examples = @ExampleObject(
                         name = "greeting",
                         summary = "Example greeting message to update",
-                        value = "{\"greeting\": \"New greeting message\"")))
+                        value = "{\"greeting\": \"New greeting message\"}")))
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateGreeting(JsonObject jsonObject) {

--- a/examples/microprofile/openapi-basic/src/main/java/io/helidon/microprofile/examples/openapi/basic/GreetResource.java
+++ b/examples/microprofile/openapi-basic/src/main/java/io/helidon/microprofile/examples/openapi/basic/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,11 +128,11 @@ public class GreetResource {
         description = "Conveys the new greeting prefix to use in building greetings",
         content = @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = GreetingMessage.class),
+                    schema = @Schema(implementation = GreetingUpdateMessage.class),
                     examples = @ExampleObject(
                         name = "greeting",
                         summary = "Example greeting message to update",
-                        value = "New greeting message")))
+                        value = "{\"greeting\": \"New greeting message\"")))
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateGreeting(JsonObject jsonObject) {
@@ -183,4 +183,31 @@ public class GreetResource {
             this.message = message;
         }
     }
+
+    /**
+     * POJO defining the greeting to use in future messages.
+     */
+    public static class GreetingUpdateMessage {
+
+        private String greeting;
+
+        /**
+         * Gets the greeting value.
+         *
+         * @return greeting value
+         */
+        public String getGreeting() {
+            return greeting;
+        }
+
+        /**
+         * Sets the greeting value.
+         *
+         * @param greeting greeting value to set
+         */
+        public void setGreeting(String greeting) {
+            this.greeting = greeting;
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #6040 

- [ ] Create backport 2.x

I've found only this `ExampleObject`-annotation. There is no anymore. Also, I changed the schema, because it was wrong as I can see.

I'm not sure about syntax `"{\"greeting\": \"New greeting message\"")))` in the docs.

Kind regards 