### PR TITLE
3.x Make OciMetricsDataTest.beforeEach non private

### DIFF
--- a/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsDataTest.java
+++ b/integrations/oci/metrics/metrics/src/test/java/io/helidon/integrations/oci/metrics/OciMetricsDataTest.java
@@ -28,7 +28,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import io.helidon.metrics.api.RegistryFactory;
 
@@ -36,7 +35,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry.Type;
 
 import com.oracle.bmc.monitoring.model.MetricDataDetails;
 
-public class OciMetricsDataTest {
+class OciMetricsDataTest {
     private final OciMetricsSupport.NameFormatter nameFormatter = new OciMetricsSupport.NameFormatter() { };
     private final Type[] types = {Type.BASE, Type.VENDOR, Type.APPLICATION};
     private final String dimensionScopeName = "scope";
@@ -47,21 +46,15 @@ public class OciMetricsDataTest {
     private final MetricRegistry appMetricRegistry = rf.getRegistry(Type.APPLICATION);
 
     @BeforeEach
-    private void beforeEach() {
-        // clear all registry
+    void clearAllRegistry() {
         for (Type type: types) {
             MetricRegistry metricRegistry = rf.getRegistry(type);
-            metricRegistry.removeMatching(new MetricFilter() {
-                @Override
-                public boolean matches(MetricID metricID, Metric metric) {
-                    return true;
-                }
-            });
+            metricRegistry.removeMatching(MetricFilter.ALL);
         }
     }
 
     @Test
-    public void testMetricRegistries() {
+    void testMetricRegistries() {
         String counterName = "DummyCounter";
         String meterName = "DummyMeter";
         String timerName = "DummyTimer";
@@ -96,7 +89,7 @@ public class OciMetricsDataTest {
     }
 
     @Test
-    public void testOciMonitoringParameters() {
+    void testOciMonitoringParameters() {
         String compartmentId = "dummy.compartmentId";
         String namespace = "dummy-namespace";
         String resourceGroup = "dummy_resourceGroup";
@@ -114,7 +107,7 @@ public class OciMetricsDataTest {
     }
 
     @Test
-    public void testDimensions() {
+    void testDimensions() {
         String dummyTagName = "DummyTag";
         String dummyTagValue = "DummyValue";
 


### PR DESCRIPTION
There is a private method with an annotation `BeforeEach` in `OciMetricsDataTest`, but `BeforeEach`-method [must not be  private](https://junit.org/junit5/docs/5.9.1/api/org.junit.jupiter.api/org/junit/jupiter/api/BeforeEach.html) . 

I made it public (or it can be without an access modificator). Also small refactoring.

P.S. It's interesting. The private `BeforeEach`-method also works. I didn't expect it. It's better to follow the docs. 

- [x] Create backport 2.x