### PR TITLE
Custom Annotation Processor Refinements

### DIFF
--- a/nima/http/processor/src/main/java/io/helidon/nima/http/processor/HttpMethodCreator.java
+++ b/nima/http/processor/src/main/java/io/helidon/nima/http/processor/HttpMethodCreator.java
@@ -121,7 +121,7 @@ public class HttpMethodCreator implements CustomAnnotationTemplateCreator {
 
         // http.params (full string)
         List<HeaderDef> headerList = new LinkedList<>();
-        List<TypedElementInfo> elementArgs = request.targetElementArgs();
+        List<TypedElementInfo> elementArgs = request.targetElement().parameterArguments();
         LinkedList<String> parameters = new LinkedList<>();
         int headerCount = 1;
         for (TypedElementInfo elementArg : elementArgs) {

--- a/pico/processor/src/main/java/io/helidon/pico/processor/CustomAnnotationProcessor.java
+++ b/pico/processor/src/main/java/io/helidon/pico/processor/CustomAnnotationProcessor.java
@@ -16,7 +16,6 @@
 
 package io.helidon.pico.processor;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -31,7 +30,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
@@ -39,7 +37,6 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNameDefault;
-import io.helidon.common.types.TypedElementInfo;
 import io.helidon.pico.api.ServiceInfoBasics;
 import io.helidon.pico.tools.AbstractFilerMessager;
 import io.helidon.pico.tools.CodeGenFiler;
@@ -55,8 +52,6 @@ import static io.helidon.pico.processor.GeneralProcessorUtils.hasValue;
 import static io.helidon.pico.processor.GeneralProcessorUtils.rootStackTraceElementOf;
 import static io.helidon.pico.tools.TypeTools.createTypeNameFromElement;
 import static io.helidon.pico.tools.TypeTools.createTypedElementInfoFromElement;
-import static io.helidon.pico.tools.TypeTools.isStatic;
-import static io.helidon.pico.tools.TypeTools.toAccess;
 import static io.helidon.pico.tools.TypeTools.toFilePath;
 
 /**
@@ -239,25 +234,7 @@ public class CustomAnnotationProcessor extends BaseAnnotationProcessor {
                 .annoTypeName(annoTypeName)
                 .serviceInfo(siInfo)
                 .targetElement(createTypedElementInfoFromElement(typeToProcess, elements).orElseThrow())
-                .enclosingTypeInfo(enclosingClassTypeInfo)
-                // the following are duplicates that should be removed - get them from the enclosingTypeInfo instead
-                // see https://github.com/helidon-io/helidon/issues/6773
-                .targetElementArgs(toArgs(typeToProcess))
-                .targetElementAccess(toAccess(typeToProcess))
-                .elementStatic(isStatic(typeToProcess));
-    }
-
-    List<TypedElementInfo> toArgs(Element typeToProcess) {
-        if (!(typeToProcess instanceof ExecutableElement)) {
-            return List.of();
-        }
-
-        Elements elements = processingEnv.getElementUtils();
-        List<TypedElementInfo> result = new ArrayList<>();
-        ExecutableElement executableElement = (ExecutableElement) typeToProcess;
-        executableElement.getParameters().forEach(v -> result.add(
-                createTypedElementInfoFromElement(v, elements).orElseThrow()));
-        return result;
+                .enclosingTypeInfo(enclosingClassTypeInfo);
     }
 
     private static TypeElement toEnclosingClassTypeElement(Element typeToProcess) {

--- a/pico/processor/src/main/java/io/helidon/pico/processor/GenericTemplateCreatorDefault.java
+++ b/pico/processor/src/main/java/io/helidon/pico/processor/GenericTemplateCreatorDefault.java
@@ -114,14 +114,10 @@ class GenericTemplateCreatorDefault implements GenericTemplateCreator {
         substitutions.put("basicServiceInfo", req.serviceInfo());
         substitutions.put("weight", req.serviceInfo().realizedWeight());
         substitutions.put("runLevel", req.serviceInfo().realizedRunLevel());
-        substitutions.put("elementAccess", req.targetElementAccess());
-        substitutions.put("elementIsStatic", req.isElementStatic());
         substitutions.put("elementKind", req.targetElement().elementTypeKind());
         substitutions.put("elementName", req.targetElement().elementName());
         substitutions.put("elementAnnotations", req.targetElement().annotations());
         substitutions.put("elementEnclosingTypeName", req.targetElement().typeName());
-        substitutions.put("elementArgs", req.targetElementArgs());
-        substitutions.put("elementArgs-declaration", GeneralProcessorUtils.toString(req.targetElementArgs()));
         substitutions.putAll(genericRequest.overrideProperties());
         return substitutions;
     }

--- a/pico/processor/src/test/java/io/helidon/pico/processor/CustomAnnotationProcessorTest.java
+++ b/pico/processor/src/test/java/io/helidon/pico/processor/CustomAnnotationProcessorTest.java
@@ -27,7 +27,6 @@ import io.helidon.common.types.TypeInfoDefault;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
 import io.helidon.common.types.TypedElementInfoDefault;
-import io.helidon.pico.api.ElementInfo;
 import io.helidon.pico.api.ServiceInfoBasics;
 import io.helidon.pico.api.ServiceInfoDefault;
 import io.helidon.pico.processor.testsubjects.BasicEndpoint;
@@ -84,8 +83,6 @@ class CustomAnnotationProcessorTest {
                 .annoTypeName(create(ExtensibleGET.class))
                 .serviceInfo(serviceInfo)
                 .targetElement(target)
-                .targetElementArgs(List.of(arg1))
-                .targetElementAccess(ElementInfo.Access.PUBLIC)
                 .enclosingTypeInfo(enclosingTypeInfo)
                 .genericTemplateCreator(genericTemplateCreator)
                 .build();

--- a/pico/tools/src/main/java/io/helidon/pico/tools/CustomAnnotationTemplateRequest.java
+++ b/pico/tools/src/main/java/io/helidon/pico/tools/CustomAnnotationTemplateRequest.java
@@ -16,14 +16,11 @@
 
 package io.helidon.pico.tools;
 
-import java.util.List;
-
 import io.helidon.builder.Builder;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
 import io.helidon.config.metadata.ConfiguredOption;
-import io.helidon.pico.api.InjectionPointInfo;
 import io.helidon.pico.api.ServiceInfoBasics;
 
 /**
@@ -46,28 +43,6 @@ public interface CustomAnnotationTemplateRequest {
      * @return the target element being processed
      */
     TypedElementInfo targetElement();
-
-    /**
-     * The access modifier of the element.
-     *
-     * @return the access modifier of the element
-     */
-    InjectionPointInfo.Access targetElementAccess();
-
-    /**
-     * Only applicable for {@link javax.lang.model.element.ElementKind#METHOD} or
-     * {@link javax.lang.model.element.ElementKind#CONSTRUCTOR}.
-     *
-     * @return the list of typed arguments for this method or constructor
-     */
-    List<TypedElementInfo> targetElementArgs();
-
-    /**
-     * Returns true if the element is declared to be static.
-     *
-     * @return returns true if the element is declared to be private
-     */
-    boolean isElementStatic();
 
     /**
      * Projects the {@link #enclosingTypeInfo()} as a {@link ServiceInfoBasics} type.


### PR DESCRIPTION
Addresses issue #6773 . Removes a few duplicate APIs that are now part of `TypeInfo`. 