### PR TITLE
Response should not be chunked if there is no entity

### DIFF
--- a/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.helidon.webserver.utils.SocketHttpClient.entityFromResponse;
 import static io.helidon.webserver.utils.SocketHttpClient.headersFromResponse;
@@ -61,6 +63,9 @@ public class PlainTest {
     private static final Logger LOGGER = Logger.getLogger(PlainTest.class.getName());
     private static final RuntimeException TEST_EXCEPTION = new RuntimeException("BOOM!");
     private static WebServer webServer;
+    private static String singleEntityResponse = "SingleEntity";
+    private static String contentLengthDataPrefix = "Server:";
+    private static String sSEEntityResponse = "id: 1\ndata: foo\nevent: bar";
 
     /**
      * Start the Web Server
@@ -69,65 +74,102 @@ public class PlainTest {
     static void startServer() {
         webServer = WebServer.builder()
                 .host("localhost")
-                .routing(Routing.builder().any((req, res) -> {
+                .routing(Routing.builder()
+                        // ex. path = "/emptyResponse200" or "/emptyResponse301"
+                        .get("/emptyResponse*", (req, res) -> {
+                            setResponseStatusCodeFromPath(req, res);
+                            res.send();
+                        })
+                        // ex. path = "/singleResponse200" or "/singleResponse301"
+                        .get("/singleEntityResponse*", (req, res) -> {
+                            setResponseStatusCodeFromPath(req, res);
+                            res.send(singleEntityResponse);
+                        })
+                        .get("/SSE", (req, res) -> {
+                            res.headers().add(Http.Header.CONTENT_TYPE, "text/event-stream");
+                            res.send(sSEEntityResponse);
+                        })
+                        // ex. path = "/multiFirstError" or "/multiFirstErrorChunked"
+                        .get("/multiFirstError*", (req, res) -> {
+                            setResponseToChunkFromPath(req, res);
+                            res.send(Multi.error(TEST_EXCEPTION));
+                        })
+                        // ex. path = "/multiSecondError" or "/multiSecondErrorChunked"
+                        .get("/multiSecondError*", (req, res) -> {
+                            setResponseToChunkFromPath(req, res);
+                            res.send(Multi.concat(Multi.just("test1\n").map(s -> DataChunk.create(s.getBytes())),
+                                                  Multi.error(TEST_EXCEPTION)));
+                        })
+                        // ex. path = "/multiThirdError" or "/multiThirdErrorChunked"
+                        .get("/multiThirdError*", (req, res) -> {
+                            setResponseToChunkFromPath(req, res);
+                            res.send(Multi.concat(Multi.just("test1\n").map(s -> DataChunk.create(s.getBytes())),
+                                                  Multi.just("test2\n").map(s -> DataChunk.create(s.getBytes())),
+                                                  Multi.error(TEST_EXCEPTION)));
+                        })
+                        .get("/contentLength*", (req, res) -> {
+                            String path = req.path().toString();
+                            int noOfChunks = Integer.valueOf(path.substring(path.length() - 1));
+                            res.addHeader(Http.Header.CONTENT_LENGTH, String.valueOf((contentLengthDataPrefix.length() + 1) * noOfChunks))
+                                    .send(Multi.range(0, noOfChunks)
+                                                  .map(i -> contentLengthDataPrefix + i)
+                                                  .map(String::getBytes)
+                                                  .map(DataChunk::create));
+                        })
+                        .any((req, res) -> {
                             res.headers().add(Http.Header.TRANSFER_ENCODING, "chunked");
                             req.next();
                         })
-                                 .any("/exception", (req, res) -> {
-                                     throw new RuntimeException("my always thrown exception");
-                                 })
-                                 .get("/", (req, res) -> {
-                                     res.send("It works!");
-                                 })
-                                 .post("/unconsumed", (req, res) -> res.send("Payload not consumed!"))
-                                 .any("/deferred", (req, res) -> ForkJoinPool.commonPool().submit(() -> {
-                                     Thread.yield();
-                                     res.send("I'm deferred!");
-                                 }))
-                                 .trace("/trace", (req, res) -> {
-                                     res.send("In trace!");
-                                 })
-                                 .get("/force-chunked", (req, res) -> {
-                                     res.headers().put(Http.Header.TRANSFER_ENCODING, "chunked");
-                                     res.send("abcd");
-                                 })
-                                 .get("/multi", (req, res) -> {
-                                     res.send(Multi.just("test 1", "test 2", "test 3")
-                                                      .map(String::getBytes)
-                                                      .map(DataChunk::create));
-                                 })
-                                 .get("/multiFirstError", (req, res) -> {
-                                     res.send(Multi.error(TEST_EXCEPTION));
-                                 })
-                                 .get("/multiSecondError", (req, res) -> {
-                                     res.send(Multi.concat(Multi.just("test1\n").map(s -> DataChunk.create(s.getBytes())),
-                                                           Multi.error(TEST_EXCEPTION)));
-                                 })
-                                 .get("/multiThirdError", (req, res) -> {
-                                     res.send(Multi.concat(Multi.just("test1\n").map(s -> DataChunk.create(s.getBytes())),
-                                                           Multi.error(TEST_EXCEPTION)));
-                                 })
-                                 .get("/multiDelayedThirdError", (req, res) -> {
-                                     res.send(Multi.interval(100, 100, TimeUnit.MILLISECONDS,
-                                                             Executors.newSingleThreadScheduledExecutor())
-                                                      .peek(i -> {
-                                                          if (i > 2) {
-                                                              throw TEST_EXCEPTION;
-                                                          }
-                                                      })
-                                                      .map(i -> DataChunk.create(("test " + i).getBytes())));
-                                 })
-                                 .get("/multi", (req, res) -> {
-                                     res.send(Multi.just("test1", "test2")
-                                                      .map(i -> DataChunk.create(String.valueOf(i).getBytes())));
-                                 })
-                                 .get("/absoluteUri", (req, res) -> {
-                                     res.send(req.absoluteUri().toString());
-                                 })
-                                 .any(Handler.create(String.class, (req, res, entity) -> {
-                                     res.send("It works! Payload: " + entity);
-                                 }))
-                                 .build())
+                        .any("/exception", (req, res) -> {
+                            throw new RuntimeException("my always thrown exception");
+                        })
+                        .get("/", (req, res) -> {
+                            res.send("It works!");
+                        })
+                        .post("/unconsumed", (req, res) -> res.send("Payload not consumed!"))
+                        .any("/deferred", (req, res) -> ForkJoinPool.commonPool().submit(() -> {
+                            Thread.yield();
+                            res.send("I'm deferred!");
+                        }))
+                        .trace("/trace", (req, res) -> {
+                            res.send("In trace!");
+                        })
+                        .get("/force-chunked*", (req, res) -> {
+                            res.headers().put(Http.Header.TRANSFER_ENCODING, "chunked");
+                            if (req.path().toString().contains("-emptyResponse")) {
+                                // ex. path = "/force-chunked-emptyResponse200" or "/force-chunked-emptyResponse301"
+                                setResponseStatusCodeFromPath(req, res);
+                                res.send();
+                            } else {
+                                res.send("abcd");
+                            }
+                        })
+                        .get("/multi", (req, res) -> {
+                            res.send(Multi.just("test 1", "test 2", "test 3")
+                                             .map(String::getBytes)
+                                             .map(DataChunk::create));
+                        })
+                        .get("/multiDelayedThirdError", (req, res) -> {
+                            res.send(Multi.interval(100, 100, TimeUnit.MILLISECONDS,
+                                                    Executors.newSingleThreadScheduledExecutor())
+                                             .peek(i -> {
+                                                 if (i > 2) {
+                                                     throw TEST_EXCEPTION;
+                                                 }
+                                             })
+                                             .map(i -> DataChunk.create(("test " + i).getBytes())));
+                        })
+                        .get("/multi", (req, res) -> {
+                            res.send(Multi.just("test1", "test2")
+                                             .map(i -> DataChunk.create(String.valueOf(i).getBytes())));
+                        })
+                        .get("/absoluteUri", (req, res) -> {
+                            res.send(req.absoluteUri().toString());
+                        })
+                        .any(Handler.create(String.class, (req, res, entity) -> {
+                            res.send("It works! Payload: " + entity);
+                        }))
+                        .build())
                 .build()
                 .start()
                 .await(10, TimeUnit.SECONDS);
@@ -487,37 +529,52 @@ public class PlainTest {
      * stream-status: 500
      * stream-result: java.lang.RuntimeException: BOOM!
      */
-    @Test
-    public void testMultiFirstError() throws Exception {
-        String s = SocketHttpClient.sendAndReceive("/multiFirstError",
+    @ParameterizedTest
+    @ValueSource(strings = {"", "Chunked"})
+    public void testMultiFirstError(String pathSuffix) throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/multiFirstError" + pathSuffix,
                                                    Http.Method.GET,
                                                    null, webServer);
-        System.out.println(s);
 
+        // Response status has not been sent yet before the exception took place, so server has still a chance to set it to 500.
         assertThat(s, startsWith("HTTP/1.1 500 Internal Server Error\n"));
+        Map<String, String> headers = headersFromResponse(s);
+        assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.TRANSFER_ENCODING), is("chunked")));
+
         assertThat(headersFromResponse(s), hasKey(equalToIgnoringCase(Http.Header.TRAILER)));
         Map<String, String> trailerHeaders = cutTrailerHeaders(s);
         assertThat(trailerHeaders, hasEntry(equalToIgnoringCase("stream-status"), is("500")));
         assertThat(trailerHeaders, hasEntry(equalToIgnoringCase("stream-result"), is(TEST_EXCEPTION.toString())));
     }
 
