### PR TITLE
4.x: Upgrades Hibernate to 6.2.7.Final with minimal changes

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -35,7 +35,7 @@
         <version.plugin.jandex>3.1.2</version.plugin.jandex>
         <version.plugin.jaxb>0.14.0</version.plugin.jaxb>
         <version.plugin.eclipselink>2.7.5.1</version.plugin.eclipselink>
-        <version.plugin.hibernate.enhance>6.1.7.Final</version.plugin.hibernate.enhance>
+        <version.plugin.hibernate.enhance>6.2.7.Final</version.plugin.hibernate.enhance>
         <mainClass>io.helidon.Main</mainClass>
     </properties>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -61,8 +61,8 @@
         <version.lib.h2>2.2.220</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.handlebars>4.3.1</version.lib.handlebars>
-        <version.lib.hibernate>6.1.7.Final</version.lib.hibernate>
-        <version.lib.hibernate-validator>7.0.2.Final</version.lib.hibernate-validator>
+        <version.lib.hibernate>6.2.7.Final</version.lib.hibernate>
+        <version.lib.hibernate-validator>8.0.1.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
         <version.lib.jackson>2.15.2</version.lib.jackson>

--- a/examples/integrations/cdi/pokemons/pom.xml
+++ b/examples/integrations/cdi/pokemons/pom.xml
@@ -31,6 +31,10 @@
     <artifactId>helidon-integrations-examples-pokemons</artifactId>
     <name>Helidon Examples CDI Extensions Pokemons JPA</name>
 
+    <properties>
+        <java.util.logging.config.file>src/test/java/logging.properties</java.util.logging.config.file>
+    </properties>
+    
     <dependencies>
         <!-- Compile-scoped dependencies. -->
         <dependency>
@@ -125,6 +129,11 @@
             <artifactId>jakarta.el</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- Test-scoped dependencies. -->
         <dependency>
@@ -158,6 +167,15 @@
                         <id>make-index</id>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>${java.util.logging.config.file}</java.util.logging.config.file>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.hibernate.orm.tooling</groupId>

--- a/examples/integrations/cdi/pokemons/src/main/resources/META-INF/persistence.xml
+++ b/examples/integrations/cdi/pokemons/src/main/resources/META-INF/persistence.xml
@@ -28,6 +28,7 @@
         <properties>
             <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
             <property name="jakarta.persistence.sql-load-script-source" value="META-INF/init_script.sql"/>
+            <property name="hibernate.column_ordering_strategy" value="legacy"/>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
         </properties>
     </persistence-unit>

--- a/examples/integrations/cdi/pokemons/src/test/java/io/helidon/examples/integrations/cdi/pokemon/MainTest.java
+++ b/examples/integrations/cdi/pokemons/src/test/java/io/helidon/examples/integrations/cdi/pokemon/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,13 +28,11 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@Disabled("3.0.0-JAKARTA") // persistence.xml failure
 class MainTest {
 
     private static Server server;

--- a/examples/integrations/cdi/pokemons/src/test/java/logging.properties
+++ b/examples/integrations/cdi/pokemons/src/test/java/logging.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = FINER
+org.hibernate.level = INFO


### PR DESCRIPTION
Upgrades Hibernate to 6.2.7.Final with minimal changes.

Documentation impact: none, other than mentioning the version upgrade.