### PR TITLE
4.x: Media Context and streaming

### DIFF
--- a/examples/webserver/streaming/src/main/java/io/helidon/examples/webserver/streaming/StreamingService.java
+++ b/examples/webserver/streaming/src/main/java/io/helidon/examples/webserver/streaming/StreamingService.java
@@ -22,6 +22,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Objects;
 import java.util.logging.Logger;
 
@@ -57,7 +58,8 @@ public class StreamingService implements HttpService {
         LOGGER.info("Entering upload ... " + Thread.currentThread());
         try {
             Path tempFilePath = Files.createTempFile("large-file", ".tmp");
-            Files.copy(request.content().inputStream(), tempFilePath);
+            Files.copy(request.content().inputStream(), tempFilePath, StandardCopyOption.REPLACE_EXISTING);
+            response.send("File was stored as " + tempFilePath);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/examples/webserver/tutorial/src/test/java/io/helidon/examples/webserver/tutorial/MainTest.java
+++ b/examples/webserver/tutorial/src/test/java/io/helidon/examples/webserver/tutorial/MainTest.java
@@ -17,12 +17,12 @@
 package io.helidon.examples.webserver.tutorial;
 
 import io.helidon.http.Http;
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,10 +50,19 @@ public class MainTest {
     }
 
     @Test
-    public void testShutDown() {
+    public void testShutDown() throws InterruptedException {
         try (Http1ClientResponse response = client.post("/mgmt/shutdown").request()) {
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(server.isRunning(), is(false));
         }
+        // there may be some delay between the request being completed, and the server shutting down
+        // let's give it a second to shut down, then fail
+        for (int i = 0; i < 10; i++) {
+            if (server.isRunning()) {
+                Thread.sleep(100);
+            } else {
+                break;
+            }
+        }
+        assertThat(server.isRunning(), is(false));
     }
 }

--- a/http/http/src/main/java/io/helidon/http/HttpToken.java
+++ b/http/http/src/main/java/io/helidon/http/HttpToken.java
@@ -16,6 +16,10 @@
 
 package io.helidon.http;
 
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.common.buffers.BufferData;
+
 /**
  * HTTP Token utility.
  * Token is defined by the HTTP specification and must not contain a set of characters.
@@ -32,25 +36,46 @@ public final class HttpToken {
      */
     public static void validate(String token) throws IllegalArgumentException {
         char[] chars = token.toCharArray();
-        for (char aChar : chars) {
+        for (int i = 0; i < chars.length; i++) {
+            char aChar = chars[i];
             if (aChar > 254) {
-                throw new IllegalArgumentException("Token contains non-ASCII character");
+                throw new IllegalArgumentException("Token contains non-ASCII character at position "
+                                                           + hex(i)
+                                                           + " \n"
+                                                           + debugToken(token));
             }
             if (Character.isISOControl(aChar)) {
-                throw new IllegalArgumentException("Token contains control character");
+                throw new IllegalArgumentException("Token contains control character at position "
+                                                           + hex(i)
+                                                           + "\n"
+                                                           + debugToken(token));
             }
             if (Character.isWhitespace(aChar)) {
-                throw new IllegalArgumentException("Token contains whitespace character");
+                throw new IllegalArgumentException("Token contains whitespace character at position "
+                                                           + hex(i)
+                                                           + "\n"
+                                                           + debugToken(token));
             }
             switch (aChar) {
             case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}' -> {
-                throw new IllegalArgumentException(
-                        "Token contains illegal character: " + aChar);
+                throw new IllegalArgumentException("Token contains illegal character at position "
+                                                           + hex(i)
+                                                           + "\n"
+                                                           + debugToken(token));
             }
             default -> {
                 // this is a valid character
             }
             }
         }
+    }
+
+    private static String hex(int i) {
+        return Integer.toHexString(i);
+    }
+
+    private static String debugToken(String token) {
+        return BufferData.create(token.getBytes(StandardCharsets.US_ASCII))
+                .debugDataHex();
     }
 }

