### PR TITLE
2.x Replace deprecated socket(String) on namedSocket(String) from ServerConfiguration

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -245,11 +245,9 @@ class NettyWebServer implements WebServer {
             for (Map.Entry<String, ServerBootstrap> entry : bootstrapEntries) {
                 ServerBootstrap bootstrap = entry.getValue();
                 String name = entry.getKey();
-                SocketConfiguration socketConfig = configuration.socket(name);
-                if (socketConfig == null) {
-                    throw new IllegalStateException(
-                            "no socket configuration found for name: " + name);
-                }
+                SocketConfiguration socketConfig = configuration.namedSocket(name)
+                        .orElseThrow(() -> new IllegalStateException("no socket configuration found for name: " + name));
+
                 int port = Math.max(socketConfig.port(), 0);
                 if (channelsUpFuture.isCompletedExceptionally()) {
                     // break because one of the previous channels already failed


### PR DESCRIPTION
Backport 2.x   - https://github.com/helidon-io/helidon/pull/7318