### PR TITLE
3.x: Upgrade graphql to 18.5 and scalars to 18.3

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -56,8 +56,8 @@
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.google-protobuf>3.21.7</version.lib.google-protobuf>
         <version.lib.graalvm>22.3.0</version.lib.graalvm>
-        <version.lib.graphql-java>17.5</version.lib.graphql-java>
-        <version.lib.graphql-java.extended.scalars>17.1</version.lib.graphql-java.extended.scalars>
+        <version.lib.graphql-java>19.5</version.lib.graphql-java>
+        <version.lib.graphql-java.extended.scalars>19.1</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
         <version.lib.grpc>1.54.1</version.lib.grpc>
         <version.lib.guava>31.1-jre</version.lib.guava>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -56,8 +56,8 @@
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.google-protobuf>3.21.7</version.lib.google-protobuf>
         <version.lib.graalvm>22.3.0</version.lib.graalvm>
-        <version.lib.graphql-java>19.5</version.lib.graphql-java>
-        <version.lib.graphql-java.extended.scalars>19.1</version.lib.graphql-java.extended.scalars>
+        <version.lib.graphql-java>18.5</version.lib.graphql-java>
+        <version.lib.graphql-java.extended.scalars>18.3</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
         <version.lib.grpc>1.54.1</version.lib.grpc>
         <version.lib.guava>31.1-jre</version.lib.guava>

--- a/microprofile/graphql/server/src/main/java/module-info.java
+++ b/microprofile/graphql/server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/graphql/server/src/main/java/module-info.java
+++ b/microprofile/graphql/server/src/main/java/module-info.java
@@ -38,7 +38,7 @@ module io.helidon.microprofile.graphql.server {
     requires io.helidon.microprofile.server;
 
     requires com.graphqljava;
-    requires graphql.java.extended.scalars;
+    requires com.graphqljava.extendedscalars;
     requires microprofile.graphql.api;
     requires microprofile.config.api;
 


### PR DESCRIPTION
Upgrades graphql and fixes #6133

Tried 19.5 but it failed microprofile graphql tck.