### PR TITLE
3.x: Create constants for outbound id and secret

### DIFF
--- a/docs/config/io_helidon_security_providers_jwt_JwtProvider.adoc
+++ b/docs/config/io_helidon_security_providers_jwt_JwtProvider.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ This type provides the following service implementations:
 |key |type |default value |description
 
 |`allow-impersonation` |boolean |`false` |Whether to allow impersonation by explicitly overriding
- username from outbound requests using #EP_PROPERTY_OUTBOUND_USER property.
+ username from outbound requests using EndpointConfig.PROPERTY_OUTBOUND_ID property.
  By default this is not allowed and identity can only be propagated.
 |`allow-unsigned` |boolean |`false` |Configure support for unsigned JWT.
  If this is set to `true` any JWT that has algorithm

--- a/docs/includes/security/providers/http-basic-auth.adoc
+++ b/docs/includes/security/providers/http-basic-auth.adoc
@@ -97,8 +97,8 @@ Subject is created based on the username and roles provided by the user store.
 When identity propagation is configured, there are several options for identifying username and password to propagate:
 
 1. We propagate the current username and password (inbound request must be authenticated using basic authentication).
-2. We use username and password from an explicitly configured property (See `HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER`
-    and `HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD`)
+2. We use username and password from an explicitly configured property (See `EndpointConfig.PROPERTY_OUTBOUND_ID`
+    and `EndpointConfig.PROPERTY_OUTBOUND_SECRET`)
 3. We use username and password associated with an outbound target (see example configuration above)
 
 Identity is propagated only if:

--- a/docs/se/grpc/server.adoc
+++ b/docs/se/grpc/server.adoc
@@ -757,8 +757,8 @@ Security security = Security.builder()  // <1>
         .build();
 
 GrpcClientSecurity clientSecurity = GrpcClientSecurity.builder(security.createContext("test.client")) // <2>
-        .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, user)
-        .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+        .property(EndpointConfig.PROPERTY_OUTBOUND_ID, user)
+        .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
         .build();
 
 ClientServiceDescriptor descriptor = ClientServiceDescriptor // <3>
@@ -784,8 +784,8 @@ property expected by the basic auth provider.
 .Example configuring client security for a specific method
 ----
 GrpcClientSecurity clientSecurity = GrpcClientSecurity.builder(security.createContext("test.client")) // <1>
-        .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, user)
-        .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+        .property(EndpointConfig.PROPERTY_OUTBOUND_ID, user)
+        .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
         .build();
 
 ClientServiceDescriptor descriptor = ClientServiceDescriptor // <2>

--- a/examples/grpc/security-outbound/src/main/java/io/helidon/grpc/examples/security/outbound/SecureGreetClient.java
+++ b/examples/grpc/security-outbound/src/main/java/io/helidon/grpc/examples/security/outbound/SecureGreetClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package io.helidon.grpc.examples.security.outbound;
 import io.helidon.config.Config;
 import io.helidon.grpc.examples.common.Greet;
 import io.helidon.grpc.examples.common.GreetServiceGrpc;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.integration.grpc.GrpcClientSecurity;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
@@ -55,8 +56,8 @@ public class SecureGreetClient {
         // create the gRPC client security call credentials
         // setting the properties used by the basic auth provider for user name and password
         GrpcClientSecurity clientSecurity = GrpcClientSecurity.builder(security.createContext("test.client"))
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "Bob")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "Bob")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .build();
 
         // create the GreetService client stub and use the GrpcClientSecurity call credentials

--- a/examples/grpc/security-outbound/src/main/java/io/helidon/grpc/examples/security/outbound/SecureServer.java
+++ b/examples/grpc/security-outbound/src/main/java/io/helidon/grpc/examples/security/outbound/SecureServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import io.helidon.grpc.server.GrpcServer;
 import io.helidon.grpc.server.GrpcServerConfiguration;
 import io.helidon.grpc.server.GrpcService;
 import io.helidon.grpc.server.ServiceDescriptor;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.integration.grpc.GrpcClientSecurity;
