### PR TITLE
[4.x] - Simple to Batch Span exporter

### DIFF
--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -307,8 +307,8 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
 
         config.get("span-processor-type").asString()
                 .ifPresent(it -> spanProcessorType(SpanProcessorType.valueOf(it.toUpperCase())));
-        config.get("exporter-timeout").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
-        config.get("schedule-delay").asInt().ifPresent(it -> scheduleDelay(Duration.ofMillis(it)));
+        config.get("exporter-timeout").as(Duration.class).ifPresent(this::exporterTimeout);
+        config.get("schedule-delay").as(Duration.class).ifPresent(this::scheduleDelay);
         config.get("max-queue-size").asInt().ifPresent(this::maxQueueSize);
         config.get("max-export-batch-size").asInt().ifPresent(this::maxExportBatchSize);
 

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -305,8 +305,8 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
 
         config.get("global").asBoolean().ifPresent(this::registerGlobal);
 
-        config.get("span-processor-type").asString().ifPresent(this::spanProcessorType);
-        config.get("exporter-timeout").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
+        config.get("span-processor-type").asString()
+                .ifPresent(it -> spanProcessorType(SpanProcessorType.valueOf(it.toUpperCase())));        config.get("exporter-timeout").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
         config.get("schedule-delay").asInt().ifPresent(it -> scheduleDelay(Duration.ofMillis(it)));
         config.get("max-queue-size").asInt().ifPresent(this::maxQueueSize);
         config.get("max-export-batch-size").asInt().ifPresent(this::maxExportBatchSize);
@@ -357,8 +357,8 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @return updated builder
      */
     @ConfiguredOption(key = "span-processor-type", value = "batch")
-    public JaegerTracerBuilder spanProcessorType(String spanProcessorType) {
-        this.spanProcessorType = SpanProcessorType.valueOf(spanProcessorType.toUpperCase());
+    public JaegerTracerBuilder spanProcessorType(SpanProcessorType spanProcessorType) {
+        this.spanProcessorType = spanProcessorType;
         return this;
     }
 

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -564,6 +564,26 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         return samplerType;
     }
 
