### PR TITLE
4.x: Docs: Remove description of Config.changes() API and other cleanup

### DIFF
--- a/docs/mp/config/advanced-configuration.adoc
+++ b/docs/mp/config/advanced-configuration.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -26,12 +26,12 @@ include::{rootdir}/includes/mp.adoc[]
 
 == Contents
 
-- <<Creating MicroProfile Config Sources for Manual Setup of Config>>
-- <<Creating Custom Config Sources>>
-- <<Creating MicroProfile Config Sources from meta-config>>
-- <<Extending Meta-Config to Create a Custom Config Source Type>>
-- <<Creating MicroProfile Config Source from Helidon SE Config Source>>
-- <<Creating MicroProfile Config Source from Helidon SE Config Instance>>
+- <<Creating MicroProfile Config Sources for Manual Setup of Config, Creating MicroProfile Config Sources for Manual Setup of Config>>
+- <<Creating Custom Config Sources, Creating Custom Config Sources>>
+- <<Creating MicroProfile Config Sources from meta-config, Creating MicroProfile Config Sources from meta-config>>
+- <<Extending Meta-Config to Create a Custom Config Source Type, Extending Meta-Config to Create a Custom Config Source Type>>
+- <<Creating MicroProfile Config Source from Helidon SE Config Source, Creating MicroProfile Config Source from Helidon SE Config Source>>
+- <<Creating MicroProfile Config Source from Helidon SE Config Instance, Creating MicroProfile Config Source from Helidon SE Config Instance>>
 
 == Creating MicroProfile Config Sources for Manual Setup of Config
 

--- a/docs/mp/config/introduction.adoc
+++ b/docs/mp/config/introduction.adoc
@@ -1,7 +1,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -30,12 +30,11 @@ include::{rootdir}/includes/mp.adoc[]
 
 == Contents
 
-- <<Overview>>
-- <<Maven Coordinates>>
-- <<Usage>>
-- <<Configuration>>
-- <<Guides>>
-- <<Reference>>
+- <<Overview, Overview>>
+- <<Maven Coordinates, Maven Coordinates>>
+- <<Usage, Usage>>
+- <<Configuration, Configuration>>
+- <<Reference, Reference>>
 
 == Overview
 
