### PR TITLE
4.x Support creating routes from standard gRPC  bindable services

### DIFF
--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/Grpc.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/Grpc.java
@@ -16,7 +16,6 @@
 
 package io.helidon.nima.grpc.webserver;
 
-import io.grpc.ServerMethodDefinition;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.PathMatcher;
 import io.helidon.common.http.PathMatchers;
@@ -25,6 +24,7 @@ import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCallHandler;
+import io.grpc.ServerMethodDefinition;
 import io.grpc.stub.ServerCalls;
 
 class Grpc<ReqT, ResT> extends GrpcRoute {

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/Grpc.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/Grpc.java
@@ -16,6 +16,7 @@
 
 package io.helidon.nima.grpc.webserver;
 
+import io.grpc.ServerMethodDefinition;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.PathMatcher;
 import io.helidon.common.http.PathMatchers;
@@ -77,6 +78,23 @@ class Grpc<ReqT, ResT> extends GrpcRoute {
         return grpc(proto, serviceName, methodName, ServerCalls.asyncClientStreamingCall(method));
     }
 
+    /**
+     * Create a {@link io.helidon.nima.grpc.webserver.Grpc gRPC route} from a {@link io.grpc.ServerMethodDefinition}.
+     *
+     * @param definition the {@link io.grpc.ServerMethodDefinition} representing the method to execute
+     * @param proto      an optional protocol buffer {@link com.google.protobuf.Descriptors.FileDescriptor}
+     *                   containing the service definition
+     * @param <ReqT>     the request type
+     * @param <ResT>     the response type
+     *
+     * @return a {@link io.helidon.nima.grpc.webserver.Grpc gRPC route} created
+     *         from the {@link io.grpc.ServerMethodDefinition}
+     */
+    static <ReqT, ResT> Grpc<ReqT, ResT> methodDefinition(ServerMethodDefinition<ReqT, ResT> definition,
+                                                          Descriptors.FileDescriptor proto) {
+        return grpc(definition.getMethodDescriptor(), definition.getServerCallHandler(), proto);
+    }
+
     @Override
     Grpc<?, ?> toGrpc(HttpPrologue grpcPrologue) {
         return this;
@@ -129,6 +147,42 @@ class Grpc<ReqT, ResT> extends GrpcRoute {
                 .setResponseMarshaller(resMarshaller).setSampledToLocalTracing(true);
 
         return new Grpc<>(grpcDesc.build(), PathMatchers.exact(path), requestType, responsetype, callHandler);
+    }
+
+
+    /**
+     * Create a {@link io.helidon.nima.grpc.webserver.Grpc gRPC route} from a {@link io.grpc.MethodDescriptor}.
+     *
+     * @param grpcDesc    the {@link io.grpc.MethodDescriptor} describing the method to execute
+     * @param callHandler the {@link io.grpc.ServerCallHandler} that will execute the method
+     * @param proto       an optional protocol buffer {@link com.google.protobuf.Descriptors.FileDescriptor} containing
+     *                    the service definition
+     * @param <ReqT>      the request type
+     * @param <ResT>      the response type
+     *
+     * @return a {@link io.helidon.nima.grpc.webserver.Grpc gRPC route} created
+     *         from the {@link io.grpc.ServerMethodDefinition}
+     */
+    private static <ResT, ReqT> Grpc<ReqT, ResT> grpc(MethodDescriptor<ReqT, ResT> grpcDesc,
+                                                      ServerCallHandler<ReqT, ResT> callHandler,
+                                                      Descriptors.FileDescriptor proto) {
+
+        Class<ReqT> requestType = null;
+        Class<ResT> responsetype = null;
+        String serviceName = grpcDesc.getServiceName();
+
+        if (proto != null && serviceName != null) {
+            Descriptors.ServiceDescriptor svc = proto.findServiceByName(serviceName);
+            Descriptors.MethodDescriptor mtd = svc.findMethodByName(grpcDesc.getBareMethodName());
+            /*
+            We have to use reflection here
+             - to load the class
+             - to invoke a static method on it
+             */
+            requestType = load(getClassName(mtd.getInputType()));
+            responsetype = load(getClassName(mtd.getOutputType()));
+        }
+        return new Grpc<>(grpcDesc, PathMatchers.exact(grpcDesc.getFullMethodName()), requestType, responsetype, callHandler);
     }
 
     private static String getClassName(Descriptors.Descriptor descriptor) {

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandler.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandler.java
@@ -200,8 +200,16 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
             public void close(Status status, Metadata trailers) {
                 // todo ignoring trailers
                 WritableHeaders<?> writable = WritableHeaders.create();
-                writable.set(GrpcStatus.OK);
-                Http2Headers http2Headers = Http2Headers.create(writable);
+
+                // write the expected gRPC headers for content type and status
+                writable.set(GRPC_CONTENT_TYPE);
+                writable.set(Http.Headers.create(GrpcStatus.STATUS_NAME, status.getCode().value()));
+                String description = status.getDescription();
+                if (description != null) {
+                    writable.set(Http.Headers.create(GrpcStatus.MESSAGE_NAME, description));
+                }
+
+                Http2Headers http2Headers = Http2Headers.create(writable).status(Http.Status.OK_200);
                 streamWriter.writeHeaders(http2Headers,
                                           streamId,
                                           Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcRouting.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcRouting.java
@@ -20,6 +20,10 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import io.grpc.BindableService;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.PathMatchers;
 import io.helidon.nima.webserver.Routing;
@@ -179,6 +183,35 @@ public class GrpcRouting implements Routing {
                                                  ServerCalls.ClientStreamingMethod<ReqT, ResT> method) {
 
             return route(Grpc.clientStream(proto, serviceName, methodName, method));
+        }
+
+        /**
+         * Add all the routes for a {@link BindableService} service.
+         *
+         * @param proto    the proto descriptor
+         * @param service  the {@link BindableService} to add routes for
+         *
+         * @return updated builder
+         */
+        public Builder service(Descriptors.FileDescriptor proto, BindableService service) {
+            for (ServerMethodDefinition<?, ?> method : service.bindService().getMethods()) {
+                route(Grpc.methodDefinition(method, proto));
+            }
+            return this;
+        }
+
+        /**
+         * Add all the routes for the {@link ServerServiceDefinition} service.
+         *
+         * @param service  the {@link ServerServiceDefinition} to add routes for
+         *
+         * @return updated builder
+         */
+        public Builder service(ServerServiceDefinition service) {
+            for (ServerMethodDefinition<?, ?> method : service.getMethods()) {
+                route(Grpc.methodDefinition(method, null));
+            }
+            return this;
         }
 
         private Builder route(GrpcRoute route) {

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcRouting.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcRouting.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,14 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import io.grpc.BindableService;
-import io.grpc.ServerMethodDefinition;
-import io.grpc.ServerServiceDefinition;
-
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.PathMatchers;
 import io.helidon.nima.webserver.Routing;
 
 import com.google.protobuf.Descriptors;
+import io.grpc.BindableService;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
 import io.grpc.stub.ServerCalls;
 
 /**

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcStatus.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcStatus.java
@@ -36,6 +36,10 @@ public final class GrpcStatus {
      */
     public static final HeaderName STATUS_NAME = HeaderNames.createFromLowercase("grpc-status");
     /**
+     * grpc status message header name.
+     */
+    public static final HeaderName MESSAGE_NAME = HeaderNames.createFromLowercase("grpc-message");
+    /**
      * The operation completed successfully.
      */
     public static final Header OK = Http.Headers.createCached(STATUS_NAME, Status.Code.OK.value());

--- a/nima/tests/integration/grpc/server/src/main/java/io/helidon/nima/tests/integration/grpc/webserver/BindableStringService.java
+++ b/nima/tests/integration/grpc/server/src/main/java/io/helidon/nima/tests/integration/grpc/webserver/BindableStringService.java
@@ -1,0 +1,70 @@
+package io.helidon.nima.tests.integration.grpc.webserver;
+
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.helidon.nima.grpc.strings.StringServiceGrpc;
+import io.helidon.nima.grpc.strings.Strings;
+import io.helidon.nima.grpc.webserver.CollectingObserver;
+
+import io.grpc.stub.StreamObserver;
+
+import static io.helidon.nima.grpc.webserver.ResponseHelper.complete;
+import static io.helidon.nima.grpc.webserver.ResponseHelper.stream;
+
+public class BindableStringService
+        extends StringServiceGrpc.StringServiceImplBase {
+
+    @Override
+    public void upper(Strings.StringMessage request, StreamObserver<Strings.StringMessage> observer) {
+        String requestText = request.getText();
+        complete(observer, Strings.StringMessage.newBuilder()
+                .setText(requestText.toUpperCase(Locale.ROOT))
+                .build());
+    }
+
+    @Override
+    public void lower(Strings.StringMessage request, StreamObserver<Strings.StringMessage> observer) {
+        String requestText = request.getText();
+        complete(observer, Strings.StringMessage.newBuilder()
+                .setText(requestText.toLowerCase(Locale.ROOT))
+                .build());
+    }
+
+    @Override
+    public void split(Strings.StringMessage request, StreamObserver<Strings.StringMessage> observer) {
+        String[] parts = request.getText().split(" ");
+        stream(observer, Stream.of(parts).map(this::response));
+    }
+
+    @Override
+    public StreamObserver<Strings.StringMessage> join(StreamObserver<Strings.StringMessage> observer) {
+        return new CollectingObserver<>(
+                Collectors.joining(" "),
+                observer,
+                Strings.StringMessage::getText,
+                this::response);
+    }
+
+    @Override
+    public StreamObserver<Strings.StringMessage> echo(StreamObserver<Strings.StringMessage> observer) {
+        return new StreamObserver<>() {
+            public void onNext(Strings.StringMessage value) {
+                observer.onNext(value);
+            }
+
+            public void onError(Throwable t) {
+                t.printStackTrace();
+            }
+
+            public void onCompleted() {
+                observer.onCompleted();
+            }
+        };
+    }
+
+    private Strings.StringMessage response(String text) {
+        return Strings.StringMessage.newBuilder().setText(text).build();
+    }
+}

--- a/nima/tests/integration/grpc/server/src/main/java/io/helidon/nima/tests/integration/grpc/webserver/BindableStringService.java
+++ b/nima/tests/integration/grpc/server/src/main/java/io/helidon/nima/tests/integration/grpc/webserver/BindableStringService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.helidon.nima.tests.integration.grpc.webserver;
 
 import java.util.Locale;

--- a/nima/tests/integration/grpc/server/src/main/java/io/helidon/nima/tests/integration/grpc/webserver/StringService.java
+++ b/nima/tests/integration/grpc/server/src/main/java/io/helidon/nima/tests/integration/grpc/webserver/StringService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/tests/integration/grpc/server/src/main/java/io/helidon/nima/tests/integration/grpc/webserver/StringService.java
+++ b/nima/tests/integration/grpc/server/src/main/java/io/helidon/nima/tests/integration/grpc/webserver/StringService.java
@@ -39,7 +39,8 @@ class StringService implements GrpcService {
 
     @Override
     public void update(Routing router) {
-        router.unary("Upper", this::grpcUnary)
+        router.unary("Upper", this::grpcUnaryUpper)
+                .unary("Lower", this::grpcUnaryLower)
                 .bidi("Echo", this::grpcBidi)
                 .serverStream("Split", this::grpcServerStream)
                 .clientStream("Join", this::grpcClientStream);
@@ -74,10 +75,17 @@ class StringService implements GrpcService {
         };
     }
 
-    private void grpcUnary(StringMessage request, StreamObserver<StringMessage> observer) {
+    private void grpcUnaryUpper(StringMessage request, StreamObserver<StringMessage> observer) {
         String requestText = request.getText();
         complete(observer, StringMessage.newBuilder()
                 .setText(requestText.toUpperCase(Locale.ROOT))
+                .build());
+    }
+
+    private void grpcUnaryLower(StringMessage request, StreamObserver<StringMessage> observer) {
+        String requestText = request.getText();
+        complete(observer, StringMessage.newBuilder()
+                .setText(requestText.toLowerCase(Locale.ROOT))
                 .build());
     }
 

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/BaseStringServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/BaseStringServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/BaseStringServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/BaseStringServiceTest.java
@@ -42,20 +42,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
 @ServerTest
-class GrpcServerTest {
+abstract class BaseStringServiceTest {
     private final int port;
 
-    private ManagedChannel channel;
-    private StringServiceGrpc.StringServiceBlockingStub blockingStub;
-    private StringServiceGrpc.StringServiceStub stub;
+    protected ManagedChannel channel;
+    protected StringServiceGrpc.StringServiceBlockingStub blockingStub;
+    protected StringServiceGrpc.StringServiceStub stub;
 
-    GrpcServerTest(WebServer server) {
+    BaseStringServiceTest(WebServer server) {
         this.port = server.port();
-    }
-
-    @SetUpRoute
-    static void routing(Router.RouterBuilder<?> router) {
-        router.addRouting(GrpcRouting.builder().service(new StringService()));
     }
 
     @BeforeEach
@@ -81,12 +76,21 @@ class GrpcServerTest {
     }
 
     @RepeatedTest(20)
-    void testUnary() {
+    void testUnaryUpper() {
         String text = "lower case original";
         StringMessage request = StringMessage.newBuilder().setText(text).build();
         StringMessage response = blockingStub.upper(request);
 
         assertThat(response.getText(), is(text.toUpperCase(Locale.ROOT)));
+    }
+
+    @RepeatedTest(20)
+    void testUnaryLower() {
+        String text = "UPPER CASE ORIGINAL";
+        StringMessage request = StringMessage.newBuilder().setText(text).build();
+        StringMessage response = blockingStub.lower(request);
+
+        assertThat(response.getText(), is(text.toLowerCase(Locale.ROOT)));
     }
 
     @RepeatedTest(20)

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/BindableGrpcServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/BindableGrpcServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/BindableGrpcServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/BindableGrpcServiceTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.grpc.webserver;
+
+import io.helidon.nima.grpc.strings.Strings;
+import io.helidon.nima.grpc.webserver.GrpcRouting;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webserver.Router;
+import io.helidon.nima.webserver.WebServer;
+
+@ServerTest
+class BindableGrpcServiceTest
+    extends BaseStringServiceTest {
+    BindableGrpcServiceTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(Strings.getDescriptor(), new BindableStringService()));
+    }
+}

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/InterceptorGrpcServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/InterceptorGrpcServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/InterceptorGrpcServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/InterceptorGrpcServiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.grpc.webserver;
+
+import io.helidon.nima.grpc.strings.Strings;
+import io.helidon.nima.grpc.webserver.GrpcRouting;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webserver.Router;
+import io.helidon.nima.webserver.WebServer;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.ServerServiceDefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class InterceptorGrpcServiceTest
+    extends BaseStringServiceTest {
+
+    private static Interceptor interceptor;
+
+    InterceptorGrpcServiceTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        interceptor = new Interceptor();
+        ServerServiceDefinition definition = ServerInterceptors.intercept(new BindableStringService(), interceptor);
+        router.addRouting(GrpcRouting.builder().service(definition));
+    }
+
+    @Test
+    public void shouldInterceptCalls() {
+        interceptor.setIntercepted(false);
+        Strings.StringMessage request = Strings.StringMessage.newBuilder().setText("FOO").build();
+        blockingStub.lower(request);
+
+        assertThat(interceptor.wasIntercepted(), is(true));
+    }
+
+    public static class Interceptor
+            implements ServerInterceptor {
+
+        private boolean intercepted;
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+                                                                     Metadata headers,
+                                                                     ServerCallHandler<ReqT, RespT> next) {
+            intercepted = true;
+            return next.startCall(call, headers);
+        }
+
+        public boolean wasIntercepted() {
+            return intercepted;
+        }
+
+        public void setIntercepted(boolean intercepted) {
+            this.intercepted = intercepted;
+        }
+    }
+
+}

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/ServiceDefinitionGrpcServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/ServiceDefinitionGrpcServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/ServiceDefinitionGrpcServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/ServiceDefinitionGrpcServiceTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.grpc.webserver;
+
+import io.helidon.nima.grpc.webserver.GrpcRouting;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webserver.Router;
+import io.helidon.nima.webserver.WebServer;
+
+@ServerTest
+class ServiceDefinitionGrpcServiceTest
+    extends BaseStringServiceTest {
+    ServiceDefinitionGrpcServiceTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new BindableStringService().bindService()));
+    }
+}

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/StringServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/StringServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/StringServiceTest.java
+++ b/nima/tests/integration/grpc/server/src/test/java/io/helidon/nima/tests/integration/grpc/webserver/StringServiceTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.tests.integration.grpc.webserver;
+
+import io.helidon.nima.grpc.webserver.GrpcRouting;
+import io.helidon.nima.testing.junit5.webserver.ServerTest;
+import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
+import io.helidon.nima.webserver.Router;
+import io.helidon.nima.webserver.WebServer;
+
+@ServerTest
+class StringServiceTest
+    extends BaseStringServiceTest {
+    StringServiceTest(WebServer server) {
+        super(server);
+    }
+
+     @SetUpRoute
+     static void routing(Router.RouterBuilder<?> router) {
+         router.addRouting(GrpcRouting.builder().service(new StringService()));
+     }
+}


### PR DESCRIPTION
The gRPC API needs to support being able to create routes from standard gRPC service implementations that have been written by extending protobuf generated services. This PR make it possible to create a set of routes by passing either a `BinadbleService` or `ServerServiceDefinition` to the `GrpcRouting` class.

These changes were required to get our Coherence gRPC client tests to pass when we build the Coherence server side on top of Nima. Our gRPC services have been written in the normal way by extending protobuf generated service classes. It would have been painful to have to register each service method individually with the `GrpcRouting` class.