+    SpanProcessorType spanProcessorType() {
+        return spanProcessorType;
+    }
+
+    Duration exporterTimeout() {
+        return exporterTimeout;
+    }
+
+    Duration scheduleDelay() {
+        return scheduleDelay;
+    }
+
+    int maxQueueSize() {
+        return maxQueueSize;
+    }
+
+    int maxExportBatchSize() {
+        return maxExportBatchSize;
+    }
+
     Number samplerParam() {
         return samplerParam;
     }

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -357,7 +357,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param spanProcessorType to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "span-processor-type", value = "batch")
+    @ConfiguredOption("batch")
     public JaegerTracerBuilder spanProcessorType(SpanProcessorType spanProcessorType) {
         this.spanProcessorType = spanProcessorType;
         return this;
@@ -369,7 +369,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param scheduleDelayMillis timeout to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "schedule-delay", value = "5000")
+    @ConfiguredOption("PT5S")
     public JaegerTracerBuilder scheduleDelay(Duration scheduleDelayMillis) {
         this.scheduleDelay = scheduleDelayMillis;
         return this;
@@ -381,7 +381,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param maxQueueSize to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "max-queue-size", value = "2048")
+    @ConfiguredOption("2048")
     public JaegerTracerBuilder maxQueueSize(int maxQueueSize) {
         this.maxQueueSize = maxQueueSize;
         return this;
@@ -393,7 +393,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param maxExportBatchSize to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "max-export-batch-size", value = "512")
+    @ConfiguredOption("512")
     public JaegerTracerBuilder maxExportBatchSize(int maxExportBatchSize) {
         this.maxExportBatchSize = maxExportBatchSize;
         return this;
@@ -405,7 +405,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param exporterTimeout timeout to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "exporter-timeout", value = "10000")
+    @ConfiguredOption("PT10S")
     public JaegerTracerBuilder exporterTimeout(Duration exporterTimeout) {
         this.exporterTimeout = exporterTimeout;
         return this;

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -306,7 +306,8 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         config.get("global").asBoolean().ifPresent(this::registerGlobal);
 
         config.get("span-processor-type").asString()
-                .ifPresent(it -> spanProcessorType(SpanProcessorType.valueOf(it.toUpperCase())));        config.get("exporter-timeout").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
+                .ifPresent(it -> spanProcessorType(SpanProcessorType.valueOf(it.toUpperCase())));
+        config.get("exporter-timeout").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
         config.get("schedule-delay").asInt().ifPresent(it -> scheduleDelay(Duration.ofMillis(it)));
         config.get("max-queue-size").asInt().ifPresent(this::maxQueueSize);
         config.get("max-export-batch-size").asInt().ifPresent(this::maxExportBatchSize);

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -100,7 +100,7 @@ import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
  *         <td>Path to be used.</td>
  *     </tr>
  *     <tr>
- *         <td>{@code exporter-timeout-millis}</td>
+ *         <td>{@code exporter-timeout}</td>
  *         <td>10 seconds</td>
  *         <td>Timeout of exporter</td>
  *     </tr>
@@ -153,7 +153,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
 
     static final boolean DEFAULT_ENABLED = true;
     static final String DEFAULT_HTTP_HOST = "localhost";
-    static final int DEFAULT_SCHEDULE_DELAY_MILLIS = 30_000;
+    static final int DEFAULT_SCHEDULE_DELAY = 30_000;
     static final int DEFAULT_HTTP_PORT = 14250;
     static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
     static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
@@ -174,7 +174,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     private byte[] trustedCertificates;
     private String path;
     private Duration exporterTimeout = Duration.ofSeconds(10);
-    private Duration scheduleDelay = Duration.ofMillis(DEFAULT_SCHEDULE_DELAY_MILLIS);
+    private Duration scheduleDelay = Duration.ofMillis(DEFAULT_SCHEDULE_DELAY);
     private int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
     private int maxExportBatchSize = DEFAULT_MAX_EXPORT_BATCH_SIZE;
     private SpanProcessorType spanProcessorType = SpanProcessorType.BATCH;

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -366,12 +366,12 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     /**
      * Schedule Delay of exporter requests.
      *
-     * @param scheduleDelayMillis timeout to use
+     * @param scheduleDelay timeout to use
      * @return updated builder
      */
     @ConfiguredOption("PT5S")
-    public JaegerTracerBuilder scheduleDelay(Duration scheduleDelayMillis) {
-        this.scheduleDelay = scheduleDelayMillis;
+    public JaegerTracerBuilder scheduleDelay(Duration scheduleDelay) {
+        this.scheduleDelay = scheduleDelay;
         return this;
     }
 

--- a/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilderTest.java
+++ b/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilderTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.tracing.providers.jaeger;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -73,7 +74,12 @@ class JaegerTracerBuilderTest {
         assertThat("Path", jBuilder.path(), nullValue());
         assertThat("Enabled", jBuilder.isEnabled(), is(true));
         assertThat("Sampler type", jBuilder.samplerType(), is(JaegerTracerBuilder.SamplerType.CONSTANT));
+        assertThat("Span Processor type", jBuilder.spanProcessorType(), is(JaegerTracerBuilder.SpanProcessorType.BATCH));
         assertThat("Sampler param", jBuilder.samplerParam(), is(Integer.valueOf(1)));
+        assertThat("Exporter timeout", jBuilder.exporterTimeout(), is(Duration.ofSeconds(10)));
+        assertThat("Schedule delay", jBuilder.scheduleDelay(), is(Duration.ofSeconds(30)));
+        assertThat("Max Queue Size", jBuilder.maxQueueSize(), is(2048));
+        assertThat("Max Export Batch Size", jBuilder.maxExportBatchSize(), is(512));
     }
 
     @Test
@@ -102,6 +108,7 @@ class JaegerTracerBuilderTest {
         assertThat("Port", jBuilder.port(), is(14240));
         assertThat("Path", jBuilder.path(), is("/api/traces/mine"));
         assertThat("Sampler type", jBuilder.samplerType(), is(JaegerTracerBuilder.SamplerType.RATIO));
+        assertThat("Span Processor type", jBuilder.spanProcessorType(), is(JaegerTracerBuilder.SpanProcessorType.SIMPLE));
         assertThat("Sampler param", jBuilder.samplerParam(), is(0.5));
         assertThat("Tags", jBuilder.tags(), is(Map.of(
                 "tag1", "tag1-value",

--- a/tracing/providers/jaeger/src/test/resources/application.yaml
+++ b/tracing/providers/jaeger/src/test/resources/application.yaml
@@ -36,6 +36,7 @@ tracing:
     sampler-type: "ratio"
     sampler-param: 0.5
     propagation: ["jaeger", "b3_single", "w3c"]
+    span-processor-type: simple
     tags:
       tag1: "tag1-value"  # JAEGER_TAGS
       tag2: "tag2-value"  # JAEGER_TAGS


### PR DESCRIPTION
Resolves internal request to switch to Batch Span Exporter to Jaeger tracer. This should significantly improve performance.

Doc impact: new config properties