### PR TITLE
[3.x] - Simple to Batch Span exporter

### DIFF
--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -309,7 +309,8 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
 
         config.get("global").asBoolean().ifPresent(this::registerGlobal);
 
-        config.get("span-processor-type").asString().ifPresent(this::spanProcessorType);
+        config.get("span-processor-type").asString()
+                .ifPresent(it -> spanProcessorType(SpanProcessorType.valueOf(it.toUpperCase())));
         config.get("exporter-timeout").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
         config.get("schedule-delay").asInt().ifPresent(it -> scheduleDelay(Duration.ofMillis(it)));
         config.get("max-queue-size").asInt().ifPresent(this::maxQueueSize);
@@ -361,8 +362,8 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @return updated builder
      */
     @ConfiguredOption(key = "span-processor-type", value = "batch")
-    public JaegerTracerBuilder spanProcessorType(String spanProcessorType) {
-        this.spanProcessorType = SpanProcessorType.valueOf(spanProcessorType.toUpperCase());
+    public JaegerTracerBuilder spanProcessorType(SpanProcessorType spanProcessorType) {
+        this.spanProcessorType = spanProcessorType;
         return this;
     }
 

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -47,7 +47,7 @@ import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
@@ -154,6 +154,10 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     static final String DEFAULT_HTTP_HOST = "localhost";
     static final int DEFAULT_HTTP_PORT = 14250;
 
+    static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 30_000;
+    static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
+    static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
+
     private final Map<String, String> tags = new HashMap<>();
     // this is a backward incompatible change, but the correct choice is Jaeger, not B3
     private final Set<PropagationFormat> propagationFormats = EnumSet.noneOf(PropagationFormat.class);
@@ -165,12 +169,16 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     private Number samplerParam = 1;
     private boolean enabled = DEFAULT_ENABLED;
     private boolean global = true;
-    private Duration exporterTimeout = Duration.ofSeconds(10);
     private byte[] privateKey;
     private byte[] certificate;
     private byte[] trustedCertificates;
     private String path;
     private Config config;
+
+    private Duration exporterTimeout = Duration.ofSeconds(10);
+    private Duration scheduleDelayMillis = Duration.ofMillis(DEFAULT_SCHEDULE_DELAY_MILLIS);
+    private int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
+    private int maxExportBatchSize = DEFAULT_MAX_EXPORT_BATCH_SIZE;
 
     /**
      * Default constructor, does not modify any state.
@@ -264,7 +272,6 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         config.get("path").asString().ifPresent(this::collectorPath);
         config.get("sampler-type").asString().as(SamplerType::create).ifPresent(this::samplerType);
         config.get("sampler-param").asDouble().ifPresent(this::samplerParam);
-        config.get("exporter-timeout-millis").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
         config.get("private-key-pem").as(io.helidon.common.configurable.Resource::create).ifPresent(this::privateKey);
         config.get("client-cert-pem").as(io.helidon.common.configurable.Resource::create).ifPresent(this::clientCertificate);
         config.get("trusted-cert-pem").as(io.helidon.common.configurable.Resource::create).ifPresent(this::trustedCertificates);
@@ -298,6 +305,11 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
                 });
 
         config.get("global").asBoolean().ifPresent(this::registerGlobal);
+
+        config.get("exporter-timeout-millis").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
+        config.get("schedule-delay-millis").asInt().ifPresent(it -> scheduleDelayMillis(Duration.ofMillis(it)));
+        config.get("max-queue-size").asInt().ifPresent(this::maxQueueSize);
+        config.get("max-export-batch-size").asInt().ifPresent(this::maxExportBatchSize);
 
         return this;
     }
@@ -347,6 +359,42 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     @ConfiguredOption(key = "exporter-timeout-millis", value = "10000")
     public JaegerTracerBuilder exporterTimeout(Duration exporterTimeout) {
         this.exporterTimeout = exporterTimeout;
+        return this;
+    }
+
+    /**
+     * Schedule Delay of exporter requests.
+     *
+     * @param scheduleDelayMillis timeout to use
+     * @return updated builder
+     */
+    @ConfiguredOption(key = "schedule-delay-millis", value = "5000")
+    public JaegerTracerBuilder scheduleDelayMillis(Duration scheduleDelayMillis) {
+        this.scheduleDelayMillis = scheduleDelayMillis;
+        return this;
+    }
+
+    /**
+     * Maximum Queue Size of exporter requests.
+     *
+     * @param maxQueueSize to use
+     * @return updated builder
+     */
+    @ConfiguredOption(key = "max-queue-size", value = "2048")
+    public JaegerTracerBuilder maxQueueSize(int maxQueueSize) {
+        this.maxQueueSize = maxQueueSize;
+        return this;
+    }
+
+    /**
+     * Maximum Export Batch Size of exporter requests.
+     *
+     * @param maxExportBatchSize to use
+     * @return updated builder
+     */
+    @ConfiguredOption(key = "max-export-batch-size", value = "512")
+    public JaegerTracerBuilder maxExportBatchSize(int maxExportBatchSize) {
+        this.maxExportBatchSize = maxExportBatchSize;
         return this;
     }
 
@@ -462,7 +510,12 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
             Resource serviceName = Resource.create(attributesBuilder.build());
             OpenTelemetry ot = OpenTelemetrySdk.builder()
                     .setTracerProvider(SdkTracerProvider.builder()
-                            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                            .addSpanProcessor(BatchSpanProcessor.builder(exporter)
+                                    .setScheduleDelay(scheduleDelayMillis)
+                                    .setMaxQueueSize(maxQueueSize)
+                                    .setMaxExportBatchSize(maxExportBatchSize)
+                                    .setExporterTimeout(exporterTimeout)
+                                    .build())
                             .setSampler(sampler)
                             .setResource(serviceName)
                             .build())

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -101,7 +101,7 @@ import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
  *         <td>Path to be used.</td>
  *     </tr>
  *     <tr>
- *         <td>{@code exporter-timeout-millis}</td>
+ *         <td>{@code exporter-timeout}</td>
  *         <td>10 seconds</td>
  *         <td>Timeout of exporter</td>
  *     </tr>
@@ -156,7 +156,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     static final String DEFAULT_HTTP_HOST = "localhost";
     static final int DEFAULT_HTTP_PORT = 14250;
 
-    static final long DEFAULT_SCHEDULE_DELAY_MILLIS = 30_000;
+    static final long DEFAULT_SCHEDULE_DELAY = 30_000;
     static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
     static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
 
@@ -177,7 +177,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     private String path;
     private Config config;
     private Duration exporterTimeout = Duration.ofSeconds(10);
-    private Duration scheduleDelay = Duration.ofMillis(DEFAULT_SCHEDULE_DELAY_MILLIS);
+    private Duration scheduleDelay = Duration.ofMillis(DEFAULT_SCHEDULE_DELAY);
     private int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
     private int maxExportBatchSize = DEFAULT_MAX_EXPORT_BATCH_SIZE;
 
@@ -383,12 +383,12 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     /**
      * Schedule Delay of exporter requests.
      *
-     * @param scheduleDelayMillis timeout to use
+     * @param scheduleDelay timeout to use
      * @return updated builder
      */
     @ConfiguredOption("PT5S")
-    public JaegerTracerBuilder scheduleDelay(Duration scheduleDelayMillis) {
-        this.scheduleDelay = scheduleDelayMillis;
+    public JaegerTracerBuilder scheduleDelay(Duration scheduleDelay) {
+        this.scheduleDelay = scheduleDelay;
         return this;
     }
 

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -361,7 +361,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param spanProcessorType to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "span-processor-type", value = "batch")
+    @ConfiguredOption("batch")
     public JaegerTracerBuilder spanProcessorType(SpanProcessorType spanProcessorType) {
         this.spanProcessorType = spanProcessorType;
         return this;
@@ -374,7 +374,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param exporterTimeout timeout to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "exporter-timeout", value = "10000")
+    @ConfiguredOption("PT10S")
     public JaegerTracerBuilder exporterTimeout(Duration exporterTimeout) {
         this.exporterTimeout = exporterTimeout;
         return this;
@@ -386,7 +386,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param scheduleDelayMillis timeout to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "schedule-delay", value = "5000")
+    @ConfiguredOption("PT5S")
     public JaegerTracerBuilder scheduleDelay(Duration scheduleDelayMillis) {
         this.scheduleDelay = scheduleDelayMillis;
         return this;
@@ -398,7 +398,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param maxQueueSize to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "max-queue-size", value = "2048")
+    @ConfiguredOption("2048")
     public JaegerTracerBuilder maxQueueSize(int maxQueueSize) {
         this.maxQueueSize = maxQueueSize;
         return this;
@@ -410,7 +410,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      * @param maxExportBatchSize to use
      * @return updated builder
      */
-    @ConfiguredOption(key = "max-export-batch-size", value = "512")
+    @ConfiguredOption("512")
     public JaegerTracerBuilder maxExportBatchSize(int maxExportBatchSize) {
         this.maxExportBatchSize = maxExportBatchSize;
         return this;

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -362,7 +362,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
      */
     @ConfiguredOption(key = "span-processor-type", value = "batch")
     public JaegerTracerBuilder spanProcessorType(String spanProcessorType) {
-        this.spanProcessorType = SpanProcessorType.valueOf(spanProcessorType);
+        this.spanProcessorType = SpanProcessorType.valueOf(spanProcessorType.toUpperCase());
         return this;
     }
 
@@ -588,6 +588,26 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
 
     boolean isEnabled() {
         return enabled;
+    }
+
+    SpanProcessorType spanProcessorType() {
+        return spanProcessorType;
+    }
+
+    Duration exporterTimeout() {
+        return exporterTimeout;
+    }
+
+    Duration scheduleDelay() {
+        return scheduleDelay;
+    }
+
+    int maxQueueSize() {
+        return maxQueueSize;
+    }
+
+    int maxExportBatchSize() {
+        return maxExportBatchSize;
     }
 
     List<TextMapPropagator> createPropagators() {

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -159,7 +159,6 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     static final long DEFAULT_SCHEDULE_DELAY = 30_000;
     static final int DEFAULT_MAX_QUEUE_SIZE = 2048;
     static final int DEFAULT_MAX_EXPORT_BATCH_SIZE = 512;
-
     private final Map<String, String> tags = new HashMap<>();
     // this is a backward incompatible change, but the correct choice is Jaeger, not B3
     private final Set<PropagationFormat> propagationFormats = EnumSet.noneOf(PropagationFormat.class);
@@ -311,8 +310,8 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
 
         config.get("span-processor-type").asString()
                 .ifPresent(it -> spanProcessorType(SpanProcessorType.valueOf(it.toUpperCase())));
-        config.get("exporter-timeout").asLong().ifPresent(it -> exporterTimeout(Duration.ofMillis(it)));
-        config.get("schedule-delay").asInt().ifPresent(it -> scheduleDelay(Duration.ofMillis(it)));
+        config.get("exporter-timeout").as(Duration.class).ifPresent(this::exporterTimeout);
+        config.get("schedule-delay").as(Duration.class).ifPresent(this::scheduleDelay);
         config.get("max-queue-size").asInt().ifPresent(this::maxQueueSize);
         config.get("max-export-batch-size").asInt().ifPresent(this::maxExportBatchSize);
 

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerTracerBuilderTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerTracerBuilderTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.tracing.jaeger;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -73,7 +74,12 @@ class JaegerTracerBuilderTest {
         assertThat("Path", jBuilder.path(), nullValue());
         assertThat("Enabled", jBuilder.isEnabled(), is(true));
         assertThat("Sampler type", jBuilder.samplerType(), is(JaegerTracerBuilder.SamplerType.CONSTANT));
+        assertThat("Span Processor type", jBuilder.spanProcessorType(), is(JaegerTracerBuilder.SpanProcessorType.BATCH));
         assertThat("Sampler param", jBuilder.samplerParam(), is(Integer.valueOf(1)));
+        assertThat("Exporter timeout", jBuilder.exporterTimeout(), is(Duration.ofSeconds(10)));
+        assertThat("Schedule delay", jBuilder.scheduleDelay(), is(Duration.ofSeconds(30)));
+        assertThat("Max Queue Size", jBuilder.maxQueueSize(), is(2048));
+        assertThat("Max Export Batch Size", jBuilder.maxExportBatchSize(), is(512));
     }
 
     @Test
@@ -102,6 +108,7 @@ class JaegerTracerBuilderTest {
         assertThat("Port", jBuilder.port(), is(14240));
         assertThat("Path", jBuilder.path(), is("/api/traces/mine"));
         assertThat("Sampler type", jBuilder.samplerType(), is(JaegerTracerBuilder.SamplerType.RATIO));
+        assertThat("Span Processor type", jBuilder.spanProcessorType(), is(JaegerTracerBuilder.SpanProcessorType.SIMPLE));
         assertThat("Sampler param", jBuilder.samplerParam(), is(0.5));
         assertThat("Tags", jBuilder.tags(), is(Map.of(
                 "tag1", "tag1-value",

--- a/tracing/jaeger/src/test/resources/application.yaml
+++ b/tracing/jaeger/src/test/resources/application.yaml
@@ -36,6 +36,7 @@ tracing:
     sampler-type: "ratio"
     sampler-param: 0.5
     propagation: ["jaeger", "b3_single", "w3c"]
+    span-processor-type: simple
     tags:
       tag1: "tag1-value"  # JAEGER_TAGS
       tag2: "tag2-value"  # JAEGER_TAGS


### PR DESCRIPTION
Resolves internal request to switch to Batch Span Exporter to Jaeger tracer. This should significantly improve performance.

Doc impact: new config properties