### PR TITLE
3.x: Add ability to deploy snapshot builds

### DIFF
--- a/.github/workflows/snapshotrelease.yaml
+++ b/.github/workflows/snapshotrelease.yaml
@@ -1,0 +1,39 @@
+# Perform a snapshot build and deploy to snapshot repository
+# Notes
+# - cannot run on Windows, as we use shell scripts
+
+name: "Snapshot Release"
+
+on:
+  workflow_dispatch:
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'oracle'
+  MAVEN_HTTP_ARGS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3'
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    timeout-minutes: 60
+    runs-on: ubuntu-20.04
+    environment: release
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3.11.0
+        with:
+          distribution: ${{ env.JAVA_DISTRO }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: Build and deploy
+        env:
+          MAVEN_SETTINGS: ${{ secrets.MAVEN_SETTINGS }}
+          RELEASE_WORKFLOW: "true"
+        run: |
+          etc/scripts/release.sh deploy_snapshot

--- a/.github/workflows/snapshotrelease.yaml
+++ b/.github/workflows/snapshotrelease.yaml
@@ -5,9 +5,6 @@
 name: "Snapshot Release"
 
 on:
-  push:
-    branches:
-      - '3.x-snapshot-releases'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/snapshotrelease.yaml
+++ b/.github/workflows/snapshotrelease.yaml
@@ -5,6 +5,9 @@
 name: "Snapshot Release"
 
 on:
+  push:
+    branches:
+      - '3.x-snapshot-releases'
   workflow_dispatch:
 
 env:

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -49,6 +49,9 @@ $(basename ${0}) [ --build-number=N ] CMD
         Perform a release build
         This will create a local branch, deploy artifacts and push a tag
 
+    deploy_snapshot
+        Perform a snapshot build and deploy to snapshot repository
+
 EOF
 }
 
@@ -238,7 +241,7 @@ release_build(){
 
     # Perform deployment
     mvn ${MAVEN_ARGS} clean deploy \
-       -Prelease,archetypes \
+       -Pdeploy,release,archetypes \
       -DskipTests \
       -DstagingRepositoryId="${STAGING_REPO_ID}" \
       -DretryFailedDeploymentCount="10"
@@ -260,6 +263,21 @@ release_build(){
 
     git tag -f "${FULL_VERSION}"
     git push --force origin refs/tags/"${FULL_VERSION}":refs/tags/"${FULL_VERSION}"
+}
+
+deploy_snapshot(){
+
+    # Make sure version ends in -SNAPSHOT
+    if [[ ${FULL_VERSION} != *-SNAPSHOT ]]; then
+        echo "Helidon version ${FULL_VERSION} is not a SNAPSHOT version. Failing snapshot release."
+        exit 1
+    fi
+
+    # Perform deployment. Since the version is SNAPSHOT this will go to snapshot repository
+    mvn ${MAVEN_ARGS} clean deploy \
+      -Pdeploy,archetypes \
+      -DskipTests \
+      -DretryFailedDeploymentCount="10"
 }
 
 # Invoke command

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -241,7 +241,7 @@ release_build(){
 
     # Perform deployment
     mvn ${MAVEN_ARGS} clean deploy \
-       -Pdeploy,release,archetypes \
+       -Prelease,archetypes \
       -DskipTests \
       -DstagingRepositoryId="${STAGING_REPO_ID}" \
       -DretryFailedDeploymentCount="10"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh-snapshots</id>
+            <id>ossrh</id>
             <name>Helidon Snapshot Repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
@@ -144,7 +144,7 @@
 
     <properties>
         <version.plugin.clean>3.3.1</version.plugin.clean>
-        <version.plugin.deploy>2.8.2</version.plugin.deploy>
+        <version.plugin.deploy>3.1.1</version.plugin.deploy>
         <version.plugin.gpg>1.6</version.plugin.gpg>
         <version.plugin.install>3.1.1</version.plugin.install>
         <version.plugin.nexus-staging>1.6.13</version.plugin.nexus-staging>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -228,6 +228,11 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
@@ -239,18 +244,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>deploy</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <extensions>true</extensions>
                     </plugin>
                 </plugins>
             </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -228,11 +228,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <extensions>true</extensions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
@@ -244,6 +239,18 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
                     </plugin>
                 </plugins>
             </build>
@@ -265,6 +272,27 @@
                     <url>https://oss.sonatype.org/content/repositories/staging/</url>
                     <snapshots>
                         <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+        <profile>
+            <id>snapshot</id>
+            <repositories>
+                <repository>
+                    <id>ossrh-snapshot</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>ossrh-snapshot</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <snapshots>
+                        <enabled>true</enabled>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>


### PR DESCRIPTION
This adds the ability to deploy snapshot builds.
Initially this will require a manual trigger.
In the future we may have it trigger on every merge to branch.
