### PR TITLE
MultiPart Builder improvements

### DIFF
--- a/media/multipart/src/main/java/io/helidon/media/multipart/MultiPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/MultiPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,12 +101,8 @@ public interface MultiPart<T extends BodyPart> {
             if (name == null) {
                 continue;
             }
-            List<T> result = results.get(name);
-            if (result == null) {
-                result = new ArrayList<>();
-                results.put(name, result);
-            }
-            result.add(part);
+            results.computeIfAbsent(name, n -> new ArrayList<>())
+                   .add(part);
         }
         return results;
     }

--- a/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,11 @@
  */
 package io.helidon.media.multipart;
 
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import io.helidon.common.http.DataChunk;
 import io.helidon.media.common.MessageBodyReadableContent;
@@ -140,11 +143,36 @@ public final class ReadableBodyPart implements BodyPart {
 
         /**
          * Set the headers for this part.
+         *
          * @param headers headers
          * @return this builder instance
          */
         public Builder headers(ReadableBodyPartHeaders headers) {
             this.headers = headers;
+            return this;
+        }
+
+        /**
+         * Set the headers for this part.
+         *
+         * @param supplier headers supplier
+         * @return this builder instance
+         */
+        public Builder headers(Supplier<ReadableBodyPartHeaders> supplier) {
+            this.headers = supplier.get();
+            return this;
+        }
+
+        /**
+         * Set the headers for this part.
+         *
+         * @param headers headers map
+         * @return this builder instance
+         */
+        public Builder headers(Map<String, List<String>> headers) {
+            this.headers = ReadableBodyPartHeaders.builder()
+                                                  .headers(headers)
+                                                  .build();
             return this;
         }
 

--- a/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPartHeaders.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPartHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ public final class ReadableBodyPartHeaders extends ReadOnlyParameters implements
 
     /**
      * Create a new instance of {@link ReadableBodyPartHeaders}.
+     *
      * @return ReadableBodyPartHeaders
      */
     public static ReadableBodyPartHeaders create() {
@@ -92,17 +93,37 @@ public final class ReadableBodyPartHeaders extends ReadOnlyParameters implements
         /**
          * Add a new header.
          *
-         * @param name header name
+         * @param name  header name
          * @param value header value
          * @return this builder
          */
-        Builder header(String name, String value) {
-            List<String> values = headers.get(name);
-            if (values == null) {
-                values = new ArrayList<>();
-                headers.put(name, values);
-            }
-            values.add(value);
+        public Builder header(String name, String value) {
+            headers.computeIfAbsent(name, n -> new ArrayList<>())
+                   .add(value);
+            return this;
+        }
+
+        /**
+         * Add a new header.
+         *
+         * @param name   header name
+         * @param values header values
+         * @return this builder
+         */
+        public Builder header(String name, List<String> values) {
+            headers.computeIfAbsent(name, n -> new ArrayList<>())
+                   .addAll(values);
+            return this;
+        }
+
+        /**
+         * Add new headers.
+         *
+         * @param headers headers map
+         * @return this builder
+         */
+        public Builder headers(Map<String, List<String>> headers) {
+            headers.forEach(this::header);
             return this;
         }
 

--- a/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.media.multipart;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Publisher;
+import java.util.function.Supplier;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
@@ -128,8 +131,32 @@ public final class WriteableBodyPart implements BodyPart {
         }
 
         /**
-         * Name which will be used in {@link ContentDisposition}.
+         * Set the headers for this part.
          *
+         * @param supplier headers supplier
+         * @return this builder instance
+         */
+        public Builder headers(Supplier<WriteableBodyPartHeaders> supplier) {
+            this.headers = supplier.get();
+            return this;
+        }
+
+        /**
+         * Set the headers for this part.
+         *
+         * @param headers headers map
+         * @return this builder instance
+         */
+        public Builder headers(Map<String, List<String>> headers) {
+            this.headers = WriteableBodyPartHeaders.builder()
+                                                  .headers(headers)
+                                                  .build();
+            return this;
+        }
+
+        /**
+         * Name which will be used in {@link ContentDisposition}.
+         * <br/>
          * This value will be ignored if an actual instance of {@link WriteableBodyPartHeaders} is set.
          *
          * @param name content disposition name parameter
@@ -142,7 +169,7 @@ public final class WriteableBodyPart implements BodyPart {
 
         /**
          * Filename which will be used in {@link ContentDisposition}.
-         *
+         * <br/>
          * This value will be ignored if an actual instance of {@link WriteableBodyPartHeaders} is set.
          *
          * @param fileName content disposition filename parameter

--- a/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPart.java
@@ -156,7 +156,7 @@ public final class WriteableBodyPart implements BodyPart {
 
         /**
          * Name which will be used in {@link ContentDisposition}.
-         * <br/>
+         * <br>
          * This value will be ignored if an actual instance of {@link WriteableBodyPartHeaders} is set.
          *
          * @param name content disposition name parameter
@@ -169,7 +169,7 @@ public final class WriteableBodyPart implements BodyPart {
 
         /**
          * Filename which will be used in {@link ContentDisposition}.
-         * <br/>
+         * <br>
          * This value will be ignored if an actual instance of {@link WriteableBodyPartHeaders} is set.
          *
          * @param fileName content disposition filename parameter

--- a/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPartHeaders.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/WriteableBodyPartHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,6 +117,30 @@ public final class WriteableBodyPartHeaders extends HashParameters implements Bo
          */
         public Builder header(String name, String value) {
             headers.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
+            return this;
+        }
+
+        /**
+         * Add a new header.
+         *
+         * @param name   header name
+         * @param values header values
+         * @return this builder
+         */
+        public Builder header(String name, List<String> values) {
+            headers.computeIfAbsent(name, n -> new ArrayList<>())
+                   .addAll(values);
+            return this;
+        }
+
+        /**
+         * Add new headers.
+         *
+         * @param headers headers map
+         * @return this builder
+         */
+        public Builder headers(Map<String, List<String>> headers) {
+            headers.forEach(this::header);
             return this;
         }
 

--- a/media/multipart/src/main/java/io/helidon/media/multipart/WriteableMultiPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/WriteableMultiPart.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Writeable multipart entity.
@@ -37,7 +38,7 @@ public class WriteableMultiPart implements MultiPart<WriteableBodyPart> {
     }
 
     /**
-     * Short-hand for creating {@link WriteableMultiPart} instances with the
+     * Shorthand for creating {@link WriteableMultiPart} instances with the
      * specified entities as body parts.
      *
      * @param entities the body part entities
@@ -52,7 +53,22 @@ public class WriteableMultiPart implements MultiPart<WriteableBodyPart> {
     }
 
     /**
-     * Short-hand for creating {@link WriteableMultiPart} instances with the
+     * Shorthand for creating {@link WriteableMultiPart} instances with the
+     * specified entities as body parts.
+     *
+     * @param suppliers suppliers of body part entity
+     * @return created MultiPart
+     */
+    public static WriteableMultiPart create(Supplier<WriteableBodyPart>... suppliers) {
+        Builder builder = builder();
+        for (Supplier<WriteableBodyPart> supplier : suppliers) {
+            builder.bodyPart(supplier);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Shorthand for creating {@link WriteableMultiPart} instances with the
      * specified entities as body parts.
      *
      * @param entities the body part entities
@@ -97,6 +113,16 @@ public class WriteableMultiPart implements MultiPart<WriteableBodyPart> {
         public Builder bodyPart(WriteableBodyPart bodyPart) {
             bodyParts.add(bodyPart);
             return this;
+        }
+
+        /**
+         * Add a body part.
+         *
+         * @param supplier supplier of body part to add
+         * @return this builder instance
+         */
+        public Builder bodyPart(Supplier<WriteableBodyPart> supplier) {
+            return bodyPart(supplier.get());
         }
 
         /**


### PR DESCRIPTION
Update MultiPart builders

- Overload methods with Supplier variants to make `.build()` optional
- Add new methods to `WriteableBodyPartHeaders` and `ReadableBodyPartHeaders`
```java
Builder headers(String name, List<String> values);
Builder headers(Map<String, List<String>> map);
```
  - Overload ReadableBodyPart.Builder.headers and WriteableBodyPart.Builder.headers
```java
Builder headers(Map<String, List<String>> map);
```
- Make `ReadableBodyPartHeaders.Builder.header(String name, String value)` public

Fixes #6843