--- a/http/media/media/src/main/java/io/helidon/http/media/EntityWriter.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/EntityWriter.java
@@ -29,6 +29,46 @@ import io.helidon.http.WritableHeaders;
  */
 public interface EntityWriter<T> {
     /**
+     * Whether this entity writer can provide more information about each entity instance, such as content length.
+     *
+     * @return whether {@code instanceWriter} methods are supported;
+     *         If not one of the {@code write} methods would be called instead
+     */
+    default boolean supportsInstanceWriter() {
+        return false;
+    }
+
+    /**
+     * Client request entity instance writer.
+     *
+     * @param type            type of entity
+     * @param object          object to write
+     * @param requestHeaders  request headers
+     * @return instance writer ready to write the provided entity
+     */
+    default InstanceWriter instanceWriter(GenericType<T> type,
+                                          T object,
+                                          WritableHeaders<?> requestHeaders) {
+        throw new UnsupportedOperationException("This writer does not support instance writers: " + getClass().getName());
+    }
+
+    /**
+     * Server response entity instance writer.
+     *
+     * @param type            type of entity
+     * @param object          object to write
+     * @param requestHeaders  request headers
+     * @param responseHeaders response headers
+     * @return instance writer ready to write the provided entity
+     */
+    default InstanceWriter instanceWriter(GenericType<T> type,
+                                          T object,
+                                          Headers requestHeaders,
+                                          WritableHeaders<?> responseHeaders) {
+        throw new UnsupportedOperationException("This writer does not support instance writers: " + getClass().getName());
+    }
+
+    /**
      * Write server response entity and close the stream.
      *
      * @param type            type of entity

--- a/http/media/media/src/main/java/io/helidon/http/media/InstanceWriter.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/InstanceWriter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.media;
+
+import java.io.OutputStream;
+import java.util.OptionalLong;
+
+/**
+ * A writer dedicated to a specific instance. Method {@link #write(java.io.OutputStream)} will write the instance
+ * to the output stream, method {@link #instanceBytes()} will provide all the bytes of entity.
+ * The caller decided which method to call depending on results of {@link #alwaysInMemory()} and {@link #contentLength()}.
+ */
+public interface InstanceWriter {
+    /**
+     * If we can determine the number of bytes to be written to the stream, provide the information here.
+     * The returned number must be a valid content length (content-length >= 0)
+     *
+     * @return number of bytes or empty if not possible (or too expensive) to find out
+     */
+    OptionalLong contentLength();
+
+    /**
+     * Whether the byte array is always available. If true {@link #instanceBytes()} will ALWAYS be called.
+     *
+     * @return whether the bytes will always be materialized in memory
+     */
+    boolean alwaysInMemory();
+
+    /**
+     * Write the instance to the output stream. This method is NEVER called if {@link #alwaysInMemory()} is {@code true},
+     * otherwise this method is ALWAYS called if {@link #contentLength()} returns empty.
+     * This method MAY be called if {@link #contentLength()} returns a value.
+     *
+     * @param stream to write to
+     */
+    void write(OutputStream stream);
+
+    /**
+     * Get the instance as byte array. This method is always called if {@link #alwaysInMemory()} returns {@code true}.
+     * This method is NEVER called if {@link #contentLength()} returns empty.
+     * This method MAY be called if {@link #contentLength()} returns a value.
+     *
+     * @return bytes of the instance
+     */
+    byte[] instanceBytes();
+}

--- a/http/media/media/src/main/java/io/helidon/http/media/MediaContextImpl.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/MediaContextImpl.java
@@ -175,7 +175,7 @@ class MediaContextImpl implements MediaContext {
                 LOGGER.log(System.Logger.Level.WARNING, "There is no media writer configured for " + type);
             }
 
-            throw new IllegalArgumentException("No server response media writer for " + type + " configured");
+            throw new UnsupportedTypeException("No server response media writer for " + type + " configured");
         }
 
         @Override
@@ -188,7 +188,7 @@ class MediaContextImpl implements MediaContext {
                 LOGGER.log(System.Logger.Level.WARNING, "There is no media writer configured for " + type);
             }
 
