### PR TITLE
Replace deprecated socket(String) on namedSocket(String) from ServerConfiguration

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,11 +235,9 @@ class NettyWebServer implements WebServer {
             for (Map.Entry<String, ServerBootstrap> entry : bootstrapEntries) {
                 ServerBootstrap bootstrap = entry.getValue();
                 String name = entry.getKey();
-                SocketConfiguration socketConfig = configuration.socket(name);
-                if (socketConfig == null) {
-                    throw new IllegalStateException(
-                            "no socket configuration found for name: " + name);
-                }
+                SocketConfiguration socketConfig = configuration.namedSocket(name)
+                        .orElseThrow(() -> new IllegalStateException("no socket configuration found for name: " + name));
+
                 int port = Math.max(socketConfig.port(), 0);
                 if (channelsUpFuture.isCompletedExceptionally()) {
                     // break because one of the previous channels already failed


### PR DESCRIPTION
There is a deprecated method `serverConfiguration.socket(string)` deprecated since 2.0.0 . I replaced on `serverConfiguration.namedSocket(String)`.

There are using this deprecated method in tests. Should I fix this too?
<img width="1670" alt="Screenshot 2023-08-05 at 22 36 09" src="https://github.com/helidon-io/helidon/assets/4740207/834c006b-8354-41a1-8e11-4bc6f6aaa596">