-    @Test
-    public void testMultiSecondError() throws Exception {
-        String s = SocketHttpClient.sendAndReceive("/multiSecondError",
+    @ParameterizedTest
+    @ValueSource(strings = {"", "Chunked"})
+    public void testMultiSecondError(String pathSuffix) throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/multiSecondError" + pathSuffix,
                                                    Http.Method.GET,
                                                    null, webServer);
-        assertThat(s, startsWith("HTTP/1.1 200 OK\n"));
+        // When response is not chunked and no content-length is set, and the error takes place after the 1st chunk, the
+        // status has not been sent yet, so it still has a chance to set it to 500. On the other hand, if response is set to
+        // chunked, the status has already been sent before the error took place and hence will get the actual status code.
+        String expectedStatus = pathSuffix.isEmpty() ? "500 Internal Server Error" : "200 OK";
+        assertThat(s, startsWith("HTTP/1.1 " + expectedStatus + "\n"));
+        Map<String, String> headers = headersFromResponse(s);
+        assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.TRANSFER_ENCODING), is("chunked")));
         Map<String, String> trailerHeaders = cutTrailerHeaders(s);
         assertThat(trailerHeaders, hasEntry("stream-status", "500"));
         assertThat(trailerHeaders, hasEntry("stream-result", TEST_EXCEPTION.toString()));
     }
 
