### PR TITLE
HTTP Proxy TODOs

### DIFF
--- a/nima/tests/integration/webclient/webclient/pom.xml
+++ b/nima/tests/integration/webclient/webclient/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>helidon-nima-webclient</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.nima.http2</groupId>
+            <artifactId>helidon-nima-http2-webclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.nima.webserver</groupId>
             <artifactId>helidon-nima-webserver</artifactId>
             <scope>test</scope>

--- a/nima/tests/integration/webclient/webclient/src/test/java/io/helidon/nima/tests/integration/webclient/AuthHttpProxyTest.java
+++ b/nima/tests/integration/webclient/webclient/src/test/java/io/helidon/nima/tests/integration/webclient/AuthHttpProxyTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.webclient;
+
+import io.helidon.common.http.Http;
+import io.helidon.nima.http2.webclient.Http2Client;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webclient.api.HttpClient;
+import io.helidon.nima.webclient.api.HttpClientResponse;
+import io.helidon.nima.webclient.api.Proxy;
+import io.helidon.nima.webclient.api.Proxy.ProxyType;
+import io.helidon.nima.webclient.http1.Http1Client;
+import io.helidon.nima.webserver.WebServer;
+import io.helidon.nima.webserver.http.HttpRouting;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.http.Http.Method.GET;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ServerTest
+class AuthHttpProxyTest {
+
+    private static final String PROXY_HOST = "localhost";
+    private static final String USER = "user";
+    private static final String PASSWORD = "password";
+    private int proxyPort;
+    private HttpProxy httpProxy;
+
+    private final HttpClient<?> clientHttp1;
+    private final HttpClient<?> clientHttp2;
+
+    AuthHttpProxyTest(WebServer server) {
+        String uri = "http://localhost:" + server.port();
+        this.clientHttp1 = Http1Client.builder()
+                .baseUri(uri)
+                .proxy(Proxy.noProxy())
+                .build();
+        this.clientHttp2 = Http2Client.builder()
+                .baseUri(uri)
+                .proxy(Proxy.noProxy())
+                .build();
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder router) {
+        router.route(GET, "/get", Routes::get);
+    }
+
+    @BeforeEach
+    void before() {
+        httpProxy = new HttpProxy(0, USER, PASSWORD);
+        httpProxy.start();
+        proxyPort = httpProxy.connectedPort();
+        assertThat(httpProxy.counter(), is(0));
+    }
+
+    @AfterEach
+    void after() {
+        httpProxy.stop();
+    }
+
+    @Test
+    void testUserPasswordCorrect1() {
+        Proxy proxy = Proxy.builder().type(ProxyType.HTTP).host(PROXY_HOST)
+                .username(USER).password(PASSWORD.toCharArray()).port(proxyPort).build();
+        successVerify(proxy, clientHttp1);
+    }
+
+    @Test
+    void testUserPasswordCorrect2() {
+        Proxy proxy = Proxy.builder().type(ProxyType.HTTP).host(PROXY_HOST)
+                .username(USER).password(PASSWORD.toCharArray()).port(proxyPort).build();
+        successVerify(proxy, clientHttp2);
+    }
+
+    @Test
+    void testUserPasswordNotCorrect1() {
+        Proxy proxy = Proxy.builder().type(ProxyType.HTTP).host(PROXY_HOST)
+                .username(USER).password("wrong".toCharArray()).port(proxyPort).build();
+        failVerify(proxy, clientHttp1);
+    }
+
+    @Test
+    void testUserPasswordNotCorrect2() {
+        Proxy proxy = Proxy.builder().type(ProxyType.HTTP).host(PROXY_HOST)
+                .username(USER).password("wrong".toCharArray()).port(proxyPort).build();
+        failVerify(proxy, clientHttp2);
+    }
+
+    private void successVerify(Proxy proxy, HttpClient<?> client) {
+        try (HttpClientResponse response = client.get("/get").proxy(proxy).request()) {
+            assertThat(response.status(), is(Http.Status.OK_200));
+            String entity = response.entity().as(String.class);
+            assertThat(entity, is("Hello"));
+        }
+        assertThat(httpProxy.counter(), is(1));
+    }
+
+    private void failVerify(Proxy proxy, HttpClient<?> client) {
+        try (HttpClientResponse response = client.get("/get").proxy(proxy).request()) {
+            fail("Expected exception");
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), is("Proxy sent wrong HTTP response code: 401 Unauthorized"));
+        }
+        assertThat(httpProxy.counter(), is(1));
+    }
+
+    private static class Routes {
+        private static String get() {
+            return "Hello";
+        }
+    }
+}

