### PR TITLE
Improved performance of metric lookups in MetricProducer

### DIFF
--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -119,6 +119,7 @@
                                 <exclude>**/TestMetricsOnOwnSocket.java</exclude>
                                 <exclude>**/TestDisabledMetrics.java</exclude>
                                 <exclude>**/TestConfigProcessing.java</exclude>
+                                <exclude>**/MetricLookupTest.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -133,6 +134,7 @@
                                 <include>**/HelloWorldAsyncResponseTest.java</include>
                                 <include>**/TestExtendedKPIMetrics.java</include>
                                 <include>**/TestMetricsOnOwnSocket.java</include>
+                                <include>**/MetricLookupTest.java</include>
                             </includes>
                         </configuration>
                     </execution>
@@ -149,6 +151,7 @@
                             <excludes>
                                 <exclude>**/HelloWorldTest.java</exclude>
                                 <exclude>**/HelloWorldAsyncResponseWithRestRequestTest.java</exclude>
+                                <exclude>**/MetricLookupTest.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -161,6 +164,9 @@
                             <includes>
                                 <include>**/TestConfigProcessing.java</include>
                             </includes>
+                            <excludes>
+                                <exclude>**/MetricLookupTest.java</exclude>
+                            </excludes>
                             <environmentVariables>
                                 <TAGS>topLevel</TAGS>
                             </environmentVariables>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -20,9 +20,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.Supplier;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -128,37 +126,33 @@ class MetricProducer {
 
     @Produces
     private Counter produceCounter(MetricRegistry registry, InjectionPoint ip) {
-        return produceMetric(registry, ip, Counted.class, registry::getCounters,
-                registry::counter, Counter.class);
+        return produceMetric(registry, ip, Counted.class, registry::counter, Counter.class);
     }
 
     @Produces
     private Meter produceMeter(MetricRegistry registry, InjectionPoint ip) {
-        return produceMetric(registry, ip, Metered.class, registry::getMeters,
-                registry::meter, Meter.class);
+        return produceMetric(registry, ip, Metered.class, registry::meter, Meter.class);
     }
 
     @Produces
     private Timer produceTimer(MetricRegistry registry, InjectionPoint ip) {
-        return produceMetric(registry, ip, Timed.class, registry::getTimers, registry::timer, Timer.class);
+        return produceMetric(registry, ip, Timed.class, registry::timer, Timer.class);
     }
 
     @Produces
     private SimpleTimer produceSimpleTimer(MetricRegistry registry, InjectionPoint ip) {
-        return produceMetric(registry, ip, SimplyTimed.class, registry::getSimpleTimers, registry::simpleTimer,
-                SimpleTimer.class);
+        return produceMetric(registry, ip, SimplyTimed.class, registry::simpleTimer, SimpleTimer.class);
     }
 
     @Produces
     private Histogram produceHistogram(MetricRegistry registry, InjectionPoint ip) {
-        return produceMetric(registry, ip, null, registry::getHistograms,
-                registry::histogram, Histogram.class);
+        return produceMetric(registry, ip, null, registry::histogram, Histogram.class);
     }
 
     @Produces
     private ConcurrentGauge produceConcurrentGauge(MetricRegistry registry, InjectionPoint ip) {
         return produceMetric(registry, ip, org.eclipse.microprofile.metrics.annotation.ConcurrentGauge.class,
-                registry::getConcurrentGauges, registry::concurrentGauge, ConcurrentGauge.class);
+                registry::concurrentGauge, ConcurrentGauge.class);
     }
 
     /**
@@ -190,21 +184,20 @@ class MetricProducer {
      * @param registry metric registry to use
      * @param ip the injection point
      * @param annotationClass annotation which represents a declaration of a metric
-     * @param getTypedMetricsFn caller-provided factory for creating the correct
      * type of metric (if there is no pre-existing one)
      * @param registerFn caller-provided function for registering a newly-created metric
      * @param clazz class for the metric type of interest
      * @return the existing metric (if any), or the newly-created and registered one
      */
