### PR TITLE
WebClient Follow Up

### DIFF
--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/ReadableEntityBase.java
@@ -219,7 +219,7 @@ public abstract class ReadableEntityBase implements ReadableEntity {
         }
 
         @Override
-        public int read(byte[] b, int off, int len) throws IOException {
+        public int read(byte[] b, int off, int len) {
             if (finished) {
                 return -1;
             }

--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/Http2CallChainBase.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/Http2CallChainBase.java
@@ -17,6 +17,7 @@
 package io.helidon.nima.http2.webclient;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -27,6 +28,8 @@ import io.helidon.common.http.ClientRequestHeaders;
 import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Http;
 import io.helidon.nima.common.tls.Tls;
+import io.helidon.nima.http.encoding.ContentDecoder;
+import io.helidon.nima.http.encoding.ContentEncodingContext;
 import io.helidon.nima.http2.Http2Headers;
 import io.helidon.nima.webclient.api.ClientUri;
 import io.helidon.nima.webclient.api.ConnectionKey;
@@ -157,7 +160,8 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
         // we need an instance to create it, so let's just use a reference
         AtomicReference<WebClientServiceResponse> response = new AtomicReference<>();
         if (stream.hasEntity()) {
-            builder.inputStream(new RequestingInputStream(stream, whenComplete, response));
+            ContentDecoder decoder = contentDecoder(responseHeaders);
+            builder.inputStream(decoder.apply(new RequestingInputStream(stream, whenComplete, response)));
         }
         WebClientServiceResponse serviceResponse = builder
                 .serviceRequest(serviceRequest)
@@ -169,6 +173,21 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
 
         response.set(serviceResponse);
         return serviceResponse;
+    }
+
+    private ContentDecoder contentDecoder(ClientResponseHeaders responseHeaders) {
+        ContentEncodingContext encodingSupport = clientConfig.contentEncoding();
+        if (encodingSupport.contentDecodingEnabled()) {
+            String contentEncoding = responseHeaders.get(Http.Header.CONTENT_ENCODING).value();
+            if (encodingSupport.contentDecodingSupported(contentEncoding)) {
+                return encodingSupport.decoder(contentEncoding);
+            } else {
+                throw new IllegalStateException("Unsupported content encoding: \n"
+                                                        + BufferData.create(contentEncoding.getBytes(StandardCharsets.UTF_8))
+                        .debugDataHex());
+            }
+        }
+        return ContentDecoder.NO_OP;
     }
 
     protected Http2Headers prepareHeaders(Http.Method method, ClientRequestHeaders headers, ClientUri uri) {

--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/Http2CallChainBase.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/Http2CallChainBase.java
@@ -43,6 +43,7 @@ import io.helidon.nima.webclient.http1.Http1ClientRequest;
 import io.helidon.nima.webclient.http1.Http1ClientResponse;
 import io.helidon.nima.webclient.spi.WebClientService;
 
+import static io.helidon.common.http.Http.Header.CONTENT_ENCODING;
 import static io.helidon.nima.webclient.api.ClientRequestBase.USER_AGENT_HEADER;
 
 abstract class Http2CallChainBase implements WebClientService.Chain {
@@ -177,8 +178,8 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
 
     private ContentDecoder contentDecoder(ClientResponseHeaders responseHeaders) {
         ContentEncodingContext encodingSupport = clientConfig.contentEncoding();
-        if (encodingSupport.contentDecodingEnabled()) {
-            String contentEncoding = responseHeaders.get(Http.Header.CONTENT_ENCODING).value();
+        if (encodingSupport.contentDecodingEnabled() && responseHeaders.contains(CONTENT_ENCODING)) {
+            String contentEncoding = responseHeaders.get(CONTENT_ENCODING).value();
             if (encodingSupport.contentDecodingSupported(contentEncoding)) {
                 return encodingSupport.decoder(contentEncoding);
             } else {

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
@@ -251,7 +251,8 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 throw new IOException("Stream already closed");
             }
             if (firstByte && firstBuffer == null) {
-                firstBuffer = buffer;
+                // if somebody re-uses the byte buffer sent to us, we must copy it
+                firstBuffer = buffer.copy();
                 return;
             }
 

--- a/nima/tests/integration/encoding/deflate/pom.xml
+++ b/nima/tests/integration/encoding/deflate/pom.xml
@@ -33,12 +33,21 @@
             <artifactId>helidon-nima-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.nima.http2</groupId>
+            <artifactId>helidon-nima-http2-webserver</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.nima.http.encoding</groupId>
             <artifactId>helidon-nima-http-encoding-deflate</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.nima.testing.junit5</groupId>
             <artifactId>helidon-nima-testing-junit5-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.nima.testing.junit5</groupId>
+            <artifactId>helidon-nima-testing-junit5-http2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nima/tests/integration/encoding/deflate/src/test/java/io/helidon/nima/tests/integration/encoding/deflate/DeflateEncodingTest.java
+++ b/nima/tests/integration/encoding/deflate/src/test/java/io/helidon/nima/tests/integration/encoding/deflate/DeflateEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,14 +32,19 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
 import io.helidon.common.http.Http;
+import io.helidon.nima.http2.webclient.Http2Client;
+import io.helidon.nima.http2.webserver.Http2Route;
 import io.helidon.nima.testing.junit5.webserver.ServerTest;
 import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webclient.api.ClientResponseTyped;
+import io.helidon.nima.webclient.http1.Http1Client;
 import io.helidon.nima.webserver.http.HttpRouting;
 import io.helidon.nima.webserver.http1.Http1Route;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -47,21 +52,41 @@ import static org.junit.jupiter.api.Assertions.fail;
 @ServerTest
 class DeflateEncodingTest {
     private static final String ENTITY = "Some arbitrary text we want to try to compress";
+    private static final byte[] DEFLATED_ENTITY;
+    private static final Http.HeaderValue CONTENT_ENCODING_DEFLATE = Http.Header.create(Http.Header.CONTENT_ENCODING, "deflate");
+
+    static {
+        ByteArrayOutputStream baos;
+        try {
+            baos = new ByteArrayOutputStream();
+            OutputStream os = new DeflaterOutputStream(baos);
+            os.write(ENTITY.getBytes(StandardCharsets.UTF_8));
+            os.close();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create deflated bytes", e);
+        }
+        DEFLATED_ENTITY = baos.toByteArray();
+    }
 
     private final URI uri;
+    private final Http1Client http1Client;
+    private final Http2Client http2Client;
     private final HttpClient client;
 
-    DeflateEncodingTest(URI uri) {
+    DeflateEncodingTest(URI uri, Http1Client http1Client, Http2Client http2Client) {
         this.uri = uri;
+        this.http1Client = http1Client;
+        this.http2Client = http2Client;
         this.client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(5))
+                .version(HttpClient.Version.HTTP_1_1)
                 .build();
     }
 
     @SetUpRoute
     static void routing(HttpRouting.Builder builder) {
         builder.route(Http1Route.route(Http.Method.PUT,
-                                       "/",
+                                       "/http1",
                                        (req, res) -> {
                                            String entity = req.content().as(String.class);
                                            if (!ENTITY.equals(entity)) {
@@ -69,29 +94,68 @@ class DeflateEncodingTest {
                                            } else {
                                                res.send(entity);
                                            }
-                                       }));
+                                       }))
+                .route(Http2Route.route(Http.Method.PUT,
+                                        "/http2",
+                                        (req, res) -> {
+                                            String entity = req.content().as(String.class);
+                                            if (!ENTITY.equals(entity)) {
+                                                res.status(Http.Status.INTERNAL_SERVER_ERROR_500).send("Wrong data");
+                                            } else {
+                                                res.send(entity);
+                                            }
+                                        }));
     }
 
     @Test
-    void testDeflate() throws IOException, InterruptedException {
+    void testDeflateJdkClient() throws IOException, InterruptedException {
         testIt("deflate");
     }
 
     @Test
-    void testDeflateMultipleAcceptedEncodings() throws IOException, InterruptedException {
+    void testDeflateHttp1Client() {
+        testIt(http1Client, "/http1", "deflate");
+    }
+
+    @Test
+    void testDeflateHttp2Client() throws IOException {
+        testIt(http2Client, "/http2", "deflate");
+    }
+
+    @Test
+    void testDeflateMultipleAcceptedEncodingsJdkClient() throws IOException, InterruptedException {
         testIt("br;q=0.9, gzip, *;q=0.1");
     }
 
+    @Test
+    void testDeflateMultipleAcceptedEncodingsHttp1Client() {
+        testIt(http1Client, "/http1", "br;q=0.9, gzip, *;q=0.1");
+    }
+
+    @Test
+    void testDeflateMultipleAcceptedEncodingsHttp2Client() {
+        testIt(http2Client, "/http2", "br;q=0.9, gzip, *;q=0.1");
+    }
+
+    void testIt(io.helidon.nima.webclient.api.HttpClient<?> client, String path, String acceptEncodingValue) {
+        ClientResponseTyped<String> response = client.put(path)
+                .header(Http.Header.ACCEPT_ENCODING, acceptEncodingValue)
+                .header(CONTENT_ENCODING_DEFLATE)
+                .submit(DEFLATED_ENTITY, String.class);
+
+        Assertions.assertAll(
+                () -> assertThat(response.status(), is(Http.Status.OK_200)),
+                () -> assertThat(response.entity(), is(ENTITY)),
+                () -> assertThat(response.headers(), hasHeader(CONTENT_ENCODING_DEFLATE))
+        );
+    }
+
     void testIt(String acceptEncodingValue) throws IOException, InterruptedException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        OutputStream os = new DeflaterOutputStream(baos);
-        os.write(ENTITY.getBytes(StandardCharsets.UTF_8));
-        os.close();
         HttpResponse<byte[]> response = client.send(HttpRequest.newBuilder()
-                                                            .PUT(HttpRequest.BodyPublishers.ofByteArray(baos.toByteArray()))
+                                                            .PUT(HttpRequest.BodyPublishers.ofByteArray(DEFLATED_ENTITY))
                                                             .header("Accept-Encoding", acceptEncodingValue)
                                                             .headers("Content-Encoding", "deflate")
-                                                            .uri(uri)
+                                                            .uri(uri.resolve("/http1"))
                                                             .build(),
                                                     HttpResponse.BodyHandlers.ofByteArray());
 

--- a/nima/tests/integration/encoding/deflate/src/test/resources/logging-test.properties
+++ b/nima/tests/integration/encoding/deflate/src/test/resources/logging-test.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+#All attributes details
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread: %5$s%6$s%n
+
+#All log level details
+.level=WARNING

--- a/nima/tests/integration/encoding/gzip/pom.xml
+++ b/nima/tests/integration/encoding/gzip/pom.xml
@@ -33,12 +33,21 @@
             <artifactId>helidon-nima-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.nima.http2</groupId>
+            <artifactId>helidon-nima-http2-webserver</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.nima.http.encoding</groupId>
             <artifactId>helidon-nima-http-encoding-gzip</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.nima.testing.junit5</groupId>
             <artifactId>helidon-nima-testing-junit5-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.nima.testing.junit5</groupId>
+            <artifactId>helidon-nima-testing-junit5-http2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nima/tests/integration/encoding/gzip/src/test/resources/logging-test.properties
+++ b/nima/tests/integration/encoding/gzip/src/test/resources/logging-test.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+#All attributes details
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread: %5$s%6$s%n
+
+#All log level details
+.level=WARNING

--- a/nima/webclient/README.md
+++ b/nima/webclient/README.md
@@ -1,0 +1,73 @@
+Helidon WebClient
+----
+
+The WebClient provides:
+
+- an HTTP client API that can be used with any HTTP version
+- HTTP version specific client API that adds HTTP version specific methods and features
+- support for additional clients that use HTTP to start with 
+
+Each client (including HTTP/2) is located in its own module. The only dependency is on HTTP/1, as it is needed by each
+other protocol currently supported by Helidon WebClient. Nevertheless the `webclient-api` module does not depend on it, so
+it could be (theoretically) used even without such support, if such a use case arrives in the future. 
+
+# DNS Resolving
+
+DNS resolution can be customized, we provide three implementations out of the box:
+
+- default Java DNS resolution
+- "first" DNS resolution (using the first IP address from the list)
+- "round-robin" DNS resolution (cycling through IP address from the list)
+
+# TCP based clients
+We provide common support for TCP based clients to use Proxies and TLS (see `TcpClientConnection`). 
+
+# HTTP Clients
+
+The main API to use is `io.helidon.webclient.WebClient` that can be used to access an HTTP server.
+
+When using plain socket, it will just use HTTP/1.1. You can configure `protocolPreference` to use a different HTTP version.
+If you use HTTP/2, an upgrade attempt would be done (and if it fails, the client falls-back to HTTP/1.1).
+You can also define `prior-knowledge` using HTTP/2 protocol configuration (through `WebClient.Builder#addProtocolConfig()`),
+in such a case we use `prior-knowledge` and fail if we cannot switch to HTTP/2.
+
+When using TLS, the client will use ALPN (protocol negotiation) to use appropriate HTTP version (either 1.1, or 2).
+
+Once (and if) HTTP/3 is supported, it cannot follow the same approach (as it is UDP and not TCP based). For such cases, we
+plan to support `Alt-Svc` header, with which the server can tell us to use a different protocol version, and the next request
+to the same authority would switch to that version.
+
+To provide HTTP version support extension, the implementation must provide `webclient.spi.HttpClientSpiProvider`.
+
+HTTP requests support the concept of `WebClientService` that can be used to add features to the client, such as metrics, tracing,
+security etc. 
+To create a new compatible service, the implementation must provide `webclient.spi.WebClientServiceProvider`
+It is sufficient to have the service on classpath for it to be used, can be disabled through configuration (or builder).
+
+We have implementation for the following services:
+
+- metrics
+- security
+- tracing
+
+# Non-HTTP Clients
+
+WebClient can be used to obtain instances of non-HTTP clients, that use HTTP to upgrade from, or as an underlying protocol.
+
+This includes:
+
+- WebSocket client - upgrades from HTTP/1.1
+- grpc client - uses HTTP/2 as the underlying protocol (not yet ready)
+
+To obtain an instance of such client, there are the following options:
+
+1. Use `WebClient.client(WsClient.PROTOCOL)` to obtain a WebSocket client with configuration of the client
+2. Use `WebClient.client(WsClient.PROTOCOL, WsClientProtocolConfig.builder()....build())` to customize protocol configuration
+3. Use `WsClient.builder()...build()` to customize client and protocol configuration
+
+Any such WebSocket client will use the HTTP/1.1 protocol of the WebClient instance to connect 
+(and inherit the TLS configuration, proxy configuration etc.).
+
+Similar rules will apply to grpc client once it is ready, with the exception of using the HTTP/2 protocol instead.
+
+To provide a compatible client, the implementation must provide `webclient.spi.ClientProtocolProvider`.

--- a/nima/webclient/api/src/main/java/io/helidon/nima/webclient/api/HttpClientConfigBlueprint.java
+++ b/nima/webclient/api/src/main/java/io/helidon/nima/webclient/api/HttpClientConfigBlueprint.java
@@ -75,7 +75,7 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      * the one configured on this type's builder will win:
      * <ul>
      *     <li>{@link #readTimeout()}</li>
-     *     <li>{@link #connectTimeout()} eout(java.time.Duration)} (Duration)}</li>
+     *     <li>{@link #connectTimeout()}</li>
      * </ul>
      *
      * @return socket options


### PR DESCRIPTION
- content encoding/decoding used in HTTP/2
- fixed javadoc in HttpClientConfig
- readme for WebClient

Fixes a few issue from #7269 