### PR TITLE
Support for proxy config properties in client and request

### DIFF
--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/ProxyBuilder.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/ProxyBuilder.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.jersey.connector;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.Optional;
+
+import io.helidon.nima.webclient.Proxy;
+
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.core.Configuration;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.ClientRequest;
+
+import static org.glassfish.jersey.client.ClientProperties.PROXY_PASSWORD;
+import static org.glassfish.jersey.client.ClientProperties.PROXY_URI;
+import static org.glassfish.jersey.client.ClientProperties.PROXY_USERNAME;
+
+class ProxyBuilder {
+
+    static Optional<Proxy> createProxy(Configuration config) {
+        Object proxyUri = config.getProperty(PROXY_URI);
+        String userName = ClientProperties.getValue(config.getProperties(), PROXY_USERNAME, String.class);
+        String password = ClientProperties.getValue(config.getProperties(), PROXY_PASSWORD, String.class);
+        return createProxy(proxyUri, userName, password);
+    }
+
+    static Optional<Proxy> createProxy(ClientRequest clientRequest) {
+        Object proxyUri = clientRequest.resolveProperty(PROXY_URI, Object.class);
+        String userName = clientRequest.resolveProperty(PROXY_USERNAME, String.class);
+        String password = clientRequest.resolveProperty(PROXY_PASSWORD, String.class);
+        return createProxy(proxyUri, userName, password);
+    }
+
+    private ProxyBuilder() {
+    }
+
+    private static Optional<Proxy> createProxy(Object proxyUri, String userName, String password) {
+        if (proxyUri != null) {
+            URI u = getProxyUri(proxyUri);
+            Proxy.Builder builder = Proxy.builder();
+            if (u.getScheme().toUpperCase(Locale.ROOT).equals("DIRECT")) {
+                builder.type(Proxy.ProxyType.NONE);
+            } else {
+                builder.host(u.getHost()).port(u.getPort());
+                if ("HTTP".equals(u.getScheme().toUpperCase(Locale.ROOT))) {
+                    builder.type(Proxy.ProxyType.HTTP);
+                } else {
+                    HelidonConnector.LOGGER.warning(String.format("Proxy schema %s not supported.", u.getScheme()));
+                    return Optional.empty();
+                }
+            }
+            if (userName != null) {
+                builder.username(userName);
+                if (password != null) {
+                    builder.password(password.toCharArray());
+                }
+            }
+            return Optional.of(builder.build());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static URI getProxyUri(final Object proxy) {
+        if (proxy instanceof URI) {
+            return (URI) proxy;
+        } else if (proxy instanceof String) {
+            return URI.create((String) proxy);
+        } else {
+            throw new ProcessingException("The proxy URI '" + proxy + "' MUST be String or URI");
+        }
+    }
+}

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/ConfigTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/ConfigTest.java
@@ -16,8 +16,11 @@
 
 package io.helidon.jersey.connector;
 
+import java.util.Optional;
+
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
+import io.helidon.nima.webclient.Proxy;
 import io.helidon.nima.webclient.http1.Http1ClientRequest;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -25,6 +28,7 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -63,5 +67,27 @@ class ConfigTest {
         HelidonConnector connector = new HelidonConnector(client, client.getConfiguration());
         Http1ClientRequest request = connector.client().get();
         assertThat(request.followRedirects(), is(false));
+    }
+
+    @Test
+    void testConfigNoProxy() {
+        Client client = ClientBuilder.newClient();
+        HelidonConnector connector = new HelidonConnector(client, client.getConfiguration());
+        assertThat(connector.proxy(), is(Proxy.noProxy()));
+    }
+
+    @Test
+    void testConfigProxy() {
+        Client client = ClientBuilder.newBuilder()
+                .property(ClientProperties.PROXY_URI, "http://localhost:8080")
+                .property(ClientProperties.PROXY_USERNAME, "user")
+                .property(ClientProperties.PROXY_PASSWORD, "pass")
+                .build();
+        HelidonConnector connector = new HelidonConnector(client, client.getConfiguration());
+        assertThat(connector.proxy().host(), is("localhost"));
+        assertThat(connector.proxy().port(), is(8080));
+        assertThat(connector.proxy().type(), is(Proxy.ProxyType.HTTP));
+        assertThat(connector.proxy().username(), is(Optional.of("user")));
+        assertThat(connector.proxy().password(), notNullValue());
     }
 }

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/Proxy.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/Proxy.java
@@ -321,6 +321,24 @@ public class Proxy {
     }
 
     /**
+     * Returns the port.
+     *
+     * @return proxy port
+     */
+    public int port() {
+        return port;
+    }
+
+    /**
+     * Returns the host.
+     *
+     * @return proxy host
+     */
+    public String host() {
+        return host;
+    }
+
+    /**
      * Returns an Optional with the username.
      * @return the username
      */


### PR DESCRIPTION
Issue #7186

- Support for proxy config properties in client and request
- Two new accessors in `Proxy` class used for testing
- Couple of new tests