-    private <T extends org.eclipse.microprofile.metrics.Metric, U extends Annotation> T produceMetric(MetricRegistry registry,
-            InjectionPoint ip, Class<U> annotationClass, Supplier<Map<MetricID, T>> getTypedMetricsFn,
-            BiFunction<Metadata, Tag[], T> registerFn, Class<T> clazz) {
+    @SuppressWarnings("unchecked")
+    <T extends org.eclipse.microprofile.metrics.Metric, U extends Annotation> T produceMetric(MetricRegistry registry,
+            InjectionPoint ip, Class<U> annotationClass, BiFunction<Metadata, Tag[], T> registerFn, Class<T> clazz) {
 
         final Metric metricAnno = ip.getAnnotated().getAnnotation(Metric.class);
         final Tag[] tags = tags(metricAnno);
         final MetricID metricID = new MetricID(getName(metricAnno, ip), tags);
 
-        T result = getTypedMetricsFn.get().get(metricID);
+        T result = (T) registry.getMetric(metricID);
         if (result != null) {
             final Annotation specificMetricAnno = annotationClass == null ? null
                     : ip.getAnnotated().getAnnotation(annotationClass);

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricLookupTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricLookupTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.metrics;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.IntStream;
+
+import io.helidon.metrics.Registry;
+import io.helidon.metrics.api.RegistrySettings;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.util.AnnotationLiteral;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.lessThan;
+
+public class MetricLookupTest {
+
+    private static final int TOTAL_COUNTERS = 5000;
+    private static final Logger LOGGER = Logger.getLogger(MetricLookupTest.class.getName());
+
+    @Test
+    void testCounterLookup() {
+        Registry registry = Registry.create(MetricRegistry.Type.APPLICATION, RegistrySettings.create());
+        MetricProducer metricProducer = new MetricProducer();
+
+        // register TOTAL_COUNTERS counters in registry
+        IntStream.range(0, TOTAL_COUNTERS).forEach(i -> {
+            MetricID metricID = new MetricID("myMetric", new Tag("tag", Integer.toString(i)));
+            registry.counter(metricID);
+        });
+
+        // lookup TOTAL_COUNTERS counters using MetricProducer
+        long start = System.nanoTime();
+        IntStream.range(0, TOTAL_COUNTERS).forEach(i -> {
+            MetricID metricID = new MetricID("myMetric", new Tag("tag", Integer.toString(i)));
+            Counter counter = metricProducer.produceMetric(registry,
+                    new TestInjectionPoint(metricID),
+                    null,
+                    null,
+                    Counter.class);
+            assertThat(counter, is(notNullValue()));
+        });
+
+        // verify lookup time is bounded
+        int elapsed = (int) Duration.ofNanos(System.nanoTime() - start).toMillis();
+        LOGGER.log(Level.INFO, "Elapsed is " + elapsed + " milliseconds");
+        assertThat(elapsed, lessThan(1000));        // very loose upper bound of 1 second
+    }
+
+    // -- Auxiliary classes ----------------------------------------------------
+
+    static class TestInjectionPoint implements InjectionPoint {
+
+        private final MetricID metricID;
+
+        TestInjectionPoint(MetricID metricID) {
+            this.metricID = metricID;
+        }
+
+        @Override
+        public Type getType() {
+            return null;
+        }
+
+        @Override
+        public Set<Annotation> getQualifiers() {
+            return null;
+        }
+
+        @Override
+        public Bean<?> getBean() {
+            return null;
+        }
+
+        @Override
+        public Member getMember() {
+            return null;
+        }
+
+        @Override
+        public Annotated getAnnotated() {
+            return new Annotated() {
+                @Override
+                public Type getBaseType() {
+                    return null;
+                }
+
+                @Override
+                public Set<Type> getTypeClosure() {
+                    return null;
+                }
+
+                @Override
+                @SuppressWarnings("unchecked")
+                public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
+                    return (T) new MetricLiteral(metricID);
+                }
+
+                @Override
+                public <T extends Annotation> Set<T> getAnnotations(Class<T> annotationType) {
+                    return null;
+                }
+
+                @Override
+                public Set<Annotation> getAnnotations() {
+                    return null;
+                }
+
+                @Override
+                public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+                    return false;
+                }
+            };
+        }
+
+        @Override
+        public boolean isDelegate() {
+            return false;
+        }
+
+        @Override
+        public boolean isTransient() {
+            return false;
+        }
+    }
+
+    static class MetricLiteral extends AnnotationLiteral<org.eclipse.microprofile.metrics.annotation.Metric>
+            implements org.eclipse.microprofile.metrics.annotation.Metric {
+
+        private final MetricID metricID;
+
+        MetricLiteral(MetricID metricID) {
+            this.metricID = metricID;
+        }
+
+        @Override
+        public String name() {
+            return metricID.getName();
+        }
+
+        @Override
+        public String[] tags() {
+            return metricID.getTagsAsList()
+                    .stream()
+                    .map(t -> t.getTagName() + "=" + t.getTagValue())
+                    .toArray(String[]::new);
+        }
+
+        @Override
+        public boolean absolute() {
+            return true;
+        }
+
+        @Override
+        public String displayName() {
+            return metricID.getName();
+        }
+
+        @Override
+        public String description() {
+            return null;
+        }
+
+        @Override
+        public String unit() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Improved performance of metric lookups in MetricProducer. There is no longer filtering by metric type before executing a lookup. New test that bounds the time expected to perform a certain number of calls. See issue #6797.