### PR TITLE
[3.x] Updates version of Micronaut libraries

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -106,9 +106,9 @@
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.micrometer>1.6.6</version.lib.micrometer>
-        <version.lib.micronaut>3.4.3</version.lib.micronaut>
-        <version.lib.micronaut.data>3.3.0</version.lib.micronaut.data>
-        <version.lib.micronaut.sql>4.4.0</version.lib.micronaut.sql>
+        <version.lib.micronaut>3.8.7</version.lib.micronaut>
+        <version.lib.micronaut.data>3.4.3</version.lib.micronaut.data>
+        <version.lib.micronaut.sql>4.8.0</version.lib.micronaut.sql>
         <version.lib.microprofile-config>3.0.1</version.lib.microprofile-config>
         <version.lib.microprofile-fault-tolerance-api>4.0</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-graphql>2.0</version.lib.microprofile-graphql>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1218,10 +1218,6 @@
                         <groupId>com.google.code.findbugs</groupId>
                         <artifactId>jsr305</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>javax.validation</groupId>
-                        <artifactId>validation-api</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
### Description
Updates versions of Micronaut libraries. The new Micronaut core library depends on Snakeyaml 2.0. Micronaut data 3.4.3 is the highest release version we can use without bringing javax dependencies. This PR also removes an exclusion from our dependencies pom to avoid class not found exceptions in simple tests. See issue #7497.

### Documentation
None
