### PR TITLE
3.x: Upgrade maven-dependency-plugin to 3.6.0

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <maven.compiler.release>${maven.compiler.source}</maven.compiler.release>
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
-        <version.plugin.dependency>3.1.2</version.plugin.dependency>
+        <version.plugin.dependency>3.6.0</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
         <version.plugin.helidon>3.0.5</version.plugin.helidon>
@@ -105,7 +105,6 @@
                                 <overWriteIfNewer>true</overWriteIfNewer>
                                 <overWriteIfNewer>true</overWriteIfNewer>
                                 <includeScope>runtime</includeScope>
-                                <excludeScope>test</excludeScope>
                             </configuration>
                         </execution>
                     </executions>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- plugin versions -->
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
-        <version.plugin.dependency>3.0.0</version.plugin.dependency>
+        <version.plugin.dependency>3.6.0</version.plugin.dependency>
         <version.plugin.eclipselink>2.7.5.1</version.plugin.eclipselink>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
@@ -188,7 +188,6 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <includeScope>runtime</includeScope>
-                            <excludeScope>test</excludeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- plugin versions -->
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
-        <version.plugin.dependency>3.0.0</version.plugin.dependency>
+        <version.plugin.dependency>3.6.0</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
         <version.plugin.helidon>3.0.5</version.plugin.helidon>
@@ -196,7 +196,6 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <includeScope>runtime</includeScope>
-                            <excludeScope>test</excludeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <version.plugin.build-helper>1.12</version.plugin.build-helper>
         <version.plugin.checkstyle>3.1.2</version.plugin.checkstyle>
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
-        <version.plugin.dependency>3.1.2</version.plugin.dependency>
+        <version.plugin.dependency>3.6.0</version.plugin.dependency>
         <version.plugin.directory>1.0</version.plugin.directory>
         <version.plugin.eclipselink>2.7.5.1</version.plugin.eclipselink>
         <version.plugin.enforcer>3.0.0-M1</version.plugin.enforcer>


### PR DESCRIPTION
This upgrade the version of the maven-dependency-plugin used by the Helidon build and Helidon applications. At some point the behavior of `<excludeScope>test</excludeScope>` changed and is no longer what we want (see https://maven.apache.org/plugins/maven-dependency-plugin/copy-dependencies-mojo.html).

