### PR TITLE
2.x: Set JAVA_HOME for Jenkins environment

### DIFF
--- a/etc/scripts/includes/pipeline-env.sh
+++ b/etc/scripts/includes/pipeline-env.sh
@@ -71,6 +71,7 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
     MAVEN_ARGS="${MAVEN_ARGS} -B ${MAVEN_HTTP_ARGS}"
 
     if [ -n "${JENKINS_HOME}" ] ; then
+        export JAVA_HOME="/tools/jdk-11.0.12"
         export PATH="/tools/apache-maven-3.8.6/bin:${JAVA_HOME}/bin:/tools/node-v12/bin:${PATH}"
         if [ -n "${GITHUB_SSH_KEY}" ] ; then
             export GIT_SSH_COMMAND="ssh -i ${GITHUB_SSH_KEY}"


### PR DESCRIPTION
Missed this when restoring Jenkins environment.