### PR TITLE
module-info parsing

### DIFF
--- a/pico/tests/resources-pico/src/test/resources/expected/module-info.java._pico_
+++ b/pico/tests/resources-pico/src/test/resources/expected/module-info.java._pico_
@@ -37,9 +37,6 @@ module io.helidon.pico.tests.pico {
     // Pico external contract usage - @io.helidon.common.Generated(value = "io.helidon.pico.tools.ActivatorCreatorDefault", trigger = "io.helidon.pico.tools.ActivatorCreatorDefault")
     requires test1;
     requires test2;
-    uses jakarta.inject.Provider;
-    uses io.helidon.pico.tests.plain.interceptor.IA;
-    uses io.helidon.pico.tests.plain.interceptor.IB;
     // Pico contract usage - @io.helidon.common.Generated(value = "io.helidon.pico.tools.ActivatorCreatorDefault", trigger = "io.helidon.pico.tools.ActivatorCreatorDefault")
     exports io.helidon.pico.tests.pico.provider;
     // Pico application - @io.helidon.common.Generated(value = "io.helidon.pico.tools.ApplicationCreatorDefault", trigger = "io.helidon.pico.tools.ApplicationCreatorDefault")

--- a/pico/tests/resources-pico/src/test/resources/expected/tests-module-info.java._pico_
+++ b/pico/tests/resources-pico/src/test/resources/expected/tests-module-info.java._pico_
@@ -3,9 +3,6 @@ module io.helidon.pico.tests.pico/test {
     exports io.helidon.pico.tests.pico;
     // Pico module - @io.helidon.common.Generated(value = "io.helidon.pico.tools.ActivatorCreatorDefault", trigger = "io.helidon.pico.tools.ActivatorCreatorDefault")
     provides io.helidon.pico.api.ModuleComponent with io.helidon.pico.tests.pico.Pico$$TestModule;
-    // Pico external contract usage - @io.helidon.common.Generated(value = "io.helidon.pico.tools.ActivatorCreatorDefault", trigger = "io.helidon.pico.tools.ActivatorCreatorDefault")
-    uses io.helidon.pico.tests.pico.stacking.Intercepted;
-    uses io.helidon.pico.tests.pico.stacking.InterceptedImpl;
     // Pico services - @io.helidon.common.Generated(value = "io.helidon.pico.tools.ActivatorCreatorDefault", trigger = "io.helidon.pico.tools.ActivatorCreatorDefault")
     requires transitive io.helidon.pico.runtime;
     // Pico application - @io.helidon.common.Generated(value = "io.helidon.pico.tools.ApplicationCreatorDefault", trigger = "io.helidon.pico.tools.ApplicationCreatorDefault")

--- a/pico/tests/resources-pico/src/test/resources/expected/tests-module-info.java._pico_
+++ b/pico/tests/resources-pico/src/test/resources/expected/tests-module-info.java._pico_
@@ -1,4 +1,4 @@
-// @io.helidon.common.Generated(value = "io.helidon.pico.tools.ModuleInfoDescriptor", trigger = "io.helidon.pico.tools.ModuleInfoDescriptor")
+// @io.helidon.common.Generated(value = "io.helidon.pico.tools.ActivatorCreatorDefault", trigger = "io.helidon.pico.tools.ActivatorCreatorDefault")
 module io.helidon.pico.tests.pico/test {
     exports io.helidon.pico.tests.pico;
     // Pico module - @io.helidon.common.Generated(value = "io.helidon.pico.tools.ActivatorCreatorDefault", trigger = "io.helidon.pico.tools.ActivatorCreatorDefault")

--- a/pico/tools/src/main/java/io/helidon/pico/tools/AbstractCreator.java
+++ b/pico/tools/src/main/java/io/helidon/pico/tools/AbstractCreator.java
@@ -258,25 +258,6 @@ public abstract class AbstractCreator {
         }
 
         Set<TypeName> allExternalContracts = toAllContracts(externalContracts);
-        for (TypeName cn : allExternalContracts) {
-            String packageName = cn.packageName();
-            if (!needToDeclarePackageUsage(packageName)) {
-                continue;
-            }
-
-            ModuleInfoItem.Builder itemBuilder = ModuleInfoItem.builder()
-                    .uses(true)
-                    .target(cn.name());
-            if (hasValue(preComment)) {
-                itemBuilder.addPrecomment(preComment);
-            }
-
-            boolean added = ModuleInfoUtil.addIfAbsent(descriptorBuilder, cn.name(), itemBuilder);
-            if (added) {
-                preComment = "";
-            }
-        }
-
         if (!isTestModule && (contracts != null)) {
             preComment = "    // Pico contract usage - " + generatedAnno;
             for (Map.Entry<TypeName, Set<TypeName>> e : contracts.entrySet()) {

--- a/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoDescriptorBlueprint.java
+++ b/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoDescriptorBlueprint.java
@@ -109,14 +109,15 @@ interface ModuleInfoDescriptorBlueprint {
     List<String> unhandledLines();
 
     /**
-     * Any throwable/errors that were encountered during parsing.
+     * Any throwable/error that were encountered during parsing.
      *
      * @return optionally any error encountered during parsing
      */
     Optional<Throwable> error();
 
     /**
-     * Returns {@code true} if there were no cases of {@link #unhandledLines()} or {@link #error()}'s encountered.
+     * Returns {@code true} if last parsing operation was successful (i.e., if there were no instances of
+     * {@link #unhandledLines()} or {@link #error()}'s encountered).
      *
      * @return true if any parsing of the given module-info descriptor appears to be full and complete
      */

--- a/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoDescriptorBlueprint.java
+++ b/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoDescriptorBlueprint.java
@@ -101,6 +101,30 @@ interface ModuleInfoDescriptorBlueprint {
     List<ModuleInfoItem> items();
 
     /**
+     * The items that were not handled (due to parsing outages, etc.).
+     *
+     * @return the list of unhandled lines
+     */
+    @Prototype.Singular
+    List<String> unhandledLines();
+
+    /**
+     * Any throwable/errors that were encountered during parsing.
+     *
+     * @return optionally any error encountered during parsing
+     */
+    Optional<Throwable> error();
+
+    /**
+     * Returns {@code true} if there were no cases of {@link #unhandledLines()} or {@link #error()}'s encountered.
+     *
+     * @return true if any parsing of the given module-info descriptor appears to be full and complete
+     */
+    default boolean handled() {
+        return error().isEmpty() && unhandledLines().isEmpty();
+    }
+
+    /**
      * Returns true if the name currently set is the same as the {@link #DEFAULT_MODULE_NAME}.
      *
      * @return true if the current name is the default name
@@ -218,8 +242,12 @@ interface ModuleInfoDescriptorBlueprint {
         descriptionComment().ifPresent(it -> subst.put("description", it));
         subst.put("hasdescription", descriptionComment().isPresent());
         String template = helper.safeLoadTemplate(templateName(), ModuleUtils.SERVICE_PROVIDER_MODULE_INFO_HBS);
-        String contents = helper.applySubstitutions(template, subst, true).trim();
-        return CommonUtils.trimLines(contents);
+        String contents = helper.applySubstitutions(template, subst, true);
+        contents = CommonUtils.trimLines(contents);
+        if (!wantAnnotation) {
+            contents = contents.replace("\t", "    ");
+        }
+        return contents;
     }
 
 }

--- a/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoDescriptorSupport.java
+++ b/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoDescriptorSupport.java
@@ -180,7 +180,7 @@ final class ModuleInfoDescriptorSupport {
                     comments = new ArrayList<>();
                 }
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             ToolsException te;
             if (line != null) {
                 e = new ToolsException("Failed to parse line: " + line, e);

--- a/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoDescriptorSupport.java
+++ b/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoDescriptorSupport.java
@@ -187,6 +187,9 @@ final class ModuleInfoDescriptorSupport {
                 descriptor.addUnhandledLine(line);
             }
             te = new ToolsException("Unable to load or parse module-info: " + moduleInfo, e);
+            if (strict) {
+                throw te;
+            }
             descriptor.error(te);
         }
 

--- a/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoItemBlueprint.java
+++ b/pico/tools/src/main/java/io/helidon/pico/tools/ModuleInfoItemBlueprint.java
@@ -175,6 +175,11 @@ interface ModuleInfoItemBlueprint {
             assert (!isStaticUsed());
             assert (!exports());
             builder.append("opens ");
+            if (!withOrTo().isEmpty()) {
+                builder.append(Objects.requireNonNull(target()));
+                builder.append(" to ").append(String.join(",\n\t\t\t", withOrToSorted()));
+                return builder.toString();
+            }
             handled = true;
         }
         if (requires()) {

--- a/pico/tools/src/test/java/io/helidon/pico/tools/ModuleInfoDescriptorTest.java
+++ b/pico/tools/src/test/java/io/helidon/pico/tools/ModuleInfoDescriptorTest.java
@@ -147,6 +147,12 @@ class ModuleInfoDescriptorTest {
     @Test
     void innerCommentsNotSupported() {
         String moduleInfo = "module test {\nprovides /* inner comment */ cn;\n}";
+        ToolsException te = assertThrows(ToolsException.class,
+                                         () -> ModuleInfoDescriptor
+                                                 .create(moduleInfo, ModuleInfoOrdering.NATURAL_PRESERVE_COMMENTS, true));
+        assertThat(te.getMessage(),
+                   equalTo("Unable to load or parse module-info: module test {\nprovides /* inner comment */ cn;\n}"));
+
         ModuleInfoDescriptor descriptor = ModuleInfoDescriptor.create(moduleInfo);
         assertThat(descriptor.handled(),
                    is(false));
@@ -172,6 +178,13 @@ class ModuleInfoDescriptorTest {
                 + "        in = {HelidonFlavor.NIMA, HelidonFlavor.SE}\n"
                 + ")\n"
                 + "module io.helidon.config {\n}\n";
+        ToolsException te = assertThrows(ToolsException.class,
+                                         () -> ModuleInfoDescriptor
+                                                 .create(moduleInfo, ModuleInfoOrdering.NATURAL_PRESERVE_COMMENTS, true));
+        assertThat(te.getCause().getMessage(),
+                   equalTo("Failed to parse line: @Feature(value = \"Config\", description = \"Configuration module\", "
+                                   + "in = {HelidonFlavor.NIMA, HelidonFlavor.SE}"));
+
         ModuleInfoDescriptor descriptor = ModuleInfoDescriptor.create(moduleInfo);
         assertThat(descriptor.handled(),
                    is(false));

--- a/pico/tools/src/test/resources/testsubjects/m0._java_
+++ b/pico/tools/src/test/resources/testsubjects/m0._java_
@@ -11,4 +11,9 @@ module io.helidon.pico {
 
     uses io.helidon.pico.api.ModuleComponent;
     uses io.helidon.pico.api.Application;
+
+    // needed when running with modules - to make private methods accessible
+    // another comment with a semicolon;
+    opens io.helidon.config to weld.core.impl,
+            io.helidon.microprofile.cdi;
 }


### PR DESCRIPTION
1. Makes the parsing best effort (i.e., will not fail the pico anno processor, etc.).
2. Handles `opens` - fixes issue #7081 
3. Handles redundant `uses` - fixes issue #6631 