### PR TITLE
Add -proc:full to javac to explicitly enable annotation processing

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -67,6 +67,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.plugin.compiler}</version>
+                    <configuration>
+                        <proc>full</proc>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,7 @@
                         <target>${version.java}</target>
                         <release>${version.java}</release>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                        <proc>full</proc>
                         <compilerArgs>
                             <arg>-Xlint:unchecked</arg>
                             <!--


### PR DESCRIPTION
### Description

Adds the Java compiler flag `-proc:full` 

Fixes #7445 

For reference:

* https://inside.java/2023/07/29/quality-heads-up/
* https://bugs.openjdk.org/browse/JDK-8310061


### Documentation

No impact