### PR TITLE
Add option to disable DNS Resolver for WebClient.

### DIFF
--- a/webclient/webclient/pom.xml
+++ b/webclient/webclient/pom.xml
@@ -91,6 +91,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <artifactId>junit-jupiter-params</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/webclient/webclient/src/main/java/io/helidon/webclient/DnsResolverType.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/DnsResolverType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,11 @@ public enum DnsResolverType {
     /**
      * Round Robin DNS resolver.
      */
-    ROUND_ROBIN
+    ROUND_ROBIN,
+
+    /**
+     * No DNS resolver.
+     */
+    NONE
 
 }

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.resolver.NoopAddressResolverGroup;
 import io.netty.resolver.dns.DnsServerAddressStreamProviders;
 import io.netty.resolver.dns.RoundRobinDnsAddressResolverGroup;
 import io.netty.util.AsciiString;
@@ -586,9 +587,16 @@ class WebClientRequestBuilderImpl implements WebClientRequestBuilder {
                     .option(ChannelOption.SO_KEEPALIVE, keepAlive)
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) connectTimeout.toMillis());
 
-            if (dnsResolverType == DnsResolverType.ROUND_ROBIN) {
-                bootstrap.resolver(new RoundRobinDnsAddressResolverGroup(NioDatagramChannel.class,
-                                                                         DnsServerAddressStreamProviders.platformDefault()));
+            switch (dnsResolverType) {
+                case ROUND_ROBIN:
+                    bootstrap.resolver(new RoundRobinDnsAddressResolverGroup(NioDatagramChannel.class,
+                                                                             DnsServerAddressStreamProviders.platformDefault()));
+                    break;
+                case NONE:
+                    bootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
+                    break;
+                default:
+                    // Do nothing and default bootstrap resolver will be used
             }
 
             ChannelFuture channelFuture = keepAlive

--- a/webclient/webclient/src/test/java/io/helidon/webclient/DnsResolverTest.java
+++ b/webclient/webclient/src/test/java/io/helidon/webclient/DnsResolverTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient;
+
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * Unit test for {@link io.helidon.webclient.DnsResolverType}.
+ */
+class DnsResolverTest {
+    @ParameterizedTest
+    @EnumSource(DnsResolverType.class)
+    void testConfig(DnsResolverType dnsResolverType) {
+        WebClientConfiguration webConfig = WebClient.builder()
+                .baseUri("http://localhost:80")
+                .dnsResolverType(dnsResolverType)
+                .configuration();
+        assertThat(webConfig.dnsResolverType(), is(dnsResolverType));
+    }
+
+    @ParameterizedTest
+    @MethodSource("expectedExceptions")
+    void testExpectedException(DnsResolverType dnsResolverType, String exeptionClass) {
+        WebClient webClient = WebClient.builder()
+                .baseUri("http://invalid.site.com")
+                .dnsResolverType(dnsResolverType)
+                .build();
+        WebClientRequestBuilder webClientRequestBuilder = webClient.method("GET");
+        ExecutionException exe = assertThrows(ExecutionException.class, () -> {
+            webClientRequestBuilder.submit().get();
+        });
+        String dnsResolverExceptionClass = exe.getCause().getCause().getClass().getName();
+        assertThat(dnsResolverExceptionClass, endsWith(exeptionClass));
+    }
+
+    private static Stream<Arguments> expectedExceptions() {
+        return Stream.of(
+                arguments(DnsResolverType.NONE, "java.nio.channels.UnresolvedAddressException"),
+                // This can either be io.netty.resolver.dns.DnsResolveContext$SearchDomainUnknownHostException
+                // or java.net.UnknownHostException
+                arguments(DnsResolverType.ROUND_ROBIN, "UnknownHostException"),
+                arguments(DnsResolverType.DEFAULT, "java.net.UnknownHostException")
+        );
+    }
+}


### PR DESCRIPTION
Example usage:
WebClientConfiguration webConfig = WebClient.builder()
                 .baseUri("http://localhost:80")
                 .dnsResolverType(DnsResolverType.NONE)
                 .configuration();