### PR TITLE
3.x: Introduces Lazy OCI Vault ConfigSource

### DIFF
--- a/integrations/oci/oci-secrets-config-source/etc/spotbugs/exclude.xml
+++ b/integrations/oci/oci-secrets-config-source/etc/spotbugs/exclude.xml
@@ -23,7 +23,7 @@
         xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
 
     <Match>
-        <Class name="io.helidon.integrations.oci.secrets.configsource.SecretBundleConfigSource"/>
+        <Class name="io.helidon.integrations.oci.secrets.configsource.SecretBundleNodeConfigSource"/>
         <Method name="secretSummaries"/>
         <!-- Spotbugs is very, very confused by try-with-resources blocks. -->
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>

--- a/integrations/oci/oci-secrets-config-source/pom.xml
+++ b/integrations/oci/oci-secrets-config-source/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <compartment-ocid/>
         <java.util.logging.config.file>src/test/java/logging.properties</java.util.logging.config.file>
+        <lazy>false</lazy>
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
         <vault-ocid/>
     </properties>

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/AbstractSecretBundleConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/AbstractSecretBundleConfigSource.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.secrets.configsource;
+
+import java.lang.System.Logger;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import io.helidon.common.LazyValue;
+import io.helidon.config.AbstractConfigSource;
+import io.helidon.config.AbstractConfigSourceBuilder;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigException;
+import io.helidon.config.spi.ConfigNode.ValueNode;
+
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import com.oracle.bmc.secrets.Secrets;
+import com.oracle.bmc.secrets.SecretsClient;
+
+import static io.helidon.integrations.oci.sdk.runtime.OciExtension.ociAuthenticationProvider;
+import static java.lang.System.Logger.Level.WARNING;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * An {@link AbstractConfigSource} that encapsulates functionality common to both {@link SecretBundleLazyConfigSource}
+ * and {@link SecretBundleNodeConfigSource}.
+ *
+ * @param <B> the type of {@link AbstractConfigSourceBuilder} subclass used to build instances of this class
+ *
+ * @see SecretBundleLazyConfigSource
+ *
+ * @see SecretBundleNodeConfigSource
+ */
+public abstract sealed class AbstractSecretBundleConfigSource<B extends AbstractConfigSourceBuilder<B, Void>>
+    extends AbstractConfigSource
+    permits SecretBundleLazyConfigSource, SecretBundleNodeConfigSource {
+
+    private static final Logger LOGGER = System.getLogger(AbstractSecretBundleConfigSource.class.getName());
+
+    static final String VAULT_OCID_PROPERTY_NAME = "vault-ocid";
+
+    /**
+     * Creates a new {@link AbstractSecretBundleConfigSource}.
+     *
+     * @param b a builder
+     */
+    protected AbstractSecretBundleConfigSource(B b) {
+        super(b);
+    }
+
+    static ValueNode valueNode(String base64EncodedContent, Base64.Decoder base64Decoder) {
+        String decodedContent = new String(base64Decoder.decode(base64EncodedContent), UTF_8);
+        return ValueNode.create(decodedContent.intern());
+    }
+
+    /**
+     * An {@link AbstractConfigSourceBuilder} used to build instances of {@link AbstractSecretBundleConfigSource}.
+     *
+     * @param <B> the builder subclass
+     */
+    public abstract static sealed class Builder<B extends AbstractConfigSourceBuilder<B, Void>>
+        extends AbstractConfigSourceBuilder<B, Void>
+        permits SecretBundleLazyConfigSource.Builder, SecretBundleNodeConfigSource.Builder {
+
+        private Supplier<? extends Secrets> secretsSupplier;
+
+        private String vaultOcid;
+
+        /**
+         * Creates a new {@link Builder}.
+         */
+        protected Builder() {
+            super();
+            SecretsClient.Builder scb = SecretsClient.builder();
+            this.secretsSupplier = () -> scb.build(adpSupplier().get());
+        }
+
+        /**
+         * Configures this {@link Builder} from the supplied meta-configuration.
+         *
+         * @param metaConfig the meta-configuration; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code metaConfig} is {@code null}
+         */
+        @Override // AbstractConfigSourceBuilder<Builder, Void>
+        public B config(Config metaConfig) {
+            metaConfig.get("change-watcher")
+                .asNode()
+                .ifPresent(n -> {
+                        throw new ConfigException("Invalid meta-configuration key: change-watcher: "
+                                                  + "Change watching is not supported by "
+                                                  + this.getClass().getName() + " instances");
+                    });
+            metaConfig.get("vault-ocid")
+                .asString()
+                .filter(Predicate.not(String::isBlank))
+                .ifPresentOrElse(this::vaultOcid,
+                                 () -> {
+                                     if (LOGGER.isLoggable(WARNING)) {
+                                         LOGGER.log(WARNING,
+                                                    "No meta-configuration value supplied for "
+                                                    + metaConfig.key().toString() + "." + VAULT_OCID_PROPERTY_NAME
+                                                    + "); resulting ConfigSource will be empty");
+                                     }
+                                 });
+            return super.config(metaConfig);
+        }
+
+        /**
+         * Sets the (required) OCID of the OCI vault from which an {@link AbstractSecretBundleConfigSource} will
+         * retrieve values.
+         *
+         * @param vaultOcid a valid OCID identifying an OCI vault; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code vaultId} is {@code null}
+         */
+        @SuppressWarnings("unchecked")
+        public B vaultOcid(String vaultOcid) {
+            this.vaultOcid = Objects.requireNonNull(vaultOcid, "vaultOcid");
+            return (B) this;
+        }
+
+        String vaultOcid() {
+            return this.vaultOcid;
+        }
+
+        /**
+         * Uses the supplied {@link Supplier} of {@link Secrets} instances, instead of the default one, for
+         * communicating with the OCI Secrets Retrieval API.
+         *
+         * @param secretsSupplier the non-default {@link Supplier} to use; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code secretsSupplier} is {@code null}
+         */
+        @SuppressWarnings("unchecked")
+        public B secretsSupplier(Supplier<? extends Secrets> secretsSupplier) {
+            this.secretsSupplier = Objects.requireNonNull(secretsSupplier, "secretsSupplier");
+            return (B) this;
+        }
+
+        Supplier<? extends Secrets> secretsSupplier() {
+            return this.secretsSupplier;
+        }
+
+        static LazyValue<? extends BasicAuthenticationDetailsProvider> adpSupplier() {
+            return LazyValue.create(() -> (BasicAuthenticationDetailsProvider) ociAuthenticationProvider().get());
+        }
+
+    }
+
+}

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/OciSecretsConfigSourceProvider.java
@@ -17,6 +17,7 @@ package io.helidon.integrations.oci.secrets.configsource;
 
 import java.util.Set;
 
