### PR TITLE
TCK Tracking: Jakarta EE 10 Core Profile #6799

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -140,7 +140,7 @@
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.perfmark-api>0.25.0</version.lib.perfmark-api>
-        <version.lib.parsson>1.0.2</version.lib.parsson>
+        <version.lib.parsson>1.1.2</version.lib.parsson>
         <version.lib.postgresql>42.4.3</version.lib.postgresql>
         <version.lib.prometheus>0.16.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>

--- a/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -136,18 +136,20 @@ public class ConfigCdiExtension implements Extension {
     private <X> void harvestConfigPropertyInjectionPointsFromEnabledObserverMethod(@Observes ProcessObserverMethod<?, X> event,
                                                                                    BeanManager beanManager) {
         AnnotatedMethod<X> annotatedMethod = event.getAnnotatedMethod();
-        List<AnnotatedParameter<X>> annotatedParameters = annotatedMethod.getParameters();
-        if (annotatedParameters != null) {
-            for (AnnotatedParameter<?> annotatedParameter : annotatedParameters) {
-                if ((annotatedParameter != null)
-                        && !annotatedParameter.isAnnotationPresent(Observes.class)) {
-                    InjectionPoint injectionPoint = beanManager.createInjectionPoint(annotatedParameter);
-                    Set<Annotation> qualifiers = injectionPoint.getQualifiers();
-                    assert qualifiers != null;
-                    for (Annotation qualifier : qualifiers) {
-                        if (qualifier instanceof ConfigProperty) {
-                            ips.add(injectionPoint);
-                            break;
+        if (annotatedMethod != null) {
+            List<AnnotatedParameter<X>> annotatedParameters = annotatedMethod.getParameters();
+            if (annotatedParameters != null) {
+                for (AnnotatedParameter<?> annotatedParameter : annotatedParameters) {
+                    if ((annotatedParameter != null)
+                            && !annotatedParameter.isAnnotationPresent(Observes.class)) {
+                        InjectionPoint injectionPoint = beanManager.createInjectionPoint(annotatedParameter);
+                        Set<Annotation> qualifiers = injectionPoint.getQualifiers();
+                        assert qualifiers != null;
+                        for (Annotation qualifier : qualifiers) {
+                            if (qualifier instanceof ConfigProperty) {
+                                ips.add(injectionPoint);
+                                break;
+                            }
                         }
                     }
                 }

--- a/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/HelidonContainerConfiguration.java
+++ b/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/HelidonContainerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.jboss.arquillian.container.spi.client.container.ContainerConfiguratio
  * is empty)</li>
  * <li>replaceConfigSourcesWithMp: (Optional) defaults to false: whether to replace config sources with microprofile if it
  * exists</li>
+ * <li>inWebContainer: defaults to false: sets web app context root, load WEB-INF/beans.xml and find any jakarta.ws.rs.core.Application in the webapp classes</li>
  * </ul>
  */
 public class HelidonContainerConfiguration implements ContainerConfiguration {
@@ -45,6 +46,7 @@ public class HelidonContainerConfiguration implements ContainerConfiguration {
     private boolean deleteTmp = true;
     private boolean useRelativePath = false;
     private boolean useParentClassloader = true;
+    private boolean inWebContainer = false;
     private final List<Consumer<ConfigBuilder>> builderConsumers = new ArrayList<>();
 
     /**
@@ -102,6 +104,14 @@ public class HelidonContainerConfiguration implements ContainerConfiguration {
 
     public void setUseParentClassloader(boolean useParentClassloader) {
         this.useParentClassloader = useParentClassloader;
+    }
+
+    public boolean isInWebContainer() {
+        return inWebContainer;
+    }
+
+    public void setInWebContainer(boolean inWebContainer) {
+        this.inWebContainer = inWebContainer;
     }
 
     @Override

--- a/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/HelidonContainerExtension.java
+++ b/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/HelidonContainerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package io.helidon.microprofile.arquillian;
 
 import java.lang.reflect.Method;
-import java.util.Optional;
 
 import jakarta.enterprise.context.control.RequestContextController;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -29,6 +28,7 @@ import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.testenricher.cdi.CDIInjectionEnricher;
+import org.testng.annotations.Test;
 
 /**
  * An arquillian LoadableExtension defining the {@link HelidonDeployableContainer}.
@@ -44,6 +44,8 @@ class HelidonContainerExtension implements LoadableExtension {
      */
     static class HelidonCDIInjectionEnricher extends CDIInjectionEnricher {
 
+        private static final String ARQUILLIAN_DATA_PROVIDER = "ARQUILLIAN_DATA_PROVIDER";
+        private static final Object[] EMPTY = new Object[0];
         private BeanManager beanManager;
         private RequestContextController requestContextController;
 
@@ -78,11 +80,11 @@ class HelidonContainerExtension implements LoadableExtension {
 
         @Override
         public Object[] resolve(Method method) {
-            return Optional.ofNullable(method.getAnnotation(org.testng.annotations.Test.class))
-                           .filter(test -> !test.dataProvider().isEmpty())
-                           // Don't resolve TestNG data providers parameters as cdi beans
-                           .map(unused -> new Object[0])
-                           .orElseGet(() -> super.resolve(method));
+            Test test = method.getAnnotation(org.testng.annotations.Test.class);
+            if (test != null && !ARQUILLIAN_DATA_PROVIDER.equals(test.dataProvider())) {
+                return EMPTY;
+            }
+            return super.resolve(method);
         }
 
         private static CDI<Object> cdi() {

--- a/microprofile/tests/arquillian/src/main/resources/templates/beans.xml
+++ b/microprofile/tests/arquillian/src/main/resources/templates/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-                           https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="all">
 </beans>
 

--- a/microprofile/tests/tck/pom.xml
+++ b/microprofile/tests/tck/pom.xml
@@ -43,6 +43,13 @@
         <module>tck-reactive-operators</module>
         <module>tck-lra</module>
         <module>tck-telemetry</module>
+        <module>tck-core-profile</module>
+        <module>tck-cdi</module>
+        <module>tck-restfull</module>
+        <module>tck-jsonb</module>
+        <module>tck-jsonp</module>
+        <module>tck-inject</module>
+        <module>tck-annotations</module>
     </modules>
 
     <properties>
@@ -51,34 +58,6 @@
          -->
         <enforcer.skip>true</enforcer.skip>
     </properties>
-
-
-
-    <dependencies>
-         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-testng</artifactId>
-                            <version>${version.plugin.surefire}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 
     <profiles>
         <profile>

--- a/microprofile/tests/tck/tck-annotations/pom.xml
+++ b/microprofile/tests/tck/tck-annotations/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>tck-annotations</artifactId>
+    <name>Helidon Microprofile Tests TCK Annotations</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- If you use proxy you need to set it as a system properties -->
+                                <get skipexisting="true" src="https://download.eclipse.org/jakartaee/annotations/2.1/jakarta-annotations-tck-${version.lib.jakarta.annotation-api}.zip" dest="jakarta-annotations-tck-${version.lib.jakarta.annotation-api}.zip"/>
+                                <unzip src="jakarta-annotations-tck-${version.lib.jakarta.annotation-api}.zip" dest="./target"/>
+                                <exec executable="java">
+                                    <arg line="-cp ${project.build.directory}/annotations-tck/lib/sigtest.jar:${project.build.directory}/lib/jakarta.annotation-api-${version.lib.jakarta.annotation-api}.jar"/>
+                                    <arg line="com.sun.tdk.signaturetest.SignatureTest"/>
+                                    <arg line="-FileName ${project.build.directory}/annotations-tck/src/com/sun/ts/tests/signaturetest/signature-repository/jakarta.annotation.sig"/>
+                                    <arg line="-Package jakarta.annotation"/>
+                                    <arg line="-Package jakarta.annotation.security"/>
+                                    <arg line="-Package jakarta.annotation.sql"/>
+                                    <arg line="-IgnoreJDKClass java.lang.Enum"/>
+                                    <arg line="-IgnoreJDKClass java.lang.annotation.Repeatable"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-cdi/pom.xml
+++ b/microprofile/tests/tck/tck-cdi/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>tck-project</artifactId>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>tck-cdi</artifactId>
+    <name>Helidon Microprofile Tests TCK CDI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-arquillian</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>cdi-tck-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>cdi-tck-core-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-porting-package-tck</artifactId>
+            <scope>test</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <excludedGroups>cdi-full,se</excludedGroups>
+                    <dependenciesToScan>
+                        <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
+                    </dependenciesToScan>
+                    <includes>
+                        <include>org/jboss/cdi/tck/tests/**/*Test.java</include>
+                        <include>org/jboss/cdi/tck/interceptors/DependentContextTesttests/**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>org/jboss/cdi/tck/tests/fulSyntheticBeanWithLookupTestl/extensions/lifecycle/bbd/broken/passivatingScope/AddingPassivatingScopeTest.java</exclude>
+                        <!-- FIXME: Next tests must be enabled -->
+                        <exclude>org/jboss/cdi/tck/tests/build/compatible/extensions/changeObserverQualifier/ChangeObserverQualifierTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/build/compatible/extensions/customStereotype/CustomStereotypeTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/build/compatible/extensions/syntheticBeanWithLookup/SyntheticBeanWithLookupTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/context/dependent/DependentContextTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/definition/bean/types/ManagedBeanTypesTest.java</exclude>
+                        <exclude>org/jboss/cdi.tck/tests/event/EventTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/event/lifecycle/StartupShutdownTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/event/observer/broken/validation/unsatisfied/ObserverMethodParameterInjectionValidationTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/event/observer/broken/validation/ambiguous/ObserverMethodParameterInjectionValidationTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/event/observer/runtimeException/ObserverExceptionRethrownTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/event/observer/conditional/ConditionalObserverTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/event/observer/ObserverNotificationTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/event/observer/async/executor/FireAsyncWithCustomExecutorTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/inheritance/generics/MemberLevelInheritanceTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/privateConstructor/PrivateConstructorTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/lookup/clientProxy/unproxyable/beanConstructor/BeanConstructorWithParametersTest.java</exclude>
+                        <exclude>org/jboss/cdi/tck/tests/implementation/simple/lifecycle/unproxyable/UnproxyableManagedBeanTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-cdi/src/test/java/io/helidon/microprofile/cdi/tck/UrlLoaderExtension.java
+++ b/microprofile/tests/tck/tck-cdi/src/test/java/io/helidon/microprofile/cdi/tck/UrlLoaderExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cdi.tck;
+
+import org.jboss.arquillian.container.test.impl.enricher.resource.URLResourceProvider;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * LoadableExtension tht will load UrlResourceProvider.
+ */
+public class UrlLoaderExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.override(ResourceProvider.class, URLResourceProvider.class, UrlResourceProvider.class);
+    }
+}

--- a/microprofile/tests/tck/tck-cdi/src/test/java/io/helidon/microprofile/cdi/tck/UrlResourceProvider.java
+++ b/microprofile/tests/tck/tck-cdi/src/test/java/io/helidon/microprofile/cdi/tck/UrlResourceProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cdi.tck;
+
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * TCKs use addition when creating URL for a client. The default Arquillian implementation returns url without the trailing
+ * /.
+ */
+public class UrlResourceProvider implements ResourceProvider {
+    @Override
+    public Object lookup(ArquillianResource arquillianResource, Annotation... annotations) {
+        try {
+            return URI.create("http://localhost:8080/").toURL();
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return URL.class.isAssignableFrom(type);
+    }
+}

--- a/microprofile/tests/tck/tck-cdi/src/test/resources/META-INF/beans.xml
+++ b/microprofile/tests/tck/tck-cdi/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/tests/tck/tck-cdi/src/test/resources/META-INF/cdi-tck.properties
+++ b/microprofile/tests/tck/tck-cdi/src/test/resources/META-INF/cdi-tck.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.jboss.cdi.tck.cdiLiteMode=true
+org.jboss.cdi.tck.libraryDirectory=
+org.jboss.cdi.tck.testDataSource=
+org.jboss.cdi.tck.testJmsConnectionFactory=
+org.jboss.cdi.tck.testJmsQueue=
+org.jboss.cdi.tck.testJmsTopic=
+org.jboss.cdi.tck.spi.Beans=org.jboss.weld.tck.BeansImpl
+org.jboss.cdi.tck.spi.Contexts=org.jboss.weld.tck.ContextsImpl
+org.jboss.cdi.tck.spi.EL=org.jboss.weld.tck.ELImpl

--- a/microprofile/tests/tck/tck-cdi/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/microprofile/tests/tck/tck-cdi/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.microprofile.cdi.tck.UrlLoaderExtension
+

--- a/microprofile/tests/tck/tck-cdi/src/test/resources/application.yaml
+++ b/microprofile/tests/tck/tck-cdi/src/test/resources/application.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mp:
+  initializer:
+    allow: true

--- a/microprofile/tests/tck/tck-cdi/src/test/resources/arquillian.xml
+++ b/microprofile/tests/tck/tck-cdi/src/test/resources/arquillian.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://jboss.org/schema/arquillian"
+        xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <engine>
+        <property name="deploymentExportPath">target/deployments</property>
+        <property name="port">8080</property>
+    </engine>
+    <container qualifier="helidon-embedded" default="true">
+        <configuration>
+            <property name="inWebContainer">true</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/microprofile/tests/tck/tck-core-profile/README.md
+++ b/microprofile/tests/tck/tck-core-profile/README.md
@@ -1,0 +1,3 @@
+# artifact-install.sh
+
+This file is used from an ant script in this module to install TCK artifacts in the local Maven repository

--- a/microprofile/tests/tck/tck-core-profile/artifact-install.sh
+++ b/microprofile/tests/tck/tck-core-profile/artifact-install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##script to install the artifact directory contents into a local maven repository
+
+VERSION="$1"
+
+# pom
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=target/core-profile-tck-"$VERSION"/artifacts/core-tck-parent-"$VERSION".pom -DgroupId=jakarta.ee.tck.coreprofile \
+-DartifactId=core-tck-parent -Dversion="$VERSION" -Dpackaging=pom
+
+# jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=target/core-profile-tck-"$VERSION"/artifacts/core-profile-tck-impl-"$VERSION".jar -DgroupId=jakarta.ee.tck.coreprofile \
+-DartifactId=core-profile-tck-impl -Dversion="$VERSION" -Dpackaging=jar

--- a/microprofile/tests/tck/tck-core-profile/pom.xml
+++ b/microprofile/tests/tck/tck-core-profile/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+    <artifactId>tck-core-profile</artifactId>
+    <name>Helidon Microprofile Tests TCK Core Profile</name>
+
+    <modules>
+        <module>tck-core-profile-test</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- If you use proxy you need to set it as a system properties -->
+                                <get skipexisting="true" src="https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip" dest="jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip"/>
+                                <unzip src="jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip" dest="./target"/>
+                                <chmod file="artifact-install.sh" perm="+x"/>
+                                <exec executable="sh">
+                                    <arg line="artifact-install.sh ${version.lib.microprofile-core-profile}"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/pom.xml
+++ b/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-core-profile</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>tck-core-profile-test</artifactId>
+    <name>Helidon Microprofile Tests TCK Core Profile</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-arquillian</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ee.tck.coreprofile</groupId>
+            <artifactId>core-profile-tck-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>jakarta.ee.tck.coreprofile:core-profile-tck-impl</dependency>
+                    </dependenciesToScan>
+                    <includes>
+                        <include>*IT.java</include>
+                    </includes>
+                    <!-- FIXME: Enable when this https://github.com/jakartaee/platform-tck/pull/1178 is integrated -->
+                    <excludes>
+                        <exclude>ee/jakarta/tck/core/jsonb/JsonbApplicationIT.java</exclude>
+                        <exclude>ee/jakarta/tck/core/json/ApplicationJsonpIT.java</exclude>
+                        <exclude>ee/jakarta/tck/core/rest/jsonb/cdi/CustomJsonbSerializationIT.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/src/test/java/io/helidon/microprofile/coreprofile/tck/UrlLoaderExtension.java
+++ b/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/src/test/java/io/helidon/microprofile/coreprofile/tck/UrlLoaderExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.coreprofile.tck;
+
+import org.jboss.arquillian.container.test.impl.enricher.resource.URLResourceProvider;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * LoadableExtension tht will load UrlResourceProvider.
+ */
+public class UrlLoaderExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.override(ResourceProvider.class, URLResourceProvider.class, UrlResourceProvider.class);
+    }
+}

--- a/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/src/test/java/io/helidon/microprofile/coreprofile/tck/UrlResourceProvider.java
+++ b/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/src/test/java/io/helidon/microprofile/coreprofile/tck/UrlResourceProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.coreprofile.tck;
+
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * TCKs use addition when creating URL for a client. The default Arquillian implementation returns url without the trailing
+ * /.
+ */
+public class UrlResourceProvider implements ResourceProvider {
+    @Override
+    public Object lookup(ArquillianResource arquillianResource, Annotation... annotations) {
+        try {
+            return URI.create("http://localhost:8080/").toURL();
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return URL.class.isAssignableFrom(type);
+    }
+}

--- a/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.microprofile.coreprofile.tck.UrlLoaderExtension
+

--- a/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/src/test/resources/arquillian.xml
+++ b/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/src/test/resources/arquillian.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <engine>
+        <property name="deploymentExportPath">target/deployments</property>
+    </engine>
+    <container qualifier="helidon-embedded" default="true">
+        <configuration>
+            <property name="useWebInfBeans">true</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/microprofile/tests/tck/tck-graphql/pom.xml
+++ b/microprofile/tests/tck/tck-graphql/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -56,6 +56,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-inject/README.md
+++ b/microprofile/tests/tck/tck-inject/README.md
@@ -1,0 +1,3 @@
+# artifact-install.sh
+
+This file is used from an ant script in this module to install TCK artifacts in the local Maven repository

--- a/microprofile/tests/tck/tck-inject/artifact-install.sh
+++ b/microprofile/tests/tck/tck-inject/artifact-install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##script to install the artifact directory contents into a local maven repository
+
+VERSION="$1"
+
+# jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=target/jakarta.inject-tck-"$VERSION"/jakarta.inject-tck-"$VERSION".jar -DgroupId=jakarta.inject \
+-DartifactId=jakarta.inject-tck -Dversion="$VERSION" -Dpackaging=jar

--- a/microprofile/tests/tck/tck-inject/pom.xml
+++ b/microprofile/tests/tck/tck-inject/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+    <artifactId>tck-inject</artifactId>
+    <name>Helidon Microprofile Tests TCK Inject</name>
+
+    <modules>
+        <module>tck-inject-test</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- If you use proxy you need to set it as a system properties -->
+                                <get skipexisting="true" src="https://download.eclipse.org/jakartaee/dependency-injection/2.0/jakarta.inject-tck-2.0.2-bin.zip" dest="jakarta.inject-tck-2.0.2-bin.zip"/>
+                                <unzip src="jakarta.inject-tck-2.0.2-bin.zip" dest="./target"/>
+                                <chmod file="artifact-install.sh" perm="+x"/>
+                                <exec executable="sh">
+                                    <arg line="artifact-install.sh 2.0.2"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-inject/tck-inject-test/pom.xml
+++ b/microprofile/tests/tck/tck-inject/tck-inject-test/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-inject</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>tck-inject-tests</artifactId>
+    <name>Helidon Microprofile Tests TCK Inject</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.weld</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-tck</artifactId>
+            <version>${version.lib.jakarta.inject}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>io.helidon.microprofile.tests.inject.TckInjectTest.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/java</source>
+                                <source>../target/jakarta.inject-tck-2.0.2/example/src/test/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-inject/tck-inject-test/src/test/java/io/helidon/microprofile/tests/inject/TckInjectTest.java
+++ b/microprofile/tests/tck/tck-inject/tck-inject-test/src/test/java/io/helidon/microprofile/tests/inject/TckInjectTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.inject;
+
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import org.atinject.tck.Tck;
+import org.atinject.tck.auto.Car;
+import org.atinject.tck.auto.Convertible;
+import org.atinject.tck.auto.DriversSeat;
+import org.atinject.tck.auto.FuelTank;
+import org.atinject.tck.auto.Seat;
+import org.atinject.tck.auto.Seatbelt;
+import org.atinject.tck.auto.Tire;
+import org.atinject.tck.auto.V8Engine;
+import org.atinject.tck.auto.accessories.Cupholder;
+import org.atinject.tck.auto.accessories.RoundThing;
+import org.atinject.tck.auto.accessories.SpareTire;
+import org.junit.jupiter.api.Test;
+
+class TckInjectTest {
+    
+    @Test
+    void test() {
+        SeContainer container = SeContainerInitializer
+                .newInstance()
+                .addExtensions(weld.AtInjectTCKExtension.class)
+                .addBeanClasses(Car.class, Convertible.class, DriversSeat.class, FuelTank.class, Seat.class,
+                        Seatbelt.class, Tire.class, V8Engine.class, Cupholder.class, RoundThing.class,
+                        SpareTire.class)
+                .initialize();
+        Car tckCar = container.select(Car.class).get();
+        Tck.testsFor(tckCar, false, true);
+    }
+
+}

--- a/microprofile/tests/tck/tck-inject/tck-inject-test/src/test/resources/META-INF/services/jakarta.enterprise.inject.se.SeContainerInitializer
+++ b/microprofile/tests/tck/tck-inject/tck-inject-test/src/test/resources/META-INF/services/jakarta.enterprise.inject.se.SeContainerInitializer
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.microprofile.cdi.HelidonContainerInitializer

--- a/microprofile/tests/tck/tck-inject/tck-inject-test/src/test/resources/application.yaml
+++ b/microprofile/tests/tck/tck-inject/tck-inject-test/src/test/resources/application.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mp:
+  initializer:
+    allow: true

--- a/microprofile/tests/tck/tck-jsonb/pom.xml
+++ b/microprofile/tests/tck/tck-jsonb/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+    <artifactId>tck-jsonb</artifactId>
+    <name>Helidon Microprofile Tests TCK JSONB</name>
+
+    <modules>
+        <module>tck-jsonb-test</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- If you use proxy you need to set it as a system properties -->
+                                <get skipexisting="true" src="https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/promoted/eftl/jakarta-jsonb-tck-${version.lib.jakarta.jsonb-api}.zip" dest="jakarta-jsonb-tck-${version.lib.jakarta.jsonb-api}.zip"/>
+                                <unzip src="jakarta-jsonb-tck-${version.lib.jakarta.jsonb-api}.zip" dest="./target"/>
+                                <chmod file="target/jsonb-tck/artifacts/artifact-install.sh" perm="+x"/>
+                                <exec dir="target/jsonb-tck/artifacts" executable="sh">
+                                    <arg line="artifact-install.sh"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-jsonb/tck-jsonb-test/pom.xml
+++ b/microprofile/tests/tck/tck-jsonb/tck-jsonb-test/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-jsonb</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>tck-jsonb-tests</artifactId>
+    <name>Helidon Microprofile Tests TCK JSONB</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-tck</artifactId>
+            <version>${version.lib.jakarta.jsonb-api}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <!-- FIXME update it in dependencies/pom.xml. Currently this version makes opentracing tcks to fail  -->
+            <version>3.0.3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>jakarta.json.bind:jakarta.json.bind-tck</dependency>
+                    </dependenciesToScan>
+                    <includes>
+                        <include>*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>*CDITest.java</exclude>
+                        <exclude>*JSONBSigTest.java</exclude>
+                        <exclude>NumberFormatCustomizationTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-jsonp/README.md
+++ b/microprofile/tests/tck/tck-jsonp/README.md
@@ -1,0 +1,3 @@
+# artifact-install.sh
+
+This file is used from an ant script in this module to install TCK artifacts in the local Maven repository

--- a/microprofile/tests/tck/tck-jsonp/artifact-install.sh
+++ b/microprofile/tests/tck/tck-jsonp/artifact-install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##script to install the artifact directory contents into a local maven repository
+
+VERSION="$1"
+
+# Parent pom
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-"$VERSION".pom -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck -Dversion="$VERSION" -Dpackaging=pom
+
+# pom
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-common-"$VERSION".pom -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-common -Dversion="$VERSION" -Dpackaging=pom
+
+# jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-common-"$VERSION".jar -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-common -Dversion="$VERSION" -Dpackaging=jar
+
+# sources jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-common-"$VERSION"-sources.jar -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-common-sources -Dversion="$VERSION" -Dpackaging=jar
+
+# pom
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-tests-"$VERSION".pom -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-tests -Dversion="$VERSION" -Dpackaging=pom
+
+# jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-tests-"$VERSION".jar -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-tests -Dversion="$VERSION" -Dpackaging=jar
+
+# sources jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-tests-"$VERSION"-sources.jar -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-tests-sources -Dversion="$VERSION" -Dpackaging=jar
+
+# pom
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-tests-pluggability-"$VERSION".pom -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-tests-pluggability -Dversion="$VERSION" -Dpackaging=pom
+
+# jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-tests-pluggability-"$VERSION".jar -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-tests-pluggability -Dversion="$VERSION" -Dpackaging=jar
+
+# sources jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta.json-tck-tests-pluggability-"$VERSION"-sources.jar -DgroupId=jakarta.json \
+-DartifactId=jakarta.json-tck-tests-pluggability-sources -Dversion="$VERSION" -Dpackaging=jar

--- a/microprofile/tests/tck/tck-jsonp/pom.xml
+++ b/microprofile/tests/tck/tck-jsonp/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+    <artifactId>tck-jsonp</artifactId>
+    <name>Helidon Microprofile Tests TCK JSONP</name>
+
+    <modules>
+        <module>tck-jsonp-test</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- If you use proxy you need to set it as a system properties -->
+                                <get skipexisting="true" src="https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/promoted/eftl/jakarta-jsonp-tck-2.1.0.zip" dest="jakarta-jsonp-tck-2.1.0.zip"/>
+                                <unzip src="jakarta-jsonp-tck-2.1.0.zip" dest="./target"/>
+                                <copy file="artifact-install.sh" todir="target/jsonp-tck/artifacts"/>
+                                <chmod file="target/jsonp-tck/artifacts/artifact-install.sh" perm="+x"/>
+                                <exec dir="target/jsonp-tck/artifacts" executable="sh">
+                                    <arg line="artifact-install.sh 2.1.0"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-jsonp/tck-jsonp-test/pom.xml
+++ b/microprofile/tests/tck/tck-jsonp/tck-jsonp-test/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-jsonp</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>tck-jsonp-test</artifactId>
+    <name>Helidon Microprofile Tests TCK JSONP</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Dependencies coming from below maven-antrun-plugin -->
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-tck-tests</artifactId>
+            <version>${version.lib.jakarta.jsonp-api}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>jakarta.json:jakarta.json-tck-tests</dependency>
+                    </dependenciesToScan>
+                    <includes>
+                        <include>*Tests.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-jwt-auth/pom.xml
+++ b/microprofile/tests/tck/tck-jwt-auth/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>arquillian-container-test-spi</artifactId>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-openapi/pom.xml
+++ b/microprofile/tests/tck/tck-openapi/pom.xml
@@ -96,6 +96,11 @@
             <version>2.3.2</version>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>helidon-microprofile-tracing</artifactId>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-reactive-operators/pom.xml
+++ b/microprofile/tests/tck/tck-reactive-operators/pom.xml
@@ -51,6 +51,11 @@
             <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
             <artifactId>microprofile-reactive-streams-operators-tck</artifactId>
         </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-rest-client/pom.xml
+++ b/microprofile/tests/tck/tck-rest-client/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-restfull/README.md
+++ b/microprofile/tests/tck/tck-restfull/README.md
@@ -1,0 +1,3 @@
+# artifact-install.sh
+
+This file is used from an ant script in this module to install TCK artifacts in the local Maven repository

--- a/microprofile/tests/tck/tck-restfull/artifact-install.sh
+++ b/microprofile/tests/tck/tck-restfull/artifact-install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##script to install the artifact directory contents into a local maven repository
+
+VERSION="$1"
+
+# jar
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=target/jakarta-restful-ws-tck-"$VERSION".jar -DgroupId=jakarta.ws.rs \
+-DartifactId=jakarta-restful-ws-tck -Dversion="$VERSION" -Dpackaging=jar

--- a/microprofile/tests/tck/tck-restfull/pom.xml
+++ b/microprofile/tests/tck/tck-restfull/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+    <artifactId>tck-restfull</artifactId>
+    <name>Helidon Microprofile Tests TCK Restfull</name>
+
+    <modules>
+        <module>tck-restfull-test</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- If you use proxy you need to set it as a system properties -->
+                                <get skipexisting="true" src="https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-${version.lib.microprofile-restfull-tck}.zip" dest="jakarta-restful-ws-tck-${version.lib.microprofile-restfull-tck}.zip"/>
+                                <unzip src="jakarta-restful-ws-tck-${version.lib.microprofile-restfull-tck}.zip" dest="./target"/>
+                                <chmod file="artifact-install.sh" perm="+x"/>
+                                <exec executable="sh">
+                                    <arg line="artifact-install.sh ${version.lib.microprofile-restfull-tck}"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-restfull/tck-restfull-test/pom.xml
+++ b/microprofile/tests/tck/tck-restfull/tck-restfull-test/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tck-restfull</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>tck-resfull-test</artifactId>
+    <name>Helidon Microprofile Tests TCK Restfull</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-arquillian</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta-restful-ws-tck</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-jaxb</artifactId>
+        </dependency>
+     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <dependenciesToScan>
+                        <dependency>jakarta.ws.rs:jakarta-restful-ws-tck</dependency>
+                    </dependenciesToScan>
+                    <includes>
+                        <include>*IT.java</include>
+                    </includes>
+                    <excludes>
+                        <!-- Gets stuck -->
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/core/request/JAXRSClientIT.java</exclude>
+                        <!-- FIXME: Next tests must be enabled -->
+                        <exclude>ee/jakarta/tck/ws/rs/spec/client/exceptions/ClientExceptionsIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/pathparam/sub/JAXRSSubClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/matrixparam/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/spec/resourceconstructor/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/pathparam/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/beanparam/plain/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/ext/providers/JAXRSProvidersClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsink/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/spec/provider/sort/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/cookieparam/locator/JAXRSLocatorClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/headerparam/sub/JAXRSSubClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/ext/paramconverter/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/beanparam/matrix/plain/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/beanparam/path/plain/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/pathparam/locator/JAXRSLocatorClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/spec/provider/standard/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/signaturetest/jaxrs/JAXRSSigTestIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/queryparam/sub/JAXRSSubClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/jaxrs21/ee/client/executor/rx/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/spec/contextprovider/JsonbContextProviderIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/spec/resource/locator/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/matrixparam/locator/JAXRSLocatorClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/ssebroadcaster/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/core/configurable/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/spec/resource/annotationprecedence/subclass/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/sebootstrap/SeBootstrapIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/core/uriinfo/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/cookieparam/sub/JAXRSSubClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/matrixparam/sub/JAXRSSubClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/formparam/sub/JAXRSSubClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/formparam/locator/JAXRSLocatorClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/servlet3/rs/applicationpath/JAXRSClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/ee/rs/headerparam/locator/JAXRSLocatorClientIT.java</exclude>
+                        <exclude>ee/jakarta/tck/ws/rs/spec/resource/valueofandfromstring/JAXRSClientIT.java</exclude>
+                    </excludes>
+                    <excludedGroups>xml_binding,servlet,security</excludedGroups>
+                    <systemPropertyVariables>
+                        <webServerHost>localhost</webServerHost>
+                        <webServerPort>8080</webServerPort>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/tests/tck/tck-restfull/tck-restfull-test/src/test/java/io/helidon/microprofile/restfull/tck/UrlLoaderExtension.java
+++ b/microprofile/tests/tck/tck-restfull/tck-restfull-test/src/test/java/io/helidon/microprofile/restfull/tck/UrlLoaderExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.restfull.tck;
+
+import org.jboss.arquillian.container.test.impl.enricher.resource.URLResourceProvider;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * LoadableExtension tht will load UrlResourceProvider.
+ */
+public class UrlLoaderExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.override(ResourceProvider.class, URLResourceProvider.class, UrlResourceProvider.class);
+    }
+}

--- a/microprofile/tests/tck/tck-restfull/tck-restfull-test/src/test/java/io/helidon/microprofile/restfull/tck/UrlResourceProvider.java
+++ b/microprofile/tests/tck/tck-restfull/tck-restfull-test/src/test/java/io/helidon/microprofile/restfull/tck/UrlResourceProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.restfull.tck;
+
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * TCKs use addition when creating URL for a client. The default Arquillian implementation returns url without the trailing
+ * /.
+ */
+public class UrlResourceProvider implements ResourceProvider {
+    @Override
+    public Object lookup(ArquillianResource arquillianResource, Annotation... annotations) {
+        try {
+            return URI.create("http://localhost:8080/").toURL();
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return URL.class.isAssignableFrom(type);
+    }
+}

--- a/microprofile/tests/tck/tck-restfull/tck-restfull-test/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/microprofile/tests/tck/tck-restfull/tck-restfull-test/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.microprofile.restfull.tck.UrlLoaderExtension
+

--- a/microprofile/tests/tck/tck-restfull/tck-restfull-test/src/test/resources/arquillian.xml
+++ b/microprofile/tests/tck/tck-restfull/tck-restfull-test/src/test/resources/arquillian.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <engine>
+        <property name="deploymentExportPath">target/deployments</property>
+        <property name="port">8080</property>
+    </engine>
+    <container qualifier="helidon-embedded" default="true">
+        <configuration>
+            <property name="useRelativePath">false</property>
+            <property name="inWebContainer">true</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/microprofile/tests/tck/tck-telemetry/pom.xml
+++ b/microprofile/tests/tck/tck-telemetry/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>microprofile-telemetry-tracing-tck</artifactId>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
         <version.lib.checkstyle>9.1</version.lib.checkstyle>
         <version.lib.commons-io>2.11.0</version.lib.commons-io>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
+        <version.lib.microprofile-core-profile>10.0.1</version.lib.microprofile-core-profile>
+        <version.lib.microprofile-cdi-tck>4.0.10</version.lib.microprofile-cdi-tck>
+        <version.lib.microprofile-restfull-tck>3.1.3</version.lib.microprofile-restfull-tck>
         <!-- Silence javadoc error org.jboss.logging.annotations.Message$Format not found -->
         <version.lib.jboss-logging-annotations>2.2.1.Final</version.lib.jboss-logging-annotations>
         <version.lib.jsoup>1.15.3</version.lib.jsoup>
@@ -94,6 +97,7 @@
         <!-- maven plugin versions -->
         <version.plugin.archetype-packaging>3.1.2</version.plugin.archetype-packaging>
         <version.plugin.archetype>3.1.2</version.plugin.archetype>
+        <version.plugin.ant>3.1.0</version.plugin.ant>
         <version.plugin.build-helper>3.4.0</version.plugin.build-helper>
         <version.plugin.checkstyle>3.1.2</version.plugin.checkstyle>
         <version.plugin.compiler>3.11.0</version.plugin.compiler>
@@ -770,6 +774,10 @@
                         <mode>fail</mode>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${version.plugin.ant}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -943,6 +951,26 @@
                 <version>${version.lib.opentracing}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.ee.tck.coreprofile</groupId>
+                <artifactId>core-profile-tck-impl</artifactId>
+                <version>${version.lib.microprofile-core-profile}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>cdi-tck-core-impl</artifactId>
+                <version>${version.lib.microprofile-cdi-tck}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>cdi-tck-api</artifactId>
+                <version>${version.lib.microprofile-cdi-tck}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta-restful-ws-tck</artifactId>
+                <version>${version.lib.microprofile-restfull-tck}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.akarnokd</groupId>
                 <artifactId>rxjava2-jdk9-interop</artifactId>
                 <version>${version.lib.rxjava2-jdk9-interop}</version>
@@ -966,6 +994,11 @@
                 <groupId>org.eclipse.jgit</groupId>
                 <artifactId>org.eclipse.jgit.junit</artifactId>
                 <version>${version.lib.jgit}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-porting-package-tck</artifactId>
+                <version>${version.lib.weld}</version>
             </dependency>
             <dependency>
                 <groupId>io.zipkin.zipkin2</groupId>


### PR DESCRIPTION
Relates to https://github.com/helidon-io/helidon/issues/6799

Some TCK tests are excluded in restfull and cdi. You can see them with a `<!-- FIXME: Next tests must be enabled -->` in the pom file. I will create a new issue to address that.

URL of the TCKS:
https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/promoted/eftl/