### PR TITLE
4.x: Fix references to interceptor. Now using decorator for builders.

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -22,7 +22,7 @@ The following list of features is currently supported:
 - `Map` options - key/value map, builders support any key/value types, but if configuration is used, the key must be a string
 - "Singular" for collection based options, which adds setter for a single value (for `List<String> algorithms()`, there would be the following setters: `algorithms(List<String>)`, `addAlgorithms(List<String>)`, `addAlgorithm(String)`)
 - A type can be `@Configured`, which adds integration with Helidon common Config module, by adding a static factory method `create(io.helidon.common.Config)` to the generated type, as well as `config(Config)` method to the generated builder, that sets all options annotated with `@ConfiguredOption` from configuration (if present in the Config instance)
-- Capability to update the builder before validation (interceptor)
+- Capability to update the builder before validation (decorator)
 - Support for custom methods (`@Prototype.CustomMethods`) for factory methods, prototype methods, and builder methods
 
 ## Non-Goals
@@ -84,4 +84,4 @@ Generated types will be available under `./target/generated-sources/annotations`
 * Support for `builder(MyConfigBean)` to create a new builder from an existing instance
 * Support for `from(MyConfigBean)` and `from(MyConfigBean.BuilderBase<?, ?>)` to update builder from an instance or builder
 * Support for validation of required and non-nullable options (required options are options that have `@ConfiguredOption(required=true)`, non-nullable option is any option that is not primitive, collection, and does not return an `Optional`)
-* Support for builder interception (`@Bluprint(builderInterceptor = MyInterceptor.class)`)
+* Support for builder decorator (`@Bluprint(decorator = MyDecorator.class)`), `class MyDecorator implements BuilderDecorator`

--- a/builder/api/README.md
+++ b/builder/api/README.md
@@ -87,14 +87,14 @@ Annotations:
 
 Interfaces:
 
-| Interface                      | Generated | Description                                                                                                                                                                                                                        |
-|--------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `RuntimeType.Api`              | `false`   | runtime type must implement this interface to mark which prototype is used to create it                                                                                                                                            |
-| `Prototype.Factory`            | `false`   | if blueprint implements factory, it means the prototype is used to create a single runtime type and will have methods `build` and `get` both on builder an on prototype interface that create a new instance of the runtime object |
-| `Prototype.BuilderInterceptor` | `false`   | custom interceptor to modidfy buider before validation is done in method `build`                                                                                                                                                   |
-| `Prototype.Api`                | `true`    | all prototypes implement this interface                                                                                                                                                                                            |
-| `Prototype.Builder`            | `true`    | all prototype builders implement this interface, defines method `buildPrototype`                                                                                                                                                   |
-| `Prototype.ConfiguredBuilder`  | `true`    | all prototype builders that support configuration implement this interface, defines method `config(Config)`                                                                                                                        |
+| Interface                     | Generated | Description                                                                                                                                                                                                                        |
+|-------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `RuntimeType.Api`             | `false`   | runtime type must implement this interface to mark which prototype is used to create it                                                                                                                                            |
+| `Prototype.Factory`           | `false`   | if blueprint implements factory, it means the prototype is used to create a single runtime type and will have methods `build` and `get` both on builder an on prototype interface that create a new instance of the runtime object |
+| `Prototype.BuilderDecorator`  | `false`   | custom decorator to modify builder before validation is done in method `build`                                                                                                                                                     |
+| `Prototype.Api`               | `true`    | all prototypes implement this interface                                                                                                                                                                                            |
+| `Prototype.Builder`           | `true`    | all prototype builders implement this interface, defines method `buildPrototype`                                                                                                                                                   |
+| `Prototype.ConfiguredBuilder` | `true`    | all prototype builders that support configuration implement this interface, defines method `config(Config)`                                                                                                                        |
 
 ## Configured providers
 

--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -84,7 +84,7 @@ public final class Prototype {
          * Any configured option that is defined on this prototype will be checked in configuration, and if it exists,
          * it will override current value for that option on this builder.
          * Options that do not exist in the provided config will not impact current values.
-         * The config instance is kept and may be used in builder interceptor, it is not available in prototype implementation.
+         * The config instance is kept and may be used in builder decorator, it is not available in prototype implementation.
          *
          * @param config configuration to use
          * @return updated builder instance
@@ -221,7 +221,7 @@ public final class Prototype {
 
         /**
          * Used to decorate the builder, right before method build is called.
-         * Validations are done AFTER the interceptor is handled.
+         * Validations are done AFTER the decorator is handled.
          * This class may be package local if located in the same package as blueprint.
          * The class must have accessible constructor with no parameters.
          *
@@ -232,13 +232,12 @@ public final class Prototype {
 
     /**
      * Provides a contract by which the {@link Prototype.Blueprint}
-     * annotated type can be intercepted (i.e., including decoration or
-     * mutation).
+     * annotated type can be decorated.
      * <p>
      * The implementation class type must provide a no-arg accessible constructor available to the generated class
      * <p>
-     * Note that when intercepting config, you may get {@code null} even for required types, as these may be configured
-     * by your very builder interceptor.
+     * The builder provides accessors to all types, using {@link java.util.Optional} for any field that is optional,
+     * or any other field unless it has a default value. Primitive types are an exception (unless declared as required).
      *
      * @param <T> the type of the bean builder to intercept
      * @see io.helidon.builder.api.Prototype.Blueprint#decorator()
@@ -246,9 +245,9 @@ public final class Prototype {
     @FunctionalInterface
     public interface BuilderDecorator<T> {
         /**
-         * Provides the ability to intercept (i.e., including decoration or mutation) the target.
+         * Provides the ability to decorate the target.
          *
-         * @param target the target being intercepted
+         * @param target the target being decorated
          */
         void decorate(T target);
     }


### PR DESCRIPTION
### Description
Updates readmes and javadocs to correctly use "Decorator" instead of "Interceptor" for prototype builders

Resolve #7303 