### PR TITLE
Support for lastEndpointUri() in Webclient responses

### DIFF
--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientRequestImpl.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientRequestImpl.java
@@ -286,7 +286,7 @@ class ClientRequestImpl implements Http2ClientRequest {
     private Http2ClientResponse readResponse(Http2ClientStream stream) {
         Http2Headers headers = stream.readHeaders();
 
-        return new ClientResponseImpl(headers, stream);
+        return new ClientResponseImpl(headers, stream, uri.toUri());
     }
 
     private byte[] entityBytes(Object entity) {

--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientRequestImpl.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientRequestImpl.java
@@ -286,7 +286,7 @@ class ClientRequestImpl implements Http2ClientRequest {
     private Http2ClientResponse readResponse(Http2ClientStream stream) {
         Http2Headers headers = stream.readHeaders();
 
-        return new ClientResponseImpl(headers, stream, uri.toUri());
+        return new ClientResponseImpl(headers, stream, uri);
     }
 
     private byte[] entityBytes(Object entity) {

--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientResponseImpl.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientResponseImpl.java
@@ -23,14 +23,15 @@ import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http;
 import io.helidon.nima.http.media.ReadableEntity;
 import io.helidon.nima.http2.Http2Headers;
+import io.helidon.nima.webclient.UriHelper;
 
 class ClientResponseImpl implements Http2ClientResponse {
     private final Http.Status responseStatus;
     private final ClientResponseHeaders responseHeaders;
-    private final URI lastEndpointUri;
+    private final UriHelper lastEndpointUri;
     private Http2ClientStream stream;
 
-    ClientResponseImpl(Http2Headers headers, Http2ClientStream stream, URI lastEndpointUri) {
+    ClientResponseImpl(Http2Headers headers, Http2ClientStream stream, UriHelper lastEndpointUri) {
         this.responseStatus = headers.status();
         this.responseHeaders = ClientResponseHeaders.create(headers.httpHeaders());
         this.stream = stream;
@@ -54,7 +55,7 @@ class ClientResponseImpl implements Http2ClientResponse {
 
     @Override
     public URI lastEndpointUri() {
-        return lastEndpointUri;
+        return lastEndpointUri.toUri();
     }
 
     @Override

--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientResponseImpl.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.nima.http2.webclient;
 
+import java.net.URI;
+
 import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http;
@@ -25,12 +27,14 @@ import io.helidon.nima.http2.Http2Headers;
 class ClientResponseImpl implements Http2ClientResponse {
     private final Http.Status responseStatus;
     private final ClientResponseHeaders responseHeaders;
+    private final URI lastEndpointUri;
     private Http2ClientStream stream;
 
-    ClientResponseImpl(Http2Headers headers, Http2ClientStream stream) {
+    ClientResponseImpl(Http2Headers headers, Http2ClientStream stream, URI lastEndpointUri) {
         this.responseStatus = headers.status();
         this.responseHeaders = ClientResponseHeaders.create(headers.httpHeaders());
         this.stream = stream;
+        this.lastEndpointUri = lastEndpointUri;
     }
 
     @Override
@@ -46,6 +50,11 @@ class ClientResponseImpl implements Http2ClientResponse {
     @Override
     public ReadableEntity entity() {
         return stream.entity().copy(() -> this.stream = null);
+    }
+
+    @Override
+    public URI lastEndpointUri() {
+        return lastEndpointUri;
     }
 
     @Override

--- a/nima/tests/integration/webclient/webclient/src/test/java/io/helidon/nima/webclient/http1/ClientRequestImplTest.java
+++ b/nima/tests/integration/webclient/webclient/src/test/java/io/helidon/nima/webclient/http1/ClientRequestImplTest.java
@@ -300,6 +300,7 @@ class ClientRequestImplTest {
         try (Http1ClientResponse response = injectedHttp1client.put("/redirect")
                 .submit("Test entity")) {
             assertThat(response.status(), is(Http.Status.OK_200));
+            assertThat(response.lastEndpointUri().getPath(), is("/afterRedirect"));
             assertThat(response.as(String.class), is(EXPECTED_GET_AFTER_REDIRECT_STRING));
         }
     }
@@ -314,6 +315,7 @@ class ClientRequestImplTest {
 
         try (Http1ClientResponse response = injectedHttp1client.put("/redirectKeepMethod")
                 .submit("Test entity")) {
+            assertThat(response.lastEndpointUri().getPath(), is("/afterRedirect"));
             assertThat(response.status(), is(Http.Status.NO_CONTENT_204));
         }
     }

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientResponse.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientResponse.java
@@ -17,6 +17,7 @@
 package io.helidon.nima.webclient;
 
 import java.io.InputStream;
+import java.net.URI;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
@@ -83,6 +84,13 @@ public interface ClientResponse extends AutoCloseable {
     default <T extends Source<?>> void source(GenericType<T> sourceType, T source) {
         throw new UnsupportedOperationException("No source available for " + sourceType);
     }
+
+    /**
+     * URI of the last request. (after redirection)
+     *
+     * @return last URI
+     */
+    URI lastEndpointUri();
 
     /**
      * Closes the response.

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/UriHelper.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/UriHelper.java
@@ -95,6 +95,15 @@ public class UriHelper {
     }
 
     /**
+     * Convert instance to {@link java.net.URI}.
+     *
+     * @return the converted URI
+     */
+    public URI toUri() {
+        return URI.create(toString());
+    }
+
+    /**
      * Scheme of this URI.
      *
      * @param scheme to use (such as {@code http})

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
@@ -381,6 +381,7 @@ class ClientRequestImpl implements Http1ClientRequest {
                                       serviceResponse.reader(),
                                       mediaContext,
                                       clientConfig.mediaTypeParserMode(),
+                                      uri.toUri(),
                                       complete);
     }
 

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
@@ -381,7 +381,7 @@ class ClientRequestImpl implements Http1ClientRequest {
                                       serviceResponse.reader(),
                                       mediaContext,
                                       clientConfig.mediaTypeParserMode(),
-                                      uri.toUri(),
+                                      uri,
                                       complete);
     }
 

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientResponseImpl.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientResponseImpl.java
@@ -16,6 +16,7 @@
 
 package io.helidon.nima.webclient.http1;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -70,6 +71,7 @@ class ClientResponseImpl implements Http1ClientResponse {
     private final List<String> trailerNames;
     // Media type parsing mode configured on client.
     private final ParserMode parserMode;
+    private final URI lastEndpointUri;
 
     private ClientConnection connection;
     private long entityLength;
@@ -83,6 +85,7 @@ class ClientResponseImpl implements Http1ClientResponse {
                        DataReader reader,
                        MediaContext mediaContext,
                        ParserMode parserMode,
+                       URI lastEndpointUri,
                        CompletableFuture<Void> whenComplete) {
         this.responseStatus = responseStatus;
         this.requestHeaders = requestHeaders;
@@ -92,6 +95,7 @@ class ClientResponseImpl implements Http1ClientResponse {
         this.mediaContext = mediaContext;
         this.parserMode = parserMode;
         this.channelId = connection.channelId();
+        this.lastEndpointUri = lastEndpointUri;
         this.whenComplete = whenComplete;
 
         if (responseHeaders.contains(Header.CONTENT_LENGTH)) {
@@ -212,6 +216,11 @@ class ClientResponseImpl implements Http1ClientResponse {
         // no entity, just complete right now
         whenComplete.complete(null);
         return ReadableEntityBase.empty();
+    }
+
+    @Override
+    public URI lastEndpointUri() {
+        return lastEndpointUri;
     }
 
     private BufferData readEntityChunked(int estimate) {

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientResponseImpl.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientResponseImpl.java
@@ -43,6 +43,7 @@ import io.helidon.nima.http.media.ReadableEntity;
 import io.helidon.nima.http.media.ReadableEntityBase;
 import io.helidon.nima.webclient.ClientConnection;
 import io.helidon.nima.webclient.ClientResponseEntity;
+import io.helidon.nima.webclient.UriHelper;
 import io.helidon.nima.webclient.http.spi.Source;
 import io.helidon.nima.webclient.http.spi.SourceHandlerProvider;
 
@@ -71,7 +72,7 @@ class ClientResponseImpl implements Http1ClientResponse {
     private final List<String> trailerNames;
     // Media type parsing mode configured on client.
     private final ParserMode parserMode;
-    private final URI lastEndpointUri;
+    private final UriHelper lastEndpointUri;
 
     private ClientConnection connection;
     private long entityLength;
@@ -85,7 +86,7 @@ class ClientResponseImpl implements Http1ClientResponse {
                        DataReader reader,
                        MediaContext mediaContext,
                        ParserMode parserMode,
-                       URI lastEndpointUri,
+                       UriHelper lastEndpointUri,
                        CompletableFuture<Void> whenComplete) {
         this.responseStatus = responseStatus;
         this.requestHeaders = requestHeaders;
@@ -220,7 +221,7 @@ class ClientResponseImpl implements Http1ClientResponse {
 
     @Override
     public URI lastEndpointUri() {
-        return lastEndpointUri;
+        return lastEndpointUri.toUri();
     }
 
     private BufferData readEntityChunked(int estimate) {


### PR DESCRIPTION
Support for lastEndpointUri() in Webclient responses. This method can be used to obtain the final redirect URI of the corresponding request. Tests updated. Note that WebClient HTTP/2 does not yet support redirects.