### PR TITLE
4.x: upgrade microprofile-openapi-api to 3.1.1 and add direct dependency

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -113,7 +113,7 @@
         <version.lib.microprofile-health>4.0</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>2.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics-api>5.0.1</version.lib.microprofile-metrics-api>
-        <version.lib.microprofile-openapi-api>3.1</version.lib.microprofile-openapi-api>
+        <version.lib.microprofile-openapi-api>3.1.1</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-reactive-messaging-api>3.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>3.0</version.lib.microprofile-reactive-streams-operators-api>
         <version.lib.microprofile-reactive-streams-operators-core>3.0</version.lib.microprofile-reactive-streams-operators-core>

--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.openapi</groupId>
+            <artifactId>microprofile-openapi-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>
         </dependency>


### PR DESCRIPTION
### Description

Upgrades microprofile-openapi-api to [3.1.1](https://github.com/eclipse/microprofile-open-api/releases/tag/3.1.1) and adds a direct dependency instead of relying on transitive dependency

### Documentation

No impact