+import io.helidon.config.AbstractConfigSource;
 import io.helidon.config.Config;
 import io.helidon.config.spi.ConfigSource;
 import io.helidon.config.spi.ConfigSourceProvider;
@@ -93,8 +94,8 @@ public final class OciSecretsConfigSourceProvider implements ConfigSourceProvide
 
 
     /**
-     * Creates and returns a non-{@code null} {@link SecretBundleConfigSource} that sources its values from an Oracle
-     * Cloud Infrastructure (OCI) <a
+     * Creates and returns a non-{@code null} {@link AbstractConfigSource} implementation that sources its values from
+     * an Oracle Cloud Infrastructure (OCI) <a
      * href="https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Concepts/keyoverview.htm">Vault</a>.
      *
      * @param type one of the {@linkplain #supported() supported types}; not actually used
@@ -102,21 +103,24 @@ public final class OciSecretsConfigSourceProvider implements ConfigSourceProvide
      * @param metaConfig a {@link Config} serving as meta-configuration for this provider; must not be {@code null} when
      * {@code type} is {@linkplain #supports(String) supported}
      *
-     * @return a non-{@code null} {@link SecretBundleConfigSource}
+     * @return a non-{@code null} {@link AbstractConfigSource} implementation
      *
      * @exception NullPointerException if {@code type} is {@linkplain #supports(String) supported} and {@code
      * metaConfig} is {@code null}
      *
      * @see #supported()
      *
-     * @see SecretBundleConfigSource
+     * @see AbstractConfigSource
      *
      * @deprecated For use by the Helidon Config subsystem only.
      */
     @Deprecated // For use by the Helidon Config subsystem only.
     @Override // ConfigSourceProvider