-            throw new IllegalArgumentException("No client request media writer for " + type + " configured");
+            throw new UnsupportedTypeException("No client request media writer for " + type + " configured");
         }
     }
 
@@ -205,7 +205,7 @@ class MediaContextImpl implements MediaContext {
             if (LOGGED_READERS.computeIfAbsent(type, it -> new AtomicBoolean()).compareAndSet(false, true)) {
                 LOGGER.log(System.Logger.Level.WARNING, "There is no media reader configured for " + type);
             }
-            throw new IllegalArgumentException("No server request media support for " + type + " configured");
+            throw new UnsupportedTypeException("No server request media support for " + type + " configured");
         }
 
         @Override
@@ -216,7 +216,7 @@ class MediaContextImpl implements MediaContext {
             if (LOGGED_READERS.computeIfAbsent(type, it -> new AtomicBoolean()).compareAndSet(false, true)) {
                 LOGGER.log(System.Logger.Level.WARNING, "There is no media reader configured for " + type);
             }
-            throw new IllegalArgumentException("No client response media support for " + type + " configured");
+            throw new UnsupportedTypeException("No client response media support for " + type + " configured");
         }
     }
 
@@ -256,6 +256,24 @@ class MediaContextImpl implements MediaContext {
 
         CloseStreamWriter(EntityWriter delegate) {
             this.delegate = delegate;
+        }
+
+        @Override
+        public boolean supportsInstanceWriter() {
+            return delegate.supportsInstanceWriter();
+        }
+
+        @Override
+        public InstanceWriter instanceWriter(GenericType type, Object object, WritableHeaders requestHeaders) {
+            return delegate.instanceWriter(type, object, requestHeaders);
+        }
+
+        @Override
+        public InstanceWriter instanceWriter(GenericType type,
+                                             Object object,
+                                             Headers requestHeaders,
+                                             WritableHeaders responseHeaders) {
+            return delegate.instanceWriter(type, object, requestHeaders, responseHeaders);
         }
 
         @Override

--- a/http/media/media/src/main/java/io/helidon/http/media/UnsupportedTypeException.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/UnsupportedTypeException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.media;
+
+/**
+ * The type that a reader or writer was requested for is not supported by a {@link io.helidon.http.media.MediaContext}.
+ */
+public class UnsupportedTypeException extends RuntimeException {
+    /**
+     * Create a new exception with a descriptive message.
+     *
+     * @param message that should contain the type that failed to be used
+     */
+    public UnsupportedTypeException(String message) {
+        super(message);
+    }
+}

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
@@ -61,7 +61,8 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
         if (thrown == null) {
             return entity;
         }
-        throw new IllegalStateException("Failed to read response entity", thrown);
+        // re-throw the same exception, somebody may be interested in catching it
+        throw thrown;
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -234,4 +234,16 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      */
     @ConfiguredOption("true")
     boolean shareConnectionCache();
+
+    /**
+     * If the entity is expected to be smaller that this number of bytes, it would be buffered in memory to optimize performance.
+     * If bigger, streaming will be used.
+     * <p>
+     * Note that for some entity types we cannot use streaming, as they are already fully in memory (String, byte[]), for such
+     * cases, this option is ignored. Default is 128Kb.
+     *
+     * @return maximal number of bytes to buffer in memory for supported writers
+     */
+    @ConfiguredOption("131072")
+    int maxInMemoryEntity();
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallEntityChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallEntityChain.java
@@ -16,33 +16,29 @@
 
 package io.helidon.webclient.http1;
 
-import java.io.ByteArrayOutputStream;
 import java.util.concurrent.CompletableFuture;
 
-import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Http;
-import io.helidon.http.media.EntityWriter;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 
 class Http1CallEntityChain extends Http1CallChainBase {
 
-    private final Http1ClientRequestImpl request;
     private final CompletableFuture<WebClientServiceRequest> whenSent;
-    private final Object entity;
+    private final byte[] entity;
 
     Http1CallEntityChain(Http1ClientImpl http1Client,
                          Http1ClientRequestImpl request,
                          CompletableFuture<WebClientServiceRequest> whenSent,
                          CompletableFuture<WebClientServiceResponse> whenComplete,
-                         Object entity) {
+                         byte[] entity) {
         super(http1Client, request, whenComplete);
-        this.request = request;
+
         this.whenSent = whenSent;
         this.entity = entity;
     }
@@ -54,38 +50,18 @@ class Http1CallEntityChain extends Http1CallChainBase {
                                               DataWriter writer,
                                               DataReader reader,
                                               BufferData writeBuffer) {
-        byte[] entityBytes;
-        if (entity == BufferData.EMPTY_BYTES) {
-            entityBytes = BufferData.EMPTY_BYTES;
-        } else {
-            entityBytes = entityBytes(entity, headers);
-        }
 
-        headers.set(Http.Headers.create(Http.HeaderNames.CONTENT_LENGTH, entityBytes.length));
+        headers.set(Http.Headers.create(Http.HeaderNames.CONTENT_LENGTH, entity.length));
 
         writeHeaders(headers, writeBuffer, protocolConfig().validateRequestHeaders());
         // we have completed writing the headers
         whenSent.complete(serviceRequest);
 
-        if (entityBytes.length > 0) {
-            writeBuffer.write(entityBytes);
+        if (entity.length > 0) {
+            writeBuffer.write(entity);
         }
         writer.write(writeBuffer);
 
         return readResponse(serviceRequest, connection, reader);
-    }
-
-    byte[] entityBytes(Object entity, ClientRequestHeaders headers) {
-        if (entity instanceof byte[] bytes) {
-            return bytes;
-        }
-        GenericType<Object> genericType = GenericType.create(entity);
-        EntityWriter<Object> writer = clientConfig().mediaContext().writer(genericType, headers);
-
-        // todo this should use output stream of client, but that would require delaying header write
-        // to first byte written
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        writer.write(genericType, entity, bos, headers);
-        return bos.toByteArray();
     }
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -16,11 +16,16 @@
 
 package io.helidon.webclient.http1;
 
+import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Http;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.InstanceWriter;
+import io.helidon.http.media.MediaContext;
 import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.WebClientServiceRequest;
@@ -59,10 +64,50 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
 
     @Override
     public Http1ClientResponse doSubmit(Object entity) {
-        if (followRedirects()) {
-            return RedirectionProcessor.invokeWithFollowRedirects(this, entity);
+        byte[] entityBytes;
+        if (entity == BufferData.EMPTY_BYTES) {
+            entityBytes = BufferData.EMPTY_BYTES;
+        } else if (entity instanceof byte[] buffer) {
+            entityBytes = buffer;
+        } else {
+            // must apply media writer, and if the writer has unknown length, or longer than we can buffer, stream it
+            GenericType<Object> genericType = GenericType.create(entity);
+            EntityWriter<Object> mediaWriter = clientConfig()
+                    .mediaContext()
+                    .writer(genericType, headers());
+
+            long configuredContentLength = headers().contentLength().orElse(-1);
+            if (mediaWriter.supportsInstanceWriter()) {
+                InstanceWriter instanceWriter = mediaWriter.instanceWriter(genericType, entity, headers());
+                if (instanceWriter.alwaysInMemory()) {
+                    entityBytes = instanceWriter.instanceBytes();
+                } else {
+                    long length = instanceWriter.contentLength().orElse(configuredContentLength);
+                    if (length == -1) {
+                        return doOutputStream(instanceWriter::write);
+                    } else if (length > clientConfig().maxInMemoryEntity()) {
+                        headers().contentLength(length);
+                        return doOutputStream(instanceWriter::write);
+                    } else {
+                        entityBytes = instanceWriter.instanceBytes();
+                    }
+                }
+            } else {
+                if (configuredContentLength == -1 || configuredContentLength > clientConfig().maxInMemoryEntity()) {
+                    return doOutputStream(it -> mediaWriter.write(genericType, entity, it, headers()));
+                } else {
+                    // safe to cast to int, as the maxInMemoryEntity configuration option is an int
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream((int) configuredContentLength);
+                    mediaWriter.write(genericType, entity, baos, headers());
+                    entityBytes = baos.toByteArray();
+                }
+            }
         }
-        return invokeRequestWithEntity(entity);
+
+        if (followRedirects()) {
+            return RedirectionProcessor.invokeWithFollowRedirects(this, entityBytes);
+        }
+        return invokeRequestWithEntity(entityBytes);
     }
 
     @Override
@@ -126,11 +171,16 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         return UpgradeResponse.failure(response);
     }
 
+    @Override
+    protected MediaContext mediaContext() {
+        return super.mediaContext();
+    }
+
     Http1ClientImpl http1Client() {
         return http1Client;
     }
 
-    Http1ClientResponseImpl invokeRequestWithEntity(Object entity) {
+    Http1ClientResponseImpl invokeRequestWithEntity(byte[] entity) {
         CompletableFuture<WebClientServiceRequest> whenSent = new CompletableFuture<>();
         CompletableFuture<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
         Http1CallChainBase callChain = new Http1CallEntityChain(http1Client,

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -17,9 +17,9 @@
 package io.helidon.webclient.http1;
 
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
@@ -46,7 +46,7 @@ class Http1ConnectionCache {
     private static final Http1ConnectionCache SHARED = create();
     private static final List<String> ALPN_ID = List.of(Http1Client.PROTOCOL_ID);
     private static final Duration QUEUE_TIMEOUT = Duration.ofMillis(10);
-    private final Map<ConnectionKey, LinkedBlockingDeque<TcpClientConnection>> cache = new HashMap<>();
+    private final Map<ConnectionKey, LinkedBlockingDeque<TcpClientConnection>> cache = new ConcurrentHashMap<>();
 
     static Http1ConnectionCache shared() {
         return SHARED;

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
@@ -28,19 +28,18 @@ class RedirectionProcessor {
     }
 
     static boolean redirectionStatusCode(Http.Status status) {
-        int code = status.code();
-        return code >= 300 && code < 400;
+        return status.family() == Http.Status.Family.REDIRECTION;
     }
 
-    static Http1ClientResponseImpl invokeWithFollowRedirects(Http1ClientRequestImpl request, Object entity) {
+    static Http1ClientResponseImpl invokeWithFollowRedirects(Http1ClientRequestImpl request, byte[] entity) {
         return invokeWithFollowRedirects(request, 0, entity);
     }
 
-    static Http1ClientResponseImpl invokeWithFollowRedirects(Http1ClientRequestImpl request, int initial, Object entity) {
+    static Http1ClientResponseImpl invokeWithFollowRedirects(Http1ClientRequestImpl request, int initial, byte[] entity) {
         //Request object which should be used for invoking the next request. This will change in case of any redirection.
         Http1ClientRequestImpl clientRequest = request;
         //Entity to be sent with the request. Will be changed when redirect happens to prevent entity sending.
-        Object entityToBeSent = entity;
+        byte[] entityToBeSent = entity;
         for (int i = initial; i < request.maxRedirects(); i++) {
             Http1ClientResponseImpl clientResponse = clientRequest.invokeRequestWithEntity(entityToBeSent);
             if (!redirectionStatusCode(clientResponse.status())) {

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -35,16 +35,17 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.Bytes;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.PeerInfo;
 import io.helidon.http.Headers;
 import io.helidon.http.Http;
 import io.helidon.http.Http1HeadersParser;
 import io.helidon.http.WritableHeaders;
-import io.helidon.common.socket.HelidonSocket;
-import io.helidon.common.socket.PeerInfo;
 import io.helidon.http.media.EntityReader;
 import io.helidon.http.media.EntityWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaContextConfig;
+import io.helidon.logging.common.LogConfig;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.HttpClientResponse;
 
@@ -167,6 +168,7 @@ class Http1ClientTest {
 
     @Test
     void testExpect100() {
+        LogConfig.configureRuntime();
         String[] requestEntityParts = {"First", "Second", "Third"};
 
         Http1Client client = Http1Client.builder()
@@ -662,7 +664,7 @@ class Http1ClientTest {
                     // Send 100-Continue if requested
                     if (reqHeaders.contains(Http.Headers.EXPECT_100)) {
                         serverWriter.write(
-                                BufferData.create("HTTP/1.1 100 Continue\r\n".getBytes(StandardCharsets.UTF_8)));
+                                BufferData.create("HTTP/1.1 100 Continue\r\n\r\n".getBytes(StandardCharsets.UTF_8)));
                     }
 
                     // Assemble the entity from the chunks

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/MediaContextTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/MediaContextTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 
 import io.helidon.http.Http;
 import io.helidon.http.media.MediaContext;
+import io.helidon.http.media.UnsupportedTypeException;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServer;
@@ -102,8 +103,8 @@ public class MediaContextTest extends TestParent {
                         .build())
                 .build();
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-                client.get().request().as(String.class));
+        UnsupportedTypeException ex = assertThrows(UnsupportedTypeException.class, () ->
+                client.get().request(String.class).entity());
         assertThat(ex.getMessage(), startsWith("No client response media support for class"));
     }
 

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseEventTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseEventTest.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.tests.sse;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.media.MediaContext;
+import io.helidon.http.media.UnsupportedTypeException;
 import io.helidon.http.sse.SseEvent;
 
 import org.junit.jupiter.api.Test;
@@ -57,7 +58,7 @@ class SseEventTest extends SseBaseTest {
                 .data("{\"hello\":\"world\"}")
                 .mediaContext(emptyMediaContext)
                 .build();
-        assertThrows(IllegalArgumentException.class, () -> event.data(Object.class));
+        assertThrows(UnsupportedTypeException.class, () -> event.data(Object.class));
     }
 
     @Test
@@ -66,7 +67,7 @@ class SseEventTest extends SseBaseTest {
                 .data("{\"hello\":\"world\"}")
                 .mediaContext(mediaContext)
                 .build();
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(UnsupportedTypeException.class,
                      () -> event.data(HelloWorld.class, MediaTypes.TEXT_YAML));
     }
 
@@ -76,7 +77,7 @@ class SseEventTest extends SseBaseTest {
                 .data("{\"hello\":\"world\"}")
                 .mediaContext(emptyMediaContext)
                 .build();
-        assertThrows(IllegalArgumentException.class, () -> event.data(HelloWorld.class));
+        assertThrows(UnsupportedTypeException.class, () -> event.data(HelloWorld.class));
     }
 
     @Test

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ValidateResponseHeadersTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ValidateResponseHeadersTest.java
@@ -22,13 +22,9 @@ import java.io.UncheckedIOException;
 import java.util.stream.Stream;
 
 import io.helidon.http.Http;
-import io.helidon.http.Http.Header;
-import io.helidon.http.Http.HeaderName;
-import io.helidon.http.ServerRequestHeaders;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
-import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.ServerRequest;
@@ -40,7 +36,6 @@ import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webserver.testing.junit5.SetUpServer;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -48,7 +43,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
@@ -128,9 +122,8 @@ class ValidateResponseHeadersTest {
     }
 
     private static void setHeader(ServerRequest request, ServerResponse response) {
-        ServerRequestHeaders headers = request.headers();
         String[] header = request.content().as(String.class).split(HEADER_NAME_VALUE_DELIMETER);
-        response.headers().add(Http.Headers.create(Http.HeaderNames.create(header[0]), header[1]));
+        response.headers().add(Http.Headers.create(header[0], header[1]));
     }
 
     private static Stream<Arguments> responseHeaders() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -262,6 +262,21 @@ interface ListenerConfigBlueprint {
     Duration idleConnectionPeriod();
 
     /**
+     * If the entity is expected to be smaller that this number of bytes, it would be buffered in memory to optimize
+     * performance when writing it.
+     * If bigger, streaming will be used.
+     * <p>
+     * Note that for some entity types we cannot use streaming, as they are already fully in memory (String, byte[]), for such
+     * cases, this option is ignored.
+     * <p>
+     * Default is 128Kb.
+     *
+     * @return maximal number of bytes to buffer in memory for supported writers
+     */
+    @ConfiguredOption("131072")
+    int maxInMemoryEntity();
+
+    /**
      * Server listener socket options.
      * Unless configured through builder, {@code SO_REUSEADDR} is set to {@code true},
      * and {@code SO_RCVBUF} is set to {@code 4096}.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -444,6 +444,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
             buffer.write(message);
         }
 
+        sendListener.status(ctx, response.status());
         sendListener.headers(ctx, headers);
         sendListener.data(ctx, buffer);
         writer.write(buffer);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConnectionListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConnectionListener.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import io.helidon.common.buffers.DataListener;
 import io.helidon.http.Headers;
+import io.helidon.http.Http;
 import io.helidon.http.HttpPrologue;
 import io.helidon.webserver.ConnectionContext;
 
@@ -53,5 +54,14 @@ public interface Http1ConnectionListener extends DataListener<ConnectionContext>
      * @param headers headers
      */
     default void headers(ConnectionContext ctx, Headers headers) {
+    }
+
+    /**
+     * Handle status (server response only).
+     *
+     * @param ctx    context
+     * @param status status
+     */
+    default void status(ConnectionContext ctx, Http.Status status) {
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1LoggingConnectionListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1LoggingConnectionListener.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.http1;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Headers;
+import io.helidon.http.Http;
 import io.helidon.http.HttpPrologue;
 import io.helidon.webserver.ConnectionContext;
 
@@ -69,5 +70,12 @@ public class Http1LoggingConnectionListener implements Http1ConnectionListener {
         ctx.log(logger, DEBUG, "%s headers: %n%s",
                 prefix,
                 headers);
+    }
+
+    @Override
+    public void status(ConnectionContext ctx, Http.Status status) {
+        ctx.log(logger, DEBUG, "%s status: %s",
+                prefix,
+                status);
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequestWithEntity.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequestWithEntity.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.buffers.BufferData;
+import io.helidon.http.Http;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.encoding.ContentDecoder;
@@ -30,6 +31,8 @@ import io.helidon.webserver.http.HttpSecurity;
 import io.helidon.webserver.http.ServerRequestEntity;
 
 final class Http1ServerRequestWithEntity extends Http1ServerRequest {
+    private static final System.Logger LOGGER = System.getLogger(Http1ServerRequestWithEntity.class.getName());
+
     private final LazyValue<ReadableEntity> entity;
     private final ConnectionContext ctx;
     private final Http1Connection connection;
@@ -85,7 +88,12 @@ final class Http1ServerRequestWithEntity extends Http1ServerRequest {
 
     private void trySend100(boolean drain) {
         if (!continueImmediately && expectContinue && !drain) {
-            ctx.dataWriter().writeNow(BufferData.create(Http1Connection.CONTINUE_100));
+            BufferData buffer = BufferData.create(Http1Connection.CONTINUE_100);
+            if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+                ctx.log(LOGGER, System.Logger.Level.DEBUG, "send: status %s", Http.Status.CONTINUE_100);
+                ctx.log(LOGGER, System.Logger.Level.DEBUG, "send %n%s", buffer.debugDataHex());
+            }
+            ctx.dataWriter().writeNow(buffer);
             this.continueSent = true;
         }
     }


### PR DESCRIPTION
### Description
Media writers now correctly handle streaming where needed, without buffering in memory.
Fixes of issues uncovered by this change.
This impacts custom Media supports only, the API remains the same.

- String support is always in-memory
- Path depends on file size (configurable) - smaller files are loaded into memory, bigger files use streaming

Fixed issues that were uncovered (as now we use streaming a bit more).


Resolves #7006 

Moved to M2 milestone, as this resolves some bigger issues (such as 100-Continue handling)