### PR TITLE
4.x: Upgrade eclipselink to 4.0.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -44,7 +44,7 @@
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
-        <version.lib.eclipselink>4.0.1</version.lib.eclipselink>
+        <version.lib.eclipselink>4.0.2</version.lib.eclipselink>
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>


### PR DESCRIPTION
### Description

Upgrade eclipselink to 4.0.2.  This brings in ASM 9.5.0 with Java 21 support.

### Documentation

No impact
