### PR TITLE
[4.x] Avoid reflecting back user data in exception messages

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/RequestException.java
+++ b/common/http/src/main/java/io/helidon/common/http/RequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ public class RequestException extends RuntimeException {
     private final DirectHandler.TransportRequest transportRequest;
     private final boolean keepAlive;
     private final ServerResponseHeaders responseHeaders;
+    private final boolean safeMessage;
 
     /**
      * A new exception with a predefined status, even type.
@@ -41,6 +42,7 @@ public class RequestException extends RuntimeException {
         this.transportRequest = builder.request;
         this.keepAlive = builder.keepAlive;
         this.responseHeaders = builder.responseHeaders;
+        this.safeMessage = builder.safeMessage;
     }
 
     /**
@@ -98,6 +100,16 @@ public class RequestException extends RuntimeException {
     }
 
     /**
+     * Safe message flag used to control which messages can be sent as
+     * part of a response and which should only be logged by the server.
+     *
+     * @return safe message flag
+     */
+    public boolean safeMessage() {
+        return safeMessage;
+    }
+
+    /**
      * Fluent API builder for {@link RequestException}.
      */
     public static class Builder implements io.helidon.common.Builder<Builder, RequestException> {
@@ -108,6 +120,7 @@ public class RequestException extends RuntimeException {
         private Http.Status status;
         private Boolean keepAlive;
         private final ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
+        private boolean safeMessage = true;
 
         private Builder() {
         }
@@ -207,6 +220,18 @@ public class RequestException extends RuntimeException {
          */
         public Builder header(Http.HeaderValue header) {
             this.responseHeaders.set(header);
+            return this;
+        }
+
+        /**
+         * Safe message flag that indicates if it safe to return message
+         * as part of the response. Defaults to {@code true}.
+         *
+         * @param safeMessage whether is safe to return message
+         * @return updated builder
+         */
+        public Builder safeMessage(boolean safeMessage) {
+            this.safeMessage = safeMessage;
             return this;
         }
     }

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ExceptionMessageTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ExceptionMessageTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.server;
+
+import java.util.Collections;
+
+import io.helidon.common.http.Http;
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test that no unwanted request data is leaked back (reflected) in response to a
+ * bad request. There are no routes defined for this test.
+ */
+@ServerTest
+class ExceptionMessageTest {
+
+    private final SocketHttpClient socketClient;
+
+    ExceptionMessageTest(SocketHttpClient socketClient) {
+        this.socketClient = socketClient;
+    }
+
+    @Test
+    void testNoUrlReflect() {
+        String response = socketClient.sendAndReceive("/anyjavascript%3a/*%3c/script%3e%3cimg/onerror%3d'\\''" +
+                        "-/%22/-/%20onmouseover%d1/-/[%60*/[]/[(new(Image)).src%3d(/%3b/%2b/255t6qeelp23xlr08hn1uv" +
+                        "vnkeqae02stgk87yvnX%3b.oastifycom/).replace(/.%3b/g%2c[])]//'\\''src%3d%3e",
+                Http.Method.GET,
+                "");
+        Http.Status status = SocketHttpClient.statusFromResponse(response);
+        String entity = SocketHttpClient.entityFromResponse(response, false);
+        assertThat(status, is(Http.Status.BAD_REQUEST_400));
+        assertThat(entity, containsString("see server log"));
+        assertThat(entity, not(containsString("javascript")));
+    }
+
+    @Test
+    void testNoHeaderReflect() {
+        String response = socketClient.sendAndReceive("/",
+                Http.Method.GET,
+                "",
+                Collections.singletonList("<Content-Type>: <javascript/>"));
+        Http.Status status = SocketHttpClient.statusFromResponse(response);
+        String entity = SocketHttpClient.entityFromResponse(response, false);
+        assertThat(status, is(Http.Status.BAD_REQUEST_400));
+        assertThat(entity, not(containsString("javascript")));
+    }
+}

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Connection.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Connection.java
@@ -364,7 +364,8 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                                                   e.eventType(),
                                                                   e.status(),
                                                                   e.responseHeaders(),
-                                                                  e);
+                                                                  e,
+                                                                  LOGGER);
 
         BufferData buffer = BufferData.growing(128);
         ServerResponseHeaders headers = response.headers();

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Prologue.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Prologue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ public final class Http1Prologue {
                 .type(DirectHandler.EventType.BAD_REQUEST)
                 .request(DirectTransportRequest.create(protocolAndVersion, method, path))
                 .message(message)
+                .safeMessage(false)
                 .build();
     }
 


### PR DESCRIPTION
Avoid reflecting back user data in exception messages. There is a new flag in RequestException that can be used to control when it is safe to include a message in a response entity and when it is not. It is by default set to true (safe) but is now set to false in Http1Prologue to avoid data leaks. New test added. See issue #6986.
