### PR TITLE
[2.x]: Fix params of @ExampleObject annotations in examples (#6785)

### DIFF
--- a/examples/cors/src/main/resources/META-INF/openapi.yml
+++ b/examples/cors/src/main/resources/META-INF/openapi.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,11 +45,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GreetingMessage'
+              $ref: '#/components/schemas/GreetingUpdateMessage'
             examples:
               greeting:
                 summary: Example greeting message to update
-                value: New greeting message
+                value: {"greeting": "New greeting message"}
       responses:
         "200":
           description: OK
@@ -76,4 +76,8 @@ components:
     GreetingMessage:
       properties:
         message:
+          type: string
+    GreetingUpdateMessage:
+      properties:
+        greeting:
           type: string

--- a/examples/microprofile/openapi-basic/src/main/java/io/helidon/microprofile/examples/openapi/basic/GreetResource.java
+++ b/examples/microprofile/openapi-basic/src/main/java/io/helidon/microprofile/examples/openapi/basic/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,11 +129,11 @@ public class GreetResource {
         description = "Conveys the new greeting prefix to use in building greetings",
         content = @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = GreetingMessage.class),
+                    schema = @Schema(implementation = GreetingUpdateMessage.class),
                     examples = @ExampleObject(
                         name = "greeting",
                         summary = "Example greeting message to update",
-                        value = "New greeting message")))
+                        value = "{\"greeting\": \"New greeting message\"}")))
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateGreeting(JsonObject jsonObject) {
@@ -184,4 +184,31 @@ public class GreetResource {
             this.message = message;
         }
     }
+
+    /**
+     * POJO defining the greeting to use in future messages.
+     */
+    public static class GreetingUpdateMessage {
+
+        private String greeting;
+
+        /**
+         * Gets the greeting value.
+         *
+         * @return greeting value
+         */
+        public String getGreeting() {
+            return greeting;
+        }
+
+        /**
+         * Sets the greeting value.
+         *
+         * @param greeting greeting value to set
+         */
+        public void setGreeting(String greeting) {
+            this.greeting = greeting;
+        }
+    }
+
 }

--- a/examples/openapi/src/main/resources/META-INF/openapi.yml
+++ b/examples/openapi/src/main/resources/META-INF/openapi.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,11 +45,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GreetingMessage'
+              $ref: '#/components/schemas/GreetingUpdateMessage'
             examples:
               greeting:
                 summary: Example greeting message to update
-                value: New greeting message
+                value: {"greeting": "New greeting message"}
       responses:
         "200":
           description: OK
@@ -76,4 +76,8 @@ components:
     GreetingMessage:
       properties:
         message:
+          type: string
+    GreetingUpdateMessage:
+      properties:
+        greeting:
           type: string


### PR DESCRIPTION
Fixes #6785 

I've found one annotation `@ExampleObject`. I fixed examples for CORS.

Kind regards