### PR TITLE
3.x: Restore env for Jenkins and do some minor cleanup

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,7 +18,6 @@ on:
 env:
   JAVA_VERSION: '17'
   JAVA_DISTRO: 'oracle'
-  HELIDON_PIPELINES: 'true'
   MAVEN_HTTP_ARGS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3'
 
 concurrency:

--- a/etc/scripts/includes/pipeline-env.sh
+++ b/etc/scripts/includes/pipeline-env.sh
@@ -72,17 +72,45 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
     MAVEN_OPTS="${MAVEN_OPTS} --add-opens=java.base/java.util=ALL-UNNAMED"
     # Needed for generating site
     MAVEN_OPTS="${MAVEN_OPTS} --add-opens=java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED"
-    export MAVEN_OPTS
-    MAVEN_ARGS="${MAVEN_ARGS} -B"
+
+    MAVEN_ARGS="${MAVEN_ARGS} -B ${MAVEN_HTTP_ARGS}"
+
+    if [ -n "${JENKINS_HOME}" ] ; then
+      export PATH="/tools/apache-maven-3.8.6/bin:${JAVA_HOME}/bin:/tools/node-v12/bin:${PATH}"
+      if [ -n "${GITHUB_SSH_KEY}" ] ; then
+          export GIT_SSH_COMMAND="ssh -i ${GITHUB_SSH_KEY}"
+      fi
+      if [ -n "${NPM_CONFIG_REGISTRY}" ] ; then
+          MAVEN_ARGS="${MAVEN_ARGS} -Dnpm.download.root=${NPM_CONFIG_REGISTRY}/npm/-/"
+      fi
+      if [ -n "${https_proxy}" ] && [[ ! "${https_proxy}" =~ ^http:// ]] ; then
+          export https_proxy="http://${https_proxy}"
+      fi
+      if [ -n "${http_proxy}" ] && [[ ! "${http_proxy}" =~ ^http:// ]] ; then
+          export http_proxy="http://${http_proxy}"
+      fi
+      if [ ! -e "${HOME}/.npmrc" ] ; then
+          if [ -n "${NPM_CONFIG_REGISTRY}" ] ; then
+              echo "registry = ${NPM_CONFIG_REGISTRY}" >> ${HOME}/.npmrc
+          fi
+          if [ -n "${https_proxy}" ] ; then
+              echo "https-proxy = ${https_proxy}" >> ${HOME}/.npmrc
+          fi
+          if [ -n "${http_proxy}" ] ; then
+              echo "proxy = ${http_proxy}" >> ${HOME}/.npmrc
+          fi
+          if [ -n "${NO_PROXY}" ] ; then
+              echo "noproxy = ${NO_PROXY}" >> ${HOME}/.npmrc
+          fi
+      fi
+    fi
 
     if [ -n "${RELEASE_WORKFLOW}" ] ; then
-        export PIPELINE="true"
         if [ -n "${MAVEN_SETTINGS}" ] ; then
             export MAVEN_SETTINGS_FILE="${HOME}/.m2/settings.xml"
             echo "${MAVEN_SETTINGS}" > "${MAVEN_SETTINGS_FILE}"
             MAVEN_ARGS="${MAVEN_ARGS} -s ${MAVEN_SETTINGS_FILE}"
         fi
-        export MAVEN_ARGS
         if [ -n "${GPG_PUBLIC_KEY}" ] ; then
             tmpfile=$(mktemp /tmp/pub.XXXXXX.key)
             echo "${GPG_PUBLIC_KEY}" > "${tmpfile}"
@@ -102,7 +130,8 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
             /usr/lib/gnupg/gpg-preset-passphrase --preset "${GPG_KEYGRIP}" <<< "${GPG_PASSPHRASE}"
         fi
     fi
-
+    export MAVEN_ARGS
+    export MAVEN_OPTS
 else
     echo "WARNING: ${WS_DIR}/etc/scripts/includes/pipeline-env.sh included multiple times."
 fi


### PR DESCRIPTION
This restores the environment used by Jenkins since we are not 100% finished with migration.

Removes `HELIDON_PIPELINES` env variable as it was not used. If we need to know if we are running in a workflow/action we should test `GITHUB_ACTIONS` (see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)

