### PR TITLE
Support for injection of ServerRequest and ServerResponse also via CDI

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,7 +184,14 @@ class JaxRsService implements HttpService {
     }
 
     private void handle(ServerRequest req, ServerResponse res) {
-        Contexts.runInContext(req.context(), () -> doHandle(req.context(), req, res));
+        Context context = req.context();
+
+        // make these available in context for ServerCdiExtension
+        context.supply(ServerRequest.class, () -> req);
+        context.supply(ServerResponse.class, () -> res);
+
+        // call doHandle in active context
+        Contexts.runInContext(context, () -> doHandle(context, req, res));
     }
 
     private void doHandle(Context ctx, ServerRequest req, ServerResponse res) {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -49,6 +49,7 @@ import io.helidon.nima.webserver.http.HttpService;
 import io.helidon.nima.webserver.http.ServerRequest;
 import io.helidon.nima.webserver.http.ServerResponse;
 import io.helidon.nima.webserver.staticcontent.StaticContentService;
+
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.BeforeDestroyed;

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -24,10 +24,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +49,6 @@ import io.helidon.nima.webserver.http.HttpService;
 import io.helidon.nima.webserver.http.ServerRequest;
 import io.helidon.nima.webserver.http.ServerResponse;
 import io.helidon.nima.webserver.staticcontent.StaticContentService;
-
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.BeforeDestroyed;
@@ -70,7 +67,6 @@ import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.ProcessManagedBean;
 import jakarta.enterprise.inject.spi.ProcessProducerField;
 import jakarta.enterprise.inject.spi.ProcessProducerMethod;
-import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.ext.ParamConverterProvider;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -607,13 +603,8 @@ public class ServerCdiExtension implements Extension {
      */
     static class ServerProducer {
 
-        @SuppressWarnings("all")
-        public static class DefaultAnnotationLiteral extends AnnotationLiteral<Default> implements Default {
-            private static final long serialVersionUID = 1L;
-        }
-
         public Set<Annotation> getQualifiers() {
-            return Collections.singleton(new DefaultAnnotationLiteral());
+            return Collections.singleton(new Default.Literal());
         }
 
         public Class<? extends Annotation> getScope() {
@@ -649,7 +640,7 @@ public class ServerCdiExtension implements Extension {
 
         @Override
         public Set<Type> getTypes() {
-            return new HashSet<>(Arrays.asList(ServerRequest.class, HttpRequest.class, Object.class));
+            return Set.of(ServerRequest.class, HttpRequest.class, Object.class);
         }
 
         @Override
@@ -673,7 +664,7 @@ public class ServerCdiExtension implements Extension {
 
         @Override
         public Set<Type> getTypes() {
-            return new HashSet<>(Arrays.asList(ServerResponse.class, Object.class));
+            return Set.of(ServerResponse.class, Object.class);
         }
 
         @Override

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -386,7 +386,8 @@ public class ServerCdiExtension implements Extension {
                 .addTransitiveTypeClosure(ServerResponse.class)
                 .scope(RequestScoped.class)
                 .createWith(cc -> Contexts.context().flatMap(c -> c.get(ServerResponse.class))
-                        .orElseThrow(() -> new CreationException("Unable to retrieve ServerResponse from context")));    }
+                        .orElseThrow(() -> new CreationException("Unable to retrieve ServerResponse from context")));
+    }
 
     private void registerJaxRsApplications(BeanManager beanManager) {
         JaxRsCdiExtension jaxRs = beanManager.getExtension(JaxRsCdiExtension.class);

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -42,6 +42,7 @@
         <module>mp-compression</module>
         <module>request-scope</module>
         <module>request-scope-cdi</module>
+        <module>request-scope-injection</module>
         <module>jax-rs-multiple-apps</module>
         <module>param-converter-provider</module>
         <module>config-profiles</module>

--- a/tests/functional/request-scope-injection/pom.xml
+++ b/tests/functional/request-scope-injection/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>helidon-tests-functional-project</artifactId>
+        <groupId>io.helidon.tests.functional</groupId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-functional-request-scope-injection</artifactId>
+    <name>Helidon Functional Test: Helidon Request Scope Injection</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/functional/request-scope-injection/src/main/java/io/helidon/tests/functional/context/injection/CheckInjectionResource.java
+++ b/tests/functional/request-scope-injection/src/main/java/io/helidon/tests/functional/context/injection/CheckInjectionResource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.context.injection;
+
+import java.util.Objects;
+
+import io.helidon.nima.webserver.http.ServerRequest;
+import io.helidon.nima.webserver.http.ServerResponse;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Verifies that {@code ServerRequest} and {@code ServerResponse} are injectable
+ * both via {@code @Context} and {@code @Inject}.
+ */
+@Path("/check")
+public class CheckInjectionResource {
+
+    @Context
+    private ServerRequest serverRequest;
+
+    @Context
+    private ServerResponse serverResponse;
+
+    @Inject
+    private ServerRequest serverRequestCdi;
+
+    @Inject
+    private ServerResponse serverResponseCdi;
+
+    @GET
+    public Response checkInjection() {
+        Objects.requireNonNull(serverRequest);
+        Objects.requireNonNull(serverResponse);
+        Objects.requireNonNull(serverRequestCdi);
+        Objects.requireNonNull(serverResponseCdi);
+        if (!serverRequestCdi.path().equals(serverRequest.path())
+                || !serverResponseCdi.status().equals(serverResponse.status())) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+        return Response.ok().build();
+    }
+}

--- a/tests/functional/request-scope-injection/src/main/java/io/helidon/tests/functional/context/injection/package-info.java
+++ b/tests/functional/request-scope-injection/src/main/java/io/helidon/tests/functional/context/injection/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Simple app to verify injection of {@code ServerRequest} and {@code ServerResponse}.
+ */
+package io.helidon.tests.functional.context.injection;

--- a/tests/functional/request-scope-injection/src/main/resources/META-INF/beans.xml
+++ b/tests/functional/request-scope-injection/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/functional/request-scope-injection/src/test/java/io/helidon/tests/functional/context/injection/CheckInjectionTest.java
+++ b/tests/functional/request-scope-injection/src/test/java/io/helidon/tests/functional/context/injection/CheckInjectionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.context.injection;
+
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Unit test for {@link CheckInjectionResource}.
+ */
+@HelidonTest
+class CheckInjectionTest {
+
+    private final WebTarget baseTarget;
+
+    @Inject
+    CheckInjectionTest(WebTarget baseTarget) {
+        this.baseTarget = baseTarget;
+    }
+
+    @Test
+    void testCheckInjection() {
+        WebTarget target = baseTarget.path("/check");
+        assertThat(target.request().get().getStatus(), is(200));
+    }
+}

--- a/tests/functional/request-scope-injection/src/test/resources/logging.properties
+++ b/tests/functional/request-scope-injection/src/test/resources/logging.properties
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+AUDIT.level=FINEST


### PR DESCRIPTION
Support for injection of ServerRequest and ServerResponse also via CDI. New functional test to verify both types of injection. See issue #6698.