### PR TITLE
Update development guidelines to include naming rules for builder types.

### DIFF
--- a/DEV-GUIDELINES.md
+++ b/DEV-GUIDELINES.md
@@ -55,13 +55,13 @@ Some of these rules are enforced by checkstyle, some are checked during code rev
 1. **Everything that can be done using config, must be possible using programmatic approach through builders**
     1. Exceptions:
         1. CDI components configured from a CDI Extension
-1. Everything that can be done using builders should be possible also using configuration, 
+2. Everything that can be done using builders should be possible also using configuration, 
         except for cases that would mandate usage of reflection 
         (such an exception may be configuration of Routing in WebServer - nevertheless we still may support 
             it (emphasis on "may" rather than "should"), or configuration of security for Jersey resources)
-2. When accepting config as a parameter, we should expect the config is located on the node that contains our configuration
+3. When accepting config as a parameter, we should expect the config is located on the node that contains our configuration
     (such as in ServerConfiguration in WebServer)
-3. Config keys:
+4. Config keys:
     1. Use lower case words separated by dashes 
         (e.g. "token-endpoint-uri", NOT "tokenEndpointUri")
     2. May be nested in a tree structure (e.g. outbound-token.name, outbound-token.algorithm)
@@ -70,9 +70,9 @@ Some of these rules are enforced by checkstyle, some are checked during code rev
         2. Default: component has a well defined and documented default value for such a property
         3. Optional: component behaves in a well defined and documented manner if such a property is not 
             configured (e.g. a component may expect tracing endpoint - if not defined, tracing may be disabled)         
-        
+5. We have introduced `helidon-builder` module, that provides capability to generate builders that support both programmatic and configuration approach. See [helidon-builder](builder/README.md) for more details about modules, and [helidon-builder-api](builder/api/README.md) for explanation of APIs and naming rules
 
-Example: [io.helidon.security.providers.oidc.common.OidcConfig](security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java)
+Example: [io.helidon.nima.faulttolerance.RetryConfigBlueprint](nima/fault-tolerance/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/RetryConfigBlueprint.java)
 
 # Getters and Setters
 1. We do not use the verb, e.g. when a property "port" exists, the following methods are used:  
@@ -105,12 +105,12 @@ Example: [io.helidon.security.providers.oidc.common.OidcConfig](security/provide
     2. May have:
         1. method _public static Builder builder(?)_ - builder with mandatory or very commonly used parameters
             - there should be a very small number of "builder(*)" methods - up to two per class
-        1. Factory method _public static FooBar create()_ that is implemented as "return builder().build()"
-        2. Factory method _public static create(io.helidon.config.Config config)_ that is implemented as 
+        2. Factory method _public static FooBar create()_ that is implemented as "return builder().build()"
+        3. Factory method _public static create(io.helidon.config.Config config)_ that is implemented as 
             "return builder().config(config).build()"
-        2. Other factory methods that build specific (predefined) instances, such as "fail(String cause)", 
+        4. Other factory methods that build specific (predefined) instances, such as "fail(String cause)", 
             "success(Subject subject)" etc. - **these methods MUST use builder to build the instance internally**
-        3. An internal class named "Builder" that is building instances of the containing class
+        5. An internal class named "Builder" that is building instances of the containing class
             1. it is allowed to have the builder as a top level class, in such a case the name must reflect the class it is 
                 building (e.g. FooBarBuilder) 
 3. Builder class

--- a/DEV-GUIDELINES.md
+++ b/DEV-GUIDELINES.md
@@ -70,7 +70,7 @@ Some of these rules are enforced by checkstyle, some are checked during code rev
         2. Default: component has a well defined and documented default value for such a property
         3. Optional: component behaves in a well defined and documented manner if such a property is not 
             configured (e.g. a component may expect tracing endpoint - if not defined, tracing may be disabled)         
-5. We have introduced `helidon-builder` module, that provides capability to generate builders that support both programmatic and configuration approach. See [helidon-builder](builder/README.md) for more details about modules, and [helidon-builder-api](builder/api/README.md) for explanation of APIs and naming rules
+5. We have introduced `helidon-builder` module, that provides capability to generate builders that support both programmatic and configuration approach. See [helidon-builder](builder/README.md) for more details about modules, and [helidon-builder-api](builder/api/README.md) for explanation of APIs and naming rules. The `Blueprint` approach should be used for all builders (and the API of the prototype). Exceptions must be consulted with project architect (this may result in either changing the processor to support the required feature, or in removing such feature and redesigning the problem, or in an exception (documented) to the rule)  
 
 Example: [io.helidon.nima.faulttolerance.RetryConfigBlueprint](nima/fault-tolerance/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/RetryConfigBlueprint.java)
 

--- a/builder/api/README.md
+++ b/builder/api/README.md
@@ -121,3 +121,28 @@ security-providers:
 ```
 
 The generated code will read all nodes under `providers` and map them to an instance.
+
+## Naming rules
+
+Part of the naming rules is constant, part depends on whether we use two or three types, as mentioned above.
+
+### Blueprint name
+Blueprint MUST be package local, and MUST be named with a `Blueprint` suffix. The part of the name before the suffix will be the prototype name.
+
+### Blueprint -> Prototype
+For cases, where the `Prototype` is the target desired type (such as `TypeName`, `Keys`), the prototype name is a name of the type we represent (no suffixes, prefixes etc.).
+
+Example: `TypeName` would have the following structure (as can be seen in the [builder/tests/common-types](../tests/common-types)):
+
+- `TypeNameBlueprint` - the definition of the type
+- `TypeName` - the generated type to be used as an API
+
+### Blueprint -> Prototype -> Runtime type
+For cases, where the `Prototype` serves as a configuration object of a runtime type (such as `WebServerConfig`, `RetryConfig`),
+the prototype name has a `Config` suffix, and the runtime type is a name of the type we represent.
+
+Example: `Retry` would have the following structure (can be seen in Fault Tolerance):
+
+- `RetryConfigBlueprint` - the definition of the config
+- `RetryConfig` - the prototype 
+- `Retry` - the runtime type

--- a/builder/api/README.md
+++ b/builder/api/README.md
@@ -139,7 +139,7 @@ Example: `TypeName` would have the following structure (as can be seen in the [b
 
 ### Blueprint -> Prototype -> Runtime type
 For cases, where the `Prototype` serves as a configuration object of a runtime type (such as `WebServerConfig`, `RetryConfig`),
-the prototype name has a `Config` suffix, and the runtime type is a name of the type we represent.
+the prototype name should have a `Config` suffix, and the runtime type is a name of the type we represent.
 
 Example: `Retry` would have the following structure (can be seen in Fault Tolerance):
 


### PR DESCRIPTION
Resolves #7066 

I have added a big part of the team FYI, as this is a core change in Helidon, and builders are used by almost any module...
