### PR TITLE
Reset channel auto-read config before upgrading websocket connection

### DIFF
--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WebSocketHandler.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WebSocketHandler.java
@@ -235,7 +235,7 @@ class WebSocketHandler extends SimpleChannelInboundHandler<Object> {
                     .onError(this::logError);
         }
 
-
+        ctx.channel().config().setAutoRead(true);
     }
 
     private void logError(Throwable throwable){


### PR DESCRIPTION
Fixes #7049 

Verified manually in our internal integration tests, difficult to write a unit test for this.