### PR TITLE
4.x: Introduces Lazy OCI Vault ConfigSource

### DIFF
--- a/integrations/oci/oci-secrets-config-source/pom.xml
+++ b/integrations/oci/oci-secrets-config-source/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <compartment-ocid/>
         <java.util.logging.config.file>src/test/java/logging.properties</java.util.logging.config.file>
+        <lazy>false</lazy>
         <vault-ocid/>
     </properties>
 

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/AbstractSecretBundleConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/AbstractSecretBundleConfigSource.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.secrets.configsource;
+
+import java.lang.System.Logger;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import io.helidon.common.LazyValue;
+import io.helidon.config.AbstractConfigSource;
+import io.helidon.config.AbstractConfigSourceBuilder;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigException;
+import io.helidon.config.spi.ConfigNode.ValueNode;
+
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import com.oracle.bmc.secrets.Secrets;
+import com.oracle.bmc.secrets.SecretsClient;
+
+import static io.helidon.integrations.oci.sdk.runtime.OciExtension.ociAuthenticationProvider;
+import static java.lang.System.Logger.Level.WARNING;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * An {@link AbstractConfigSource} that encapsulates functionality common to both {@link SecretBundleLazyConfigSource}
+ * and {@link SecretBundleNodeConfigSource}.
+ *
+ * @param <B> the type of {@link AbstractConfigSourceBuilder} subclass used to build instances of this class
+ *
+ * @see SecretBundleLazyConfigSource
+ *
+ * @see SecretBundleNodeConfigSource
+ */
+public abstract sealed class AbstractSecretBundleConfigSource<B extends AbstractConfigSourceBuilder<B, Void>>
+    extends AbstractConfigSource
+    permits SecretBundleLazyConfigSource, SecretBundleNodeConfigSource {
+
+    private static final Logger LOGGER = System.getLogger(AbstractSecretBundleConfigSource.class.getName());
+
+    static final String VAULT_OCID_PROPERTY_NAME = "vault-ocid";
+
+    /**
+     * Creates a new {@link AbstractSecretBundleConfigSource}.
+     *
+     * @param b a builder
+     */
+    protected AbstractSecretBundleConfigSource(B b) {
+        super(b);
+    }
+
+    static ValueNode valueNode(String base64EncodedContent, Base64.Decoder base64Decoder) {
+        String decodedContent = new String(base64Decoder.decode(base64EncodedContent), UTF_8);
+        return ValueNode.create(decodedContent.intern());
+    }
+
+    /**
+     * An {@link AbstractConfigSourceBuilder} used to build instances of {@link AbstractSecretBundleConfigSource}.
+     *
+     * @param <B> the builder subclass
+     */
+    public abstract static sealed class Builder<B extends AbstractConfigSourceBuilder<B, Void>>
+        extends AbstractConfigSourceBuilder<B, Void>
+        permits SecretBundleLazyConfigSource.Builder, SecretBundleNodeConfigSource.Builder {
+
+        private Supplier<? extends Secrets> secretsSupplier;
+
+        private String vaultOcid;
+
+        /**
+         * Creates a new {@link Builder}.
+         */
+        protected Builder() {
+            super();
+            SecretsClient.Builder scb = SecretsClient.builder();
+            this.secretsSupplier = () -> scb.build(adpSupplier().get());
+        }
+
+        /**
+         * Configures this {@link Builder} from the supplied meta-configuration.
+         *
+         * @param metaConfig the meta-configuration; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code metaConfig} is {@code null}
+         */
+        @Override // AbstractConfigSourceBuilder<Builder, Void>
+        public B config(Config metaConfig) {
+            metaConfig.get("change-watcher")
+                .asNode()
+                .ifPresent(n -> {
+                        throw new ConfigException("Invalid meta-configuration key: change-watcher: "
+                                                  + "Change watching is not supported by "
+                                                  + this.getClass().getName() + " instances");
+                    });
+            metaConfig.get("vault-ocid")
+                .asString()
+                .filter(Predicate.not(String::isBlank))
+                .ifPresentOrElse(this::vaultOcid,
+                                 () -> {
+                                     if (LOGGER.isLoggable(WARNING)) {
+                                         LOGGER.log(WARNING,
+                                                    "No meta-configuration value supplied for "
+                                                    + metaConfig.key().toString() + "." + VAULT_OCID_PROPERTY_NAME
+                                                    + "); resulting ConfigSource will be empty");
+                                     }
+                                 });
+            return super.config(metaConfig);
+        }
+
+        /**
+         * Sets the (required) OCID of the OCI vault from which an {@link AbstractSecretBundleConfigSource} will
+         * retrieve values.
+         *
+         * @param vaultOcid a valid OCID identifying an OCI vault; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code vaultId} is {@code null}
+         */
+        @SuppressWarnings("unchecked")
+        public B vaultOcid(String vaultOcid) {
+            this.vaultOcid = Objects.requireNonNull(vaultOcid, "vaultOcid");
+            return (B) this;
+        }
+
+        String vaultOcid() {
+            return this.vaultOcid;
+        }
+
+        /**
+         * Uses the supplied {@link Supplier} of {@link Secrets} instances, instead of the default one, for
+         * communicating with the OCI Secrets Retrieval API.
+         *
+         * @param secretsSupplier the non-default {@link Supplier} to use; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code secretsSupplier} is {@code null}
+         */
+        @SuppressWarnings("unchecked")
+        public B secretsSupplier(Supplier<? extends Secrets> secretsSupplier) {
+            this.secretsSupplier = Objects.requireNonNull(secretsSupplier, "secretsSupplier");
+            return (B) this;
+        }
+
+        Supplier<? extends Secrets> secretsSupplier() {
+            return this.secretsSupplier;
+        }
+
+        static LazyValue<? extends BasicAuthenticationDetailsProvider> adpSupplier() {
+            return LazyValue.create(() -> (BasicAuthenticationDetailsProvider) ociAuthenticationProvider().get());
+        }
+
+    }
+
+}

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
@@ -114,7 +114,10 @@ public final class OciSecretsConfigSourceProvider implements ConfigSourceProvide
      */
     @Deprecated // For use by the Helidon Config subsystem only.
     @Override // ConfigSourceProvider
