### PR TITLE
Enables OIDC integration tests and fixes a couple of problems in WebClient

### DIFF
--- a/nima/tests/integration/webclient/webclient/src/test/java/io/helidon/nima/tests/integration/webclient/CookieTest.java
+++ b/nima/tests/integration/webclient/webclient/src/test/java/io/helidon/nima/tests/integration/webclient/CookieTest.java
@@ -87,6 +87,14 @@ class CookieTest {
         }
     }
 
+    @Test
+    @Order(3)
+    void testCookieGetAfterPut() {
+        try (Http1ClientResponse response = client.get("/cookie").request()) {
+            assertThat(response.status(), is(Http.Status.OK_200));
+        }
+    }
+
     private static void getHandler(ServerRequest req, ServerResponse res) {
         if (req.headers().contains(Http.HeaderNames.COOKIE)) {
             Http.Header cookies = req.headers().get(Http.HeaderNames.COOKIE);
@@ -111,6 +119,10 @@ class CookieTest {
                     && cookies.allValues().contains("flavor2=vanilla")
                     && cookies.allValues().contains("flavor3=strawberry")
                     && cookies.allValues().contains("flavor4=raspberry")) {
+                // clear flavor1 and flavor2
+                res.header(Http.HeaderNames.SET_COOKIE,
+                        "flavor1=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0",
+                        "flavor2=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0");
                 res.status(Http.Status.OK_200).send();
             } else {
                 res.status(Http.Status.BAD_REQUEST_400).send();

--- a/nima/webclient/api/src/main/java/io/helidon/nima/webclient/api/ClientUri.java
+++ b/nima/webclient/api/src/main/java/io/helidon/nima/webclient/api/ClientUri.java
@@ -193,8 +193,8 @@ public class ClientUri implements UriInfo {
 
         uriBuilder.path(resolvePath(uriBuilder.path().path(), uri.getPath()));
 
-        if (uri.getRawQuery() != null) {
-            query.fromQueryString(uri.getRawQuery());
+        if (uri.getQuery() != null) {
+            query.fromQueryString(uri.getQuery());
         }
 
         if (uri.getRawFragment() != null) {

--- a/nima/webclient/api/src/main/java/io/helidon/nima/webclient/api/WebClientCookieManager.java
+++ b/nima/webclient/api/src/main/java/io/helidon/nima/webclient/api/WebClientCookieManager.java
@@ -142,12 +142,12 @@ public class WebClientCookieManager extends CookieManager implements RuntimeType
 
                 if (headers.contains(Http.HeaderNames.SET_COOKIE)) {
                     cookies = new HashMap<>();
-                    cookies.put(SET_COOKIE, headers.values(Http.HeaderNames.SET_COOKIE));
+                    cookies.put(SET_COOKIE, headers.get(Http.HeaderNames.SET_COOKIE).allValues());
                 }
 
                 if (headers.contains(Http.HeaderNames.SET_COOKIE2)) {
                     cookies = cookies == null ? new HashMap<>() : cookies;
-                    cookies.put(SET_COOKIE2, headers.values(Http.HeaderNames.SET_COOKIE2));
+                    cookies.put(SET_COOKIE2, headers.get(Http.HeaderNames.SET_COOKIE2).allValues());
                 }
 
                 if (cookies != null) {

--- a/nima/webclient/api/src/test/java/io/helidon/nima/webclient/api/ClientUriTest.java
+++ b/nima/webclient/api/src/test/java/io/helidon/nima/webclient/api/ClientUriTest.java
@@ -70,7 +70,10 @@ class ClientUriTest {
         assertThat(helper.path(), is(UriPath.create("/loom/quick")));
         assertThat(helper.port(), is(8080));
         assertThat(helper.scheme(), is("http"));
-        assertThat(helper.query(), is(query));
+        assertThat(helper.query().value("p1"), is("v1"));
+        assertThat(helper.query().value("p2"), is("v2"));
+        assertThat(helper.query().value("p3"), is("//v3//"));
+        assertThat(helper.query().getRaw("p3"), is("%2F%2Fv3%2F%2F"));
     }
 
     @Test

--- a/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/CookieBasedLoginIT.java
+++ b/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/CookieBasedLoginIT.java
@@ -22,7 +22,6 @@ import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.Response;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.tests.integration.oidc.TestResource.EXPECTED_POST_LOGOUT_TEST_MESSAGE;
@@ -31,7 +30,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Disabled("https://github.com/helidon-io/helidon/issues/7094")
 class CookieBasedLoginIT extends CommonLoginBase {
 
     @Test

--- a/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/QueryBasedLoginIT.java
+++ b/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/QueryBasedLoginIT.java
@@ -26,7 +26,6 @@ import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientProperties;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.tests.integration.oidc.TestResource.EXPECTED_TEST_MESSAGE;
@@ -34,7 +33,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Disabled("https://github.com/helidon-io/helidon/issues/7094")
 @AddConfig(key = "security.providers.1.oidc.cookie-use", value = "false")
 @AddConfig(key = "security.providers.1.oidc.query-param-use", value = "true")
 class QueryBasedLoginIT extends CommonLoginBase {

--- a/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/TenantIdentificationIT.java
+++ b/tests/integration/oidc/src/test/java/io/helidon/tests/integration/oidc/TenantIdentificationIT.java
@@ -33,7 +33,6 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientProperties;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -42,7 +41,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-@Disabled("https://github.com/helidon-io/helidon/issues/7094")
 @HelidonTest(resetPerTest = true)
 @AddBean(TestResource.class)
 @AddConfig(key = "security.providers.1.oidc.oidc-metadata-well-known", value = "false")

--- a/tests/integration/oidc/src/test/resources/application.yaml
+++ b/tests/integration/oidc/src/test/resources/application.yaml
@@ -15,8 +15,9 @@
 #
 
 client:
-  cookies:
+  cookie-manager:
     automatic-store-enabled: true
+  send-expect-continue: false
   follow-redirects: true
 
 security:


### PR DESCRIPTION
### Description

Enables OIDC integration tests. Fixes two additional issues in WebClient:

 1. In ClientUri, UriQueryWriteable is initialized from a decoded string. If initialized using an encoded string as before, a second encoding will take place internally.
 2. The WebClientCookieManager now correctly handles cookie values, including those that may contain commas (such as expiration values).

There are new or updated tests to cover the changes in (1) and (2).

### Documentation

None
