### PR TITLE
4.x: HTTP/2 Locally half-closed streams needs to be able to receive frames

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -575,8 +575,10 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         // TODO buffer now contains the actual data bytes
         stream.stream().data(frameHeader, buffer);
 
-        if (frameHeader.flags(Http2FrameTypes.DATA).endOfStream()
-                && (REMOVABLE_STREAMS.contains(stream.stream.streamState()))) {
+        // 5.1 - In HALF-CLOSED state we need to wait for either RST-STREAM or DATA with endStream flag
+        // even when handler has already finished
+        if ((REMOVABLE_STREAMS.contains(stream.stream.streamState()))
+                && frameHeader.flags(Http2FrameTypes.DATA).endOfStream()) {
             streams.remove(streamId);
         }
 
@@ -855,7 +857,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                     throw e;
                 }
             } finally {
-                //5.1 - In HALF-CLOSED state we need to wait for either RST-STREAM or DATA with endStream flag
+                // 5.1 - In HALF-CLOSED state we need to wait for either RST-STREAM or DATA with endStream flag
                 if (stream.streamState() == Http2StreamState.CLOSED) {
                     streams.remove(stream.streamId());
                 }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 
 import io.helidon.common.buffers.BufferData;
@@ -80,7 +81,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
 
     private static final System.Logger LOGGER = System.getLogger(Http2Connection.class.getName());
     private static final int FRAME_HEADER_LENGTH = 9;
-
+    private static final Set<Http2StreamState> REMOVABLE_STREAMS =
+            Set.of(Http2StreamState.CLOSED, Http2StreamState.HALF_CLOSED_LOCAL);
     private final Map<Integer, StreamContext> streams = new HashMap<>(1000);
     private final ConnectionContext ctx;
     private final Http2Config http2Config;
@@ -573,6 +575,11 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         // TODO buffer now contains the actual data bytes
         stream.stream().data(frameHeader, buffer);
 
+        if (frameHeader.flags(Http2FrameTypes.DATA).endOfStream()
+                && (REMOVABLE_STREAMS.contains(stream.stream.streamState()))) {
+            streams.remove(streamId);
+        }
+
         state = State.READ_FRAME;
     }
 
@@ -716,10 +723,11 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
 
     private void rstStream() {
         Http2RstStream rstStream = Http2RstStream.create(inProgressFrame());
-        receiveFrameListener.frame(ctx, frameHeader.streamId(), rstStream);
+        int streamId = frameHeader.streamId();
+        receiveFrameListener.frame(ctx, streamId, rstStream);
 
         try {
-            StreamContext streamContext = stream(frameHeader.streamId());
+            StreamContext streamContext = stream(streamId);
             streamContext.stream().rstStream(rstStream);
 
             state = State.READ_FRAME;
@@ -730,6 +738,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                 return;
             }
             throw e;
+        } finally {
+            streams.remove(streamId);
         }
     }
 
@@ -845,7 +855,10 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                     throw e;
                 }
             } finally {
-                streams.remove(stream.streamId());
+                //5.1 - In HALF-CLOSED state we need to wait for either RST-STREAM or DATA with endStream flag
+                if (stream.streamState() == Http2StreamState.CLOSED) {
+                    streams.remove(stream.streamId());
+                }
             }
         }
     }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.http2;
 
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Semaphore;
 
@@ -68,6 +69,8 @@ public class Http2ServerStream implements Runnable, Http2Stream {
                                                   Http2Flag.DataFlags.create(Http2Flag.DataFlags.END_OF_STREAM),
                                                   0), BufferData.empty());
     private static final System.Logger LOGGER = System.getLogger(Http2Stream.class.getName());
+    private static final Set<Http2StreamState> DATA_RECEIVABLE_STATES =
+            Set.of(Http2StreamState.OPEN, Http2StreamState.HALF_CLOSED_LOCAL);
 
     private final ConnectionContext ctx;
     private final Http2Config http2Config;
@@ -153,7 +156,7 @@ public class Http2ServerStream implements Runnable, Http2Stream {
      * @throws Http2Exception in case data cannot be received
      */
     public void checkDataReceivable() throws Http2Exception {
-        if (state != Http2StreamState.OPEN) {
+        if (!DATA_RECEIVABLE_STATES.contains(state)) {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received data for stream "
                     + streamId + " in state " + state);
         }

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HalfClosedStreamsTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HalfClosedStreamsTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.Handler;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.http.Http.Method.GET;
+import static io.helidon.http.Http.Method.POST;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ServerTest
+public class HalfClosedStreamsTest {
+
+    private final int port;
+    private final URI uri;
+
+    HalfClosedStreamsTest(WebServer server) {
+        this.port = server.port();
+        uri = URI.create("http://localhost:" + port + "/test");
+    }
+
+    @SetUpRoute
+    static void router(HttpRouting.Builder router) {
+        Handler peerPortRturningHandler = (req, res) -> res.send(String.valueOf(req.remotePeer().port()));
+        router.route(GET, "/test", peerPortRturningHandler)
+                .route(Http2Route.route(POST, "/test", peerPortRturningHandler));
+    }
+
+    @Test
+    void closeDataFrameAfterHandlerIsDone() {
+        try (HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .version(HttpClient.Version.HTTP_2)
+                .build()) {
+
+            // Upgrade to http2 GET (jdk client doesn't support prior-knowledge)
+            int expectedClientPort = getClientPort(client);
+
+            PipedInputStream in = new PipedInputStream();
+            PipedOutputStream out = new PipedOutputStream(in);
+
+            HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.ofInputStream(() -> in);
+
+            // Force the client to send end-stream flagged data frame after server handler finished
+            Thread.ofVirtual().start(() -> {
+                try {
+                    Thread.sleep(300);
+                    out.close();
+                } catch (IOException | InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            var respPut = client.send(HttpRequest.newBuilder().POST(bodyPublisher).uri(uri).build(),
+                                      HttpResponse.BodyHandlers.ofString());
+
+            assertThat(respPut.statusCode(), is(200));
+            assertThat(Integer.parseInt(respPut.body()), is(expectedClientPort));
+
+            // Another call would either fail, or be executed on a new connection(different client port)
+            // in case locally half-closed stream is dropped after handler finishes
+            int latestClientPort = getClientPort(client);
+            assertThat(latestClientPort, is(expectedClientPort));
+
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private int getClientPort(HttpClient client) {
+        HttpResponse<String> r = null;
+        try {
+            r = client.send(HttpRequest.newBuilder()
+                                    .GET()
+                                    .uri(uri).build(),
+                            HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            fail(e);
+        }
+        assertThat(r.statusCode(), is(200));
+        assertTrue(r.body().matches("\\d+"));
+        return Integer.parseInt(r.body());
+    }
+}

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HalfClosedStreamsTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HalfClosedStreamsTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ServerTest
-public class HalfClosedStreamsTest {
+class HalfClosedStreamsTest {
 
     private final int port;
     private final URI uri;


### PR DESCRIPTION
Fixes #7498
