### PR TITLE
Removed calls to allowThreadLocals(true) to get ready for Java 21

### DIFF
--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/LoomServer.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/LoomServer.java
@@ -137,7 +137,6 @@ class LoomServer implements WebServer {
 
         this.listeners = Map.copyOf(listeners);
         this.executorService = Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
-                                                                          .allowSetThreadLocals(true)
                                                                           .inheritInheritableThreadLocals(inheritThreadLocals)
                                                                           .factory());
     }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ServerListener.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ServerListener.java
@@ -95,7 +95,6 @@ class ServerListener implements ListenerContext {
         this.context = listenerConfig.context();
 
         this.serverThread = Thread.ofPlatform()
-                .allowSetThreadLocals(true)
                 .inheritInheritableThreadLocals(true)
                 .daemon(false)
                 .name("server-" + socketName + "-listener")
@@ -103,13 +102,11 @@ class ServerListener implements ListenerContext {
 
         // to read requests and execute tasks
         this.readerExecutor = ThreadPerTaskExecutor.create(Thread.ofVirtual()
-                                                                         .allowSetThreadLocals(true)
                                                                          .inheritInheritableThreadLocals(inheritThreadLocals)
                                                                          .factory());
 
         // to do anything else (writers etc.)
         this.sharedExecutor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
-                                                                         .allowSetThreadLocals(true)
                                                                          .inheritInheritableThreadLocals(inheritThreadLocals)
                                                                          .factory());
 

--- a/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/ThreadPerTaskExecutorTest.java
+++ b/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/ThreadPerTaskExecutorTest.java
@@ -97,7 +97,6 @@ class ThreadPerTaskExecutorTest {
 
     private static HelidonTaskExecutor newExecutor() {
         return ThreadPerTaskExecutor.create(Thread.ofVirtual()
-                .allowSetThreadLocals(true)
                 .inheritInheritableThreadLocals(false)
                 .factory());
     }


### PR DESCRIPTION
The method allowThreadLocals() was removed in Java 21, so should be removed, especially since it's always set to "true" anyway.