### PR TITLE
3.x: upgrade okio to 3.4.0

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -105,6 +105,8 @@
                                 <overWriteIfNewer>true</overWriteIfNewer>
                                 <overWriteIfNewer>true</overWriteIfNewer>
                                 <includeScope>runtime</includeScope>
+                                <!-- Hack to work-around https://github.com/square/okio/issues/1306 -->
+                                <excludeArtifactIds>okio</excludeArtifactIds>
                             </configuration>
                         </execution>
                     </executions>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -134,7 +134,8 @@
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.okhttp3>3.14.9</version.lib.okhttp3>
-        <version.lib.okio>1.17.5</version.lib.okio>
+        <!-- Force upgrade to more current version -->
+        <version.lib.okio>3.4.0</version.lib.okio>
         <version.lib.opentelemetry>1.22.0</version.lib.opentelemetry>
         <version.lib.opentelemetry.semconv>1.22.0-alpha</version.lib.opentelemetry.semconv>
         <version.lib.opentelemetry.opentracing.shim>1.22.0-alpha</version.lib.opentelemetry.opentracing.shim>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -92,5 +92,19 @@
    <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
 </suppress>
 
+<!-- False Positive. This does not apply to server Java deployment and certainly not to our use of graalvm SDK.
+    This vulnerability applies to Java deployments, typically in clients running sandboxed
+    Java Web Start applications or sandboxed Java applets, that load and run untrusted code
+    (e.g., code that comes from the internet) and rely on the Java sandbox for security. This
+    vulnerability does not apply to Java deployments, typically in servers, that load and run only trusted code 
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: graal-sdk-22.3.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.sdk/graal\-sdk@.*$</packageUrl>
+   <vulnerabilityName>CVE-2023-22006</vulnerabilityName>
+</suppress>
+
 
 </suppressions>

--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -82,6 +82,13 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <!-- Hack to get around module issue in okio. See module-info.java -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>1.8.0</version>
+            <scope>provided</scope>
+        </dependency>
         <!--
          - Test dependencies
          -->

--- a/tracing/jaeger/src/main/java/module-info.java
+++ b/tracing/jaeger/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/jaeger/src/main/java/module-info.java
+++ b/tracing/jaeger/src/main/java/module-info.java
@@ -25,6 +25,12 @@ module io.helidon.tracing.jaeger {
     requires io.helidon.common.context;
     requires io.helidon.common.configurable;
 
+    // Hack because okhttp and okio are not modularized
+    // but kotlin.stdlib is, and therefore kotlin.stdlib
+    // will be missing from module graph unless some module
+    // requires it.
+    requires kotlin.stdlib;
+
     requires static io.helidon.config.metadata;
 
     requires java.logging;


### PR DESCRIPTION
* upgrade okio to 3.4.0
* suppress graalvm sdk false positive

This version of okio has issues with Java modules (for example see https://github.com/square/okio/issues/1306).  This version of okio is written in Kotlin and splits the original `okio` artifact into `okio` (platform agnostic stuff) and `okio-jvm` (Java classes).  We don't need `okio` at runtime (only `okio-jvm`), and it was causing modularity problems. To work-around this:

1. Exclude `okio` from the runtime environment (`libs` folder). 
2. In `helidon-tracing-jaeger` add `requires kotlin.stdlib;` so that `kotlin-stdlib` is included in the module graph. We need this because `kotlin-stdlib` is a well-formed Java module, but `okio-jvm` (which depends on it) is not, and therefore we need some module to depend on `kotlin.stdlib` for it to be included in the module graph.

Okio is a transative dependency of okhttp which is a transitive dependency of a couple third parties (opentelemetry-exporter-jaeger for example).  okhttp is not a direct third party dependency of Helidon -- except for one or two test dependencies.
