### PR TITLE
6962 include proxy setting for relative uris  4.x

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -179,8 +179,7 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
      *
      * @return relative URIs flag
      */
-    // TODO Set the default value to false when proxy is implemented and see Http1CallChainBase.prologue for other changes
-    @ConfiguredOption("true")
+    @ConfiguredOption("false")
     boolean relativeUris();
 
     /**

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
@@ -188,8 +188,7 @@ class HttpClientConfigSupport {
             }
 
             if (target.proxy().isEmpty()) {
-                // Defaults to NoProxy type if Proxy is not set
-                target.proxy(Proxy.noProxy());
+                target.proxy(Proxy.create());
             }
         }
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigSupport.java
@@ -188,7 +188,8 @@ class HttpClientConfigSupport {
             }
 
             if (target.proxy().isEmpty()) {
-                target.proxy(Proxy.create());
+                // Defaults to NoProxy type if Proxy is not set
+                target.proxy(Proxy.noProxy());
             }
         }
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -294,7 +294,7 @@ public class Proxy {
      * @param uri the uri
      * @return true if it is in no hosts, otherwise false
      */
-    private boolean isNoHosts(InetSocketAddress uri) {
+    public boolean isNoHosts(InetSocketAddress uri) {
         return noProxy.apply(uri);
     }
 

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -299,6 +299,21 @@ public class Proxy {
     }
 
     /**
+     * Verifies whether the specified Uri is using system proxy.
+     *
+     * @param uri the uri
+     * @return true if the uri resource will be proxied
+     */
+    public boolean isUsingSystemProxy(String uri) {
+        if (systemProxySelector != null) {
+            List<java.net.Proxy> proxies = systemProxySelector
+                    .select(URI.create(uri));
+            return !proxies.isEmpty() && !proxies.get(0).equals(java.net.Proxy.NO_PROXY);
+        }
+        return false;
+    }
+
+    /**
      * Creates an Optional with the InetSocketAddress of the server proxy for the specified uri.
      *
      * @param uri the uri

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -18,6 +18,7 @@ package io.helidon.webclient.http1;
 
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -157,7 +158,13 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                     + request.headers().get(Http.HeaderNames.HOST).value()
                     + " HTTP/1.1\r\n");
         } else {
-            String schemeHostPort = clientConfig.relativeUris() ? "" : uri.scheme() + "://" + uri.host() + ":" + uri.port();
+            // When proxy is set, ensure that the request uses absolute URI because of Section 5.1.2 Request-URI in
+            // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html which states: "The absoluteURI form is REQUIRED when the
+            // request is being made to a proxy."
+            InetSocketAddress uriAddress = new InetSocketAddress(uri.host(), uri.port());
+            String schemeHostPort = proxy == Proxy.noProxy() || proxy.isNoHosts(uriAddress) || clientConfig.relativeUris()
+                    ? ""                                                      // relative URI
+                    : uri.scheme() + "://" + uri.host() + ":" + uri.port();   // absolute URI
             nonEntityData.writeAscii(request.method().text()
                     + " "
                     + schemeHostPort

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -161,13 +161,17 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             // When proxy is set, ensure that the request uses absolute URI because of Section 5.1.2 Request-URI in
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html which states: "The absoluteURI form is REQUIRED when the
             // request is being made to a proxy."
+            String absoluteUri = uri.scheme() + "://" + uri.host() + ":" + uri.port();
             InetSocketAddress uriAddress = new InetSocketAddress(uri.host(), uri.port());
-            String schemeHostPort = proxy == Proxy.noProxy() || proxy.isNoHosts(uriAddress) || clientConfig.relativeUris()
-                    ? ""                                                      // relative URI
-                    : uri.scheme() + "://" + uri.host() + ":" + uri.port();   // absolute URI
+            String requestUri = proxy == Proxy.noProxy()
+                    || (proxy.type() == Proxy.ProxyType.HTTP && proxy.isNoHosts(uriAddress))
+                    || (proxy.type() == Proxy.ProxyType.SYSTEM && !proxy.isUsingSystemProxy(absoluteUri))
+                    || clientConfig.relativeUris()
+                    ? "" // don't set host details, so it becomes relative URI
+                    : absoluteUri;
             nonEntityData.writeAscii(request.method().text()
                     + " "
-                    + schemeHostPort
+                    + requestUri
                     + uri.pathWithQueryAndFragment()
                     + " HTTP/1.1\r\n");
         }


### PR DESCRIPTION
**Description:**
This is a feature parity change with prior versions related to relativeUris config logic. When proxy is set or host is in no-proxy list, the request uses absolute URI because of Section 5.1.2 Request-URI spec in https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html which states: "The absoluteURI form is REQUIRED when the request is being made to a proxy.". If absoluteURI does not work as the request URI, then relativeUris config can be set to true to override this behavior.

**Documentation impact:**
When relativeUris is documented as a webclient config, we can add the notes mentioned in the Description above.

**Additional notes:**
This change can be compared to this code section in 3.x that performs the same logic: https://github.com/helidon-io/helidon/blob/helidon-3.x/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java#L756-L763
