### PR TITLE
CONNECT host:port is wrong

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/HeaderEnum.java
+++ b/common/http/src/main/java/io/helidon/common/http/HeaderEnum.java
@@ -77,6 +77,7 @@ enum HeaderEnum implements Http.HeaderName {
     LINK("Link"),
     LOCATION("Location"),
     PRAGMA("Pragma"),
+    PROXY_CONNECTION("Proxy-Connection"),
     PUBLIC_KEY_PINS("Public-Key-Pins"),
     RETRY_AFTER("Retry-After"),
     SERVER("Server"),

--- a/common/http/src/main/java/io/helidon/common/http/Http.java
+++ b/common/http/src/main/java/io/helidon/common/http/Http.java
@@ -1333,6 +1333,13 @@ public final class Http {
          */
         public static final HeaderName PRAGMA = HeaderEnum.PRAGMA;
         /**
+         * The {@code Proxy-Connection} header name.
+         * Implemented as a misunderstanding of the HTTP specifications. Common because of mistakes in
+         * implementations of early HTTP versions. Has exactly the same functionality as standard
+         * Connection field. Must not be used with HTTP/2.
+         */
+        public static final HeaderName PROXY_CONNECTION = HeaderEnum.PROXY_CONNECTION;
+        /**
          * The {@code Public-Key-Pins} header name.
          * HTTP Public Key Pinning, announces hash of website's authentic TLS certificate.
          */

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/Http1ClientConnection.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/Http1ClientConnection.java
@@ -157,6 +157,14 @@ class Http1ClientConnection implements ClientConnection {
         uriHelper.scheme("http");
         uriHelper.host(proxyAddress.getHostName());
         uriHelper.port(proxyAddress.getPort());
+        /*
+         * Example:
+         * CONNECT www.youtube.com:443 HTTP/1.1
+         * User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0
+         * Proxy-Connection: keep-alive
+         * Connection: keep-alive
+         * Host: www.youtube.com:443
+         */
         Http1ClientConfig clientConfig = Http1ClientConfig.builder().mediaContext(MediaContext.create())
                 .socketOptions(options).dnsResolver(connectionKey.dnsResolver())
                 .dnsAddressLookup(connectionKey.dnsAddressLookup()).defaultHeaders(WritableHeaders.create()).build();
@@ -164,7 +172,10 @@ class Http1ClientConnection implements ClientConnection {
                 Method.CONNECT, uriHelper, UriQueryWriteable.create(), Collections.emptyMap());
         httpClient.connection(proxyConnection);
         httpClient.header(Header.HOST, hostPort);
-        httpClient.header(Header.ACCEPT, "*/*");
+        if (keepAlive) {
+            httpClient.header(Header.CONNECTION, "keep-alive");
+            httpClient.header(Header.PROXY_CONNECTION, "keep-alive");
+        }
         Http1ClientResponse response  = httpClient.request();
 
         // Re-use socket

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/HttpCallChainBase.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/HttpCallChainBase.java
@@ -24,6 +24,8 @@ import io.helidon.common.http.ClientRequestHeaders;
 import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.Http.Header;
+import io.helidon.common.http.Http.Method;
 import io.helidon.common.http.Http1HeadersParser;
 import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.common.tls.Tls;
@@ -89,15 +91,20 @@ abstract class HttpCallChainBase implements WebClientService.Chain {
                                                 BufferData writeBuffer);
 
     void prologue(BufferData nonEntityData, WebClientServiceRequest request, UriHelper uri) {
-        // TODO When proxy is implemented, change default value of Http1ClientConfig.relativeUris to false
-        //  and below conditional statement to:
-        //  proxy == Proxy.noProxy() || proxy.noProxyPredicate().apply(finalUri) || clientConfig.relativeUris
-        String schemeHostPort = clientConfig.relativeUris() ? "" : uri.scheme() + "://" + uri.host() + ":" + uri.port();
-        nonEntityData.writeAscii(request.method().text()
-                                         + " "
-                                         + schemeHostPort
-                                         + uri.pathWithQueryAndFragment(request.query(), request.fragment())
-                                         + " HTTP/1.1\r\n");
+        if (request.method() == Method.CONNECT) {
+            // When CONNECT, the first line contains the remote host:port, in the same way as the HOST header.
+            nonEntityData.writeAscii(request.method().text()
+                    + " "
+                    + request.headers().get(Header.HOST).value()
+                    + " HTTP/1.1\r\n");
+        } else {
+            String schemeHostPort = clientConfig.relativeUris() ? "" : uri.scheme() + "://" + uri.host() + ":" + uri.port();
+            nonEntityData.writeAscii(request.method().text()
+                    + " "
+                    + schemeHostPort
+                    + uri.pathWithQueryAndFragment(request.query(), request.fragment())
+                    + " HTTP/1.1\r\n");
+        }
     }
 
     ClientResponseHeaders readHeaders(DataReader reader) {


### PR DESCRIPTION
This address the point _HTTP CONNECT should specify the host:port of the remote (not the proxy)_
in https://github.com/helidon-io/helidon/issues/7143

In my opinion, it makes no sense because the header HOST is mandatory and it contains the remote host:port, but you can try it by yourself configuring a proxy in your browser. For example when you visit youtube you will see the next:
```
CONNECT www.youtube.com:443 HTTP/1.1
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0
Proxy-Connection: keep-alive
Connection: keep-alive
Host: www.youtube.com:443
```
Some proxies could not work properly if the CONNECT is not set correctly.

I added also the keep alive headers.