### PR TITLE
2.x: Upgrade EclipseLink and ByteBuddy for Java 21

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -93,6 +93,15 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate.enhance}</version>
+                    <dependencies>
+                        <dependency>
+                            <!-- Force upgrade byte-buddy for Java 21.     -->
+                            <!-- Remove after upgrading to Hibernate -->
+                            <groupId>net.bytebuddy</groupId>
+                            <artifactId>byte-buddy</artifactId>
+                            <version>${version.lib.byte-buddy}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -45,10 +45,12 @@
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <!-- commons-codec is for dependency convergence only -->
         <version.lib.commons-codec>1.15</version.lib.commons-codec>
+        <!-- Force upgrade byte-buddy for Java 21. Remove after upgrading hibernate -->
+        <version.lib.byte-buddy>1.14.6</version.lib.byte-buddy>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
-        <version.lib.eclipselink>2.7.12</version.lib.eclipselink>
+        <version.lib.eclipselink>2.7.13</version.lib.eclipselink>
         <version.lib.el-api>3.0.3</version.lib.el-api>
         <version.lib.el-impl>3.0.4</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>

--- a/pom.xml
+++ b/pom.xml
@@ -633,6 +633,15 @@
                   <groupId>org.hibernate.orm.tooling</groupId>
                   <artifactId>hibernate-enhance-maven-plugin</artifactId>
                   <version>${version.plugin.hibernate-enhance}</version>
+                  <dependencies>
+                      <dependency>
+                          <!-- Force upgrade byte-buddy for Java 21.     -->
+                          <!-- Remove after upgrading  -->
+                          <groupId>net.bytebuddy</groupId>
+                          <artifactId>byte-buddy</artifactId>
+                          <version>${version.lib.byte-buddy}</version>
+                      </dependency>
+                  </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.jaxb2.maven2</groupId>


### PR DESCRIPTION
### Description

Upgrades EclipseLink to 2.7.13 (which upgrades ASM) and ByteBuddy for Java 21 support

### Documentation

No impact
