### PR TITLE
3.x Replace try/catch in tests on assertThrows

### DIFF
--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -262,11 +262,7 @@ public class SingleTest {
 
     @Test
     public void testMapNullMapper() {
-        try {
-            Single.just("foo").map(null);
-            fail("NullPointerException should be thrown");
-        } catch (NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class, () -> Single.just("foo").map(null), "NullPointerException should be thrown");
     }
 
     @Test
@@ -375,11 +371,7 @@ public class SingleTest {
 
     @Test
     public void testFlatMapNullMapper() {
-        try {
-            Single.just("bar").flatMap(null);
-            fail("NullPointerException should have been thrown");
-        } catch (NullPointerException ex) {
-        }
+        assertThrows(NullPointerException.class, () -> Single.just("bar").flatMap(null), "NullPointerException should have been thrown");
     }
 
     @Test

--- a/config/config-mp/src/test/java/io/helidon/config/mp/MpMetaConfigTest.java
+++ b/config/config-mp/src/test/java/io/helidon/config/mp/MpMetaConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 class MpMetaConfigTest {
@@ -107,10 +107,7 @@ class MpMetaConfigTest {
     void testMetaPropertiesNotOptional() {
         System.setProperty(MpMetaConfig.META_CONFIG_SYSTEM_PROPERTY,
                 "custom-mp-meta-config-not-optional.properties");
-        try {
-            config = ConfigProvider.getConfig();
-            Assertions.fail("Expecting meta-config to fail due to not optional non-existent config source");
-        } catch (ConfigException e) {}
+        assertThrows(ConfigException.class, ConfigProvider::getConfig, "Expecting meta-config to fail due to not optional non-existent config source");
     }
 
     @Test

--- a/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
+++ b/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HoconJsonMpMetaConfigTest {
     private static ConfigProviderResolver configResolver;
@@ -150,9 +150,6 @@ class HoconJsonMpMetaConfigTest {
     @Test
     void testMetaHoconNonExistentNotOptional() {
         System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-hocon-path-not-optional.yaml");
-        try {
-            config = ConfigProvider.getConfig();
-            Assertions.fail("Expecting meta-config to fail due to not optional non-existent config source");
-        } catch (ConfigException e) {}
+        assertThrows(ConfigException.class, ConfigProvider::getConfig, "Expecting meta-config to fail due to not optional non-existent config source");
     }
 }

--- a/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpMetaConfigTest.java
+++ b/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpMetaConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class YamlMpMetaConfigTest {
     private static ConfigProviderResolver configResolver;
@@ -120,9 +120,6 @@ class YamlMpMetaConfigTest {
     @Test
     void testMetaNonExistentNotOptional() {
         System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-path-not-optional.yaml");
-        try {
-            config = ConfigProvider.getConfig();
-            Assertions.fail("Expecting meta-config to fail due to not optional non-existent config source");
-        } catch (ConfigException e) {}
+        assertThrows(ConfigException.class, ConfigProvider::getConfig, "Expecting meta-config to fail due to not optional non-existent config source");
     }
 }

--- a/security/jwt/src/test/java/io/helidon/security/jwt/SignedJwtTest.java
+++ b/security/jwt/src/test/java/io/helidon/security/jwt/SignedJwtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for {@link SignedJwt}.
@@ -94,12 +93,8 @@ public class SignedJwtTest {
                 {"payload", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9+lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"},
                 {"signature", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV/adQssw5c"}
         };
-        for (int i=0; i < tokens.length; i++) {
-            try {
-                SignedJwt.parseToken(tokens[i][1]);
-                fail("Parsing should have failed as the token " + tokens[i][0] + " is incorrectly encoded");
-            } catch (JwtException t) {
-            }
+        for (String[] token : tokens) {
+            assertThrows(JwtException.class, () -> SignedJwt.parseToken(token[1]), "Parsing should have failed as the token " + token[0] + " is incorrectly encoded");
         }
     }
 


### PR DESCRIPTION
There are many cases in tests:

```
try {
  someMethod();
  Assertions.fail("Should be exception");
} catch (SomeException e) {}
```
I think, it's better to use [assertThrows](https://junit.org/junit5/docs/5.8.2/api/org.junit.jupiter.api/org/junit/jupiter/api/Assertions.html#assertThrows(java.lang.Class,org.junit.jupiter.api.function.Executable,java.lang.String))