-    @Test
-    public void testMultiThirdError() throws Exception {
-        String s = SocketHttpClient.sendAndReceive("/multiThirdError",
+    @ParameterizedTest
+    @ValueSource(strings = {"", "Chunked"})
+    public void testMultiThirdError(String pathSuffix) throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/multiThirdError" + pathSuffix,
                                                    Http.Method.GET,
                                                    null, webServer);
+        // Response status has already been sent before the exception took place, hence getting the 200 instead of 500.
         assertThat(s, startsWith("HTTP/1.1 200 OK\n"));
+        Map<String, String> headers = headersFromResponse(s);
+        assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.TRANSFER_ENCODING), is("chunked")));
         Map<String, String> trailerHeaders = cutTrailerHeaders(s);
         assertThat(trailerHeaders, hasEntry("stream-status", "500"));
         assertThat(trailerHeaders, hasEntry("stream-result", TEST_EXCEPTION.toString()));
@@ -548,6 +605,98 @@ public class PlainTest {
         Map<String, String> headers = cutTrailerHeaders(s);
         assertThat(headers, hasEntry("stream-status", "500"));
         assertThat(headers, hasEntry("stream-result", TEST_EXCEPTION.toString()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"301", "200"})
+    void testEmptyResponse(String responseStatus) throws Exception {
+        // ex. path = "/emptyResponse200" or "/emptyResponse301"
+        String s = SocketHttpClient.sendAndReceive("/emptyResponse" + responseStatus,
+                                                   Http.Method.GET,
+                                                   null, webServer);
+        assertThat(s, startsWith("HTTP/1.1 " + responseStatus));
+        Map<String, String> headers = headersFromResponse(s);
+        assertThat(headers, not(hasKey(Http.Header.TRANSFER_ENCODING)));
+        assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.CONTENT_LENGTH), is("0")));
+        // Verify that there is no entity
+        assertThat(entityFromResponse(s, false), is(""));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"301", "200"})
+    void testForcedChunkedEmptyResponse(String responseStatus) throws Exception {
+        // ex. path = "/force-chunked-emptyResponse200" or "/force-chunked-emptyResponse301"
+        String s = SocketHttpClient.sendAndReceive("/force-chunked-emptyResponse" + responseStatus,
+                                                   Http.Method.GET,
+                                                   null, webServer);
+        assertThat(s, startsWith("HTTP/1.1 " + responseStatus));
+        Map<String, String> headers = headersFromResponse(s);
+        assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.TRANSFER_ENCODING), is("chunked")));
+        assertThat(headers, not(hasKey(Http.Header.CONTENT_LENGTH)));
+        // Verify that there is no entity
+        assertThat(entityFromResponse(s, false), is("0\n\n"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"301", "200"})
+    void testSingleEntityResponse(String responseStatus) throws Exception {
+        // ex. path = "/singleResponse200" or "/singleResponse301"
+        String s = SocketHttpClient.sendAndReceive("/singleEntityResponse" + responseStatus,
+                                                   Http.Method.GET,
+                                                   null, webServer);
+        assertThat(s, startsWith("HTTP/1.1 " + responseStatus));
+        Map<String, String> headers = headersFromResponse(s);
+        assertThat(headers, not(hasKey(Http.Header.TRANSFER_ENCODING)));
+        assertThat(headers,
+                   hasEntry(equalToIgnoringCase(Http.Header.CONTENT_LENGTH), is(String.valueOf(singleEntityResponse.length()))));
+        // Verify that entity received is correct
+        assertThat(entityFromResponse(s, false), is(singleEntityResponse));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 5})
+    void testContentLength(int entityCount) throws Exception {
+        // ex. path = "/contentLength0" or "/contentLength1" or "/contentLength5"
+        String s = SocketHttpClient.sendAndReceive("/contentLength" + entityCount,
+                                                   Http.Method.GET,
+                                                   null, webServer);
+        assertThat(s, startsWith("HTTP/1.1 200 OK\n"));
+        Map<String, String> headers = headersFromResponse(s);
+        String contentLength = String.valueOf((contentLengthDataPrefix.length() + 1) * entityCount);
+        assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.CONTENT_LENGTH), is(contentLength)));
+        String expectedResponse = "";
+        for (int i = 0; i < entityCount; i++) {
+            expectedResponse += contentLengthDataPrefix + i;
+        }
+        assertThat(entityFromResponse(s, false), is(expectedResponse));
+    }
+
+    @Test
+    void testSSEShouldBeChunked() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/SSE",
+                                                   Http.Method.GET,
+                                                   null, webServer);
+        assertThat(s, startsWith("HTTP/1.1 200 OK"));
+        Map<String, String> headers = headersFromResponse(s);
+        assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.TRANSFER_ENCODING), is("chunked")));
+        assertThat(headers, hasEntry(equalToIgnoringCase(Http.Header.CONNECTION), is("keep-alive")));
+        assertThat(headers, not(hasKey(Http.Header.CONTENT_LENGTH)));
+        // Verify that entity received is correct
+        assertThat(entityFromResponse(s, false),
+                   is(Integer.toHexString(sSEEntityResponse.length()) + "\n" + sSEEntityResponse + "\n0\n\n"));
+    }
+
+    // Extract last 3 string from path and use as response status code
+    private static void setResponseStatusCodeFromPath(ServerRequest req, ServerResponse res) {
+        String path = req.path().toString();
+        int responseStatus = Integer.valueOf(path.substring(path.length() - 3));
+        res.status(responseStatus);
+    }
+
+    private static void setResponseToChunkFromPath(ServerRequest req, ServerResponse res) {
+        if (req.path().toString().endsWith("Chunked")) {
+            res.headers().add(Http.Header.TRANSFER_ENCODING, "chunked");
+        }
     }
 
     private Map<String, String> cutTrailerHeaders(String response) {


### PR DESCRIPTION
NOTE: Difference with 3.x PR 6637 is that 2.x has WebSocket request and when it is used, writeStatusAndHeaders() needs to send the header right via initWriteResponse()