--- a/nima/webclient/http1/src/main/java/io/helidon/nima/webclient/http1/Http1StatusParser.java
+++ b/nima/webclient/http1/src/main/java/io/helidon/nima/webclient/http1/Http1StatusParser.java
@@ -24,14 +24,14 @@ import io.helidon.common.buffers.DataReader;
 import io.helidon.common.http.Http;
 
 /**
- * Parser of HTTP/1.1 response status.
+ * Parser of HTTP/1.0 or HTTP/1.1 response status.
  */
 public final class Http1StatusParser {
     private Http1StatusParser() {
     }
 
     /**
-     * Read the status line from HTTP/1.1 response.
+     * Read the status line from HTTP/1.0 or HTTP/1.1 response.
      *
      * @param reader    data reader to obtain bytes from
      * @param maxLength maximal number of bytes that can be processed before end of line is reached
@@ -73,15 +73,15 @@ public final class Http1StatusParser {
         reader.skip(1); // space
         newLine -= space;
         newLine--;
-        if (!protocolVersion.equals("1.1")) {
-            throw new IllegalStateException("HTTP response did not contain correct status line. Version is not 1.1: \n"
+        if (!protocolVersion.equals("1.0") && !protocolVersion.equals("1.1")) {
+            throw new IllegalStateException("HTTP response did not contain correct status line. Version is not 1.0 or 1.1: \n"
                                                     + BufferData.create(protocolVersion.getBytes(StandardCharsets.US_ASCII))
                     .debugDataHex());
         }
-        // HTTP/1.1 200 OK
+        // HTTP/1.0 or HTTP/1.1 200 OK
         space = reader.findOrNewLine(Bytes.SPACE_BYTE, newLine);
         if (space == newLine) {
-            throw new IllegalStateException("HTTP Response did not contain HTTP status line. Line: HTTP/1.1\n"
+            throw new IllegalStateException("HTTP Response did not contain HTTP status line. Line: HTTP/1.0 or HTTP/1.1\n"
                                                     + reader.readBuffer(newLine).debugDataHex());
         }
         String code = reader.readAsciiString(space);
@@ -94,7 +94,7 @@ public final class Http1StatusParser {
         try {
             return Http.Status.create(Integer.parseInt(code), phrase);
         } catch (NumberFormatException e) {
-            throw new IllegalStateException("HTTP Response did not contain HTTP status line. Line HTTP/1.1 \n"
+            throw new IllegalStateException("HTTP Response did not contain HTTP status line. Line HTTP/1.0 or HTTP/1.1 \n"
                                                     + BufferData.create(code.getBytes(StandardCharsets.US_ASCII)) + "\n"
                                                     + BufferData.create(phrase.getBytes(StandardCharsets.US_ASCII)));
         }

--- a/nima/webclient/http1/src/test/java/io/helidon/nima/webclient/http1/Http1StatusParserTest.java
+++ b/nima/webclient/http1/src/test/java/io/helidon/nima/webclient/http1/Http1StatusParserTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.webclient.http1;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.http.Http.Status;
+
+import org.junit.jupiter.api.Test;
+
+class Http1StatusParserTest {
+
+    @Test
+    public void http10() {
+        String response = "HTTP/1.0 200 Connection established\r\n";
+        Status status = Http1StatusParser.readStatus(new DataReader(() -> response.getBytes()), 256);
+        assertEquals(200, status.code());
+    }
+
+    @Test
+    public void http11() {
+        String response = "HTTP/1.1 200 Connection established\r\n";
+        Status status = Http1StatusParser.readStatus(new DataReader(() -> response.getBytes()), 256);
+        assertEquals(200, status.code());
+    }
+
+    @Test
+    public void wrong() {
+        String response = "HTTP/1.2 200 Connection established\r\n";
+        assertThrows(IllegalStateException.class,
+                () -> Http1StatusParser.readStatus(new DataReader(() -> response.getBytes()), 256));
+    }
+}


### PR DESCRIPTION
https://github.com/helidon-io/helidon/issues/7143

- [x] Support it in HTTP 2 (Tomas already did it, but I added tests)
- [x] Support Proxy HTTP authentication
- [x] Proxy keep alive headers
- [x] Some proxies respond with HTTP 1.0 protocol and Http1StatusParser will fail
- [x] HTTP CONNECT should specify the host:port of the remote (not the proxy)
In my opinion, it makes no sense because the header HOST is mandatory and it contains the remote host:port, but you can try it by yourself configuring a proxy in your browser. For example when you visit youtube you will see the next:
```
CONNECT www.youtube.com:443 HTTP/1.1
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0
Proxy-Connection: keep-alive
Connection: keep-alive
Host: www.youtube.com:443
```
Some proxies could not work properly if the CONNECT is not set correctly.
