### PR TITLE
Fix path handling for metrics observe provider

### DIFF
--- a/nima/observe/metrics/src/main/java/io/helidon/nima/observe/metrics/MetricsFeature.java
+++ b/nima/observe/metrics/src/main/java/io/helidon/nima/observe/metrics/MetricsFeature.java
@@ -182,6 +182,11 @@ public class MetricsFeature extends HelidonFeatureSupport {
     }
 
     @Override
+    protected void context(String context) {
+        super.context(context);
+    }
+
+    @Override
     protected void postSetup(HttpRouting.Builder defaultRouting, HttpRouting.Builder featureRouting) {
         configureVendorMetrics(defaultRouting);
     }
@@ -356,7 +361,7 @@ public class MetricsFeature extends HelidonFeatureSupport {
         private MetricsSettings.Builder metricsSettingsBuilder = MetricsSettings.builder();
 
         private Builder() {
-            super("/metrics");
+            super("metrics");
         }
 
         @Override

--- a/nima/observe/metrics/src/main/java/io/helidon/nima/observe/metrics/MetricsObserveProvider.java
+++ b/nima/observe/metrics/src/main/java/io/helidon/nima/observe/metrics/MetricsObserveProvider.java
@@ -82,6 +82,8 @@ public class MetricsObserveProvider implements ObserveProvider {
                 : explicitService;
 
         if (observer.enabled()) {
+            // when created as part of observer, we need to use component path
+            observer.context(componentPath);
             routing.addFeature(observer);
         } else {
             String finalPath = componentPath + (componentPath.endsWith("/") ? "*" : "/*");


### PR DESCRIPTION
Resolves #7044 

1. Looks like a line was omitted from the `MetricsObserveProvider#register` method when it was first created that deals with this scenario. (At least it seems that way comparing to health.)
2. A stray `/` in the `MetricsFeature` ctor needed to go away.

Also requires adding a protected method to `MetricsFeature` for visibility.