@@ -230,7 +229,7 @@ Current properties may be set in `application.yaml` or in `microprofile-config.p
 
 See xref:#Config-Profiles[Config Profiles] for more information.
 
-== Guides
+== Additional Information
 
 [PILLARS]
 ====

--- a/docs/se/config/advanced-configuration.adoc
+++ b/docs/se/config/advanced-configuration.adoc
@@ -621,6 +621,7 @@ Config config = Config.builder()
         .disableValueResolving()
         // other Config builder settings
         .build();
+
 ----
 
 == Executors for Asynchronous Config Activity

--- a/docs/se/config/config-profiles.adoc
+++ b/docs/se/config/config-profiles.adoc
@@ -27,7 +27,7 @@ include::{rootdir}/includes/se.adoc[]
 == Contents
 
 - <<Overview, Overview>>
-- <<Profile options, Profile options>>
+- <<Profile Options, Profile Options>>
 - <<Profile-Config-Source, Profile Config Source>>
 - <<Profile-File, Profile Files>>
 
@@ -37,7 +37,7 @@ Configuration profiles provide a capability to prepare structure of configuratio
 environment in advance, and then simply switch between these structures using a system property
 or an environment variable.
 
-== Profile options
+== Profile Options
 To choose a configuration profile to use at runtime, you can use:
 
 1. A system property `config.profile`

--- a/docs/se/config/extensions.adoc
+++ b/docs/se/config/extensions.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -26,16 +26,15 @@ include::{rootdir}/includes/se.adoc[]
 
 == Contents
 
-- <<Overview,>>
-- <<Introduction>>
-- <<Setting up an extension>>
-- <<Config-SPI-ConfigSource>>
-- <<Config-SPI-ConfigParser>>
-- <<Config-SPI-OverrideSource>>
-- <<Config-SPI-ConfigFilter>>
-- <<Config-SPI-ConfigMapperProvider>>
-- <<Change support SPI>>
-- <<Config-SPI-RetryPolicy>>
+- <<Overview, Overview>>
+- <<Configuring an Extension, Configuring an Extension>>
+- <<Config-SPI-ConfigSource, Config-SPI-ConfigSource>>
+- <<Config-SPI-ConfigParser, Config-SPI-ConfigParser>>
+- <<Config-SPI-OverrideSource, Config-SPI-OverrideSource>>
+- <<Config-SPI-ConfigFilter, Config-SPI-ConfigFilter>>
+- <<Config-SPI-ConfigMapperProvider, Config-SPI-ConfigMapperProvider>>
+- <<Change Support SPI, Change Support SPI>>
+- <<Config-SPI-RetryPolicy, Config-SPI-RetryPolicy>>
 
 == Overview
 
@@ -47,7 +46,7 @@ to Java types, fine-tune the look-up of config data, and reload and
 reprocess data when it changes. _Config extensions_ provided by the application
 modify and expand the way the config system performs these steps.
 
-== Introduction
+
 Each config extension implements one of the interfaces defined in the Configuration SPI:
 
 //Once our asciidoc processing handles labeled lists, uncomment the following
@@ -90,14 +89,14 @@ Service providers:
 
 The config system itself implements several of these SPIs, as noted in the sections below.
 
-== Setting up an extension
+== Configuring an Extension
 
 You can configure a custom extension in two ways:
 
 1. Manual configuration with builder
 2. Automatic configuration using a Java service loader
 
-=== Manual configuration with builder
+=== Manual Configuration with Builder
 
 The following example shows configuration of all possible extensions with `Config` (all custom extension have a name prefix `My`):
 
@@ -115,7 +114,7 @@ Config config = Config.builder()
                 .build()
 ----
 
-=== Automatic configuration using a service loader
+=== Automatic Configuration Using a Service Loader
 
 The following extensions are loaded using a service loader for any configuration instance, and do not require an explicit setup:
 
@@ -369,9 +368,9 @@ module my.module {
 }
 ----
 
-== Change support SPI [[Config-SPI-PollingStrategy]]
+== Change Support SPI [[Config-SPI-PollingStrategy]]
 
-Once it loads a `Config` tree from ``ConfigSource``s the config system does not itself change the in-memory `Config`
+Once it loads a `Config` tree from ``ConfigSource``, the config system does not itself change the in-memory `Config`
  tree. Even so, the underlying data available via the tree's ``ConfigSource``s can change.
 Implementations of link:{config-javadoc-base-url}/io/helidon/config/spi/PollingStrategy.html[`PollingStrategy`]
 may trigger regular check whether a source has new data.

--- a/docs/se/config/hierarchical-features.adoc
+++ b/docs/se/config/hierarchical-features.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -27,13 +27,14 @@ include::{rootdir}/includes/se.adoc[]
 
 == Contents
 
-- <<Overview>>
-- <<Configuration Node Types>>
-- <<Configuration Key>>
-- <<In-memory Representation of Configuration>>
-- <<Access by Key>>
-- <<Access by General Navigation>>
-- <<Detaching a Config Subtree>>
+- <<Overview, Overview>>
+- <<Configuration Node Types, Configuration Node Types>>
+- <<Configuration Key, Configuration Key>>
+- <<In-memory Representation of Configuration, In-memory Representation of Configuration>>
+- <<Access by Key, Access by Key>>
+- <<Access by General Navigation, Access by General Navigation>>
+- <<Detaching a Config Subtree, Detaching a Config Subtree>>
+
 
 == Overview
 

--- a/docs/se/config/introduction.adoc
+++ b/docs/se/config/introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -27,12 +27,12 @@ include::{rootdir}/includes/se.adoc[]
 
 == Contents
 
-- <<Overview>>
-- <<Maven Coordinates>>
-- <<Getting Started>>
-- <<Usage>>
-- <<Guides>>
-- <<Additional Information>>
+- <<Overview, Overview>>
+- <<Maven Coordinates, Maven Coordinates>>
+- <<Usage, Usage>>
+- <<Configuration, Configuration>>
+- <<Reference, Reference>>
+- <<Additional Information, Additional Information>>
 
 == Overview
 
@@ -51,7 +51,7 @@ include::{rootdir}/includes/dependencies.adoc[]
 </dependencies>
 ----
 
-== Getting Started
+== Usage
 A brief overview of the config system helps clarify its different parts and how they work together. Most applications will typically deal with more than one of these parts.
 
 image::config/overview.png["Configuration Overview",align="center"]
@@ -95,9 +95,8 @@ You can extend the system with custom parsers of your own. Implement the link:{c
 
 See the xref:advanced-configuration.adoc#_advanced_config_parsers[advanced topics'] page for further information on some more involved aspects of config parsers.
 
-== Usage
 
-=== Default Configuration
+== Configuration
 
 Helidon has an internal configuration, so you are not required to provide any configuration data for your application, though in practice you most likely would.
 
@@ -305,7 +304,7 @@ to handle other types of sources by implementing the
 link:{config-javadoc-base-url}/io/helidon/config/spi/ConfigSource.html[`ConfigSource`] interface. See
 the xref:extensions.adoc[extensions'] documentation for complete information.
 
-== Guides
+== Reference
 
 [PILLARS]
 ====

--- a/docs/se/config/mutability-support.adoc
+++ b/docs/se/config/mutability-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ include::{rootdir}/includes/se.adoc[]
 
 == Contents
 
-- <<Overview>>
-- <<Using Config Metadata>>
-- <<Responding to Changes in Config Sources>>
-- <<Accessing Always-current Values>>
+- <<Overview, Overview>>
+- <<Using Config Metadata, Using Config Metadata>>
+- <<Responding to Changes in Config Sources, Responding to Changes in Config Sources>>
+- <<Accessing Always-current Values, Accessing Always-current Values>>
 
 == Overview
 An in-memory config tree, once loaded, is immutable, even though the data in the underlying
@@ -74,18 +74,6 @@ It by itself does not help your application decide _when_ reloading the config m
 useful.
 
 == Responding to Changes in Config Sources [[polling]]
-[IMPORTANT]
-.Evolving API
-====
-This section describes the `Config.changes()` method. It is marked
-as deprecated because it returns an `io.helidon.reactive.Flow.Publisher` object.
-In a future Helidon release that requires Java 11 or later this method will be un-deprecated
-and changed -- or a similar method will be added -- so that the return type is
-`java.util.concurrent.Flow.Publisher` instead.
-
-Any code you write using the existing `Config.changes()` method might need
-to change at that time.
-====
 
 Although in-memory config trees do not change once loaded, applications can respond to change
 in the underlying config sources by:
@@ -130,7 +118,7 @@ Config config = Config.create(
         ConfigSources.file("conf/config.properties")
                 .changeWatcher(FileSystemWatcher.create())                         // <2>
                 .optional(),
-        ConfigSources.classpath("application.properties")
+        ConfigSources.file("my.properties")
                 .pollingStrategy(PollingStrategies::nop));                         // <3>
 ----
 
@@ -138,7 +126,7 @@ Config config = Config.create(
  `2` seconds.
 <2> Optional `file` source `conf/config.properties` will be watched by the Java
  `WatchService` for changes on filesystem.
-<3> The `classpath` resource `application.properties` will not be checked for
+<3> The `file` resource `my.properties` will not be checked for
  changes.
 `PollingStrategies.nop()` polling strategy is default.
 
@@ -153,14 +141,11 @@ your application of any change within the subtree rooted at that node.
 In particular, if you register on the root node,
 then the config system notifies your code of changes anywhere in the config tree.
 
-You can register in either of two ways:
-
-1. register an action to be run upon each change, or
-2. subscribe to a `Flow.Publisher` that notifies of changes.
-
 ==== Registering Actions
-A simple approach is for your application to register a function that should
-run when any change occurs.
+
+You register a function that runs when when a change occurs by using the
+link:{config-javadoc-base-url}/io/helidon/config/Config.html#onChange(java.util.function.Consumer)[`Config.onChange()`]
+method on the node of interest.
 
 [source,java]
 .Subscribe on `greeting` property changes via `onChange` method
@@ -179,70 +164,6 @@ The config system invokes that function each time the subtree rooted at the
 representing the updated subtree rooted at `greeting`.
 <3> The function should return `true` to continue being run on subsequent changes, `false`
 to stop.
-
-==== Subscribing to Events
-The config system also supports the flow publisher/subscriber model for applications
-that need more control over the pace at which the config system delivers
-config change events.
-
-Each `Config` instance exposes the link:{config-javadoc-base-url}/io/helidon/config/Config.html#changes--[`Config.changes()`]
-method which returns a `Flow.Publisher<Config>`.
-Your application can invoke this method, then invoke `subscribe` on the returned
-`Flow.Publisher`, passing your own `Flow.Subscriber` implementation. The config system will
-invoke your subscriber's methods as appropriate, most notably calling `onNext`
-whenever it detects a change in one of the underlying config sources for the config
-node of interest.
-
-Mote that your subscriber will be notified when a change occurs anywhere in the
-subtree represented by the `Config` node.
-
-[source,java]
-.Subscribe on `greeting` property changes
-----
-config.get("greeting")                                                             // <1>
-        .changes()                                                                 // <2>
-        .subscribe(new Flow.Subscriber<>() {                                       // <3>
-            Flow.Subscription subscription;
-
-            @Override
-            public void onSubscribe(Flow.Subscription subscription) {              // <4>
-                this.subscription = subscription;
-                subscription.request(1);
-            }
-
-            @Override
-            public void onNext(Config changedNode) {                               // <5>
-                System.out.println("Node " + changedNode.key() + " has changed!");
-                subscription.request(1);
-            }
-
-            @Override
-            public void onError(Throwable throwable) {                             // <6>
-            }
-
-            @Override
-            public void onComplete() {                                             // <7>
-            }
-        });
-----
-
-<1> Navigate to the `Config` node on which you want to register.
-<2> Invoke `changes` to get the `Flow.Publisher` of changes to the subtree rooted
-at the `Config` node.
-<3> Subscribe to the publisher passing a custom `Flow.Subscriber<Config>` implementation.
-<4> Request the first event delivery in `onSubscribe` method.
-<5> The config system invokes `onNext` each time the subtree rooted at the
-`greeting` node changes. The `changedNode` is a new instance of `Config` representing
-the updated subtree rooted at `greeting`, regardless of where in the subtree
-the change actually occurred. Remember to request the next event delivery in `onNext`.
-<6> The config system does not currently invoke `onError`.
-<7> The config system invokes `onComplete` if all config sources indicate _there will
- be no other change event_.
-
-[NOTE]
-Your application _does not_ need to subscribe to the new `Config` instance passed
-to your `onNext` method. The original subscription remains in force for changes
-to the "new" instance.
 
 == Accessing Always-current Values
 Some applications do not need to respond to change as they happen. Instead, it's
@@ -272,5 +193,6 @@ value.
 [IMPORTANT]
 =========
 Supplier support requires that you create the `Config` object from config sources that
-have proper polling strategies set up.
+have proper polling strategies set up. The supplier returns refreshed values only
+after changes have been detected by the polling strategy.
 =========

--- a/docs/se/config/mutability-support.adoc
+++ b/docs/se/config/mutability-support.adoc
@@ -101,7 +101,7 @@ on the link:{config-javadoc-base-url}/io/helidon/config/PollingStrategies.html[`
 - `regular(Duration interval)` - a general-purpose scheduled polling strategy with a specified,
  constant polling interval.
 - `watch(Path watchedPath)` - a filesystem-specific strategy to watch