@@ -224,8 +225,8 @@ public class SecureServer {
                     .path("upper")
                     .queryParam("value", name)
                     .context(context)
-                    .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "Ted")
-                    .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "secret")
+                    .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "Ted")
+                    .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "secret")
                     .request()
                     .thenAccept(it -> handleResponse(it, observer))
                     .exceptionally(throwable -> {
@@ -291,8 +292,8 @@ public class SecureServer {
                 // Create the gRPC client security credentials from the current request
                 // overriding with the admin user's credentials
                 GrpcClientSecurity clientSecurity = GrpcClientSecurity.builder(req)
-                        .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "Ted")
-                        .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "secret")
+                        .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "Ted")
+                        .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "secret")
                         .build();
 
                 StringServiceGrpc.StringServiceBlockingStub stub = StringServiceGrpc.newBlockingStub(ensureChannel())

--- a/examples/grpc/security/src/main/java/io/helidon/grpc/examples/security/SecureGreetClient.java
+++ b/examples/grpc/security/src/main/java/io/helidon/grpc/examples/security/SecureGreetClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 package io.helidon.grpc.examples.security;
 
-
 import io.helidon.config.Config;
 import io.helidon.grpc.client.ClientServiceDescriptor;
 import io.helidon.grpc.client.GrpcServiceClient;
 import io.helidon.grpc.examples.common.Greet;
 import io.helidon.grpc.examples.common.GreetServiceGrpc;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.integration.grpc.GrpcClientSecurity;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
@@ -64,8 +64,8 @@ public class SecureGreetClient {
         // create the gRPC client security call credentials
         // setting the properties used by the basic auth provider for user name and password
         GrpcClientSecurity clientSecurity = GrpcClientSecurity.builder(security.createContext("test.client"))
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, user)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, user)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
                 .build();
 
         // Create the client service descriptor and add the call credentials

--- a/examples/grpc/security/src/main/java/io/helidon/grpc/examples/security/SecureStringClient.java
+++ b/examples/grpc/security/src/main/java/io/helidon/grpc/examples/security/SecureStringClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.helidon.grpc.client.ClientServiceDescriptor;
 import io.helidon.grpc.client.GrpcServiceClient;
 import io.helidon.grpc.examples.common.StringServiceGrpc;
 import io.helidon.grpc.examples.common.Strings;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.integration.grpc.GrpcClientSecurity;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
@@ -64,8 +65,8 @@ public class SecureStringClient {
         // create the gRPC client security call credentials
         // setting the properties used by the basic auth provider for user name and password
         GrpcClientSecurity clientSecurity = GrpcClientSecurity.builder(security.createContext("test.client"))
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, user)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, user)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
                 .build();
 
         // Create the client service descriptor and add the call credentials

--- a/examples/security/basic-auth-with-static-content/src/test/java/io/helidon/security/examples/webserver/basic/BasicExampleTest.java
+++ b/examples/security/basic-auth-with-static-content/src/test/java/io/helidon/security/examples/webserver/basic/BasicExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.http.Http;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.WebClient;
@@ -151,8 +152,8 @@ public abstract class BasicExampleTest {
         // here we call the endpoint
         return client.get()
                 .uri(uri)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, username)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, username)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
                 .request()
                 .await(5, TimeUnit.SECONDS);
     }

--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideExample.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package io.helidon.security.examples.outbound;
 import java.util.concurrent.CompletionStage;
 
 import io.helidon.config.Config;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Principal;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.Subject;
 import io.helidon.security.integration.webserver.WebSecurity;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
@@ -93,8 +93,8 @@ public final class OutboundOverrideExample {
         SecurityContext context = getSecurityContext(req);
 
         webTarget(servingPort)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jill")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "anotherPassword")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jill")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "anotherPassword")
                 .request(String.class)
                 .thenAccept(result -> res.send("You are: " + context.userName()
                                                        + ", backend service returned: " + result + "\n"))

--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExample.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package io.helidon.security.examples.outbound;
 import java.util.concurrent.CompletionStage;
 
 import io.helidon.config.Config;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Principal;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.Subject;
 import io.helidon.security.integration.webserver.WebSecurity;