-    public SecretBundleConfigSource create(String type, Config metaConfig) {
+    public ConfigSource create(String type, Config metaConfig) {
+        if (metaConfig.get("lazy").asBoolean().orElse(Boolean.FALSE)) {
+            return SecretBundleLazyConfigSource.builder().config(metaConfig).build();
+        }
         return SecretBundleConfigSource.builder().config(metaConfig).build();
     }
 

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
@@ -18,6 +18,7 @@ package io.helidon.integrations.oci.secrets.configsource;
 import java.util.Set;
 
 import io.helidon.common.Weight;
+import io.helidon.config.AbstractConfigSource;
 import io.helidon.config.Config;
 import io.helidon.config.spi.ConfigSource;
 import io.helidon.config.spi.ConfigSourceProvider;
@@ -92,8 +93,8 @@ public final class OciSecretsConfigSourceProvider implements ConfigSourceProvide
 
 
     /**
-     * Creates and returns a non-{@code null} {@link SecretBundleConfigSource} that sources its values from an Oracle
-     * Cloud Infrastructure (OCI) <a
+     * Creates and returns a non-{@code null} {@link AbstractConfigSource} implementation that sources its values from
+     * an Oracle Cloud Infrastructure (OCI) <a
      * href="https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Concepts/keyoverview.htm">Vault</a>.
      *
      * @param type one of the {@linkplain #supported() supported types}; not actually used
@@ -101,24 +102,24 @@ public final class OciSecretsConfigSourceProvider implements ConfigSourceProvide
      * @param metaConfig a {@link Config} serving as meta-configuration for this provider; must not be {@code null} when
      * {@code type} is {@linkplain #supports(String) supported}
      *
-     * @return a non-{@code null} {@link SecretBundleConfigSource}
+     * @return a non-{@code null} {@link AbstractConfigSource} implementation
      *
      * @exception NullPointerException if {@code type} is {@linkplain #supports(String) supported} and {@code
      * metaConfig} is {@code null}
      *
      * @see #supported()
      *
-     * @see SecretBundleConfigSource
+     * @see AbstractConfigSource
      *
      * @deprecated For use by the Helidon Config subsystem only.
      */
     @Deprecated // For use by the Helidon Config subsystem only.
     @Override // ConfigSourceProvider
-    public ConfigSource create(String type, Config metaConfig) {
+    public AbstractConfigSource create(String type, Config metaConfig) {
         if (metaConfig.get("lazy").asBoolean().orElse(Boolean.FALSE)) {
             return SecretBundleLazyConfigSource.builder().config(metaConfig).build();
         }
-        return SecretBundleConfigSource.builder().config(metaConfig).build();
+        return SecretBundleNodeConfigSource.builder().config(metaConfig).build();
     }
 
     /**

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
@@ -59,7 +59,7 @@ import io.helidon.config.spi.ConfigSourceProvider;
  *
  * @see ConfigSourceProvider
  */
-// @Weight(300D) // a higher weight than the default (100D)
+@Weight(300D) // a higher weight than the default (100D)
 public final class OciSecretsConfigSourceProvider implements ConfigSourceProvider {
 
 

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
@@ -59,7 +59,7 @@ import io.helidon.config.spi.ConfigSourceProvider;
  *
  * @see ConfigSourceProvider
  */
-@Weight(300D) // a higher weight than the default (100D)
+// @Weight(300D) // a higher weight than the default (100D)
 public final class OciSecretsConfigSourceProvider implements ConfigSourceProvider {
 
 

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleLazyConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleLazyConfigSource.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.secrets.configsource;
+
+import java.lang.System.Logger;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import io.helidon.common.LazyValue;
+import io.helidon.config.AbstractConfigSource;
+import io.helidon.config.AbstractConfigSourceBuilder;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigException;
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.config.spi.ConfigNode.ValueNode;
+import io.helidon.config.spi.LazyConfigSource;
+
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import com.oracle.bmc.secrets.Secrets;
+import com.oracle.bmc.secrets.SecretsClient;
+import com.oracle.bmc.secrets.model.Base64SecretBundleContentDetails;
+import com.oracle.bmc.secrets.requests.GetSecretBundleByNameRequest;
+
+import static io.helidon.integrations.oci.sdk.runtime.OciExtension.ociAuthenticationProvider;
+import static java.lang.System.Logger.Level.WARNING;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * An {@link AbstractConfigSource} and a {@link LazyConfigSource} implementation that sources its values from the Oracle
+ * Cloud Infrastructure (OCI) <a
+ * href="https://docs.oracle.com/en-us/iaas/tools/java/latest/com/oracle/bmc/secrets/package-summary.html">Secrets
+ * Retrieval</a> and <a
+ * href="https://docs.oracle.com/en-us/iaas/tools/java/latest/com/oracle/bmc/vault/package-summary.html">Vault</a> APIs.
+ */
+public final class SecretBundleLazyConfigSource extends AbstractConfigSource implements LazyConfigSource {
+
+
+    /*
+     * Static fields.
+     */
+
+
+    private static final Logger LOGGER = System.getLogger(SecretBundleLazyConfigSource.class.getName());
+
+    private static final String VAULT_OCID_PROPERTY_NAME = "vault-ocid";
+
+
+    /*
+     * Instance fields.
+     */
+
+
+    private final Function<? super String, ? extends Optional<ConfigNode>> nodeFunction;
+
+
+    /*
+     * Constructors.
+     */
+
+
+    private SecretBundleLazyConfigSource(Builder b) {
+        super(b);
+        if (b.vaultOcid == null) {
+            this.nodeFunction = secretName -> Optional.empty();
+        } else {
+            LazyValue<? extends Secrets> secretsSupplier = LazyValue.create(b.secretsSupplier::get);
+            this.nodeFunction = secretName -> node(secretsSupplier, b.vaultOcid, secretName);
+        }
+    }
+
+
+    /*
+     * Instance methods.
+     */
+
+
+    @Deprecated // For use by the Helidon Config subsystem only.
+    @Override // NodeConfigSource
+    public Optional<ConfigNode> node(String key) {
+        return this.nodeFunction.apply(key);
+    }
+
+
+    /*
+     * Static methods.
+     */
+
+
+    /**
+     * Creates and returns a new {@link Builder} for {@linkplain Builder#build() building} {@link
+     * SecretBundleConfigSource} instances.
+     *
+     * @return a new {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static Optional<ConfigNode> node(LazyValue<? extends Secrets> secretsSupplier, String vaultOcid, String secretName) {
+        Secrets s = secretsSupplier.get();
+        return node(() -> s.getSecretBundleByName(request(vaultOcid, secretName)).getSecretBundle().getSecretBundleContent());
+    }
+
+    private static Optional<ConfigNode> node(Supplier<?> secretBundleContentDetailsSupplier) {
+        Object secretBundleContentDetails = secretBundleContentDetailsSupplier.get();
+        if (secretBundleContentDetails instanceof Base64SecretBundleContentDetails base64SecretBundleContentDetails) {
+            return Optional.of(valueNode(base64SecretBundleContentDetails.getContent(), Base64.getDecoder()));
+        }
+        return Optional.empty();
+    }
+
+    private static GetSecretBundleByNameRequest request(String vaultOcid, String secretName) {
+        return GetSecretBundleByNameRequest.builder()
+            .vaultId(vaultOcid)
+            .secretName(secretName)
+            .build();
+    }
+
+    static ValueNode valueNode(String base64EncodedContent, Base64.Decoder base64Decoder) {
+        String decodedContent = new String(base64Decoder.decode(base64EncodedContent), UTF_8);
+        return ValueNode.create(decodedContent.intern());
+    }
+
+
+    /*
+     * Inner and nested classes.
+     */
+
+
+    /**
+     * An {@link AbstractConfigSourceBuilder} that {@linkplain #build() builds} {@link SecretBundleConfigSource}
+     * instances.
+     */
+    public static final class Builder extends AbstractConfigSourceBuilder<Builder, Void> {
+
+
+        /*
+         * Instance fields.
+         */
+
+
+        private Supplier<? extends Secrets> secretsSupplier;
+
+        private String vaultOcid;
+
+
+        /*
+         * Constructors.
+         */
+
+
+        private Builder() {
+            super();
+            Supplier<? extends BasicAuthenticationDetailsProvider> adpSupplier =
+                LazyValue.create(() -> (BasicAuthenticationDetailsProvider) ociAuthenticationProvider().get());
+            SecretsClient.Builder scb = SecretsClient.builder();
+            this.secretsSupplier = () -> scb.build(adpSupplier.get());
+        }
+
+
+        /*
+         * Instance methods.
+         */
+
+
+        /**
+         * Creates and returns a new {@link SecretBundleConfigSource} instance initialized from the state of this {@link
+         * Builder}.
+         *
+         * @return a new {@link SecretBundleConfigSource}
+         */
+        public SecretBundleLazyConfigSource build() {
+            return new SecretBundleLazyConfigSource(this);
+        }
+
+        /**
+         * Configures this {@link Builder} from the supplied meta-configuration.
+         *
+         * @param metaConfig the meta-configuration; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code metaConfig} is {@code null}
+         */
+        @Override // AbstractConfigSourceBuilder<Builder, Void>
+        public Builder config(Config metaConfig) {
+            metaConfig.get("change-watcher")
+                .asNode()
+                .ifPresent(n -> {
+                        throw new ConfigException("Invalid meta-configuration key: change-watcher: "
+                                                  + "Change watching is not supported by "
+                                                  + this.getClass().getName() + " instances");
+                    });
+            metaConfig.get("polling-strategy")
+                .asNode()
+                .ifPresent(n -> {
+                        throw new ConfigException("Invalid meta-configuration key: polling-strategy: "
+                                                  + "Polling is not supported by "
+                                                  + this.getClass().getName() + " instances");
+                    });
+            metaConfig.get("vault-ocid")
+                .asString()
+                .filter(Predicate.not(String::isBlank))
+                .ifPresentOrElse(this::vaultOcid,
+                                 () -> {
+                                     if (LOGGER.isLoggable(WARNING)) {
+                                         LOGGER.log(WARNING,
+                                                    "No meta-configuration value supplied for "
+                                                    + metaConfig.key().toString() + "." + VAULT_OCID_PROPERTY_NAME
+                                                    + "); resulting ConfigSource will be empty");
+                                     }
+                                 });
+            return super.config(metaConfig);
+        }
+
+        /**
+         * Uses the supplied {@link Supplier} of {@link Secrets} instances, instead of the default one, for
+         * communicating with the OCI Secrets Retrieval API.
+         *
+         * @param secretsSupplier the non-default {@link Supplier} to use; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code secretsSupplier} is {@code null}
+         */
+        public Builder secretsSupplier(Supplier<? extends Secrets> secretsSupplier) {
+            this.secretsSupplier = Objects.requireNonNull(secretsSupplier, "secretsSupplier");
+            return this;
+        }
+
+        /**
+         * Sets the (required) OCID of the OCI vault from which a {@link SecretBundleConfigSource} will retrieve values.
+         *
+         * @param vaultOcid a valid OCID identifying an OCI vault; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code vaultId} is {@code null}
+         */
+        public Builder vaultOcid(String vaultOcid) {
+            this.vaultOcid = Objects.requireNonNull(vaultOcid, "vaultOcid");
+            return this;
+        }
+
+    }
+
+}

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleNodeConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleNodeConfigSource.java
@@ -37,11 +37,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import io.helidon.common.LazyValue;
 import io.helidon.config.AbstractConfigSource;
 import io.helidon.config.AbstractConfigSourceBuilder;
 import io.helidon.config.Config;
-import io.helidon.config.ConfigException;
 import io.helidon.config.spi.ConfigContent.NodeContent;
 import io.helidon.config.spi.ConfigNode.ObjectNode;
 import io.helidon.config.spi.ConfigNode.ValueNode;
@@ -49,9 +47,7 @@ import io.helidon.config.spi.NodeConfigSource;
 import io.helidon.config.spi.PollableSource;
 import io.helidon.config.spi.PollingStrategy;
 
-import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.secrets.Secrets;
-import com.oracle.bmc.secrets.SecretsClient;
 import com.oracle.bmc.secrets.model.Base64SecretBundleContentDetails;
 import com.oracle.bmc.secrets.requests.GetSecretBundleRequest;
 import com.oracle.bmc.secrets.responses.GetSecretBundleResponse;
@@ -61,9 +57,7 @@ import com.oracle.bmc.vault.model.SecretSummary;
 import com.oracle.bmc.vault.model.SecretSummary.LifecycleState;
 import com.oracle.bmc.vault.requests.ListSecretsRequest;
 
-import static io.helidon.integrations.oci.sdk.runtime.OciExtension.ociAuthenticationProvider;
 import static java.lang.System.Logger.Level.WARNING;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.now;
 import static java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor;
 
@@ -74,8 +68,9 @@ import static java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor;
  * Retrieval</a> and <a
  * href="https://docs.oracle.com/en-us/iaas/tools/java/latest/com/oracle/bmc/vault/package-summary.html">Vault</a> APIs.
  */
-public final class SecretBundleConfigSource
-    extends AbstractConfigSource implements NodeConfigSource, PollableSource<SecretBundleConfigSource.Stamp> {
+public final class SecretBundleNodeConfigSource
+    extends AbstractSecretBundleConfigSource<SecretBundleNodeConfigSource.Builder>
+    implements NodeConfigSource, PollableSource<SecretBundleNodeConfigSource.Stamp> {
 
 
     /*
@@ -88,9 +83,7 @@ public final class SecretBundleConfigSource
 
     private static final String COMPARTMENT_OCID_PROPERTY_NAME = "compartment-ocid";
 
-    private static final Logger LOGGER = System.getLogger(SecretBundleConfigSource.class.getName());
-
-    private static final String VAULT_OCID_PROPERTY_NAME = "vault-ocid";
+    private static final Logger LOGGER = System.getLogger(SecretBundleNodeConfigSource.class.getName());
 
 
     /*
@@ -108,20 +101,18 @@ public final class SecretBundleConfigSource
      */
 
 
-    private SecretBundleConfigSource(Builder b) {
+    private SecretBundleNodeConfigSource(Builder b) {
         super(b);
-        Supplier<? extends Secrets> secretsSupplier = Objects.requireNonNull(b.secretsSupplier, "b.secretsSupplier");
+        Supplier<? extends Secrets> secretsSupplier = Objects.requireNonNull(b.secretsSupplier(), "b.secretsSupplier()");
         Supplier<? extends Vaults> vaultsSupplier = Objects.requireNonNull(b.vaultsSupplier, "b.vaultsSupplier");
-        String compartmentOcid = b.compartmentOcid;
-        String vaultOcid = b.vaultOcid;
-        if (compartmentOcid == null || vaultOcid == null) {
+        if (b.compartmentOcid == null || b.vaultOcid() == null) {
             this.loader = this::absentNodeContent;
             this.stamper = Stamp::new;
         } else {
             ListSecretsRequest listSecretsRequest = ListSecretsRequest.builder()
-                .compartmentId(compartmentOcid)
+                .compartmentId(b.compartmentOcid)
                 .lifecycleState(LifecycleState.Active)
-                .vaultId(vaultOcid)
+                .vaultId(b.vaultOcid())
                 .build();
             this.loader = () -> this.load(vaultsSupplier, secretsSupplier, listSecretsRequest);
             this.stamper = () -> toStamp(secretSummaries(vaultsSupplier, listSecretsRequest), secretsSupplier);
@@ -135,7 +126,7 @@ public final class SecretBundleConfigSource
 
 
     /**
-     * Returns {@code true} if the values in this {@link SecretBundleConfigSource} have been modified.
+     * Returns {@code true} if the values in this {@link SecretBundleNodeConfigSource} have been modified.
      *
      * @param lastKnownStamp a {@link Stamp}
      *
@@ -265,7 +256,7 @@ public final class SecretBundleConfigSource
 
     /**
      * Creates and returns a new {@link Builder} for {@linkplain Builder#build() building} {@link
-     * SecretBundleConfigSource} instances.
+     * SecretBundleNodeConfigSource} instances.
      *
      * @return a new {@link Builder}
      */
@@ -405,11 +396,6 @@ public final class SecretBundleConfigSource
         return valueNode(details.getContent(), base64Decoder);
     }
 
-    static ValueNode valueNode(String base64EncodedContent, Base64.Decoder base64Decoder) {
-        String decodedContent = new String(base64Decoder.decode(base64EncodedContent), UTF_8);
-        return ValueNode.create(decodedContent.intern());
-    }
-
 
     /*
      * Inner and nested classes.
@@ -417,11 +403,11 @@ public final class SecretBundleConfigSource
 
 
     /**
-     * An {@link AbstractConfigSourceBuilder} that {@linkplain #build() builds} {@link SecretBundleConfigSource}
+     * An {@link AbstractConfigSourceBuilder} that {@linkplain #build() builds} {@link SecretBundleNodeConfigSource}
      * instances.
      */
-    public static final class Builder extends AbstractConfigSourceBuilder<Builder, Void> {
-
+    // public static final class Builder extends AbstractConfigSourceBuilder<Builder, Void> {
+    public static final class Builder extends AbstractSecretBundleConfigSource.Builder<Builder> {
 
         /*
          * Instance fields.
@@ -429,10 +415,6 @@ public final class SecretBundleConfigSource
 
 
         private String compartmentOcid;
-
-        private Supplier<? extends Secrets> secretsSupplier;
-
-        private String vaultOcid;
 
         private Supplier<? extends Vaults> vaultsSupplier;
 
@@ -444,12 +426,8 @@ public final class SecretBundleConfigSource
 
         private Builder() {
             super();
-            Supplier<? extends BasicAuthenticationDetailsProvider> adpSupplier =
-                LazyValue.create(() -> (BasicAuthenticationDetailsProvider) ociAuthenticationProvider().get());
-            SecretsClient.Builder scb = SecretsClient.builder();
-            this.secretsSupplier = () -> scb.build(adpSupplier.get());
             VaultsClient.Builder vcb = VaultsClient.builder();
-            this.vaultsSupplier = () -> vcb.build(adpSupplier.get());
+            this.vaultsSupplier = () -> vcb.build(adpSupplier().get());
         }
 
 
@@ -459,18 +437,18 @@ public final class SecretBundleConfigSource
 
 
         /**
-         * Creates and returns a new {@link SecretBundleConfigSource} instance initialized from the state of this {@link
-         * Builder}.
+         * Creates and returns a new {@link SecretBundleNodeConfigSource} instance initialized from the state of this
+         * {@link Builder}.
          *
-         * @return a new {@link SecretBundleConfigSource}
+         * @return a new {@link SecretBundleNodeConfigSource}
          */
-        public SecretBundleConfigSource build() {
-            return new SecretBundleConfigSource(this);
+        public SecretBundleNodeConfigSource build() {
+            return new SecretBundleNodeConfigSource(this);
         }
 
         /**
          * Sets the (required) OCID of the OCI compartment housing the vault from which a {@link
-         * SecretBundleConfigSource} will retrieve values.
+         * SecretBundleNodeConfigSource} will retrieve values.
          *
          * @param compartmentOcid a valid OCID identifying an OCI compartment; must not be {@code null}
          *
@@ -494,13 +472,6 @@ public final class SecretBundleConfigSource
          */
         @Override // AbstractConfigSourceBuilder<Builder, Void>
         public Builder config(Config metaConfig) {
-            metaConfig.get("change-watcher")
-                .asNode()
-                .ifPresent(n -> {
-                        throw new ConfigException("Invalid meta-configuration key: change-watcher: "
-                                                  + "Change watching is not supported by "
-                                                  + this.getClass().getName() + " instances");
-                    });
             metaConfig.get("compartment-ocid")
                 .asString()
                 .filter(Predicate.not(String::isBlank))
@@ -510,18 +481,6 @@ public final class SecretBundleConfigSource
                                          LOGGER.log(WARNING,
                                                     "No meta-configuration value supplied for "
                                                     + metaConfig.key().toString() + "." + COMPARTMENT_OCID_PROPERTY_NAME
-                                                    + "); resulting ConfigSource will be empty");
-                                     }
-                                 });
-            metaConfig.get("vault-ocid")
-                .asString()
-                .filter(Predicate.not(String::isBlank))
-                .ifPresentOrElse(this::vaultOcid,
-                                 () -> {
-                                     if (LOGGER.isLoggable(WARNING)) {
-                                         LOGGER.log(WARNING,
-                                                    "No meta-configuration value supplied for "
-                                                    + metaConfig.key().toString() + "." + VAULT_OCID_PROPERTY_NAME
                                                     + "); resulting ConfigSource will be empty");
                                      }
                                  });
@@ -549,35 +508,6 @@ public final class SecretBundleConfigSource
          */
         public Builder pollingStrategy(PollingStrategy pollingStrategy) {
             return super.pollingStrategy(pollingStrategy);
-        }
-
-        /**
-         * Uses the supplied {@link Supplier} of {@link Secrets} instances, instead of the default one, for
-         * communicating with the OCI Secrets Retrieval API.
-         *
-         * @param secretsSupplier the non-default {@link Supplier} to use; must not be {@code null}
-         *
-         * @return this {@link Builder}
-         *
-         * @exception NullPointerException if {@code secretsSupplier} is {@code null}
-         */
-        public Builder secretsSupplier(Supplier<? extends Secrets> secretsSupplier) {
-            this.secretsSupplier = Objects.requireNonNull(secretsSupplier, "secretsSupplier");
-            return this;
-        }
-
-        /**
-         * Sets the (required) OCID of the OCI vault from which a {@link SecretBundleConfigSource} will retrieve values.
-         *
-         * @param vaultOcid a valid OCID identifying an OCI vault; must not be {@code null}
-         *
-         * @return this {@link Builder}
-         *
-         * @exception NullPointerException if {@code vaultId} is {@code null}
-         */
-        public Builder vaultOcid(String vaultOcid) {
-            this.vaultOcid = Objects.requireNonNull(vaultOcid, "vaultOcid");
-            return this;
         }
 
         /**

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleNodeConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleNodeConfigSource.java
@@ -105,14 +105,15 @@ public final class SecretBundleNodeConfigSource
         super(b);
         Supplier<? extends Secrets> secretsSupplier = Objects.requireNonNull(b.secretsSupplier(), "b.secretsSupplier()");
         Supplier<? extends Vaults> vaultsSupplier = Objects.requireNonNull(b.vaultsSupplier, "b.vaultsSupplier");
-        if (b.compartmentOcid == null || b.vaultOcid() == null) {
+        String vaultOcid = b.vaultOcid();
+        if (b.compartmentOcid == null || vaultOcid == null) {
             this.loader = this::absentNodeContent;
             this.stamper = Stamp::new;
         } else {
             ListSecretsRequest listSecretsRequest = ListSecretsRequest.builder()
                 .compartmentId(b.compartmentOcid)
                 .lifecycleState(LifecycleState.Active)
-                .vaultId(b.vaultOcid())
+                .vaultId(vaultOcid)
                 .build();
             this.loader = () -> this.load(vaultsSupplier, secretsSupplier, listSecretsRequest);
             this.stamper = () -> toStamp(secretSummaries(vaultsSupplier, listSecretsRequest), secretsSupplier);

--- a/integrations/oci/oci-secrets-config-source/src/test/java/io/helidon/integrations/oci/secrets/configsource/IsModifiedTest.java
+++ b/integrations/oci/oci-secrets-config-source/src/test/java/io/helidon/integrations/oci/secrets/configsource/IsModifiedTest.java
@@ -18,11 +18,11 @@ package io.helidon.integrations.oci.secrets.configsource;
 import java.time.Instant;
 import java.util.Set;
 
-import io.helidon.integrations.oci.secrets.configsource.SecretBundleConfigSource.Stamp;
+import io.helidon.integrations.oci.secrets.configsource.SecretBundleNodeConfigSource.Stamp;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.integrations.oci.secrets.configsource.SecretBundleConfigSource.isModified;
+import static io.helidon.integrations.oci.secrets.configsource.SecretBundleNodeConfigSource.isModified;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/integrations/oci/oci-secrets-config-source/src/test/java/io/helidon/integrations/oci/secrets/configsource/ValueNodeTest.java
+++ b/integrations/oci/oci-secrets-config-source/src/test/java/io/helidon/integrations/oci/secrets/configsource/ValueNodeTest.java
@@ -19,7 +19,7 @@ import java.util.Base64;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.integrations.oci.secrets.configsource.SecretBundleConfigSource.valueNode;
+import static io.helidon.integrations.oci.secrets.configsource.AbstractSecretBundleConfigSource.valueNode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/integrations/oci/oci-secrets-config-source/src/test/resources/meta-config.yaml
+++ b/integrations/oci/oci-secrets-config-source/src/test/resources/meta-config.yaml
@@ -17,5 +17,7 @@ sources:
   - type: 'system-properties' # for testing
   - type: 'oci-secrets'
     properties: # required
-        compartment-ocid: ${compartment-ocid}
-        vault-ocid: ${vault-ocid}
+        accept-pattern: '^FrancqueSecret$'
+        compartment-ocid: '${compartment-ocid}'
+        lazy: ${lazy}
+        vault-ocid: '${vault-ocid}'


### PR DESCRIPTION
Introduces a `LazyConfigSource` version of an OCI Vault `ConfigSource` and integrates it into the existing `OciSecretsConfigSourceProvider`. Extracts common functionality into an abstract base class.

Now users can pick what they want.

Documentation impact: none.