- specified path. You can use this strategy with the `file` and `classpath`
+ specified path. You can use this strategy with the `file`
 built-in config sources.
 - `nop()` - a no-op strategy
 

--- a/docs/se/config/property-mapping.adoc
+++ b/docs/se/config/property-mapping.adoc
@@ -26,7 +26,7 @@ include::{rootdir}/includes/se.adoc[]
 
 == Contents
 
-- <<Overview>>
+- <<Overview, Overview>>
 - <<Converting Configuration to Simple Types, Converting Configuration to Simple Types>>
 - <<Converting Configuration to `enum` Values, Converting Configuration to `enum` Values>>
 - <<Converting Configuration to Complex Types, Converting Configuration to Complex Types>>
@@ -223,6 +223,7 @@ Here are two approaches that will always work without requiring changes
 to the target class. For both approaches, you write your own conversion function.
 The difference is in how your application triggers the use of that mapper.
 
+[[customConfigAs]]
 ==== Use Custom Mapper Explicitly: `Config.as` method
 Any time your application has a `Config` instance to map to the target class
 it invokes `Config.as` passing an instance of the corresponding conversion function:
@@ -336,7 +337,6 @@ WebConfig web = config.get("web")
 Either of the two approaches just described will _always_ work without requiring you to change
 the POJO class.
 
-[[customConfigAs]]
 == Advanced Conversions using Explicit Mapping Logic
 If the target Java class you want to use meets certain conditions -- or if you can change
 it to meet one of those conditions -- you might not need to write a separate mapper


### PR DESCRIPTION
### Description

The Config.changes() API was removed after Helidon 1. This PR removes it from our documentation.

It also corrects the code snippet since the classpath config source does not support polling strategy.

Plus forward ports some fixes from 3.x docs

See #6518

### Documentation

Changes are in this PR
