### PR TITLE
3.x: Suppress disputed Jackson positive

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -106,5 +106,21 @@
    <vulnerabilityName>CVE-2023-22006</vulnerabilityName>
 </suppress>
 
+<!-- 
+    This CVE is being disputed by the Jackson project and the community seems in agreement that this
+    CVE should be rejected. We are suppressing this for now to reduce noise in our scan and will
+    continue to monitor progress.
+    https://nvd.nist.gov/vuln/detail/CVE-2023-35116
+    https://github.com/FasterXML/jackson-databind/issues/3972
+
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: jackson-databind-2.15.2.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+   <cve>CVE-2023-35116</cve>
+</suppress>
+
 
 </suppressions>


### PR DESCRIPTION
This CVE is being disputed by the Jackson project and the community seems in agreement that it should be rejected. We are suppressing this for now to reduce noise in our scan and will continue to monitor progress.
