### PR TITLE
4.x: Upgrade microprofile-health to 4.0.1 and microprofile-lra-api to 2.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -110,7 +110,7 @@
         <!-- FIXME upgrade to 4.1 when it is released in Maven -->
         <version.lib.microprofile-fault-tolerance-api>4.0.2</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-graphql>2.0</version.lib.microprofile-graphql>
-        <version.lib.microprofile-health>4.0</version.lib.microprofile-health>
+        <version.lib.microprofile-health>4.0.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>2.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics-api>5.0.1</version.lib.microprofile-metrics-api>
         <version.lib.microprofile-openapi-api>3.1</version.lib.microprofile-openapi-api>
@@ -120,7 +120,7 @@
         <version.lib.microprofile-rest-client>3.0</version.lib.microprofile-rest-client>
         <version.lib.microprofile-telemetry-tck>1.0</version.lib.microprofile-telemetry-tck>
         <version.lib.microprofile-tracing>3.0</version.lib.microprofile-tracing>
-        <version.lib.microprofile-lra-api>2.0-RC1</version.lib.microprofile-lra-api>
+        <version.lib.microprofile-lra-api>2.0</version.lib.microprofile-lra-api>
         <version.lib.microstream>05.00.02-MS-GA</version.lib.microstream>
         <version.lib.mongodb>4.9.1</version.lib.mongodb>
         <version.lib.mssql-jdbc>8.4.1.jre8</version.lib.mssql-jdbc>


### PR DESCRIPTION
### Description

- Upgrade microprofile-health to 4.0.1 
- Upgrade microprofile-lra-api to 2.0

### Documentation

No impact
