### PR TITLE
Allow HTTP 1.0 responses

### DIFF
--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/Http1StatusParser.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/Http1StatusParser.java
@@ -24,14 +24,14 @@ import io.helidon.common.buffers.DataReader;
 import io.helidon.common.http.Http;
 
 /**
- * Parser of HTTP/1.1 response status.
+ * Parser of HTTP/1.0 or HTTP/1.1 response status.
  */
 public final class Http1StatusParser {
     private Http1StatusParser() {
     }
 
     /**
-     * Read the status line from HTTP/1.1 response.
+     * Read the status line from HTTP/1.0 or HTTP/1.1 response.
      *
      * @param reader    data reader to obtain bytes from
      * @param maxLength maximal number of bytes that can be processed before end of line is reached
@@ -73,15 +73,15 @@ public final class Http1StatusParser {
         reader.skip(1); // space
         newLine -= space;
         newLine--;
-        if (!protocolVersion.equals("1.1")) {
-            throw new IllegalStateException("HTTP response did not contain correct status line. Version is not 1.1: \n"
+        if (!protocolVersion.equals("1.0") && !protocolVersion.equals("1.1")) {
+            throw new IllegalStateException("HTTP response did not contain correct status line. Version is not 1.0 or 1.1: \n"
                                                     + BufferData.create(protocolVersion.getBytes(StandardCharsets.US_ASCII))
                     .debugDataHex());
         }
-        // HTTP/1.1 200 OK
+        // HTTP/1.0 or HTTP/1.1 200 OK
         space = reader.findOrNewLine(Bytes.SPACE_BYTE, newLine);
         if (space == newLine) {
-            throw new IllegalStateException("HTTP Response did not contain HTTP status line. Line: HTTP/1.1\n"
+            throw new IllegalStateException("HTTP Response did not contain HTTP status line. Line: HTTP/1.0 or HTTP/1.1\n"
                                                     + reader.readBuffer(newLine).debugDataHex());
         }
         String code = reader.readAsciiString(space);
@@ -94,7 +94,7 @@ public final class Http1StatusParser {
         try {
             return Http.Status.create(Integer.parseInt(code), phrase);
         } catch (NumberFormatException e) {
-            throw new IllegalStateException("HTTP Response did not contain HTTP status line. Line HTTP/1.1 \n"
+            throw new IllegalStateException("HTTP Response did not contain HTTP status line. Line HTTP/1.0 or HTTP/1.1 \n"
                                                     + BufferData.create(code.getBytes(StandardCharsets.US_ASCII)) + "\n"
                                                     + BufferData.create(phrase.getBytes(StandardCharsets.US_ASCII)));
         }

--- a/nima/webclient/webclient/src/test/java/io/helidon/nima/webclient/http1/Http1StatusParserTest.java
+++ b/nima/webclient/webclient/src/test/java/io/helidon/nima/webclient/http1/Http1StatusParserTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webclient.http1;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.http.Http.Status;
+
+import org.junit.jupiter.api.Test;
+
+class Http1StatusParserTest {
+
+    @Test
+    public void http10() {
+        String response = "HTTP/1.0 200 Connection established\r\n";
+        Status status = Http1StatusParser.readStatus(new DataReader(() -> response.getBytes()), 256);
+        assertEquals(200, status.code());
+    }
+
+    @Test
+    public void http11() {
+        String response = "HTTP/1.1 200 Connection established\r\n";
+        Status status = Http1StatusParser.readStatus(new DataReader(() -> response.getBytes()), 256);
+        assertEquals(200, status.code());
+    }
+
+    @Test
+    public void wrong() {
+        String response = "HTTP/1.2 200 Connection established\r\n";
+        assertThrows(IllegalStateException.class,
+                () -> Http1StatusParser.readStatus(new DataReader(() -> response.getBytes()), 256));
+    }
+}


### PR DESCRIPTION
Relates to the point `Some proxies respond with HTTP 1.0 protocol and Http1StatusParser will fail` in https://github.com/helidon-io/helidon/issues/7143