### PR TITLE
4.x: Tests to validate requested URI is correctly used with IPv6

### DIFF
--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/RedirectionTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/RedirectionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.server;
+
+import java.net.URI;
+
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.DisableDiscovery;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@DisableDiscovery
+@AddBean(RedirectionTest.TestResource.class)
+@AddExtension(ServerCdiExtension.class)
+@AddExtension(JaxRsCdiExtension.class)
+@AddExtension(CdiComponentProvider.class)
+class RedirectionTest {
+    @Test
+    void streamingOutput() {
+        Client client = ClientBuilder.newClient();
+
+        int port = CDI.current().getBeanManager().getExtension(ServerCdiExtension.class).port();
+        WebTarget baseTarget = client.target("http://[::1]:" + port);
+
+        Response response = baseTarget.path("/uri")
+                .request()
+                .get();
+
+        assertThat(response.readEntity(String.class), is("http://[::1]:" + port + "/uri"));
+
+        response = baseTarget.path("/redirect")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+        assertThat(response.readEntity(String.class), is("http://[::1]:" + port + "/uri"));
+    }
+
+    @Path("/")
+    public static class TestResource {
+
+        @GET
+        @Path("/uri")
+        public String uri(@Context UriInfo uriInfo) {
+            return uriInfo.getRequestUri().toString();
+        }
+
+        @GET
+        @Path("/redirect")
+        public Response redirect() {
+            return Response
+                    .seeOther(URI.create("/uri"))
+                    .build();
+        }
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RequestedUriTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RequestedUriTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests;
+
+import io.helidon.http.Http;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@ServerTest
+class RequestedUriTest {
+    private final WebServer webServer;
+
+    RequestedUriTest(WebServer webServer) {
+        this.webServer = webServer;
+    }
+
+    @SetUpServer
+    static void setUp(WebServerConfig.Builder server) {
+        // default is localhost only, we need all, so it listens on ipv6 as well
+        server.host("0.0.0.0");
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.get("/uri", (req, res) -> {
+            try {
+                res.send(req.requestedUri().toUri().toString());
+            } catch (Exception e) {
+                e.printStackTrace();
+                res.status(Http.Status.INTERNAL_SERVER_ERROR_500)
+                        .send(e.getClass().getName() + ":" + e.getMessage());
+            }
+        });
+    }
+
+    @Test
+    void ipV6Test() {
+        int port = webServer.port();
+        WebClient client = WebClient.builder()
+                .baseUri("http://[::1]:" + port)
+                .build();
+
+        ClientResponseTyped<String> response = client.get()
+                .path("/uri")
+                .request(String.class);
+
+        assertAll(
+                () -> assertThat(response.entity(), is("http://[::1]:" + port + "/uri")),
+                () -> assertThat(response.status(), is(Http.Status.OK_200))
+        );
+    }
+}


### PR DESCRIPTION
### Description
Fixes #7478 
Related to #7416 

This PR adds tests for ipv6 and requested URI. There is no bug in 4.x, but the tests were not there.