-    public SecretBundleConfigSource create(String type, Config metaConfig) {
-        return SecretBundleConfigSource.builder().config(metaConfig).build();
+    public AbstractConfigSource create(String type, Config metaConfig) {
+        if (metaConfig.get("lazy").asBoolean().orElse(Boolean.FALSE)) {
+            return SecretBundleLazyConfigSource.builder().config(metaConfig).build();
+        }
+        return SecretBundleNodeConfigSource.builder().config(metaConfig).build();
     }
 
     /**

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleLazyConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleLazyConfigSource.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.secrets.configsource;
+
+import java.lang.System.Logger;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import io.helidon.common.LazyValue;
+import io.helidon.config.AbstractConfigSource;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigException;
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.config.spi.LazyConfigSource;
+
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.secrets.Secrets;
+import com.oracle.bmc.secrets.model.Base64SecretBundleContentDetails;
+import com.oracle.bmc.secrets.requests.GetSecretBundleByNameRequest;
+
+import static java.lang.System.Logger.Level.DEBUG;
+
+/**
+ * An {@link AbstractConfigSource} and a {@link LazyConfigSource} implementation that sources its values from the Oracle
+ * Cloud Infrastructure (OCI) <a
+ * href="https://docs.oracle.com/en-us/iaas/tools/java/latest/com/oracle/bmc/secrets/package-summary.html">Secrets
+ * Retrieval</a> and <a
+ * href="https://docs.oracle.com/en-us/iaas/tools/java/latest/com/oracle/bmc/vault/package-summary.html">Vault</a> APIs.
+ */
+public final class SecretBundleLazyConfigSource
+    extends AbstractSecretBundleConfigSource<SecretBundleLazyConfigSource.Builder>
+    implements LazyConfigSource {
+
+
+    /*
+     * Static fields.
+     */
+
+
+    private static final Logger LOGGER = System.getLogger(SecretBundleLazyConfigSource.class.getName());
+
+
+    /*
+     * Instance fields.
+     */
+
+
+    private final Function<? super String, ? extends Optional<ConfigNode>> nodeFunction;
+
+
+    /*
+     * Constructors.
+     */
+
+
+    private SecretBundleLazyConfigSource(Builder b) {
+        super(b);
+        String vaultOcid = b.vaultOcid();
+        if (vaultOcid == null) {
+            this.nodeFunction = secretName -> Optional.empty();
+        } else {
+            LazyValue<? extends Secrets> secretsSupplier = LazyValue.create(b.secretsSupplier()::get);
+            this.nodeFunction = secretName -> node(b.acceptPattern, secretsSupplier, vaultOcid, secretName);
+        }
+    }
+
+
+    /*
+     * Instance methods.
+     */
+
+
+    @Deprecated // For use by the Helidon Config subsystem only.
+    @Override // NodeConfigSource
+    public Optional<ConfigNode> node(String key) {
+        return this.nodeFunction.apply(key);
+    }
+
+
+    /*
+     * Static methods.
+     */
+
+
+    /**
+     * Creates and returns a new {@link Builder} for {@linkplain Builder#build() building} {@link
+     * SecretBundleLazyConfigSource} instances.
+     *
+     * @return a new {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static Optional<ConfigNode> node(Pattern acceptPattern,
+                                             LazyValue<? extends Secrets> secretsSupplier,
+                                             String vaultOcid,
+                                             String secretName) {
+        if (!acceptPattern.matcher(secretName).matches()) {
+            if (LOGGER.isLoggable(DEBUG)) {
+                LOGGER.log(DEBUG, "Ignoring ConfigNode request for name "
+                           + secretName
+                           + " because it was not matched by "
+                           + acceptPattern);
+            }
+            return Optional.empty();
+        }
+        Secrets s = secretsSupplier.get();
+        return node(() -> secretBundleContentDetails(s, vaultOcid, secretName));
+    }
+
+    private static Object secretBundleContentDetails(Secrets s, String vaultOcid, String secretName) {
+        try {
+            if (LOGGER.isLoggable(DEBUG)) {
+                LOGGER.log(DEBUG, "Getting SecretBundle with name " + secretName);
+            }
+            return s.getSecretBundleByName(request(vaultOcid, secretName)).getSecretBundle().getSecretBundleContent();
+        } catch (BmcException e) {
+            if (e.getStatusCode() == 404) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    static Optional<ConfigNode> node(Supplier<?> secretBundleContentDetailsSupplier) {
+        Object secretBundleContentDetails = secretBundleContentDetailsSupplier.get();
+        if (secretBundleContentDetails instanceof Base64SecretBundleContentDetails base64SecretBundleContentDetails) {
+            return Optional.of(valueNode(base64SecretBundleContentDetails.getContent(), Base64.getDecoder()));
+        }
+        return Optional.empty();
+    }
+
+    static GetSecretBundleByNameRequest request(String vaultOcid, String secretName) {
+        return GetSecretBundleByNameRequest.builder()
+            .vaultId(vaultOcid)
+            .secretName(secretName)
+            .build();
+    }
+
+
+    /*
+     * Inner and nested classes.
+     */
+
+
+    /**
+     * An {@link AbstractSecretBundleConfigSource.Builder} that {@linkplain #build() builds} {@link
+     * SecretBundleLazyConfigSource} instances.
+     */
+    public static final class Builder extends AbstractSecretBundleConfigSource.Builder<Builder> {
+
+
+        /*
+         * Static fields.
+         */
+
+
+        private static final Pattern ACCEPT_EVERYTHING_PATTERN = Pattern.compile("^.*$");
+
+
+        /*
+         * Instance fields.
+         */
+
+
+        private Pattern acceptPattern;
+
+
+        /*
+         * Constructors.
+         */
+
+
+        private Builder() {
+            super();
+            this.acceptPattern = ACCEPT_EVERYTHING_PATTERN;
+        }
+
+
+        /*
+         * Instance methods.
+         */
+
+
+        /**
+         * Sets the {@link Pattern} that will dictate which configuration property names are allowed to reach a {@link
+         * SecretBundleLazyConfigSource} instance.
+         *
+         * @param acceptPattern the {@link Pattern}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception NullPointerException if {@code acceptPattern} is {@code null}
+         */
+        public Builder acceptPattern(Pattern acceptPattern) {
+            this.acceptPattern = Objects.requireNonNull(acceptPattern, "acceptPattern");
+            return this;
+        }
+
+        /**
+         * Creates and returns a new {@link SecretBundleLazyConfigSource} instance initialized from the state of this
+         * {@link Builder}.
+         *
+         * @return a new {@link SecretBundleLazyConfigSource}
+         */
+        public SecretBundleLazyConfigSource build() {
+            return new SecretBundleLazyConfigSource(this);
+        }
+
+        /**
+         * Configures this {@link Builder} from the supplied meta-configuration.
+         *
+         * @param metaConfig the meta-configuration; must not be {@code null}
+         *
+         * @return this {@link Builder}
+         *
+         * @exception io.helidon.config.ConfigException if a {@code change-watcher} or {@code polling-strategy} is
+         * specified
+         *
+         * @exception NullPointerException if {@code metaConfig} is {@code null}
+         *
+         * @exception java.util.regex.PatternSyntaxException if the {@code accept-pattern} key's value could not be
+         * {@linkplain Pattern#compile(String) compiled}
+         */
+        @Override // AbstractSecretBundleConfigSource.Builder<Builder, Void>
+        public Builder config(Config metaConfig) {
+            metaConfig.get("polling-strategy")
+                .asNode()
+                .ifPresent(n -> {
+                        throw new ConfigException("Invalid meta-configuration key: polling-strategy: "
+                                                  + "Polling is not supported by "
+                                                  + this.getClass().getName() + " instances");
+                    });
+            metaConfig.get("accept-pattern")
+                .asString()
+                .ifPresent(s -> this.acceptPattern(Pattern.compile(s)));
+            return super.config(metaConfig);
+        }
+
+    }
+
+}

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleNodeConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleNodeConfigSource.java
@@ -37,11 +37,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import io.helidon.common.LazyValue;
 import io.helidon.config.AbstractConfigSource;
 import io.helidon.config.AbstractConfigSourceBuilder;
 import io.helidon.config.Config;
-import io.helidon.config.ConfigException;
 import io.helidon.config.spi.ConfigContent.NodeContent;
 import io.helidon.config.spi.ConfigNode.ObjectNode;
 import io.helidon.config.spi.ConfigNode.ValueNode;
@@ -49,9 +47,7 @@ import io.helidon.config.spi.NodeConfigSource;
 import io.helidon.config.spi.PollableSource;
 import io.helidon.config.spi.PollingStrategy;
 
-import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.secrets.Secrets;
-import com.oracle.bmc.secrets.SecretsClient;
 import com.oracle.bmc.secrets.model.Base64SecretBundleContentDetails;
 import com.oracle.bmc.secrets.requests.GetSecretBundleRequest;
 import com.oracle.bmc.secrets.responses.GetSecretBundleResponse;
@@ -61,9 +57,7 @@ import com.oracle.bmc.vault.model.SecretSummary;
 import com.oracle.bmc.vault.model.SecretSummary.LifecycleState;
 import com.oracle.bmc.vault.requests.ListSecretsRequest;
 
-import static io.helidon.integrations.oci.sdk.runtime.OciExtension.ociAuthenticationProvider;
 import static java.lang.System.Logger.Level.WARNING;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.now;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
@@ -74,8 +68,9 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
  * Retrieval</a> and <a
  * href="https://docs.oracle.com/en-us/iaas/tools/java/latest/com/oracle/bmc/vault/package-summary.html">Vault</a> APIs.
  */
-public final class SecretBundleConfigSource
-    extends AbstractConfigSource implements NodeConfigSource, PollableSource<SecretBundleConfigSource.Stamp> {
+public final class SecretBundleNodeConfigSource
+    extends AbstractSecretBundleConfigSource<SecretBundleNodeConfigSource.Builder>
+    implements NodeConfigSource, PollableSource<SecretBundleNodeConfigSource.Stamp> {
 
 
     /*
@@ -88,9 +83,7 @@ public final class SecretBundleConfigSource
 
     private static final String COMPARTMENT_OCID_PROPERTY_NAME = "compartment-ocid";
 
-    private static final Logger LOGGER = System.getLogger(SecretBundleConfigSource.class.getName());
-
-    private static final String VAULT_OCID_PROPERTY_NAME = "vault-ocid";
+    private static final Logger LOGGER = System.getLogger(SecretBundleNodeConfigSource.class.getName());
 
 
     /*
@@ -110,7 +103,7 @@ public final class SecretBundleConfigSource
      */
 
 
-    private SecretBundleConfigSource(Builder b) {
+    private SecretBundleNodeConfigSource(Builder b) {
         super(b);
         // From Executors#newCachedThreadPool() javadoc: "Creates a thread pool that creates new threads as needed,
         // but will reuse previously constructed threads when they are available. These pools will typically improve
@@ -120,16 +113,15 @@ public final class SecretBundleConfigSource
         // Helidon Config has no defined lifecycle so the best we can do is forcibly close the ExecutorService on VM
         // exit.
         Runtime.getRuntime().addShutdownHook(new Thread(this.es::shutdownNow));
-        Supplier<? extends Secrets> secretsSupplier = Objects.requireNonNull(b.secretsSupplier, "b.secretsSupplier");
+        Supplier<? extends Secrets> secretsSupplier = Objects.requireNonNull(b.secretsSupplier(), "b.secretsSupplier()");
         Supplier<? extends Vaults> vaultsSupplier = Objects.requireNonNull(b.vaultsSupplier, "b.vaultsSupplier");
-        String compartmentOcid = b.compartmentOcid;
-        String vaultOcid = b.vaultOcid;
-        if (compartmentOcid == null || vaultOcid == null) {
+        String vaultOcid = b.vaultOcid();
+        if (b.compartmentOcid == null || vaultOcid == null) {
             this.loader = this::absentNodeContent;
             this.stamper = Stamp::new;
         } else {
             ListSecretsRequest listSecretsRequest = ListSecretsRequest.builder()
-                .compartmentId(compartmentOcid)
+                .compartmentId(b.compartmentOcid)
                 .lifecycleState(LifecycleState.Active)
                 .vaultId(vaultOcid)
                 .build();
@@ -145,7 +137,7 @@ public final class SecretBundleConfigSource
 
 
     /**
-     * Returns {@code true} if the values in this {@link SecretBundleConfigSource} have been modified.
+     * Returns {@code true} if the values in this {@link SecretBundleNodeConfigSource} have been modified.
      *
      * @param lastKnownStamp a {@link Stamp}
      *
@@ -290,7 +282,7 @@ public final class SecretBundleConfigSource
 
     /**
      * Creates and returns a new {@link Builder} for {@linkplain Builder#build() building} {@link
-     * SecretBundleConfigSource} instances.
+     * SecretBundleNodeConfigSource} instances.
      *
      * @return a new {@link Builder}
      */
@@ -414,11 +406,6 @@ public final class SecretBundleConfigSource
         return valueNode(details.getContent(), base64Decoder);
     }
 
-    static ValueNode valueNode(String base64EncodedContent, Base64.Decoder base64Decoder) {
-        String decodedContent = new String(base64Decoder.decode(base64EncodedContent), UTF_8);
-        return ValueNode.create(decodedContent.intern());
-    }
-
 
     /*
      * Inner and nested classes.
@@ -426,11 +413,11 @@ public final class SecretBundleConfigSource
 
 
     /**
-     * An {@link AbstractConfigSourceBuilder} that {@linkplain #build() builds} {@link SecretBundleConfigSource}
+     * An {@link AbstractConfigSourceBuilder} that {@linkplain #build() builds} {@link SecretBundleNodeConfigSource}
      * instances.
      */
-    public static final class Builder extends AbstractConfigSourceBuilder<Builder, Void> {
-
+    // public static final class Builder extends AbstractConfigSourceBuilder<Builder, Void> {
+    public static final class Builder extends AbstractSecretBundleConfigSource.Builder<Builder> {
 
         /*
          * Instance fields.
@@ -438,10 +425,6 @@ public final class SecretBundleConfigSource
 
 
         private String compartmentOcid;
-
-        private Supplier<? extends Secrets> secretsSupplier;
-
-        private String vaultOcid;
 
         private Supplier<? extends Vaults> vaultsSupplier;
 
@@ -453,12 +436,8 @@ public final class SecretBundleConfigSource
 
         private Builder() {
             super();
-            Supplier<? extends BasicAuthenticationDetailsProvider> adpSupplier =
-                LazyValue.create(() -> (BasicAuthenticationDetailsProvider) ociAuthenticationProvider().get());
-            SecretsClient.Builder scb = SecretsClient.builder();
-            this.secretsSupplier = () -> scb.build(adpSupplier.get());
             VaultsClient.Builder vcb = VaultsClient.builder();
-            this.vaultsSupplier = () -> vcb.build(adpSupplier.get());
+            this.vaultsSupplier = () -> vcb.build(adpSupplier().get());
         }
 
 
@@ -468,18 +447,18 @@ public final class SecretBundleConfigSource
 
 
         /**
-         * Creates and returns a new {@link SecretBundleConfigSource} instance initialized from the state of this {@link
-         * Builder}.
+         * Creates and returns a new {@link SecretBundleNodeConfigSource} instance initialized from the state of this
+         * {@link Builder}.
          *
-         * @return a new {@link SecretBundleConfigSource}
+         * @return a new {@link SecretBundleNodeConfigSource}
          */
-        public SecretBundleConfigSource build() {
-            return new SecretBundleConfigSource(this);
+        public SecretBundleNodeConfigSource build() {
+            return new SecretBundleNodeConfigSource(this);
         }
 
         /**
          * Sets the (required) OCID of the OCI compartment housing the vault from which a {@link
-         * SecretBundleConfigSource} will retrieve values.
+         * SecretBundleNodeConfigSource} will retrieve values.
          *
          * @param compartmentOcid a valid OCID identifying an OCI compartment; must not be {@code null}
          *
@@ -503,13 +482,6 @@ public final class SecretBundleConfigSource
          */
         @Override // AbstractConfigSourceBuilder<Builder, Void>
         public Builder config(Config metaConfig) {
-            metaConfig.get("change-watcher")
-                .asNode()
-                .ifPresent(n -> {
-                        throw new ConfigException("Invalid meta-configuration key: change-watcher: "
-                                                  + "Change watching is not supported by "
-                                                  + this.getClass().getName() + " instances");
-                    });
             metaConfig.get("compartment-ocid")
                 .asString()
                 .filter(Predicate.not(String::isBlank))
@@ -519,18 +491,6 @@ public final class SecretBundleConfigSource
                                          LOGGER.log(WARNING,
                                                     "No meta-configuration value supplied for "
                                                     + metaConfig.key().toString() + "." + COMPARTMENT_OCID_PROPERTY_NAME
-                                                    + "); resulting ConfigSource will be empty");
-                                     }
-                                 });
-            metaConfig.get("vault-ocid")
-                .asString()
-                .filter(Predicate.not(String::isBlank))
-                .ifPresentOrElse(this::vaultOcid,
-                                 () -> {
-                                     if (LOGGER.isLoggable(WARNING)) {
-                                         LOGGER.log(WARNING,
-                                                    "No meta-configuration value supplied for "
-                                                    + metaConfig.key().toString() + "." + VAULT_OCID_PROPERTY_NAME
                                                     + "); resulting ConfigSource will be empty");
                                      }
                                  });
@@ -558,35 +518,6 @@ public final class SecretBundleConfigSource
          */
         public Builder pollingStrategy(PollingStrategy pollingStrategy) {
             return super.pollingStrategy(pollingStrategy);
-        }
-
-        /**
-         * Uses the supplied {@link Supplier} of {@link Secrets} instances, instead of the default one, for
-         * communicating with the OCI Secrets Retrieval API.
-         *
-         * @param secretsSupplier the non-default {@link Supplier} to use; must not be {@code null}
-         *
-         * @return this {@link Builder}
-         *
-         * @exception NullPointerException if {@code secretsSupplier} is {@code null}
-         */
-        public Builder secretsSupplier(Supplier<? extends Secrets> secretsSupplier) {
-            this.secretsSupplier = Objects.requireNonNull(secretsSupplier, "secretsSupplier");
-            return this;
-        }
-
-        /**
-         * Sets the (required) OCID of the OCI vault from which a {@link SecretBundleConfigSource} will retrieve values.
-         *
-         * @param vaultOcid a valid OCID identifying an OCI vault; must not be {@code null}
-         *
-         * @return this {@link Builder}
-         *
-         * @exception NullPointerException if {@code vaultId} is {@code null}
-         */
-        public Builder vaultOcid(String vaultOcid) {
-            this.vaultOcid = Objects.requireNonNull(vaultOcid, "vaultOcid");
-            return this;
         }
 
         /**

--- a/integrations/oci/oci-secrets-config-source/src/test/java/io/helidon/integrations/oci/secrets/configsource/IsModifiedTest.java
+++ b/integrations/oci/oci-secrets-config-source/src/test/java/io/helidon/integrations/oci/secrets/configsource/IsModifiedTest.java
@@ -18,11 +18,11 @@ package io.helidon.integrations.oci.secrets.configsource;
 import java.time.Instant;
 import java.util.Set;
 
-import io.helidon.integrations.oci.secrets.configsource.SecretBundleConfigSource.Stamp;
+import io.helidon.integrations.oci.secrets.configsource.SecretBundleNodeConfigSource.Stamp;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.integrations.oci.secrets.configsource.SecretBundleConfigSource.isModified;
+import static io.helidon.integrations.oci.secrets.configsource.SecretBundleNodeConfigSource.isModified;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/integrations/oci/oci-secrets-config-source/src/test/java/io/helidon/integrations/oci/secrets/configsource/ValueNodeTest.java
+++ b/integrations/oci/oci-secrets-config-source/src/test/java/io/helidon/integrations/oci/secrets/configsource/ValueNodeTest.java
@@ -19,7 +19,7 @@ import java.util.Base64;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.integrations.oci.secrets.configsource.SecretBundleConfigSource.valueNode;
+import static io.helidon.integrations.oci.secrets.configsource.AbstractSecretBundleConfigSource.valueNode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/integrations/oci/oci-secrets-config-source/src/test/resources/meta-config.yaml
+++ b/integrations/oci/oci-secrets-config-source/src/test/resources/meta-config.yaml
@@ -17,5 +17,7 @@ sources:
   - type: 'system-properties' # for testing
   - type: 'oci-secrets'
     properties: # required
-        compartment-ocid: ${compartment-ocid}
-        vault-ocid: ${vault-ocid}
+        accept-pattern: '^FrancqueSecret$'
+        compartment-ocid: '${compartment-ocid}'
+        lazy: ${lazy}
+        vault-ocid: '${vault-ocid}'


### PR DESCRIPTION
Introduces Lazy OCI Vault ConfigSource. Backport of #7470.

Documentation impact: none.