-import io.helidon.security.providers.jwt.JwtProvider;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
@@ -102,7 +102,7 @@ public final class OutboundOverrideJwtExample {
         SecurityContext context = getSecurityContext(req);
 
         webTarget(servingPort)
-                .property(JwtProvider.EP_PROPERTY_OUTBOUND_USER, "jill")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jill")
                 .request(String.class)
                 .thenAccept(result -> res.send("You are: " + context.userName() + ", backend service returned: " + result))
                 .exceptionally(throwable -> sendError(throwable, res));

--- a/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideExampleTest.java
+++ b/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.security.examples.outbound;
 
 import java.util.concurrent.CompletionStage;
 
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.WebClient;
@@ -60,8 +61,8 @@ public class OutboundOverrideExampleTest {
     public void testOverrideExample() {
         String value = webClient.get()
                 .path("/override")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request(String.class)
                 .await();
 
@@ -72,8 +73,8 @@ public class OutboundOverrideExampleTest {
     public void testPropagateExample() {
         String value = webClient.get()
                 .path("/propagate")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request(String.class)
                 .await();
 

--- a/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExampleTest.java
+++ b/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.security.examples.outbound;
 
 import java.util.concurrent.CompletionStage;
 
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.WebClient;
@@ -60,8 +61,8 @@ public class OutboundOverrideJwtExampleTest {
     public void testOverrideExample() {
         String value = webClient.get()
                 .path("/override")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request(String.class)
                 .await();
 
@@ -72,8 +73,8 @@ public class OutboundOverrideJwtExampleTest {
     public void testPropagateExample() {
         String value = webClient.get()
                 .path("/propagate")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request(String.class)
                 .await();
 

--- a/examples/security/webserver-signatures/src/test/java/io/helidon/security/examples/signatures/SignatureExampleTest.java
+++ b/examples/security/webserver-signatures/src/test/java/io/helidon/security/examples/signatures/SignatureExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ import io.helidon.webserver.WebServer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.security.providers.httpauth.HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD;
-import static io.helidon.security.providers.httpauth.HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER;
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_ID;
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_SECRET;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -99,8 +99,8 @@ public abstract class SignatureExampleTest {
                                String service) {
         client.get()
                 .uri(uri)
-                .property(EP_PROPERTY_OUTBOUND_USER, username)
-                .property(EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(PROPERTY_OUTBOUND_ID, username)
+                .property(PROPERTY_OUTBOUND_SECRET, password)
                 .request(String.class)
                 .thenAccept(it -> {
                     // check login

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -107,7 +107,10 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
 
     /**
      * Configure this for outbound requests to override user to use.
+     * @deprecated use {@link io.helidon.security.EndpointConfig#PROPERTY_OUTBOUND_ID} instead,
+     *          the value will change in 4.x as well
      */
+    @Deprecated(since = "3.2.3", forRemoval = true)
     public static final String EP_PROPERTY_OUTBOUND_USER = "io.helidon.security.outbound.user";
     /**
      * Configuration key for expected issuer of incoming tokens. Used for validation of JWT.
@@ -360,7 +363,7 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
                                                  SecurityEnvironment outboundEnv,
                                                  EndpointConfig outboundEndpointConfig) {
 
-        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EP_PROPERTY_OUTBOUND_USER);
+        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EndpointConfig.PROPERTY_OUTBOUND_ID);
         return maybeUsername
                 .map(String::valueOf)
                 .flatMap(username -> {
@@ -928,7 +931,7 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
 
         /**
          * Whether to allow impersonation by explicitly overriding
-         * username from outbound requests using {@link #EP_PROPERTY_OUTBOUND_USER} property.
+         * username from outbound requests using {@link io.helidon.security.EndpointConfig#PROPERTY_OUTBOUND_ID} property.
          * By default this is not allowed and identity can only be propagated.
          *
          * @param allowImpersonation set to true to allow impersonation

--- a/security/integration/grpc/src/test/java/io/helidon/security/integration/grpc/OutboundSecurityIT.java
+++ b/security/integration/grpc/src/test/java/io/helidon/security/integration/grpc/OutboundSecurityIT.java
@@ -28,6 +28,7 @@ import io.helidon.grpc.server.GrpcServerConfiguration;
 import io.helidon.grpc.server.ServiceDescriptor;
 import io.helidon.grpc.server.test.Echo;
 import io.helidon.grpc.server.test.EchoServiceGrpc;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.integration.webserver.WebSecurity;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
@@ -208,8 +209,8 @@ public class OutboundSecurityIT {
     private static void overrideCredentialsWebRequest(ServerRequest req, ServerResponse res) {
         try {
             GrpcClientSecurity clientSecurity = GrpcClientSecurity.builder(req)
-                    .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "Ted")
-                    .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "secret")
+                    .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "Ted")
+                    .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "secret")
                     .build();
 
             EchoServiceGrpc.EchoServiceBlockingStub stub = noCredsEchoStub.withCallCredentials(clientSecurity);

--- a/security/integration/webserver/src/test/java/io/helidon/security/integration/webserver/WebSecurityBuilderGateDefaultsTest.java
+++ b/security/integration/webserver/src/test/java/io/helidon/security/integration/webserver/WebSecurityBuilderGateDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.config.Config;
 import io.helidon.security.AuditEvent;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
@@ -263,8 +264,8 @@ public class WebSecurityBuilderGateDefaultsTest {
         // here we call the endpoint
         return securitySetup.get()
                 .uri(uri)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, username)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, username)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
                 .request()
                 .toCompletableFuture()
                 .get();

--- a/security/integration/webserver/src/test/java/io/helidon/security/integration/webserver/WebSecurityTests.java
+++ b/security/integration/webserver/src/test/java/io/helidon/security/integration/webserver/WebSecurityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutionException;
 
 import io.helidon.common.http.Http;
 import io.helidon.security.AuditEvent;
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
 import io.helidon.webclient.WebClient;
@@ -208,8 +209,8 @@ public abstract class WebSecurityTests {
             throws ExecutionException, InterruptedException {
         return securitySetup.get()
                 .uri(uri)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, username)
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, password)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, username)
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, password)
                 .request()
                 .toCompletableFuture()
                 .get();

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,9 @@ import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SynchronousProvider;
 import io.helidon.security.util.TokenHandler;
 
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_ID;
+import static io.helidon.security.EndpointConfig.PROPERTY_OUTBOUND_SECRET;
+
 /**
  * Http authentication security provider.
  * Provides support for username and password authentication, with support for roles list.
@@ -59,12 +62,18 @@ import io.helidon.security.util.TokenHandler;
 public class HttpBasicAuthProvider extends SynchronousProvider implements AuthenticationProvider, OutboundSecurityProvider {
     /**
      * Configure this for outbound requests to override user to use.
+     * @deprecated use {@link io.helidon.security.EndpointConfig#PROPERTY_OUTBOUND_ID} instead,
+     *          the value will change in 4.x as well
      */
+    @Deprecated(since = "3.2.3", forRemoval = true)
     public static final String EP_PROPERTY_OUTBOUND_USER = "io.helidon.security.outbound.user";
 
     /**
      * Configure this for outbound requests to override password to use.
+     * @deprecated use {@link io.helidon.security.EndpointConfig#PROPERTY_OUTBOUND_SECRET} instead,
+     *          the value will change in 4.x as well
      */
+    @Deprecated(since = "3.2.3", forRemoval = true)
     public static final String EP_PROPERTY_OUTBOUND_PASSWORD = "io.helidon.security.outbound.password";
 
     static final String HEADER_AUTHENTICATION_REQUIRED = "WWW-Authenticate";
@@ -130,7 +139,7 @@ public class HttpBasicAuthProvider extends SynchronousProvider implements Authen
                                        EndpointConfig outboundEp) {
 
         // explicitly overridden username and/or password
-        if (outboundEp.abacAttributeNames().contains(EP_PROPERTY_OUTBOUND_USER)) {
+        if (outboundEp.abacAttributeNames().contains(PROPERTY_OUTBOUND_ID)) {
             return true;
         }
 
@@ -143,7 +152,7 @@ public class HttpBasicAuthProvider extends SynchronousProvider implements Authen
                                                     EndpointConfig outboundEp) {
 
         // explicit username in request properties
-        Optional<Object> maybeUsername = outboundEp.abacAttribute(EP_PROPERTY_OUTBOUND_USER);
+        Optional<Object> maybeUsername = outboundEp.abacAttribute(PROPERTY_OUTBOUND_ID);
         if (maybeUsername.isPresent()) {
             String username = maybeUsername.get().toString();
             char[] password = passwordFromEndpoint(outboundEp);
@@ -183,7 +192,7 @@ public class HttpBasicAuthProvider extends SynchronousProvider implements Authen
                         .flatMap(this::credentialsFromSubject);
             }
 
-            Optional<char[]> overridePassword = outboundEp.abacAttribute(EP_PROPERTY_OUTBOUND_PASSWORD)
+            Optional<char[]> overridePassword = outboundEp.abacAttribute(PROPERTY_OUTBOUND_SECRET)
                     .map(String::valueOf)
                     .map(String::toCharArray);
 
@@ -202,7 +211,7 @@ public class HttpBasicAuthProvider extends SynchronousProvider implements Authen
     }
 
     private char[] passwordFromEndpoint(EndpointConfig outboundEp) {
-        return outboundEp.abacAttribute(EP_PROPERTY_OUTBOUND_PASSWORD)
+        return outboundEp.abacAttribute(PROPERTY_OUTBOUND_SECRET)
                 .map(String::valueOf)
                 .map(String::toCharArray)
                 .orElse(HttpBasicOutboundConfig.EMPTY_PASSWORD);

--- a/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/BasicAuthOutboundOverrideTest.java
+++ b/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/BasicAuthOutboundOverrideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.security.EndpointConfig;
 import io.helidon.security.Security;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.integration.jersey.client.ClientSecurity;
@@ -68,16 +69,16 @@ public class BasicAuthOutboundOverrideTest {
         when(requestContext.getConfiguration()).thenReturn(configuration);
         when(requestContext.getProperty(ClientSecurity.PROPERTY_CONTEXT)).thenReturn(context);
         when(requestContext.getProperty(ClientSecurity.PROPERTY_PROVIDER)).thenReturn("http-basic-auth");
-        when(requestContext.getProperty(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER)).thenReturn(user);
-        when(requestContext.getProperty(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD)).thenReturn(password);
+        when(requestContext.getProperty(EndpointConfig.PROPERTY_OUTBOUND_ID)).thenReturn(user);
+        when(requestContext.getProperty(EndpointConfig.PROPERTY_OUTBOUND_SECRET)).thenReturn(password);
         when(requestContext.getUri()).thenReturn(URI.create("http://localhost:7070/test"));
         when(requestContext.getStringHeaders()).thenReturn(new MultivaluedHashMap<>());
         when(requestContext.getHeaders()).thenReturn(jerseyHeaders);
         when(requestContext.getPropertyNames()).thenReturn(List.of(
                 ClientSecurity.PROPERTY_CONTEXT,
                 ClientSecurity.PROPERTY_PROVIDER,
-                HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER,
-                HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD
+                EndpointConfig.PROPERTY_OUTBOUND_ID,
+                EndpointConfig.PROPERTY_OUTBOUND_SECRET
         ));
 
         ClientSecurityFilter csf = new ClientSecurityFilter();

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,10 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
 
     /**
      * Configure this for outbound requests to override user to use.
+     * @deprecated use {@link io.helidon.security.EndpointConfig#PROPERTY_OUTBOUND_ID} instead,
+     *          the value will change in 4.x as well
      */
+    @Deprecated(since = "3.2.3", forRemoval = true)
     public static final String EP_PROPERTY_OUTBOUND_USER = "io.helidon.security.outbound.user";
 
     private final boolean optional;
@@ -271,7 +274,7 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
                                                     SecurityEnvironment outboundEnv,
                                                     EndpointConfig outboundEndpointConfig) {
 
-        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EP_PROPERTY_OUTBOUND_USER);
+        Optional<Object> maybeUsername = outboundEndpointConfig.abacAttribute(EndpointConfig.PROPERTY_OUTBOUND_ID);
         return maybeUsername
                 .map(String::valueOf)
                 .flatMap(username -> attemptImpersonation(outboundEnv, username))
@@ -654,7 +657,7 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
 
         /**
          * Whether to allow impersonation by explicitly overriding
-         * username from outbound requests using {@link #EP_PROPERTY_OUTBOUND_USER} property.
+         * username from outbound requests using {@link io.helidon.security.EndpointConfig#PROPERTY_OUTBOUND_ID} property.
          * By default this is not allowed and identity can only be propagated.
          *
          * @param allowImpersonation set to true to allow impersonation

--- a/security/security/src/main/java/io/helidon/security/EndpointConfig.java
+++ b/security/security/src/main/java/io/helidon/security/EndpointConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,17 @@ import io.helidon.security.util.AbacSupport;
  * @see SecurityProvider#supportedAttributes
  */
 public class EndpointConfig implements AbacSupport {
+    /**
+     * Configure this for outbound requests to override id to use (client id, user - depending on use case).
+     * This is supported for example for HTTP Basic authentication and JWT authentication providers.
+     */
+    public static final String PROPERTY_OUTBOUND_ID = "io.helidon.security.outbound.user";
+    /**
+     * Configure this for outbound requests to override secret to use (client secret, actual password - depending on use case).
+     * This is supported for example for HTTP Basic authentication provider.
+     */
+    public static final String PROPERTY_OUTBOUND_SECRET = "io.helidon.security.outbound.password";
+
     private final List<SecurityLevel> securityLevels;
     private final AbacSupport attributes;
     private final ClassToInstanceStore<Object> customObjects;

--- a/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/ContextCheckTest.java
+++ b/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/ContextCheckTest.java
@@ -34,7 +34,7 @@ class ContextCheckTest extends TestParent {
         WebClientResponse r = webClient.get()
                 .path("/contextCheck")
                 .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
-                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                 .request()
                 .await();
         assertThat(r.status().code(), is(Http.Status.OK_200.code()));

--- a/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/ContextCheckTest.java
+++ b/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/ContextCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package io.helidon.tests.integration.webclient;
 
 import io.helidon.common.http.Http;
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
+import io.helidon.security.EndpointConfig;
 import io.helidon.webclient.WebClient;
 import io.helidon.webclient.WebClientResponse;
 
@@ -33,8 +33,8 @@ class ContextCheckTest extends TestParent {
         WebClient webClient = createNewClient();
         WebClientResponse r = webClient.get()
                 .path("/contextCheck")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "password")
                 .request()
                 .await();
         assertThat(r.status().code(), is(Http.Status.OK_200.code()));

--- a/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/SecurityTest.java
+++ b/tests/integration/webclient/src/test/java/io/helidon/tests/integration/webclient/SecurityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.tests.integration.webclient;
 
-import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
+import io.helidon.security.EndpointConfig;
 import io.helidon.webclient.security.WebClientSecurity;
 
 import jakarta.json.JsonObject;
@@ -46,8 +46,8 @@ public class SecurityTest extends TestParent {
         try {
             webClient.get()
                     .path(path)
-                    .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
-                    .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                    .property(EndpointConfig.PROPERTY_OUTBOUND_ID, "jack")
+                    .property(EndpointConfig.PROPERTY_OUTBOUND_SECRET, "password")
                     .request(JsonObject.class)
                     .thenAccept(jsonObject -> assertThat(jsonObject.getString("message"), is("Hello jack!")))
                     .toCompletableFuture()


### PR DESCRIPTION
Deprecate existing constants (multiple), refactor usage to use the new constants.

Resolves #7432 

### Description
Backport of changes (and removals) done in 4.x - for 3.x we just deprecate the constants to be removed.

### Documentation
Updated docs