### PR TITLE
4.x: Unified constants for configuring outbound id and secret.

### DIFF
--- a/examples/security/basic-auth-with-static-content/src/test/java/io/helidon/examples/security/basicauth/BasicExampleTest.java
+++ b/examples/security/basic-auth-with-static-content/src/test/java/io/helidon/examples/security/basicauth/BasicExampleTest.java
@@ -142,8 +142,8 @@ public abstract class BasicExampleTest {
         // here we call the endpoint
         return client.get()
                 .uri(uri)
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, username)
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, password)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, username)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
                 .request();
     }
 

--- a/examples/security/basic-auth-with-static-content/src/test/java/io/helidon/examples/security/basicauth/BasicExampleTest.java
+++ b/examples/security/basic-auth-with-static-content/src/test/java/io/helidon/examples/security/basicauth/BasicExampleTest.java
@@ -20,12 +20,13 @@ import java.net.URI;
 import java.util.Set;
 
 import io.helidon.http.Http;
-import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.security.EndpointConfig;
+import io.helidon.security.Security;
+import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.security.WebClientSecurity;
-import io.helidon.security.Security;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
+import io.helidon.webserver.testing.junit5.ServerTest;
 
 import org.junit.jupiter.api.Test;
 
@@ -141,8 +142,8 @@ public abstract class BasicExampleTest {
         // here we call the endpoint
         return client.get()
                 .uri(uri)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, username)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, username)
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, password)
                 .request();
     }
 

--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/JwtOverrideService.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/JwtOverrideService.java
@@ -47,7 +47,7 @@ final class JwtOverrideService implements HttpService {
                 .orElseThrow(() -> new RuntimeException("WebServer not found in context"));
 
         String result = client.get("http://localhost:" + server.port("backend") + "/hello")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jill")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jill")
                 .requestEntity(String.class);
 
         res.send("You are: " + context.userName() + ", backend service returned: " + result);

--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/JwtOverrideService.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/JwtOverrideService.java
@@ -15,8 +15,8 @@
  */
 package io.helidon.security.examples.outbound;
 
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.SecurityContext;
-import io.helidon.security.providers.jwt.JwtProvider;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.security.WebClientSecurity;
 import io.helidon.webserver.WebServer;
@@ -47,7 +47,7 @@ final class JwtOverrideService implements HttpService {
                 .orElseThrow(() -> new RuntimeException("WebServer not found in context"));
 
         String result = client.get("http://localhost:" + server.port("backend") + "/hello")
-                .property(JwtProvider.EP_PROPERTY_OUTBOUND_USER, "jill")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jill")
                 .requestEntity(String.class);
 
         res.send("You are: " + context.userName() + ", backend service returned: " + result);

--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OverrideService.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OverrideService.java
@@ -48,8 +48,8 @@ class OverrideService implements HttpService {
                 .orElseThrow(() -> new RuntimeException("WebServer not found in context"));
 
         String result = client.get("http://localhost:" + server.port("backend") + "/hello")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jill")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "anotherPassword")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jill")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "anotherPassword")
                 .requestEntity(String.class);
 
         res.send("You are: " + context.userName() + ", backend service returned: " + result + "\n");

--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OverrideService.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OverrideService.java
@@ -15,8 +15,8 @@
  */
 package io.helidon.security.examples.outbound;
 
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.SecurityContext;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.security.WebClientSecurity;
 import io.helidon.webserver.WebServer;
@@ -48,8 +48,8 @@ class OverrideService implements HttpService {
                 .orElseThrow(() -> new RuntimeException("WebServer not found in context"));
 
         String result = client.get("http://localhost:" + server.port("backend") + "/hello")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jill")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "anotherPassword")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jill")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "anotherPassword")
                 .requestEntity(String.class);
 
         res.send("You are: " + context.userName() + ", backend service returned: " + result + "\n");

