### PR TITLE
4.x: Supplier in builder

### DIFF
--- a/builder/processor/src/main/java/io/helidon/builder/processor/TypeHandler.java
+++ b/builder/processor/src/main/java/io/helidon/builder/processor/TypeHandler.java
@@ -56,6 +56,9 @@ class TypeHandler {
         if (TypeNames.OPTIONAL.equals(returnType)) {
             return new TypeHandlerOptional(name, getterName, setterName, returnType);
         }
+        if (TypeNames.SUPPLIER.equals(returnType)) {
+            return new TypeHandlerSupplier(name, getterName, setterName, returnType);
+        }
         if (TypeNames.SET.equals(returnType)) {
             return new TypeHandlerSet(name, getterName, setterName, returnType);
         }
@@ -202,7 +205,7 @@ class TypeHandler {
 
     String generateFromConfig(FactoryMethods factoryMethods) {
         if (actualType().fqName().equals("char[]")) {
-            return ".asString().map(String::toCharArray)";
+            return ".asString().as(String::toCharArray)";
         }
 
         TypeName boxed = actualType().boxed();
@@ -214,7 +217,7 @@ class TypeHandler {
 
     void generateFromConfig(Method.Builder method, FactoryMethods factoryMethods) {
         if (actualType().fqName().equals("char[]")) {
-            method.add(".asString().map(").typeName(String.class).add("::toCharArray)");
+            method.add(".asString().as(").typeName(String.class).add("::toCharArray)");
             return;
         }
 
@@ -296,10 +299,10 @@ class TypeHandler {
 
     }
 
-    private void declaredSetter(InnerClass.Builder classBuilder,
-                                PrototypeProperty.ConfiguredOption configured,
-                                TypeName returnType,
-                                Javadoc blueprintJavadoc) {
+    protected void declaredSetter(InnerClass.Builder classBuilder,
+                                  PrototypeProperty.ConfiguredOption configured,
+                                  TypeName returnType,
+                                  Javadoc blueprintJavadoc) {
         Method.Builder builder = Method.builder()
                 .name(setterName())
                 .returnType(returnType, "updated builder instance")

--- a/builder/processor/src/main/java/io/helidon/builder/processor/TypeHandlerMap.java
+++ b/builder/processor/src/main/java/io/helidon/builder/processor/TypeHandlerMap.java
@@ -416,7 +416,8 @@ class TypeHandlerMap extends TypeHandler {
                 .addLine("return self();"));
     }
 
-    private void declaredSetter(InnerClass.Builder classBuilder,
+    @Override
+    protected void declaredSetter(InnerClass.Builder classBuilder,
                                 PrototypeProperty.ConfiguredOption configured,
                                 TypeName returnType,
                                 Javadoc blueprintJavadoc) {

--- a/builder/processor/src/main/java/io/helidon/builder/processor/TypeHandlerSupplier.java
+++ b/builder/processor/src/main/java/io/helidon/builder/processor/TypeHandlerSupplier.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.processor;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import io.helidon.common.processor.classmodel.Field;
+import io.helidon.common.processor.classmodel.InnerClass;
+import io.helidon.common.processor.classmodel.Javadoc;
+import io.helidon.common.processor.classmodel.Method;
+import io.helidon.common.types.TypeName;
+
+import static io.helidon.builder.processor.Types.CHAR_ARRAY_TYPE;
+import static io.helidon.builder.processor.Types.STRING_TYPE;
+import static io.helidon.common.types.TypeNames.SUPPLIER;
+
+class TypeHandlerSupplier extends TypeHandler.OneTypeHandler {
+
+    TypeHandlerSupplier(String name, String getterName, String setterName, TypeName declaredType) {
+        super(name, getterName, setterName, declaredType);
+    }
+
+    @Override
+    Field.Builder fieldDeclaration(PrototypeProperty.ConfiguredOption configured, boolean isBuilder, boolean alwaysFinal) {
+        Field.Builder builder = Field.builder()
+                .type(declaredType())
+                .name(name())
+                .isFinal(alwaysFinal || !isBuilder);
+
+        if (isBuilder && configured.hasDefault()) {
+            builder.defaultValue("() -> " + configured.defaultValue());
+        }
+
+        return builder;
+    }
+
+    @Override
+    TypeName argumentTypeName() {
+        return TypeName.builder(SUPPLIER)
+                .addTypeArgument(toWildcard(actualType()))
+                .build();
+    }
+
+    @Override
+    void generateFromConfig(Method.Builder method, PrototypeProperty.ConfiguredOption configured, FactoryMethods factoryMethods) {
+        if (configured.provider()) {
+            return;
+        }
+        if (factoryMethods.createFromConfig().isPresent()) {
+            method.addLine(configGet(configured)
+                                   + generateFromConfig(factoryMethods)
+                                   + ".ifPresent(this::" + setterName() + ");");
+        } else {
+            method.add(setterName() + "(");
+            method.add(configGet(configured));
+            method.add(generateFromConfig(factoryMethods));
+            method.addLine(".supplier());");
+        }
+    }
+
+    @Override
+    void setters(InnerClass.Builder classBuilder,
+                 PrototypeProperty.ConfiguredOption configured,
+                 PrototypeProperty.Singular singular,
+                 FactoryMethods factoryMethod,
+                 TypeName returnType,
+                 Javadoc blueprintJavadoc) {
+
+        declaredSetter(classBuilder, configured, returnType, blueprintJavadoc);
+
+        // and add the setter with the actual type
+        Method.Builder method = Method.builder()
+                .name(setterName())
+                .description(blueprintJavadoc.content())
+                .returnType(returnType, "updated builder instance")
+                .addParameter(param -> param.name(name())
+                        .type(actualType())
+                        .description(blueprintJavadoc.returnDescription()))
+                .addJavadocTag("see", "#" + getterName() + "()")
+                .typeName(Objects.class)
+                .addLine(".requireNonNull(" + name() + ");")
+                .addLine("this." + name() + " = () -> " + name() + ";")
+                .addLine("return self();");
+        classBuilder.addMethod(method);
+
+        if (actualType().equals(CHAR_ARRAY_TYPE)) {
+            classBuilder.addMethod(builder -> builder.name(setterName())
+                    .returnType(returnType, "updated builder instance")
+                    .description(blueprintJavadoc.content())
+                    .addJavadocTag("see", "#" + getterName() + "()")
+                    .addParameter(param -> param.name(name())
+                            .type(STRING_TYPE)
+                            .description(blueprintJavadoc.returnDescription()))
+                    .accessModifier(setterAccessModifier(configured))
+                    .typeName(Objects.class).addLine(".requireNonNull(" + name() + ");")
+                    .addLine("this." + name() + " = () -> " + name() + ".toCharArray();")
+                    .addLine("return self();"));
+        }
+
+        if (factoryMethod.createTargetType().isPresent()) {
+            // if there is a factory method for the return type, we also have setters for the type (probably config object)
+            FactoryMethods.FactoryMethod fm = factoryMethod.createTargetType().get();
+            String argumentName = name() + "Config";
+
+            classBuilder.addMethod(builder -> builder.name(setterName())
+                    .accessModifier(setterAccessModifier(configured))
+                    .description(blueprintJavadoc.content())
+                    .returnType(returnType, "updated builder instance")
+                    .addParameter(param -> param.name(argumentName)
+                            .type(fm.argumentType())
+                            .description(blueprintJavadoc.returnDescription()))
+                    .addJavadocTag("see", "#" + getterName() + "()")
+                    .typeName(Objects.class)
+                    .addLine(".requireNonNull(" + argumentName + ");")
+                    .add("this." + name() + " = ")
+                    .typeName(fm.typeWithFactoryMethod().genericTypeName())
+                    .addLine("." + fm.createMethodName() + "(" + argumentName + ");")
+                    .addLine("return self();"));
+        }
+
+        if (factoryMethod.builder().isPresent()) {
+            // if there is a factory method for the return type, we also have setters for the type (probably config object)
+            FactoryMethods.FactoryMethod fm = factoryMethod.builder().get();
+
+            TypeName builderType;
+            String className = fm.factoryMethodReturnType().className();
+            if (className.equals("Builder") || className.endsWith(".Builder")) {
+                builderType = fm.factoryMethodReturnType();
+            } else {
+                builderType = TypeName.create(fm.factoryMethodReturnType().fqName() + ".Builder");
+            }
+            String argumentName = "consumer";
+            TypeName argumentType = TypeName.builder()
+                    .type(Consumer.class)
+                    .addTypeArgument(builderType)
+                    .build();
+
+            classBuilder.addMethod(builder -> builder.name(setterName())
+                    .accessModifier(setterAccessModifier(configured))
+                    .description(blueprintJavadoc.content())
+                    .returnType(returnType, "updated builder instance")
+                    .addParameter(param -> param.name(argumentName)
+                            .type(argumentType)
+                            .description(blueprintJavadoc.returnDescription()))
+                    .addJavadocTag("see", "#" + getterName() + "()")
+                    .typeName(Objects.class)
+                    .addLine(".requireNonNull(" + argumentName + ");")
+                    .add("var builder = ")
+                    .typeName(fm.typeWithFactoryMethod().genericTypeName())
+                    .addLine("." + fm.createMethodName() + "();")
+                    .addLine("consumer.accept(builder);")
+                    .addLine("this." + name() + "(builder.build());")
+                    .addLine("return self();"));
+        }
+    }
+
+    protected void declaredSetter(InnerClass.Builder classBuilder,
+                                  PrototypeProperty.ConfiguredOption configured,
+                                  TypeName returnType,
+                                  Javadoc blueprintJavadoc) {
+        Method.Builder builder = Method.builder()
+                .name(setterName())
+                .returnType(returnType, "updated builder instance")
+                .description(blueprintJavadoc.content())
+                .addJavadocTag("see", "#" + getterName() + "()")
+                .addParameter(param -> param.name(name())
+                        .type(argumentTypeName())
+                        .description(blueprintJavadoc.returnDescription()))
+                .accessModifier(setterAccessModifier(configured));
+        builder.typeName(Objects.class).addLine(".requireNonNull(" + name() + ");");
+        builder.addLine("this." + name() + " = " + name() + "::get;")
+                .addLine("return self();");
+        classBuilder.addMethod(builder);
+    }
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SupplierBeanBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SupplierBeanBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import io.helidon.config.metadata.ConfiguredOption;
  */
 @Prototype.Blueprint
 @Configured
-interface SupplierBlueprint {
+interface SupplierBeanBlueprint {
     /**
      * This value is either explicitly configured, or uses config to get the supplier.
      * If config source with change support is changed, the supplier should provide the latest value from configuration.

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SupplierBeanBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SupplierBeanBlueprint.java
@@ -16,6 +16,7 @@
 
 package io.helidon.builder.test.testsubjects;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.helidon.builder.api.Prototype;
@@ -39,4 +40,10 @@ interface SupplierBeanBlueprint {
 
     @ConfiguredOption(key = "string-supplier")
     Supplier<char[]> charSupplier();
+
+    @ConfiguredOption
+    Supplier<Optional<String>> optionalSupplier();
+
+    @ConfiguredOption(key = "optional-supplier")
+    Supplier<Optional<char[]>> optionalCharSupplier();
 }

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SupplierBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SupplierBlueprint.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.function.Supplier;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.config.metadata.Configured;
+import io.helidon.config.metadata.ConfiguredOption;
+
+/**
+ * Blueprint with a supplier from configuration.
+ */
+@Prototype.Blueprint
+@Configured
+interface SupplierBlueprint {
+    /**
+     * This value is either explicitly configured, or uses config to get the supplier.
+     * If config source with change support is changed, the supplier should provide the latest value from configuration.
+     *
+     * @return supplier with latest value
+     */
+    @ConfiguredOption
+    Supplier<String> stringSupplier();
+
+    @ConfiguredOption(key = "string-supplier")
+    Supplier<char[]> charSupplier();
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/SupplierTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/SupplierTest.java
@@ -1,0 +1,49 @@
+package io.helidon.builder.test;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigException;
+import io.helidon.config.spi.ConfigContent;
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.config.spi.ConfigSource;
+import io.helidon.config.spi.EventConfigSource;
+import io.helidon.config.spi.NodeConfigSource;
+
+import org.junit.jupiter.api.Test;
+
+class SupplierTest {
+    private static final String KEY = "string-supplier";
+    private static final String ORIGINAL_VALUE = "value";
+    private static final String NEW_VALUE = "new-value";
+
+    @Test
+    void testChange() {
+        Config config = Config.just(new TestSource());
+
+    }
+
+    private static class TestSource implements ConfigSource, EventConfigSource, NodeConfigSource {
+
+        private BiConsumer<String, ConfigNode> consumer;
+
+        @Override
+        public void onChange(BiConsumer<String, ConfigNode> changedNode) {
+            this.consumer = changedNode;
+        }
+
+        @Override
+        public Optional<ConfigContent.NodeContent> load() throws ConfigException {
+            return Optional.of(ConfigContent.NodeContent.builder()
+                                       .node(ConfigNode.ObjectNode.builder()
+                                                     .addValue(KEY, ORIGINAL_VALUE)
+                                                     .build())
+                                       .build());
+        }
+
+        void update() {
+            consumer.accept(KEY, ConfigNode.ValueNode.create(NEW_VALUE));
+        }
+    }
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/SupplierTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/SupplierTest.java
@@ -1,8 +1,26 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.helidon.builder.test;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
+import io.helidon.builder.test.testsubjects.SupplierBean;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigException;
 import io.helidon.config.spi.ConfigContent;
@@ -13,16 +31,33 @@ import io.helidon.config.spi.NodeConfigSource;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 class SupplierTest {
     private static final String KEY = "string-supplier";
     private static final String ORIGINAL_VALUE = "value";
     private static final String NEW_VALUE = "new-value";
 
     @Test
-    void testChange() {
-        Config config = Config.just(new TestSource());
+    void testChangeString() {
+        TestSource testSource = new TestSource();
+        Config config = Config.just(testSource);
+        SupplierBean b = SupplierBean.create(config);
 
+        Supplier<String> stringSupplier = b.stringSupplier();
+        Supplier<char[]> arraySupplier = b.charSupplier();
+
+        assertThat(stringSupplier.get(), is(ORIGINAL_VALUE));
+        assertThat(arraySupplier.get(), is(ORIGINAL_VALUE.toCharArray()));
+
+        testSource.update();
+
+        assertThat(stringSupplier.get(), is(NEW_VALUE));
+        assertThat(arraySupplier.get(), is(NEW_VALUE.toCharArray()));
     }
+
+
 
     private static class TestSource implements ConfigSource, EventConfigSource, NodeConfigSource {
 

--- a/common/config/src/main/java/io/helidon/common/config/ConfigValue.java
+++ b/common/config/src/main/java/io/helidon/common/config/ConfigValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -284,4 +284,41 @@ public interface ConfigValue<T> {
         return asOptional().stream();
     }
 
+    /**
+     * Returns a supplier of a typed value. The semantics depend on implementation, this may always return the
+     * same value, or it may provide latest value if changes are enabled.
+     * <p>
+     * Note that {@link Supplier#get()} can throw a {@link io.helidon.common.config.ConfigException} if the value
+     * cannot be converted, or if the value is missing.
+     *
+     * @return a supplier of a typed value
+     */
+    Supplier<T> supplier();
+
+    /**
+     * Returns a supplier of a typed value with a default.
+     * <p>
+     * The semantics depend on implementation, this may always return the
+     * same value, or it may provide latest value if changes are enabled.
+     * <p>
+     * Note that {@link Supplier#get()} can throw a {@link io.helidon.common.config.ConfigException} if the value
+     * cannot be converted.
+     *
+     * @param defaultValue a value to be returned if the supplied value represents a {@link Config} node that has no direct
+     *                     value
+     * @return a supplier of a typed value
+     */
+    Supplier<T> supplier(T defaultValue);
+
+    /**
+     * Returns a {@link Supplier} of an {@link Optional Optional&lt;T&gt;} of the configuration node.
+     * <p>
+     * Supplier returns a {@link Optional#empty() empty} if the node does not have a direct value.
+     *
+     * @return a supplier of the value as an {@link Optional} typed instance, {@link Optional#empty() empty} in case the node
+     * does not have a direct value
+     * @see #asOptional()
+     * @see #supplier()
+     */
+    Supplier<Optional<T>> optionalSupplier();
 }

--- a/common/config/src/main/java/io/helidon/common/config/EmptyConfig.java
+++ b/common/config/src/main/java/io/helidon/common/config/EmptyConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 final class EmptyConfig {
     static final Config.Key ROOT_KEY = new KeyImpl(null, "");
@@ -138,6 +139,21 @@ final class EmptyConfig {
         @Override
         public <N> ConfigValue<N> as(Function<T, N> mapper) {
             return new EmptyValue<>(key);
+        }
+
+        @Override
+        public Supplier<T> supplier() {
+            return this::get;
+        }
+
+        @Override
+        public Supplier<T> supplier(T defaultValue) {
+            return () -> defaultValue;
+        }
+
+        @Override
+        public Supplier<Optional<T>> optionalSupplier() {
+            return this::asOptional;
         }
     }
 


### PR DESCRIPTION
### Description
A blueprint can now define a `Supplier<T>`. If this type is `@Configured` and the method has `@ConfiguredOption`, the supplier will be used directly from `Config` (if used).
This means the supplier will provide the latest value if changes are enabled in config.

Added appropriate test with a mutable configuration.

Resolves #7323
May require rebase after #7400 is merged

### Documentation
This enhancement adds support for a typed `Supplier` in prototype blueprints (Helidon builder). 
The following blueprint:
```java
@Prototype.Blueprint
@Configured
interface SupplierBeanBlueprint {
    @ConfiguredOption
    Supplier<String> stringSupplier();
}
```

will work with `io.helidon.config.Config` that has support for changes (using polling, file watcher, or an event based config source) in the following way:
- if the `SupplierBean` is created with config (such as `SupplierBean.create(Config)` or `SupplierBean.Builder.config(Config)` is used), the returning supplier will always provide the latest known value from the configuration key `string-supplier`

Of course the supplier can also be set explicitly (`SupplierBean.Builder.stringSupplier(() -> "someValue)`) - in this case, the supplier that is provided by user will be used