### PR TITLE
Remove license from generated hibernate.properties (2.x)

### DIFF
--- a/archetypes/database-mp/src/main/resources/src/main/resources/hibernate.properties
+++ b/archetypes/database-mp/src/main/resources/src/main/resources/hibernate.properties
@@ -1,19 +1,3 @@
-#
-# Copyright (c) 2020 Oracle and/or its affiliates.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 # Byte code for JPA must be generated at compile time.
 # This is a limitation of native image
 hibernate.bytecode.provider=none


### PR DESCRIPTION
#279

I found another file being generated with the license header: `hibernate.properties` for the Database MP archetype of version 2.x.

This time I generated all archetypes for all versions in one directory and used the command `grep -rni "copyr"`, so hopefully now all cases have been caught.