--- a/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideExampleTest.java
+++ b/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideExampleTest.java
@@ -17,14 +17,15 @@ package io.helidon.security.examples.outbound;
 
 import java.net.URI;
 
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.security.EndpointConfig;
+import io.helidon.security.Security;
+import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.security.WebClientSecurity;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
-import io.helidon.security.Security;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,8 +60,8 @@ public class OutboundOverrideExampleTest {
     public void testOverrideExample() {
         String value = client.get()
                 .path("/override")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
                 .requestEntity(String.class);
 
         assertThat(value, is("You are: jack, backend service returned: jill\n"));
@@ -70,8 +71,8 @@ public class OutboundOverrideExampleTest {
     public void testPropagateExample() {
         String value = client.get()
                 .path("/propagate")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
                 .requestEntity(String.class);
 
         assertThat(value, is("You are: jack, backend service returned: jack\n"));

--- a/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideExampleTest.java
+++ b/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideExampleTest.java
@@ -60,8 +60,8 @@ public class OutboundOverrideExampleTest {
     public void testOverrideExample() {
         String value = client.get()
                 .path("/override")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .requestEntity(String.class);
 
         assertThat(value, is("You are: jack, backend service returned: jill\n"));
@@ -71,8 +71,8 @@ public class OutboundOverrideExampleTest {
     public void testPropagateExample() {
         String value = client.get()
                 .path("/propagate")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .requestEntity(String.class);
 
         assertThat(value, is("You are: jack, backend service returned: jack\n"));

--- a/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExampleTest.java
+++ b/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExampleTest.java
@@ -17,15 +17,16 @@ package io.helidon.security.examples.outbound;
 
 import java.net.URI;
 
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.security.EndpointConfig;
+import io.helidon.security.Security;
+import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.security.WebClientSecurity;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
-import io.helidon.security.Security;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -60,8 +61,8 @@ public class OutboundOverrideJwtExampleTest {
     public void testOverrideExample() {
         try (Http1ClientResponse response = client.get()
                 .path("/override")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
 
             assertThat(response.status().code(), is(200));
@@ -75,8 +76,8 @@ public class OutboundOverrideJwtExampleTest {
     public void testPropagateExample() {
         try (Http1ClientResponse response = client.get()
                 .path("/propagate")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
 
             assertThat(response.status().code(), is(200));

--- a/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExampleTest.java
+++ b/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExampleTest.java
@@ -61,8 +61,8 @@ public class OutboundOverrideJwtExampleTest {
     public void testOverrideExample() {
         try (Http1ClientResponse response = client.get()
                 .path("/override")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
 
             assertThat(response.status().code(), is(200));
@@ -76,8 +76,8 @@ public class OutboundOverrideJwtExampleTest {
     public void testPropagateExample() {
         try (Http1ClientResponse response = client.get()
                 .path("/propagate")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
 
             assertThat(response.status().code(), is(200));

--- a/examples/security/webserver-signatures/src/test/java/io/helidon/examples/security/signatures/SignatureExampleTest.java
+++ b/examples/security/webserver-signatures/src/test/java/io/helidon/examples/security/signatures/SignatureExampleTest.java
@@ -29,8 +29,8 @@ import io.helidon.webserver.testing.junit5.ServerTest;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_ID;
-import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET;
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_ID;
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_SECRET;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -66,8 +66,8 @@ public abstract class SignatureExampleTest {
 
     private void test(String uri, Set<String> expectedRoles, Set<String> invalidRoles, String service) {
         try (Http1ClientResponse response = client.get(uri)
-                .property(EP_PROPERTY_OUTBOUND_ID, "jack")
-                .property(EP_PROPERTY_OUTBOUND_SECRET, "password")
+                .property(PROPERTY_OUTBOUND_ID, "jack")
+                .property(PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
 
             assertThat(response.status().code(), is(200));

--- a/examples/security/webserver-signatures/src/test/java/io/helidon/examples/security/signatures/SignatureExampleTest.java
+++ b/examples/security/webserver-signatures/src/test/java/io/helidon/examples/security/signatures/SignatureExampleTest.java
@@ -19,21 +19,21 @@ package io.helidon.examples.security.signatures;
 import java.net.URI;
 import java.util.Set;
 
-import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.security.Security;
+import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.security.WebClientSecurity;
 import io.helidon.webserver.WebServer;
-import io.helidon.security.Security;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
+import io.helidon.webserver.testing.junit5.ServerTest;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.security.providers.httpauth.HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD;
-import static io.helidon.security.providers.httpauth.HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER;
+import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_ID;
+import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ServerTest
@@ -66,8 +66,8 @@ public abstract class SignatureExampleTest {
 
     private void test(String uri, Set<String> expectedRoles, Set<String> invalidRoles, String service) {
         try (Http1ClientResponse response = client.get(uri)
-                .property(EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EP_PROPERTY_OUTBOUND_ID, "jack")
+                .property(EP_PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
 
             assertThat(response.status().code(), is(200));

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -94,6 +94,7 @@ import org.eclipse.microprofile.auth.LoginConfig;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -101,10 +102,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurityProvider {
 
-    /**
-     * Configure this for outbound requests to override user to use.
-     */
-    public static final String EP_PROPERTY_OUTBOUND_USER = "io.helidon.security.outbound.user";
     /**
      * Configuration key for expected issuer of incoming tokens. Used for validation of JWT.
      */
@@ -379,7 +376,7 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
                                                      SecurityEnvironment outboundEnv,
                                                      EndpointConfig outboundEndpointConfig) {
 
-        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EP_PROPERTY_OUTBOUND_USER);
+        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EP_PROPERTY_OUTBOUND_ID);
         return maybeUsername
                 .map(String::valueOf)
                 .flatMap(username -> {
@@ -951,7 +948,8 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
 
         /**
          * Whether to allow impersonation by explicitly overriding
-         * username from outbound requests using {@link #EP_PROPERTY_OUTBOUND_USER} property.
+         * username from outbound requests using {@link io.helidon.security.EndpointConfig#EP_PROPERTY_OUTBOUND_ID}
+         * property.
          * By default this is not allowed and identity can only be propagated.
          *
          * @param allowImpersonation set to true to allow impersonation

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -94,7 +94,7 @@ import org.eclipse.microprofile.auth.LoginConfig;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
-import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_ID;
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -376,7 +376,7 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
                                                      SecurityEnvironment outboundEnv,
                                                      EndpointConfig outboundEndpointConfig) {
 
-        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EP_PROPERTY_OUTBOUND_ID);
+        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(PROPERTY_OUTBOUND_ID);
         return maybeUsername
                 .map(String::valueOf)
                 .flatMap(username -> {
@@ -948,7 +948,7 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
 
         /**
          * Whether to allow impersonation by explicitly overriding
-         * username from outbound requests using {@link io.helidon.security.EndpointConfig#EP_PROPERTY_OUTBOUND_ID}
+         * username from outbound requests using {@link io.helidon.security.EndpointConfig#PROPERTY_OUTBOUND_ID}
          * property.
          * By default this is not allowed and identity can only be propagated.
          *

--- a/microprofile/security/src/test/java/io/helidon/microprofile/security/BasicAuthOutboundOverrideTest.java
+++ b/microprofile/security/src/test/java/io/helidon/microprofile/security/BasicAuthOutboundOverrideTest.java
@@ -67,16 +67,16 @@ public class BasicAuthOutboundOverrideTest {
         when(requestContext.getConfiguration()).thenReturn(configuration);
         when(requestContext.getProperty(ClientSecurity.PROPERTY_CONTEXT)).thenReturn(context);
         when(requestContext.getProperty(ClientSecurity.PROPERTY_PROVIDER)).thenReturn("http-basic-auth");
-        when(requestContext.getProperty(EndpointConfig.EP_PROPERTY_OUTBOUND_ID)).thenReturn(user);
-        when(requestContext.getProperty(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET)).thenReturn(password);
+        when(requestContext.getProperty(EndpointConfig.PROPERTY_OUTBOUND_ID)).thenReturn(user);
+        when(requestContext.getProperty(EndpointConfig.PROPERTY_OUTBOUND_SECRET)).thenReturn(password);
         when(requestContext.getUri()).thenReturn(URI.create("http://localhost:7070/test"));
         when(requestContext.getStringHeaders()).thenReturn(new MultivaluedHashMap<>());
         when(requestContext.getHeaders()).thenReturn(jerseyHeaders);
         when(requestContext.getPropertyNames()).thenReturn(List.of(
                 ClientSecurity.PROPERTY_CONTEXT,
                 ClientSecurity.PROPERTY_PROVIDER,
-                EndpointConfig.EP_PROPERTY_OUTBOUND_ID,
-                EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET
+                EndpointConfig.PROPERTY_OUTBOUND_ID,
+                EndpointConfig.PROPERTY_OUTBOUND_SECRET
         ));
 
         ClientSecurityFilter csf = new ClientSecurityFilter();

--- a/microprofile/security/src/test/java/io/helidon/microprofile/security/BasicAuthOutboundOverrideTest.java
+++ b/microprofile/security/src/test/java/io/helidon/microprofile/security/BasicAuthOutboundOverrideTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
@@ -66,16 +67,16 @@ public class BasicAuthOutboundOverrideTest {
         when(requestContext.getConfiguration()).thenReturn(configuration);
         when(requestContext.getProperty(ClientSecurity.PROPERTY_CONTEXT)).thenReturn(context);
         when(requestContext.getProperty(ClientSecurity.PROPERTY_PROVIDER)).thenReturn("http-basic-auth");
-        when(requestContext.getProperty(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER)).thenReturn(user);
-        when(requestContext.getProperty(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD)).thenReturn(password);
+        when(requestContext.getProperty(EndpointConfig.EP_PROPERTY_OUTBOUND_ID)).thenReturn(user);
+        when(requestContext.getProperty(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET)).thenReturn(password);
         when(requestContext.getUri()).thenReturn(URI.create("http://localhost:7070/test"));
         when(requestContext.getStringHeaders()).thenReturn(new MultivaluedHashMap<>());
         when(requestContext.getHeaders()).thenReturn(jerseyHeaders);
         when(requestContext.getPropertyNames()).thenReturn(List.of(
                 ClientSecurity.PROPERTY_CONTEXT,
                 ClientSecurity.PROPERTY_PROVIDER,
-                HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER,
-                HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD
+                EndpointConfig.EP_PROPERTY_OUTBOUND_ID,
+                EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET
         ));
 
         ClientSecurityFilter csf = new ClientSecurityFilter();

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
@@ -56,16 +56,6 @@ import io.helidon.security.util.TokenHandler;
  * Provides support for username and password authentication, with support for roles list.
  */
 public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSecurityProvider {
-    /**
-     * Configure this for outbound requests to override user to use.
-     */
-    public static final String EP_PROPERTY_OUTBOUND_USER = "io.helidon.security.outbound.user";
-
-    /**
-     * Configure this for outbound requests to override password to use.
-     */
-    public static final String EP_PROPERTY_OUTBOUND_PASSWORD = "io.helidon.security.outbound.password";
-
     static final String HEADER_AUTHENTICATION_REQUIRED = "WWW-Authenticate";
     static final String HEADER_AUTHENTICATION = "authorization";
     static final String BASIC_PREFIX = "basic ";
@@ -129,7 +119,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
                                        EndpointConfig outboundEp) {
 
         // explicitly overridden username and/or password
-        if (outboundEp.abacAttributeNames().contains(EP_PROPERTY_OUTBOUND_USER)) {
+        if (outboundEp.abacAttributeNames().contains(EndpointConfig.EP_PROPERTY_OUTBOUND_ID)) {
             return true;
         }
 
@@ -142,7 +132,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
                                                      EndpointConfig outboundEp) {
 
         // explicit username in request properties
-        Optional<Object> maybeUsername = outboundEp.abacAttribute(EP_PROPERTY_OUTBOUND_USER);
+        Optional<Object> maybeUsername = outboundEp.abacAttribute(EndpointConfig.EP_PROPERTY_OUTBOUND_ID);
         if (maybeUsername.isPresent()) {
             String username = maybeUsername.get().toString();
             char[] password = passwordFromEndpoint(outboundEp);
@@ -182,7 +172,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
                         .flatMap(this::credentialsFromSubject);
             }
 
-            Optional<char[]> overridePassword = outboundEp.abacAttribute(EP_PROPERTY_OUTBOUND_PASSWORD)
+            Optional<char[]> overridePassword = outboundEp.abacAttribute(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET)
                     .map(String::valueOf)
                     .map(String::toCharArray);
 
@@ -201,7 +191,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
     }
 
     private char[] passwordFromEndpoint(EndpointConfig outboundEp) {
-        return outboundEp.abacAttribute(EP_PROPERTY_OUTBOUND_PASSWORD)
+        return outboundEp.abacAttribute(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET)
                 .map(String::valueOf)
                 .map(String::toCharArray)
                 .orElse(HttpBasicOutboundConfig.EMPTY_PASSWORD);

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
@@ -119,7 +119,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
                                        EndpointConfig outboundEp) {
 
         // explicitly overridden username and/or password
-        if (outboundEp.abacAttributeNames().contains(EndpointConfig.EP_PROPERTY_OUTBOUND_ID)) {
+        if (outboundEp.abacAttributeNames().contains(EndpointConfig.PROPERTY_OUTBOUND_ID)) {
             return true;
         }
 
@@ -132,7 +132,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
                                                      EndpointConfig outboundEp) {
 
         // explicit username in request properties
-        Optional<Object> maybeUsername = outboundEp.abacAttribute(EndpointConfig.EP_PROPERTY_OUTBOUND_ID);
+        Optional<Object> maybeUsername = outboundEp.abacAttribute(EndpointConfig.PROPERTY_OUTBOUND_ID);
         if (maybeUsername.isPresent()) {
             String username = maybeUsername.get().toString();
             char[] password = passwordFromEndpoint(outboundEp);
@@ -172,7 +172,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
                         .flatMap(this::credentialsFromSubject);
             }
 
-            Optional<char[]> overridePassword = outboundEp.abacAttribute(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET)
+            Optional<char[]> overridePassword = outboundEp.abacAttribute(EndpointConfig.PROPERTY_OUTBOUND_SECRET)
                     .map(String::valueOf)
                     .map(String::toCharArray);
 
@@ -191,7 +191,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
     }
 
     private char[] passwordFromEndpoint(EndpointConfig outboundEp) {
-        return outboundEp.abacAttribute(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET)
+        return outboundEp.abacAttribute(EndpointConfig.PROPERTY_OUTBOUND_SECRET)
                 .map(String::valueOf)
                 .map(String::toCharArray)
                 .orElse(HttpBasicOutboundConfig.EMPTY_PASSWORD);

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -265,7 +265,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
                                                      SecurityEnvironment outboundEnv,
                                                      EndpointConfig outboundEndpointConfig) {
 
-        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EndpointConfig.EP_PROPERTY_OUTBOUND_ID);
+        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EndpointConfig.PROPERTY_OUTBOUND_ID);
         return maybeUsername
                 .map(String::valueOf)
                 .flatMap(username -> attemptImpersonation(outboundEnv, username))
@@ -648,7 +648,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
 
         /**
          * Whether to allow impersonation by explicitly overriding
-         * username from outbound requests using {@link io.helidon.security.EndpointConfig#EP_PROPERTY_OUTBOUND_ID}
+         * username from outbound requests using {@link io.helidon.security.EndpointConfig#PROPERTY_OUTBOUND_ID}
          * property.
          * By default this is not allowed and identity can only be propagated.
          *

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -66,11 +66,6 @@ import io.helidon.security.util.TokenHandler;
 public final class JwtProvider implements AuthenticationProvider, OutboundSecurityProvider {
     private static final System.Logger LOGGER = System.getLogger(JwtProvider.class.getName());
 
-    /**
-     * Configure this for outbound requests to override user to use.
-     */
-    public static final String EP_PROPERTY_OUTBOUND_USER = "io.helidon.security.outbound.user";
-
     private final boolean optional;
     private final boolean authenticate;
     private final boolean propagate;
@@ -270,7 +265,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
                                                      SecurityEnvironment outboundEnv,
                                                      EndpointConfig outboundEndpointConfig) {
 
-        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EP_PROPERTY_OUTBOUND_USER);
+        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EndpointConfig.EP_PROPERTY_OUTBOUND_ID);
         return maybeUsername
                 .map(String::valueOf)
                 .flatMap(username -> attemptImpersonation(outboundEnv, username))
@@ -653,7 +648,8 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
 
         /**
          * Whether to allow impersonation by explicitly overriding
-         * username from outbound requests using {@link #EP_PROPERTY_OUTBOUND_USER} property.
+         * username from outbound requests using {@link io.helidon.security.EndpointConfig#EP_PROPERTY_OUTBOUND_ID}
+         * property.
          * By default this is not allowed and identity can only be propagated.
          *
          * @param allowImpersonation set to true to allow impersonation

--- a/security/security/src/main/java/io/helidon/security/EndpointConfig.java
+++ b/security/security/src/main/java/io/helidon/security/EndpointConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,17 @@ import io.helidon.security.util.AbacSupport;
  * @see SecurityProvider#supportedAttributes
  */
 public class EndpointConfig implements AbacSupport {
+    /**
+     * Configure this for outbound requests to override id to use (client id, user - depending on use case).
+     * This is supported for example for HTTP Basic authentication and JWT authentication providers.
+     */
+    public static final String EP_PROPERTY_OUTBOUND_ID = "io.helidon.security.outbound.identity";
+    /**
+     * Configure this for outbound requests to override secret to use (client secret, actual password - depending on use case).
+     * This is supported for example for HTTP Basic authentication provider.
+     */
+    public static final String EP_PROPERTY_OUTBOUND_SECRET = "io.helidon.security.outbound.secret";
+
     private final List<SecurityLevel> securityLevels;
     private final AbacSupport attributes;
     private final ClassToInstanceStore<Object> customObjects;

--- a/security/security/src/main/java/io/helidon/security/EndpointConfig.java
+++ b/security/security/src/main/java/io/helidon/security/EndpointConfig.java
@@ -51,12 +51,12 @@ public class EndpointConfig implements AbacSupport {
      * Configure this for outbound requests to override id to use (client id, user - depending on use case).
      * This is supported for example for HTTP Basic authentication and JWT authentication providers.
      */
-    public static final String EP_PROPERTY_OUTBOUND_ID = "io.helidon.security.outbound.identity";
+    public static final String PROPERTY_OUTBOUND_ID = "io.helidon.security.outbound.identity";
     /**
      * Configure this for outbound requests to override secret to use (client secret, actual password - depending on use case).
      * This is supported for example for HTTP Basic authentication provider.
      */
-    public static final String EP_PROPERTY_OUTBOUND_SECRET = "io.helidon.security.outbound.secret";
+    public static final String PROPERTY_OUTBOUND_SECRET = "io.helidon.security.outbound.secret";
 
     private final List<SecurityLevel> securityLevels;
     private final AbacSupport attributes;

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/ContextCheckTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/ContextCheckTest.java
@@ -38,8 +38,8 @@ class ContextCheckTest extends TestParent {
         Http1Client webClient = createNewClient();
         try (Http1ClientResponse r = webClient.get()
                 .path("/contextCheck")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
             assertThat(r.status().code(), is(Http.Status.OK_200.code()));
         }

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/ContextCheckTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/ContextCheckTest.java
@@ -17,10 +17,10 @@
 package io.helidon.webclient.tests;
 
 import io.helidon.http.Http;
+import io.helidon.security.EndpointConfig;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServer;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,8 +38,8 @@ class ContextCheckTest extends TestParent {
         Http1Client webClient = createNewClient();
         try (Http1ClientResponse r = webClient.get()
                 .path("/contextCheck")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
             assertThat(r.status().code(), is(Http.Status.OK_200.code()));
         }

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/SecurityTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/SecurityTest.java
@@ -51,8 +51,8 @@ public class SecurityTest extends TestParent {
     private void performOperation(String path) {
         try (Http1ClientResponse response = client.get()
                 .path(path)
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/SecurityTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/SecurityTest.java
@@ -17,10 +17,10 @@
 package io.helidon.webclient.tests;
 
 import io.helidon.http.Http;
+import io.helidon.security.EndpointConfig;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.security.WebClientSecurity;
 import io.helidon.webserver.WebServer;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 
 import jakarta.json.JsonObject;
 import org.junit.jupiter.api.Test;
@@ -51,8 +51,8 @@ public class SecurityTest extends TestParent {
     private void performOperation(String path) {
         try (Http1ClientResponse response = client.get()
                 .path(path)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, "password")
                 .request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityBuilderGateDefaultsTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityBuilderGateDefaultsTest.java
@@ -218,8 +218,8 @@ class WebSecurityBuilderGateDefaultsTest {
     private HttpClientResponse callProtected(String uri, String username, String password) {
         // here we call the endpoint
         return securityClient.get(uri)
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, username)
-                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, password)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, username)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
                 .request();
     }
 }

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityBuilderGateDefaultsTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityBuilderGateDefaultsTest.java
@@ -21,11 +21,14 @@ import java.util.Set;
 
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
+import io.helidon.config.Config;
 import io.helidon.http.Http;
 import io.helidon.http.HttpMediaTypes;
-import io.helidon.config.Config;
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.security.AuditEvent;
+import io.helidon.security.EndpointConfig;
+import io.helidon.security.Security;
+import io.helidon.security.SecurityContext;
+import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
@@ -34,10 +37,8 @@ import io.helidon.webclient.security.WebClientSecurity;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.context.ContextFeature;
-import io.helidon.security.AuditEvent;
-import io.helidon.security.Security;
-import io.helidon.security.SecurityContext;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -217,8 +218,8 @@ class WebSecurityBuilderGateDefaultsTest {
     private HttpClientResponse callProtected(String uri, String username, String password) {
         // here we call the endpoint
         return securityClient.get(uri)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, username)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_ID, username)
+                .property(EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET, password)
                 .request();
     }
 }

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityTests.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityTests.java
@@ -31,8 +31,8 @@ import io.helidon.webserver.WebServer;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_ID;
-import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET;
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_ID;
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_SECRET;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -163,8 +163,8 @@ abstract class WebSecurityTests {
 
     private HttpClientResponse callProtected(String uri, String username, String password) {
         return securityClient.get(uri)
-                .property(EP_PROPERTY_OUTBOUND_ID, username)
-                .property(EP_PROPERTY_OUTBOUND_SECRET, password)
+                .property(PROPERTY_OUTBOUND_ID, username)
+                .property(PROPERTY_OUTBOUND_SECRET, password)
                 .request();
     }
 

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityTests.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityTests.java
@@ -19,20 +19,20 @@ package io.helidon.webserver.security;
 import java.util.Set;
 
 import io.helidon.http.Http;
+import io.helidon.security.AuditEvent;
+import io.helidon.security.Security;
+import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.security.WebClientSecurity;
 import io.helidon.webserver.WebServer;
-import io.helidon.security.AuditEvent;
-import io.helidon.security.Security;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.security.providers.httpauth.HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD;
-import static io.helidon.security.providers.httpauth.HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER;
+import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_ID;
+import static io.helidon.security.EndpointConfig.EP_PROPERTY_OUTBOUND_SECRET;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -163,8 +163,8 @@ abstract class WebSecurityTests {
 
     private HttpClientResponse callProtected(String uri, String username, String password) {
         return securityClient.get(uri)
-                .property(EP_PROPERTY_OUTBOUND_USER, username)
-                .property(EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(EP_PROPERTY_OUTBOUND_ID, username)
+                .property(EP_PROPERTY_OUTBOUND_SECRET, password)
                 .request();
     }
 


### PR DESCRIPTION
### Description
A single location to store constants that allow overriding of user id and secret (username and password for Basic authentication, user id for JWT).
This PR does not change Digest authentication at all, as we do not support outbound security with digest, and we do not plan to (it is an outdated insecure technology).

Related to #7207 

### Documentation
We had a few constants in the providers named `EP_PROPERTY_OUTBOUND_USER` and `EP_PROPERTY_OUTBOUND_PASSWORD`.
The new location is `io.helidon.security.EndpointConfig`.
New constants:
- `PROPERTY_OUTBOUND_ID` - user name, client id to be used for the outbound call
- `PROPERTY_OUTBOUND_SECRET` - password, client secret to be used for the outbound call

The set of providers supporting these constants is current unchanges (Basic authentication, JWT Authentication provider, and MP JWT Authentication provider).

To use, configure the client request similar to the following:
```
client.get()
  .uri(uri)
  .property(EndpointConfig.PROPERTY_OUTBOUND_ID, username)
  .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
  .request();
```

And if the correct outbound provider is configured with web client security, the provided values will be used.
This also works when security is invoked manually through API (and other clients may support configuraiton of custom properites that are propagated to security).