### PR TITLE
4.x: Change h2 dependency to provided

### DIFF
--- a/archetypes/helidon/src/main/archetype/se/custom/database.xml
+++ b/archetypes/helidon/src/main/archetype/se/custom/database.xml
@@ -48,6 +48,12 @@ Instructions for H2 can be found here: https://www.h2database.com/html/cheatShee
                                             <value key="artifactId">h2</value>
                                         </map>
                                     </list>
+                                    <list key="dependencies">
+                                        <map>
+                                            <value key="groupId">com.h2database</value>
+                                            <value key="artifactId">h2</value>
+                                        </map>
+                                    </list>
                                     <list key="db-connection">
                                         <value><![CDATA[    url: jdbc:h2:~/test
     # Server mode, run: docker run --rm --name h2 -p 9092:9082 -p 8082:8082 nemerosa/h2

--- a/integrations/db/h2/pom.xml
+++ b/integrations/db/h2/pom.xml
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>

--- a/lra/coordinator/server/pom.xml
+++ b/lra/coordinator/server/pom.xml
@@ -113,6 +113,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/microprofile/lra/jax-rs/pom.xml
+++ b/microprofile/lra/jax-rs/pom.xml
@@ -77,6 +77,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+       <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.testing</groupId>
             <artifactId>helidon-microprofile-testing-junit5</artifactId>

--- a/microprofile/tests/tck/tck-lra/pom.xml
+++ b/microprofile/tests/tck/tck-lra/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>helidon-lra-coordinator-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Changes the scope of our H2 dependency to `provided`.  

This means users will need to add an explicit dependency on H2 to use it.