### PR TITLE
Upgrade to OCI SDK 3.12.1 (#7163)

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/oci/files/server/src/test/java/__pkg__/server/GreetResourceMockedTest.java.mustache
+++ b/archetypes/helidon/src/main/archetype/mp/oci/files/server/src/test/java/__pkg__/server/GreetResourceMockedTest.java.mustache
@@ -98,6 +98,9 @@ class GreetResourceMockedTest {
         public void setRegion(String region) {}
 
         @Override
+        public void useRealmSpecificEndpointTemplate(boolean b) {}
+
+        @Override
         public void refreshClient() {}
 
         @Override
@@ -125,6 +128,9 @@ class GreetResourceMockedTest {
 
         @Override
         public void setRegion(String s) {}
+
+        @Override
+        public void useRealmSpecificEndpointTemplate(boolean b) {}
 
         @Override
         public ChangeAlarmCompartmentResponse changeAlarmCompartment(ChangeAlarmCompartmentRequest changeAlarmCompartmentRequest) {

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -127,7 +127,7 @@
         <version.lib.neo4j>4.4.11</version.lib.neo4j>
         <version.lib.netty>4.1.94.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.8.Final</version.lib.netty-io_uring>
-        <version.lib.oci>3.8.0</version.lib.oci>
+        <version.lib.oci>3.12.1</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.okhttp3>3.14.9</version.lib.okhttp3>

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
@@ -181,6 +181,10 @@ class OciMetricsCdiExtensionTest {
         }
 
         @Override
+        public void useRealmSpecificEndpointTemplate(boolean b) {
+        }
+
+        @Override
         public void refreshClient() {
         }
 


### PR DESCRIPTION
Notes:
1. Update mocking test to include new method for the Monitoring interface
2. Update mocking test of oci mp archetype to include the new method for the Monitoring interface
3. Tested successfully against OCI Logging and Monitoring services using oci-mp archetype generated from the cli tool and this change