### PR TITLE
[1.x] Fix native-image with Netty >= 4.1.83.Final

### DIFF
--- a/webserver/webserver/src/main/resources/META-INF/native-image/helidon-webserver-reflection-config.json
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/helidon-webserver-reflection-config.json
@@ -3,5 +3,9 @@
         "name": "io.netty.channel.socket.nio.NioServerSocketChannel",
         "allPublicConstructors": true,
         "allPublicMethods": true
+    },
+    {
+        "name": "io.netty.channel.DefaultChannelPipeline$TailContext",
+        "queryAllDeclaredMethods" : true
     }
 ]


### PR DESCRIPTION
Add a reflection configuration entry in WebServer for io.netty.channel.DefaultChannelPipeline$TailContext
 Fixes #6869