### PR TITLE
3.x: Security context not overridden

### DIFF
--- a/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/SecurityPreMatchingFilter.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/SecurityPreMatchingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/security/pom.xml
+++ b/tests/integration/security/pom.xml
@@ -41,5 +41,6 @@
         <module>gh2772</module>
         <module>path-params</module>
         <module>security-response-mapper</module>
+        <module>security-context-not-overridden</module>
     </modules>
 </project>

--- a/tests/integration/security/security-context-not-overridden/pom.xml
+++ b/tests/integration/security/security-context-not-overridden/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>helidon-tests-integration-security</artifactId>
+        <groupId>io.helidon.tests.integration</groupId>
+        <version>3.2.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-security-context-not-overridden</artifactId>
+    <name>Helidon Tests Integration Security Response Mappers</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/security/security-context-not-overridden/src/main/java/io/helidon/tests/integration/context/TestEndpointResource.java
+++ b/tests/integration/security/security-context-not-overridden/src/main/java/io/helidon/tests/integration/context/TestEndpointResource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.context;
+
+import io.helidon.security.SecurityContext;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Simple test endpoint.
+ */
+@Path("/test-endpoint")
+public class TestEndpointResource {
+
+    /**
+     * Return user greeting.
+     *
+     * @return {@link String}
+     */
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getDefaultMessage(@Context SecurityContext securityContext) {
+        return "Hello " + securityContext.userName();
+    }
+
+}

--- a/tests/integration/security/security-context-not-overridden/src/main/java/io/helidon/tests/integration/context/TestProvider.java
+++ b/tests/integration/security/security-context-not-overridden/src/main/java/io/helidon/tests/integration/context/TestProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.context;
+
+import io.helidon.security.AuthenticationResponse;
+import io.helidon.security.ProviderRequest;
+import io.helidon.security.spi.AuthenticationProvider;
+import io.helidon.security.spi.SynchronousProvider;
+
+class TestProvider extends SynchronousProvider implements AuthenticationProvider{
+
+    @Override
+    protected AuthenticationResponse syncAuthenticate(ProviderRequest providerRequest) {
+        return AuthenticationResponse.abstain();
+    }
+
+}

--- a/tests/integration/security/security-context-not-overridden/src/main/java/io/helidon/tests/integration/context/TestProviderService.java
+++ b/tests/integration/security/security-context-not-overridden/src/main/java/io/helidon/tests/integration/context/TestProviderService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.context;
+
+import io.helidon.config.Config;
+import io.helidon.security.spi.SecurityProvider;
+import io.helidon.security.spi.SecurityProviderService;
+
+public class TestProviderService implements SecurityProviderService {
+    @Override
+    public String providerConfigKey() {
+        return "test";
+    }
+
+    @Override
+    public Class<? extends SecurityProvider> providerClass() {
+        return TestProvider.class;
+    }
+
+    @Override
+    public SecurityProvider providerInstance(Config config) {
+        return new TestProvider();
+    }
+
+}

--- a/tests/integration/security/security-context-not-overridden/src/main/resources/META-INF/services/io.helidon.security.spi.SecurityProviderService
+++ b/tests/integration/security/security-context-not-overridden/src/main/resources/META-INF/services/io.helidon.security.spi.SecurityProviderService
@@ -1,0 +1,1 @@
+io.helidon.tests.integration.context.TestProviderService

--- a/tests/integration/security/security-context-not-overridden/src/main/resources/application.yaml
+++ b/tests/integration/security/security-context-not-overridden/src/main/resources/application.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+security:
+  providers:
+  - abac:
+  - test:
+      optional: true
+  - http-basic-auth:
+      realm: "helidon"
+      users:
+      - login: "test"
+        password: "password"
+        roles: ["user"]
+  web-server:
+    paths:
+    - path: "/test-endpoint[/{*}]"
+      authenticate: true
+      authenticator: "http-basic-auth"

--- a/tests/integration/security/security-context-not-overridden/src/main/resources/logging.properties
+++ b/tests/integration/security/security-context-not-overridden/src/main/resources/logging.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers = java.util.logging.ConsoleHandler
+
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = [%1$tc] %4$s: %2$s - %5$s %6$s%n
+
+.level = INFO

--- a/tests/integration/security/security-context-not-overridden/src/test/java/io/helidon/tests/integration/context/SecurityTest.java
+++ b/tests/integration/security/security-context-not-overridden/src/test/java/io/helidon/tests/integration/context/SecurityTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.context;
+
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@AddBean(TestEndpointResource.class)
+public class SecurityTest {
+
+    private final WebTarget target;
+
+    @Inject
+    SecurityTest(WebTarget target) {
+        this.target = target;
+    }
+
+    @Test
+    void testNotPropagatedSecurityContext() {
+        String response = target.register(HttpAuthenticationFeature.basic("test", "password"))
+                .path("/test-endpoint")
+                .request()
+                .get(String.class);
+        assertThat(response, is("Hello test"));
+    }
+
+
+}


### PR DESCRIPTION
### Description
Security context is no longer overridden when combining WebSecurity and JAX-RS endpoint. This issue was happening in `SecurityPreMatchingFilter` in cases where `WebSecurity` authenticated user. `SecurityPreMatchingFilter`  obtained already processed `SecurityContext` and replaced it with not processed one.

Fixes #7509
Backport of #7511

### Documentation

None
