### PR TITLE
4.x: Make check for audience claim in access token optional in OIDC provider

### DIFF
--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -959,8 +959,7 @@ public class Jwt {
      *                 issuer claim mandatory
      * @param audience validates that this JWT was issued for this audience. Setting this to non-null value will make
      *                 audience claim mandatory
-     * @param checkAudience whether audience claim check is turned on. Validation will fail when {@code true}
-     *                      and audience claim is null
+     * @param checkAudience whether audience claim validation should be executed
      * @return errors instance to check for validation result
      */
     public Errors validate(String issuer, String audience, boolean checkAudience) {
@@ -982,8 +981,7 @@ public class Jwt {
      *                 issuer claim mandatory
      * @param audience validates that this JWT was issued for this audience. Setting this to non-null value and with
      *                 any non-null value in the Set will make audience claim mandatory
-     * @param checkAudience whether audience claim check is configured as mandatory. Validation will fail when {@code true}
-     *                      and audience claim is null
+     * @param checkAudience whether audience claim validation should be executed
      * @return errors instance to check for validation result
      */
     public Errors validate(String issuer, Set<String> audience, boolean checkAudience) {

--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -953,6 +953,22 @@ public class Jwt {
 
     /**
      * Validates all default values.
+     * Values validated: {@link #validate(String, Set, boolean)}
+     *
+     * @param issuer   validates that this JWT was issued by this issuer. Setting this to non-null value will make
+     *                 issuer claim mandatory
+     * @param audience validates that this JWT was issued for this audience. Setting this to non-null value will make
+     *                 audience claim mandatory
+     * @param checkAudience whether audience claim check is turned on. Validation will fail when {@code true}
+     *                      and audience claim is null
+     * @return errors instance to check for validation result
+     */
+    public Errors validate(String issuer, String audience, boolean checkAudience) {
+        return validate(issuer, audience == null ? Set.of() : Set.of(audience), checkAudience);
+    }
+
+    /**
+     * Validates all default values.
      * Values validated:
      * <ul>
      * <li>{@link #expirationTime() Expiration time} if defined</li>
@@ -966,21 +982,41 @@ public class Jwt {
      *                 issuer claim mandatory
      * @param audience validates that this JWT was issued for this audience. Setting this to non-null value and with
      *                 any non-null value in the Set will make audience claim mandatory
+     * @param checkAudience whether audience claim check is configured as mandatory. Validation will fail when {@code true}
+     *                      and audience claim is null
      * @return errors instance to check for validation result
      */
-    public Errors validate(String issuer, Set<String> audience) {
+    public Errors validate(String issuer, Set<String> audience, boolean checkAudience) {
         List<Validator<Jwt>> validators = defaultTimeValidators();
         if (null != issuer) {
             addIssuerValidator(validators, issuer, true);
         }
-        if (null != audience) {
-            audience.stream()
-                    .filter(Objects::nonNull)
-                    .findAny()
-                    .ifPresent(it -> addAudienceValidator(validators, audience, true));
+        // Audience check is turned on
+        if (checkAudience) {
+            if (null != audience) {
+                audience.stream()
+                        .filter(Objects::nonNull)
+                        .findAny()
+                        .ifPresent(it -> addAudienceValidator(validators, audience, true));
+            }
         }
         addUserPrincipalValidator(validators);
         return validate(validators);
+    }
+
+    /**
+     * Validates all default values.
+     * Audience claim check is not mandatory.
+     * Values validated: {@link #validate(String, Set, boolean)}
+     *
+     * @param issuer   validates that this JWT was issued by this issuer. Setting this to non-null value will make
+     *                 issuer claim mandatory
+     * @param audience validates that this JWT was issued for this audience. Setting this to non-null value and with
+     *                 any non-null value in the Set will make audience claim mandatory
+     * @return errors instance to check for validation result
+     */
+    public Errors validate(String issuer, Set<String> audience) {
+        return validate(issuer, audience, true);
     }
 
     /**

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
@@ -65,6 +65,8 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
     private URI introspectUri;
     private String scopeAudience;
     private boolean useWellKnown = true;
+    // Audience claim is optional
+    private boolean optionalAudience = false;
 
     BaseBuilder() {
     }
@@ -78,7 +80,7 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
         OidcUtil.validateExists(collector, clientSecret, "Client Secret", "client-secret");
         OidcUtil.validateExists(collector, identityUri, "Identity URI", "identity-uri");
 
-        if ((audience == null) && (identityUri != null)) {
+        if (audience == null && !optionalAudience && identityUri != null) {
             this.audience = identityUri.toString();
         }
         // first set of validations
@@ -501,4 +503,13 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
     String name() {
         return TenantConfigFinder.DEFAULT_TENANT_ID;
     }
+
+    boolean optionalAudience() {
+        return optionalAudience;
+    }
+
+    void setOptionalAudience(boolean optional) {
+        this.optionalAudience = optional;
+    }
+
 }

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
@@ -420,6 +420,18 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
         return identity();
     }
 
+    /**
+     * Allow audience claim to be optional.
+     *
+     * @param optional whether the audience claim is optional (true) or not (false)
+     * @return updated builder instance
+     */
+    @ConfiguredOption("false")
+    public B optionalAudience(boolean optional) {
+        this.optionalAudience = optional;
+        return identity();
+    }
+
     private void clientTimeoutMillis(long millis) {
         this.clientTimeout(Duration.ofMillis(millis));
     }
@@ -506,10 +518,6 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
 
     boolean optionalAudience() {
         return optionalAudience;
-    }
-
-    void setOptionalAudience(boolean optional) {
-        this.optionalAudience = optional;
     }
 
 }

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
@@ -65,7 +65,7 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
     private URI introspectUri;
     private String scopeAudience;
     private boolean useWellKnown = true;
-    // Audience claim is optional
+    // Whether audience claim is optional
     private boolean optionalAudience = false;
 
     BaseBuilder() {
@@ -126,6 +126,7 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
         config.get("server-type").asString().ifPresent(this::serverType);
 
         config.get("client-timeout-millis").asLong().ifPresent(this::clientTimeoutMillis);
+        config.get("optional-audience").asBoolean().ifPresent(this::optionalAudience);
         return identity();
     }
 
@@ -514,10 +515,6 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
 
     String name() {
         return TenantConfigFinder.DEFAULT_TENANT_ID;
-    }
-
-    boolean optionalAudience() {
-        return optionalAudience;
     }
 
 }

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
@@ -65,8 +65,10 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
     private URI introspectUri;
     private String scopeAudience;
     private boolean useWellKnown = true;
-    // Whether audience claim is optional
+    // Whether audience claim is optional (turned off by default)
     private boolean optionalAudience = false;
+    // Whether to check audience claim (turned on by default)
+    private boolean checkAudience = true;
 
     BaseBuilder() {
     }
@@ -127,6 +129,7 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
 
         config.get("client-timeout-millis").asLong().ifPresent(this::clientTimeoutMillis);
         config.get("optional-audience").asBoolean().ifPresent(this::optionalAudience);
+        config.get("check-audience").asBoolean().ifPresent(this::checkAudience);
         return identity();
     }
 
@@ -424,12 +427,24 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
     /**
      * Allow audience claim to be optional.
      *
-     * @param optional whether the audience claim is optional (true) or not (false)
+     * @param optional whether the audience claim is optional ({@code true}) or not ({@code false})
      * @return updated builder instance
      */
     @ConfiguredOption("false")
     public B optionalAudience(boolean optional) {
         this.optionalAudience = optional;
+        return identity();
+    }
+
+    /**
+     * Configure audience claim check.
+     *
+     * @param checkAudience whether the audience claim will be checked ({@code true}) or not ({@code false})
+     * @return updated builder instance
+     */
+    @ConfiguredOption("false")
+    public B checkAudience(boolean checkAudience) {
+        this.checkAudience = checkAudience;
         return identity();
     }
 
@@ -471,6 +486,10 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
 
     String audience() {
         return audience;
+    }
+
+    boolean checkAudience() {
+        return checkAudience;
     }
 
     String serverType() {

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -368,7 +368,6 @@ public final class OidcConfig extends TenantConfigImpl {
     private final OidcCookieHandler tokenCookieHandler;
     private final OidcCookieHandler idTokenCookieHandler;
     private final OidcCookieHandler tenantCookieHandler;
-    private final boolean optionalAudience;
 
     private OidcConfig(Builder builder) {
         super(builder);
@@ -399,7 +398,6 @@ public final class OidcConfig extends TenantConfigImpl {
 
         this.webClientBuilderSupplier = builder.webClientBuilderSupplier;
         this.defaultTenant = LazyValue.create(() -> Tenant.create(this, this));
-        this.optionalAudience = builder.optionalAudience();
 
         LOGGER.log(Level.TRACE, () -> "Redirect URI with host: " + frontendUri + redirectUri);
     }
@@ -1005,8 +1003,6 @@ public final class OidcConfig extends TenantConfigImpl {
             config.get("tenants").asList(Config.class)
                     .ifPresent(confList -> confList.forEach(tenantConfig -> tenantFromConfig(config, tenantConfig)));
 
-            config.get("optional-audience").asBoolean().ifPresent(this::optionalAudience);
-
             return this;
         }
 
@@ -1537,6 +1533,5 @@ public final class OidcConfig extends TenantConfigImpl {
             tenantConfigurations.put(tenantConfig.name(), tenantConfig);
             return this;
         }
-
     }
 }

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -1538,17 +1538,5 @@ public final class OidcConfig extends TenantConfigImpl {
             return this;
         }
 
-        /**
-         * Allow audience claim to be optional.
-         *
-         * @param optional whether the audience claim is be optional (true) or not (false)
-         * @return updated builder instance
-         */
-        @ConfiguredOption("false")
-        public Builder optionalAudience(Boolean optional) {
-            setOptionalAudience(optional);
-            return this;
-        }
-
     }
 }

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -307,6 +307,11 @@ import io.helidon.webclient.api.WebClientConfig;
  *     <td>Force https for redirects to identity provider.
  *     This is helpful if you have a frontend SSL or cloud load balancer in front and Helidon is serving plain http.</td>
  * </tr>
+ * <tr>
+ *     <td>{@code optional-audience}</td>
+ *     <td>{@code false}</td>
+ *     <td>Allow audience claim to be optional.</td>
+ * </tr>
  * </table>
  */
 public final class OidcConfig extends TenantConfigImpl {
@@ -363,6 +368,7 @@ public final class OidcConfig extends TenantConfigImpl {
     private final OidcCookieHandler tokenCookieHandler;
     private final OidcCookieHandler idTokenCookieHandler;
     private final OidcCookieHandler tenantCookieHandler;
+    private final boolean optionalAudience;
 
     private OidcConfig(Builder builder) {
         super(builder);
@@ -393,6 +399,7 @@ public final class OidcConfig extends TenantConfigImpl {
 
         this.webClientBuilderSupplier = builder.webClientBuilderSupplier;
         this.defaultTenant = LazyValue.create(() -> Tenant.create(this, this));
+        this.optionalAudience = builder.optionalAudience();
 
         LOGGER.log(Level.TRACE, () -> "Redirect URI with host: " + frontendUri + redirectUri);
     }
@@ -998,6 +1005,8 @@ public final class OidcConfig extends TenantConfigImpl {
             config.get("tenants").asList(Config.class)
                     .ifPresent(confList -> confList.forEach(tenantConfig -> tenantFromConfig(config, tenantConfig)));
 
+            config.get("optional-audience").asBoolean().ifPresent(this::optionalAudience);
+
             return this;
         }
 
@@ -1528,5 +1537,18 @@ public final class OidcConfig extends TenantConfigImpl {
             tenantConfigurations.put(tenantConfig.name(), tenantConfig);
             return this;
         }
+
+        /**
+         * Allow audience claim to be optional.
+         *
+         * @param optional whether the audience claim is be optional (true) or not (false)
+         * @return updated builder instance
+         */
+        @ConfiguredOption("false")
+        public Builder optionalAudience(Boolean optional) {
+            setOptionalAudience(optional);
+            return this;
+        }
+
     }
 }

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -312,6 +312,11 @@ import io.helidon.webclient.api.WebClientConfig;
  *     <td>{@code false}</td>
  *     <td>Allow audience claim to be optional.</td>
  * </tr>
+ * <tr>
+ *     <td>{@code check-audience}</td>
+ *     <td>{@code true}</td>
+ *     <td>Turn audience claim check on when {@code true} or off when {@code false}.</td>
+ * </tr>
  * </table>
  */
 public final class OidcConfig extends TenantConfigImpl {

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/TenantConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/TenantConfig.java
@@ -117,6 +117,13 @@ public interface TenantConfig {
     String audience();
 
     /**
+     * Whether to validate audience token.
+     *
+     * @return audience
+     */
+    boolean checkAudience();
+
+    /**
      * Audience URI of custom scopes.
      *
      * @return scope audience

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/TenantConfigImpl.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/TenantConfigImpl.java
@@ -40,6 +40,7 @@ class TenantConfigImpl implements TenantConfig {
     private final boolean validateJwtWithJwk;
     private final String issuer;
     private final String audience;
+    private final boolean checkAudience;
     private final String realm;
     private final OidcConfig.ClientAuthentication tokenEndpointAuthentication;
     private final Duration clientTimeout;
@@ -60,6 +61,7 @@ class TenantConfigImpl implements TenantConfig {
         this.validateJwtWithJwk = builder.validateJwtWithJwk();
         this.issuer = builder.issuer();
         this.audience = builder.audience();
+        this.checkAudience = builder.checkAudience();
         this.identityUri = builder.identityUri();
         this.realm = builder.realm();
         this.tokenEndpointUri = builder.tokenEndpointUri();
@@ -142,6 +144,11 @@ class TenantConfigImpl implements TenantConfig {
     @Override
     public String audience() {
         return audience;
+    }
+
+    @Override
+    public boolean checkAudience() {
+        return checkAudience;
     }
 
     @Override

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
@@ -205,6 +205,17 @@ class OidcConfigFromBuilderTest extends OidcConfigAbstractTest {
         assertThat(audience, nullValue());
     }
 
+    @Test
+    void testCheckAudience() {
+        OidcConfig config = OidcConfig.builder()
+                .identityUri(URI.create("http://localhost/identity"))
+                .clientSecret("top-secret")
+                .clientId("client-id")
+                .checkAudience(false)
+                .build();
+        assertThat(config.checkAudience(), is(false));
+    }
+
     // Stub the Builder class to be able to retrieve the cookie-encryption-password value
     private static class TestOidcConfigBuilder extends OidcConfig.Builder {
 

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromBuilderTest.java
@@ -193,6 +193,18 @@ class OidcConfigFromBuilderTest extends OidcConfigAbstractTest {
         }
     }
 
+    @Test
+    void testOptionalAudience() {
+        OidcConfig config = OidcConfig.builder()
+                .identityUri(URI.create("http://localhost/identity"))
+                .clientSecret("top-secret")
+                .clientId("client-id")
+                .optionalAudience(true)
+                .build();
+        String audience = config.audience();
+        assertThat(audience, nullValue());
+    }
+
     // Stub the Builder class to be able to retrieve the cookie-encryption-password value
     private static class TestOidcConfigBuilder extends OidcConfig.Builder {
 

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromConfigTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromConfigTest.java
@@ -20,6 +20,7 @@ import io.helidon.config.Config;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -49,6 +50,12 @@ class OidcConfigFromConfigTest extends OidcConfigAbstractTest {
         OidcConfig oidcConfig = OidcConfig.create(config.get("security.oidc-optional-aud"));
         String audience = oidcConfig.audience();
         assertThat(audience, nullValue());
+    }
+
+    @Test
+    void testDisabledAudience() {
+        OidcConfig oidcConfig = OidcConfig.create(config.get("security.oidc-disabled-aud"));
+        assertThat(oidcConfig.checkAudience(), is(false));
     }
 
 }

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromConfigTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigFromConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,20 @@ package io.helidon.security.providers.oidc.common;
 
 import io.helidon.config.Config;
 
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 /**
  * Unit test for {@link OidcConfig}.
  */
 class OidcConfigFromConfigTest extends OidcConfigAbstractTest {
     private OidcConfig oidcConfig;
+    private Config config;
 
     OidcConfigFromConfigTest() {
-        Config config = Config.builder()
+        config = Config.builder()
                 .disableSystemPropertiesSource()
                 .disableEnvironmentVariablesSource()
                 .build();
@@ -37,4 +43,12 @@ class OidcConfigFromConfigTest extends OidcConfigAbstractTest {
     OidcConfig getConfig() {
         return oidcConfig;
     }
+
+    @Test
+    void testOptionalAudience() {
+        OidcConfig oidcConfig = OidcConfig.create(config.get("security.oidc-optional-aud"));
+        String audience = oidcConfig.audience();
+        assertThat(audience, nullValue());
+    }
+
 }

--- a/security/providers/oidc-common/src/test/resources/application.yaml
+++ b/security/providers/oidc-common/src/test/resources/application.yaml
@@ -36,3 +36,9 @@ security:
     client-id: "my-id"
     client-secret: "my-well-known-secret"
     optional-audience: true
+
+  oidc-disabled-aud:
+    identity-uri: "https://my.identity"
+    client-id: "my-id"
+    client-secret: "my-well-known-secret"
+    check-audience: false

--- a/security/providers/oidc-common/src/test/resources/application.yaml
+++ b/security/providers/oidc-common/src/test/resources/application.yaml
@@ -16,6 +16,7 @@
 
 security:
   config.require-encryption: false
+
   oidc-test:
     identity-uri: "https://identity.oracle.com"
     scope-audience: "https://something:7987/test-application"
@@ -29,3 +30,9 @@ security:
     authorization-endpoint-uri: "https://identity.oracle.com/authorization"
     introspect-endpoint-uri: "https://identity.oracle.com/introspect"
     relative-uris: true
+
+  oidc-optional-aud:
+    identity-uri: "https://my.identity"
+    client-id: "my-id"
+    client-secret: "my-well-known-secret"
+    optional-audience: true

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -439,7 +439,9 @@ class TenantAuthenticationHandler {
                                                            Errors.Collector collector) {
         Jwt jwt = signedJwt.getJwt();
         Errors errors = collector.collect();
-        Errors validationErrors = jwt.validate(tenant.issuer(), tenantConfig.audience());
+        Errors validationErrors = jwt.validate(tenant.issuer(),
+                                               tenantConfig.audience(),
+                                               tenantConfig.checkAudience());
 
         if (errors.isValid() && validationErrors.isValid()) {
 


### PR DESCRIPTION
Added `optional-audience` config option to make audience claim optional.
Automatic audience claim generation is disabled when this option is set to true.

Resolves #5860 