### PR TITLE
4.x: Force upgrade of bytebuddy to 1.14.6 to support Java 21.

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -73,6 +73,15 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate.enhance}</version>
+                    <dependencies>
+                        <dependency>
+                            <!-- Force upgrade byte-buddy for Java 21.     -->
+                            <!-- Remove after upgrading to Hibernate 6.2.7 -->
+                            <groupId>net.bytebuddy</groupId>
+                            <artifactId>byte-buddy</artifactId>
+                            <version>${version.lib.byte-buddy}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -40,6 +40,8 @@
         <version.lib.animal-sniffer>1.18</version.lib.animal-sniffer>
         <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
+        <!-- Force upgrade byte-buddy for Java 21. Remove after upgrading hibernate to 6.2.7 -->
+        <version.lib.byte-buddy>1.14.6</version.lib.byte-buddy>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>

--- a/pom.xml
+++ b/pom.xml
@@ -634,6 +634,15 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate-enhance}</version>
+                    <dependencies>
+                        <dependency>
+                            <!-- Force upgrade byte-buddy for Java 21.     -->
+                            <!-- Remove after upgrading to Hibernate 6.2.7 -->
+                            <groupId>net.bytebuddy</groupId>
+                            <artifactId>byte-buddy</artifactId>
+                            <version>${version.lib.byte-buddy}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
### Description

Force upgrade of bytebuddy to 1.14.6 to support Java 21.

Once we upgrade to to Hibernate 6.2.7  or later we can remove this.

### Documentation

No impact