### PR TITLE
2.x: Fix SeConfig.asMap to not truncate keys

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/SeConfig.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/SeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,8 +260,12 @@ class SeConfig implements Config {
                     continue;
                 }
                 if (propertyName.startsWith(stringKey + ".")) {
-                    String noPrefix = propertyName.substring(stringPrefix.length() + 1);
-
+                    String noPrefix;
+                    if (stringPrefix.isEmpty()) {
+                        noPrefix = propertyName;
+                    } else {
+                        noPrefix = propertyName.substring(stringPrefix.length() + 1);
+                    }
                     children.put(noPrefix, delegate.getValue(propertyName, String.class));
                 }
             }

--- a/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigTest.java
+++ b/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,6 +178,23 @@ public class MpConfigTest {
 
         MpConfig.toHelidonConfig(config);
         assertThat(TestMapperProvider.getCreationCount(), is(1));
+    }
+
+    @Test
+    public void testSeConfigAsMap() {
+        Config mpConfig = ConfigProviderResolver.instance().getBuilder()
+                .withSources(MpConfigSources.create(Map.of(
+                        "client.headers.0.name", "foo"
+                )))
+                .build();
+        io.helidon.config.Config seConfig = MpConfig.toHelidonConfig(mpConfig);
+        Map<String, String> map;
+
+        map = seConfig.get("client").asMap().orElse(Map.of());
+        assertThat(map.get("client.headers.0.name"), is("foo"));
+
+        map = seConfig.get("client").detach().asMap().orElse(Map.of());
+        assertThat(map.get("headers.0.name"), is("foo"));
     }
 
     // Github issue #2206


### PR DESCRIPTION
Fixes #7491

---

No impact on docs.
