### PR TITLE
4.x: Value mapping API and implementation in modules.

### DIFF
--- a/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/FileService.java.multipart.mustache
+++ b/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/FileService.java.multipart.mustache
@@ -92,7 +92,7 @@ final class FileService implements HttpService {
     }
 
     private void download(ServerRequest req, ServerResponse res) {
-        Path filePath = storage.resolve(req.path().pathParameters().value("fname"));
+        Path filePath = storage.resolve(req.path().pathParameters().get("fname"));
         if (!filePath.getParent().equals(storage)) {
             res.status(BAD_REQUEST_400).send("Invalid file name");
             return;

--- a/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/FtService.java.mustache
+++ b/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/FtService.java.mustache
@@ -57,13 +57,13 @@ public class FtService implements HttpService {
     }
 
     private void timeoutHandler(ServerRequest request, ServerResponse response) {
-        long sleep = Long.parseLong(request.path().pathParameters().value("millis"));
+        long sleep = request.path().pathParameters().first("millis").getLong();
 
         response.send(timeout.invoke(() -> sleep(sleep)));
     }
 
     private void retryHandler(ServerRequest request, ServerResponse response) {
-        int count = Integer.parseInt(request.path().pathParameters().value("count"));
+        int count = request.path().pathParameters().first("count").getInt();
 
         AtomicInteger call = new AtomicInteger(1);
         AtomicInteger failures = new AtomicInteger();
@@ -79,7 +79,7 @@ public class FtService implements HttpService {
     }
 
     private void fallbackHandler(ServerRequest request, ServerResponse response) {
-        boolean success = "true".equalsIgnoreCase(request.path().pathParameters().value("success"));
+        boolean success = request.path().pathParameters().first("success").getBoolean();
         if (success) {
             response.send(fallback.invoke(this::reactiveData));
         } else {
@@ -88,7 +88,7 @@ public class FtService implements HttpService {
     }
 
     private void circuitBreakerHandler(ServerRequest request, ServerResponse response) {
-        boolean success = "true".equalsIgnoreCase(request.path().pathParameters().value("success"));
+        boolean success = request.path().pathParameters().first("success").getBoolean();
         if (success) {
             response.send(circuitBreaker.invoke(this::reactiveData));
         } else {
@@ -97,7 +97,7 @@ public class FtService implements HttpService {
     }
 
     private void bulkheadHandler(ServerRequest request, ServerResponse response) {
-        long sleep = Long.parseLong(request.path().pathParameters().value("millis"));
+        long sleep = request.path().pathParameters().first("millis").getLong();
         CompletableFuture<String> future = async.invoke(() -> bulkhead.invoke(() -> sleep(sleep)));
         sleep(100);
         if (bulkhead.stats().callsRejected() > 0) {

--- a/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/GreetService.java.json.mustache
+++ b/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/GreetService.java.json.mustache
@@ -65,7 +65,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/GreetService.java.jsonp.mustache
+++ b/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/GreetService.java.jsonp.mustache
@@ -86,7 +86,7 @@ class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/GreetService.java.mustache
+++ b/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/GreetService.java.mustache
@@ -80,7 +80,7 @@ class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/MetricsService.java.mustache
+++ b/archetypes/helidon/src/main/archetype/se/custom/files/src/main/java/__pkg__/MetricsService.java.mustache
@@ -72,7 +72,7 @@ class MetricsService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/archetypes/helidon/src/main/archetype/se/database/files/src/main/java/__pkg__/PokemonMapper.java.mustache
+++ b/archetypes/helidon/src/main/archetype/se/database/files/src/main/java/__pkg__/PokemonMapper.java.mustache
@@ -23,7 +23,7 @@ public class PokemonMapper implements DbMapper<Pokemon> {
         }
 
         DbColumn type = row.column("type");
-        return new Pokemon(name.as(String.class), type.as(String.class));
+        return new Pokemon(name.get(String.class), type.get(String.class));
     }
 
     @Override

--- a/archetypes/helidon/src/main/archetype/se/database/files/src/main/java/__pkg__/PokemonService.java.mustache
+++ b/archetypes/helidon/src/main/archetype/se/database/files/src/main/java/__pkg__/PokemonService.java.mustache
@@ -91,7 +91,7 @@ public class PokemonService implements HttpService {
     private void insertPokemonSimple(ServerRequest req, ServerResponse res) {
         Parameters params = req.path().pathParameters();
         // Test Pokémon POJO mapper
-        Pokemon pokemon = new Pokemon(params.value("name"), params.value("type"));
+        Pokemon pokemon = new Pokemon(params.get("name"), params.get("type"));
 
         long count = dbClient.execute().createNamedInsert("insert2")
                 .namedParam(pokemon)
@@ -106,7 +106,7 @@ public class PokemonService implements HttpService {
      * @param res server response
      */
     private void getPokemon(ServerRequest req, ServerResponse res) {
-        String pokemonName = req.path().pathParameters().value("name");
+        String pokemonName = req.path().pathParameters().get("name");
         res.send(dbClient.execute()
                 .namedGet("select-one", pokemonName)
                 .orElseThrow(() -> new NotFoundException("Pokemon " + pokemonName + " not found"))
@@ -141,8 +141,8 @@ public class PokemonService implements HttpService {
      */
     private void updatePokemonType(ServerRequest req, ServerResponse res) {
         Parameters params = req.path().pathParameters();
-        String name = params.value("name");
-        String type = params.value("type");
+        String name = params.get("name");
+        String type = params.get("type");
         long count = dbClient.execute()
                 .createNamedUpdate("update")
                 .addParam("name", name)
@@ -177,7 +177,7 @@ public class PokemonService implements HttpService {
      * @param res the server response
      */
     private void deletePokemon(ServerRequest req, ServerResponse res) {
-        String name = req.path().pathParameters().value("name");
+        String name = req.path().pathParameters().get("name");
         long count = dbClient.execute().namedDelete("delete", name);
         res.send("Deleted: " + count + " values");
     }

--- a/common/config/pom.xml
+++ b/common/config/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-mapper</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/config/src/main/java/io/helidon/common/config/ConfigValue.java
+++ b/common/config/src/main/java/io/helidon/common/config/ConfigValue.java
@@ -17,11 +17,11 @@
 package io.helidon.common.config;
 
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.OptionalValue;
 
 /**
  * A typed value of a {@link Config} node.
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
  *
  * @param <T> type of the value
  */
-public interface ConfigValue<T> {
+public interface ConfigValue<T> extends OptionalValue<T> {
 
     /**
      * Returns the fully-qualified key of the originating {@code Config} node.
@@ -76,33 +76,10 @@ public interface ConfigValue<T> {
      * @see #key()
      * @see io.helidon.common.config.Config.Key#name()
      */
+    @Override
     default String name() {
         return key().name();
     }
-
-    /**
-     * Returns a typed value as {@link java.util.Optional}.
-     * Returns a {@link java.util.Optional#empty() empty} for nodes without a value.
-     * As this class implements all methods of {@link java.util.Optional}, this is only a utility method if an actual
-     * {@link java.util.Optional}
-     * instance is needed.
-     *
-     * @return value as type instance as {@link java.util.Optional}, {@link java.util.Optional#empty() empty} in case the node
-     * does not have
-     * a direct value
-     * @throws io.helidon.common.config.ConfigException in case the value cannot be converted to the expected type
-     * @see #get()
-     */
-    Optional<T> asOptional() throws ConfigException;
-
-    /**
-     * Typed value of the represented {@link Config} node.
-     * Throws {@link io.helidon.common.config.ConfigException} if the node is Type#MISSING type.
-     *
-     * @return direct value of this node converted to the expected type
-     * @throws io.helidon.common.config.ConfigException in case the value cannot be converted to the expected type
-     */
-    T get() throws ConfigException;
 
     /**
      * Convert this {@code ConfigValue} to a different type using a mapper function.
@@ -111,178 +88,13 @@ public interface ConfigValue<T> {
      * @param <N>    type of the returned {@code ConfigValue}
      * @return a new value with the new type
      */
-    <N> ConfigValue<N> as(Function<T, N> mapper);
+    <N> ConfigValue<N> as(Function<? super T, ? extends N> mapper);
 
-    /**
-     * Return {@code true} if there is a value present, otherwise {@code false}.
-     * <p>
-     * Copied from {@link java.util.Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @return {@code true} if there is a value present, otherwise {@code false}
-     * @see java.util.Optional#isPresent()
-     */
-    default boolean isPresent() {
-        return asOptional().isPresent();
-    }
+    @Override
+    <N> ConfigValue<N> as(Class<N> type);
 
-    /**
-     * If a value is present, performs the given action with the value,
-     * otherwise performs the given empty-based action.
-     *
-     * @param action      the action to be performed, if a value is present
-     * @param emptyAction the empty-based action to be performed, if no value is
-     *                    present
-     * @throws NullPointerException if a value is present and the given action
-     *                              is {@code null}, or no value is present and the given empty-based
-     *                              action is {@code null}.
-     */
-    default void ifPresentOrElse(Consumer<T> action, Runnable emptyAction) {
-        Optional<T> optional = asOptional();
-        if (optional.isPresent()) {
-            action.accept(optional.get());
-        } else {
-            emptyAction.run();
-        }
-    }
-
-    /**
-     * If a value is present, invoke the specified consumer with the value,
-     * otherwise do nothing.
-     * <p>
-     * Copied from {@link java.util.Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param consumer block to be executed if a value is present
-     * @throws NullPointerException if value is present and {@code consumer} is
-     *                              null
-     * @see java.util.Optional#ifPresent(java.util.function.Consumer)
-     */
-    default void ifPresent(Consumer<? super T> consumer) {
-        asOptional().ifPresent(consumer);
-    }
-
-    /**
-     * If a value is present, and the value matches the given predicate,
-     * return an {@code Optional} describing the value, otherwise return an
-     * empty {@code Optional}.
-     * <p>
-     * Copied from {@link java.util.Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param predicate a predicate to apply to the value, if present
-     * @return an {@code Optional} describing the value of this {@code Optional}
-     * if a value is present and the value matches the given predicate,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the predicate is null
-     * @see java.util.Optional#filter(java.util.function.Predicate)
-     */
-    default Optional<T> filter(Predicate<? super T> predicate) {
-        return asOptional().filter(predicate);
-    }
-
-    /**
-     * If a value is present, apply the provided mapping function to it,
-     * and if the result is non-null, return an {@code Optional} describing the
-     * result.  Otherwise return an empty {@code Optional}.
-     *
-     * @param <U>    The type of the result of the mapping function
-     * @param mapper a mapping function to apply to the value, if present
-     * @return an {@code Optional} describing the result of applying a mapping
-     * function to the value of this {@code Optional}, if a value is present,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the mapping function is null
-     *
-     *                              <p>
-     *                              Copied from {@link java.util.Optional}. You can get real optional from {@link #asOptional()}.
-     * @see java.util.Optional#map(java.util.function.Function)
-     */
-    default <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
-        return asOptional().map(mapper);
-    }
-
-    /**
-     * If a value is present, apply the provided {@code Optional}-bearing
-     * mapping function to it, return that result, otherwise return an empty
-     * {@code Optional}.  This method is similar to {@link #map(java.util.function.Function)},
-     * but the provided mapper is one whose result is already an {@code Optional},
-     * and if invoked, {@code flatMap} does not wrap it with an additional
-     * {@code Optional}.
-     *
-     * <p>
-     * Copied from {@link java.util.Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param <U>    The type parameter to the {@code Optional} returned by
-     * @param mapper a mapping function to apply to the value, if present
-     *               the mapping function
-     * @return the result of applying an {@code Optional}-bearing mapping
-     * function to the value of this {@code Optional}, if a value is present,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the mapping function is null or returns
-     *                              a null result
-     * @see java.util.Optional#flatMap(java.util.function.Function)
-     */
-    default <U> Optional<U> flatMap(Function<? super T, Optional<U>> mapper) {
-        return asOptional().flatMap(mapper);
-    }
-
-    /**
-     * Return the value if present, otherwise return {@code other}.
-     * <p>
-     * Copied from {@link java.util.Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param other the value to be returned if there is no value present, may
-     *              be null
-     * @return the value, if present, otherwise {@code other}
-     * @see java.util.Optional#orElse(Object)
-     */
-    default T orElse(T other) {
-        return asOptional().orElse(other);
-    }
-
-    /**
-     * Return the value if present, otherwise invoke {@code other} and return
-     * the result of that invocation.
-     * <p>
-     * Copied from {@link java.util.Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param other a {@code Supplier} whose result is returned if no value
-     *              is present
-     * @return the value if present otherwise the result of {@code other.get()}
-     * @throws NullPointerException if value is not present and {@code other} is
-     *                              null
-     * @see java.util.Optional#orElseGet(java.util.function.Supplier)
-     */
-    default T orElseGet(Supplier<? extends T> other) {
-        return asOptional().orElseGet(other);
-    }
-
-    /**
-     * Return the contained value, if present, otherwise throw an exception
-     * to be created by the provided supplier.
-     *
-     * <p>
-     * Copied from {@link java.util.Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param <X>               Type of the exception to be thrown
-     * @param exceptionSupplier The supplier which will return the exception to
-     *                          be thrown
-     * @return the present value
-     * @throws X                    if there is no value present
-     * @throws NullPointerException if no value is present and
-     *                              {@code exceptionSupplier} is null
-     * @see java.util.Optional#orElseThrow(java.util.function.Supplier)
-     */
-    default <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
-        return asOptional().orElseThrow(exceptionSupplier);
-    }
-
-    /**
-     * If a value is present, returns a sequential {@link java.util.stream.Stream} containing
-     * only that value, otherwise returns an empty {@code Stream}.
-     *
-     * @return the optional value as a {@code Stream}
-     */
-    default Stream<T> stream() {
-        return asOptional().stream();
-    }
+    @Override
+    <N> ConfigValue<N> as(GenericType<N> type);
 
     /**
      * Returns a supplier of a typed value. The semantics depend on implementation, this may always return the

--- a/common/config/src/main/java/io/helidon/common/config/EmptyConfig.java
+++ b/common/config/src/main/java/io/helidon/common/config/EmptyConfig.java
@@ -25,6 +25,9 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperException;
+
 final class EmptyConfig {
     static final Config.Key ROOT_KEY = new KeyImpl(null, "");
     static final Config EMPTY = new EmptyNode(ROOT_KEY);
@@ -137,7 +140,12 @@ final class EmptyConfig {
         }
 
         @Override
-        public <N> ConfigValue<N> as(Function<T, N> mapper) {
+        public <N> ConfigValue<N> as(Function<? super T, ? extends N> mapper) {
+            return new EmptyValue<>(key);
+        }
+
+        @Override
+        public <N> ConfigValue<N> as(GenericType<N> type) throws MapperException {
             return new EmptyValue<>(key);
         }
 
@@ -154,6 +162,11 @@ final class EmptyConfig {
         @Override
         public Supplier<Optional<T>> optionalSupplier() {
             return this::asOptional;
+        }
+
+        @Override
+        public <N> ConfigValue<N> as(Class<N> type) throws MapperException {
+            return null;
         }
     }
 

--- a/common/config/src/main/java/module-info.java
+++ b/common/config/src/main/java/module-info.java
@@ -19,7 +19,8 @@
  */
 module io.helidon.common.config {
 
-    requires io.helidon.common;
+    requires transitive io.helidon.common;
+    requires transitive io.helidon.common.mapper;
 
     exports io.helidon.common.config;
     exports io.helidon.common.config.spi;

--- a/common/mapper/etc/spotbugs/exclude.xml
+++ b/common/mapper/etc/spotbugs/exclude.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <!-- The programmer must request the mapping to Path or File -->
+        <Class name="io.helidon.common.mapper.BuiltInMappers"/>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+    </Match>
+</FindBugsFilter>

--- a/common/mapper/pom.xml
+++ b/common/mapper/pom.xml
@@ -32,6 +32,10 @@
         A generic mapper to convert types.
     </description>
 
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/common/mapper/src/main/java/io/helidon/common/mapper/BuiltInMappers.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/BuiltInMappers.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import io.helidon.common.mapper.spi.MapperProvider;
+
+/*
+ * Built in mapper that are "clean" to use across all components.
+ * This does not contain many of date/time mapping, as that is context sensitive (e.g. you need a different
+ * format depending on the component used).
+ */
+class BuiltInMappers implements MapperProvider {
+    private static final Map<ClassPair, Mapper<?, ?>> MAPPERS;
+
+    static {
+        Map<ClassPair, Mapper<?, ?>> mappers = new HashMap<>();
+        // basic types
+        addStringMapper(mappers, Boolean.class, BuiltInMappers::asBoolean);
+        addStringMapper(mappers, Byte.class, BuiltInMappers::asByte);
+        addStringMapper(mappers, Short.class, BuiltInMappers::asShort);
+        addStringMapper(mappers, Integer.class, BuiltInMappers::asInt);
+        addStringMapper(mappers, Long.class, BuiltInMappers::asLong);
+        addStringMapper(mappers, Float.class, BuiltInMappers::asFloat);
+        addStringMapper(mappers, Double.class, BuiltInMappers::asDouble);
+        addStringMapper(mappers, Character.class, BuiltInMappers::asChar);
+        addStringMapper(mappers, Class.class, BuiltInMappers::asClass);
+        //javax.math
+        addStringMapper(mappers, BigDecimal.class, BigDecimal::new);
+        addStringMapper(mappers, BigInteger.class, BigInteger::new);
+        //java.io
+        addStringMapper(mappers, File.class, File::new);
+        //java.nio
+        addStringMapper(mappers, Path.class, Paths::get);
+        addStringMapper(mappers, Charset.class, Charset::forName);
+        //java.net
+        addStringMapper(mappers, URI.class, URI::create);
+        addStringMapper(mappers, URL.class, BuiltInMappers::asUrl);
+        //java.util
+        addStringMapper(mappers, Pattern.class, Pattern::compile);
+        addStringMapper(mappers, UUID.class, UUID::fromString);
+        //time/date operations
+        addStringMapper(mappers, Duration.class, Duration::parse);
+        addStringMapper(mappers, Period.class, Period::parse);
+        addStringMapper(mappers, ZoneId.class, ZoneId::of);
+        addStringMapper(mappers, ZoneOffset.class, ZoneOffset::of);
+        // time/date formatted operations
+        addStringMapper(mappers, LocalDate.class, LocalDate::parse);
+        addStringMapper(mappers, LocalDateTime.class, LocalDateTime::parse);
+        addStringMapper(mappers, LocalTime.class, LocalTime::parse);
+        addStringMapper(mappers, ZonedDateTime.class, ZonedDateTime::parse);
+        addStringMapper(mappers, Instant.class, Instant::parse);
+        addStringMapper(mappers, OffsetTime.class, OffsetTime::parse);
+        addStringMapper(mappers, OffsetDateTime.class, OffsetDateTime::parse);
+        addStringMapper(mappers, YearMonth.class, YearMonth::parse);
+
+        MAPPERS = Map.copyOf(mappers);
+    }
+
+    private static <T> void addStringMapper(Map<ClassPair, Mapper<?, ?>> mappers,
+
+                                            Class<T> targetType,
+                                            Function<String, T> mapperFx) {
+        Mapper<String, T> mapper = mapperFx::apply;
+        mappers.put(new ClassPair(String.class, targetType), mapper);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code byte}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code byte}
+     */
+    private static Byte asByte(String stringValue) {
+        return Byte.parseByte(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code short}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code short}
+     */
+    private static Short asShort(String stringValue) {
+        return Short.parseShort(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code int}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code int}
+     */
+    private static Integer asInt(String stringValue) {
+        return Integer.parseInt(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code long}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code long}
+     */
+    private static Long asLong(String stringValue) {
+        return Long.parseLong(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code float}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code float}
+     */
+    private static Float asFloat(String stringValue) {
+        return Float.parseFloat(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code double}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code double}
+     */
+    private static Double asDouble(String stringValue) {
+        return Double.parseDouble(stringValue);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code boolean}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code boolean}
+     */
+    private static Boolean asBoolean(String stringValue) {
+        String lower = stringValue.toLowerCase();
+        // according to microprofile config specification (section Built-in Converters)
+        return switch (lower) {
+            case "true", "1", "yes", "y", "on" -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code char}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code char}
+     */
+    private static Character asChar(String stringValue) {
+        if (stringValue.length() != 1) {
+            throw new IllegalArgumentException("Cannot convert to 'char'. The value must be just single character, "
+                                                       + "but was '" + stringValue + "'.");
+        }
+        return stringValue.charAt(0);
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code Class<?>}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code Class<?>}
+     */
+    private static Class<?> asClass(String stringValue) {
+        try {
+            return Class.forName(stringValue);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Maps {@code stringValue} to {@code URL}.
+     *
+     * @param stringValue source value as a {@code String}
+     * @return mapped {@code stringValue} to {@code URL}
+     */
+    private static URL asUrl(String stringValue) {
+        try {
+            return URI.create(stringValue).toURL();
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public ProviderResponse mapper(Class<?> sourceClass, Class<?> targetClass, String qualifier) {
+        if (!qualifier.isEmpty()) {
+            return ProviderResponse.unsupported();
+        }
+        Mapper<?, ?> mapper = MAPPERS.get(new ClassPair(sourceClass, targetClass));
+        if (mapper != null) {
+            return new ProviderResponse(Support.SUPPORTED, mapper);
+        }
+        if (targetClass.equals(String.class)) {
+            return new ProviderResponse(Support.COMPATIBLE, String::valueOf);
+        }
+        return ProviderResponse.unsupported();
+    }
+
+    static final class ClassPair {
+        private final Class<?> source;
+        private final Class<?> target;
+
+        ClassPair(Class<?> source, Class<?> target) {
+            this.source = source;
+            this.target = target;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ClassPair classPair = (ClassPair) o;
+            return source.equals(classPair.source) && target.equals(classPair.target);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(source, target);
+        }
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/GlobalManager.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/GlobalManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.LazyValue;
+
+final class GlobalManager {
+    private static final LazyValue<MapperManager> DEFAULT_MAPPER = LazyValue.create(() -> MapperManager.builder()
+            .useBuiltIn(true)
+            .build());
+    private static final AtomicReference<MapperManager> MANAGER = new AtomicReference<>();
+
+    private GlobalManager() {
+    }
+
+    public static void mapperManager(MapperManager manager) {
+        MANAGER.set(manager);
+    }
+
+    static MapperManager mapperManager() {
+        MapperManager mapperManager = MANAGER.get();
+        return mapperManager == null ? DEFAULT_MAPPER.get() : mapperManager;
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/MapperManager.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MapperManager.java
@@ -153,12 +153,7 @@ public interface MapperManager {
          * Add a new {@link io.helidon.common.mapper.spi.MapperProvider} to the list of providers loaded from
          * system service loader.
          * <p>
-         * You may add multiple instances of the same implementation class.
-         * <p>
-         * If the same provider implementation would be loaded by Java Service loader, the service loader instance is ignored.
-         * If you need to add a new implementation of the same type, please use the full features
-         * of the {@link io.helidon.common.HelidonServiceLoader} and invoke
-         * {@link MapperManager#create(io.helidon.common.HelidonServiceLoader)}.
+         * You can control whether discovered services are loaded through see {@link #discoverServices(boolean)}
          *
          * @param provider prioritized mapper provider to use
          * @return updated builder instance

--- a/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
@@ -66,17 +66,6 @@ final class MapperManagerImpl implements MapperManager {
     }
 
     @Override
-    public <SOURCE, TARGET> Optional<Mapper<SOURCE, TARGET>> mapper(Class<SOURCE> sourceType,
-                                                                    Class<TARGET> targetType,
-                                                                    String... qualifiers) {
-        Mapper<SOURCE, TARGET> mapper = findMapper(sourceType, targetType, false, qualifiers);
-        if (mapper instanceof NotFoundMapper) {
-            return Optional.empty();
-        }
-        return Optional.of(mapper);
-    }
-
-    @Override
     public <SOURCE, TARGET> Optional<Mapper<SOURCE, TARGET>> mapper(GenericType<SOURCE> sourceType,
                                                                     GenericType<TARGET> targetType,
                                                                     String... qualifiers) {

--- a/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.common.mapper;
 
 import java.util.Arrays;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.mapper.spi.MapperProvider;
@@ -63,16 +65,33 @@ final class MapperManagerImpl implements MapperManager {
         }
     }
 
+    @Override
+    public <SOURCE, TARGET> Optional<Mapper<SOURCE, TARGET>> mapper(Class<SOURCE> sourceType,
+                                                                    Class<TARGET> targetType,
+                                                                    String... qualifiers) {
+        Mapper<SOURCE, TARGET> mapper = findMapper(sourceType, targetType, false, qualifiers);
+        if (mapper instanceof NotFoundMapper) {
+            return Optional.empty();
+        }
+        return Optional.of(mapper);
+    }
+
+    @Override
+    public <SOURCE, TARGET> Optional<Mapper<SOURCE, TARGET>> mapper(GenericType<SOURCE> sourceType,
+                                                                    GenericType<TARGET> targetType,
+                                                                    String... qualifiers) {
+        Mapper<SOURCE, TARGET> mapper = findMapper(sourceType, targetType, false, qualifiers);
+        if (mapper instanceof NotFoundMapper) {
+            return Optional.empty();
+        }
+        return Optional.of(mapper);
+    }
+
+    @SuppressWarnings("unchecked")
     private static <SOURCE, TARGET> Mapper<SOURCE, TARGET> notFoundMapper(GenericType<SOURCE> sourceType,
                                                                           GenericType<TARGET> targetType,
                                                                           String... qualifier) {
-        String qualifierString = Arrays.toString(qualifier);
-        return source -> {
-            throw createMapperException(source,
-                                        sourceType,
-                                        targetType,
-                                        "Failed to find mapper. Qualifiers: " + qualifierString + ".");
-        };
+        return new NotFoundMapper(sourceType, targetType, qualifier);
     }
 
     private static RuntimeException createMapperException(Object source,
@@ -84,16 +103,6 @@ final class MapperManagerImpl implements MapperManager {
                                   targetType,
                                   "Failed to map source of class '" + source.getClass().getName() + "'",
                                   throwable);
-    }
-
-    private static RuntimeException createMapperException(Object source,
-                                                          GenericType<?> sourceType,
-                                                          GenericType<?> targetType,
-                                                          String message) {
-
-        throw new MapperException(sourceType,
-                                  targetType,
-                                  message + ", source of class '" + source.getClass().getName() + "'");
     }
 
     @SuppressWarnings("unchecked")
@@ -138,14 +147,36 @@ final class MapperManagerImpl implements MapperManager {
         return (Mapper<SOURCE, TARGET>) mapper;
     }
 
-    private <SOURCE, TARGET> Optional<Mapper<?, ?>> fromProviders(Class<SOURCE> sourceType,
-                                                                  Class<TARGET> targetType,
-                                                                  String... qualifiers) {
-        Mapper<?, ?> compatible = null;
+    private Optional<Mapper<?, ?>>
+    fromProviders(BiFunction<MapperProvider, String, MapperProvider.ProviderResponse> qualifiedMapper,
+                  String... qualifiers) {
 
-        for (String qualifier : qualifiers) {
+        Mapper<?, ?> compatible = null;
+        for (int i = 0; i < qualifiers.length; i++) {
+            String fullQ;
+            if (i == 0) {
+                fullQ = String.join("/", qualifiers);
+            } else {
+                fullQ = String.join("/", Arrays.copyOf(qualifiers, qualifiers.length - i));
+            }
             for (MapperProvider provider : providers) {
-                MapperProvider.ProviderResponse response = provider.mapper(sourceType, targetType, qualifier);
+                MapperProvider.ProviderResponse response = qualifiedMapper.apply(provider, fullQ);
+                switch (response.support()) {
+                case SUPPORTED -> {
+                    return Optional.of(response.mapper());
+                }
+                case COMPATIBLE -> {
+                    compatible = (compatible == null) ? response.mapper() : compatible;
+                }
+                default -> {
+                }
+                }
+            }
+        }
+
+        if (qualifiers.length == 0 || !qualifiers[0].isEmpty()) {
+            for (MapperProvider provider : providers) {
+                MapperProvider.ProviderResponse response = qualifiedMapper.apply(provider, "");
                 switch (response.support()) {
                 case SUPPORTED -> {
                     return Optional.of(response.mapper());
@@ -160,36 +191,51 @@ final class MapperManagerImpl implements MapperManager {
         }
 
         return Optional.ofNullable(compatible);
+
+    }
+
+    private <SOURCE, TARGET> Optional<Mapper<?, ?>> fromProviders(Class<SOURCE> sourceType,
+                                                                  Class<TARGET> targetType,
+                                                                  String... qualifiers) {
+
+        return fromProviders((provider, qualifier) -> provider.mapper(sourceType, targetType, qualifier),
+                             qualifiers);
     }
 
     private <SOURCE, TARGET> Optional<Mapper<?, ?>> fromProviders(GenericType<SOURCE> sourceType,
                                                                   GenericType<TARGET> targetType,
                                                                   String... qualifiers) {
 
-        Mapper<?, ?> compatible = null;
-
-        for (String qualifier : qualifiers) {
-            for (MapperProvider provider : providers) {
-                MapperProvider.ProviderResponse response = provider.mapper(sourceType, targetType, qualifier);
-                switch (response.support()) {
-                case SUPPORTED -> {
-                    return Optional.of(response.mapper());
-                }
-                case COMPATIBLE -> {
-                    compatible = (compatible == null) ? response.mapper() : compatible;
-                }
-                default -> {
-                }
-                }
-            }
-        }
-
-        return Optional.ofNullable(compatible);
+        return fromProviders((provider, qualifier) -> provider.mapper(sourceType, targetType, qualifier),
+                             qualifiers);
     }
 
     private record GenericCacheKey(GenericType<?> sourceType, GenericType<?> targetType, String... qualifiers) {
     }
 
     private record ClassCacheKey(Class<?> sourceType, Class<?> targetType, String... qualifiers) {
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static class NotFoundMapper implements Mapper {
+        private final GenericType sourceType;
+        private final GenericType targetType;
+        private final String qualifierString;
+
+        private NotFoundMapper(GenericType sourceType,
+                               GenericType targetType,
+                               String[] qualifier) {
+            this.sourceType = sourceType;
+            this.targetType = targetType;
+            this.qualifierString = String.join(",", qualifier);
+        }
+
+        @Override
+        public Object map(Object source) {
+            throw new MapperException(sourceType,
+                                      targetType,
+                                      "Failed to find mapper. Qualifiers: " + qualifierString
+                                              + ", source of class '" + source.getClass().getName() + "'");
+        }
     }
 }

--- a/common/mapper/src/main/java/io/helidon/common/mapper/OptionalValue.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/OptionalValue.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.helidon.common.GenericType;
+
+/**
+ * A typed value with support for mapping (conversion) to other types.
+ *
+ * @param <T> type of the value
+ */
+public interface OptionalValue<T> extends Value<T> {
+    /**
+     * Create an empty value.
+     * Empty value is not backed by data and all of its methods consider it is empty.
+     *
+     * @param mapperManager mapper manager to use for mapping types
+     * @param name          name of the value
+     * @param type          type of the value, to correctly handle mapping exceptions
+     * @param <T>           type of the value
+     * @param qualifiers    qualifiers of the mapper
+     * @return an empty value
+     */
+    static <T> OptionalValue<T> create(MapperManager mapperManager, String name, Class<T> type, String... qualifiers) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        return create(mapperManager, name, GenericType.create(type), qualifiers);
+    }
+
+    /**
+     * Create an empty value.
+     * Empty value is not backed by data and all of its methods consider it is empty.
+     *
+     * @param mapperManager mapper manager to use for mapping types
+     * @param name          name of the value
+     * @param type          type of the value, to correctly handle mapping exceptions
+     * @param qualifiers    qualifiers of the mapper
+     * @param <T>           type of the value
+     * @return an empty value
+     */
+    static <T> OptionalValue<T> create(MapperManager mapperManager, String name, GenericType<T> type, String... qualifiers) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        return new ValueEmpty<>(mapperManager, type, name, qualifiers);
+    }
+
+    /**
+     * Create a value backed by data. The type of the value is "guessed" from the instance provided.
+     *
+     * @param mapperManager mapper manager to use for mapping types
+     * @param name          name of the value
+     * @param value         value, must not be null
+     * @param qualifiers    qualifiers of the mapper
+     * @param <T>           type of the value
+     * @return a value backed by data
+     */
+    static <T> OptionalValue<T> create(MapperManager mapperManager, String name, T value, String... qualifiers) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        return new ValueBacked<>(mapperManager, name, value, qualifiers);
+    }
+
+    /**
+     * Create a value backed by data.
+     *
+     * @param mapperManager mapper manager to use for mapping types
+     * @param name          name of the value
+     * @param value         value, must not be null
+     * @param type          a more precise type that could be guessed form an instance
+     * @param qualifiers    qualifiers of the mapper
+     * @param <T>           type of the value
+     * @return a value backed by data
+     */
+    static <T> OptionalValue<T> create(MapperManager mapperManager,
+                                       String name,
+                                       T value,
+                                       GenericType<T> type,
+                                       String... qualifiers) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        return new ValueBacked<>(mapperManager, name, value, type, qualifiers);
+    }
+
+    @Override
+    <N> OptionalValue<N> as(Class<N> type);
+
+    @Override
+    <N> OptionalValue<N> as(GenericType<N> type);
+
+    @Override
+    <N> OptionalValue<N> as(Function<? super T, ? extends N> mapper);
+
+    // it is a pity that Optional is not an interface :(
+
+    /**
+     * Typed value.
+     *
+     * @return direct value converted to the expected type
+     * @throws java.util.NoSuchElementException or appropriate module specific exception if the value is not present
+     */
+    @Override
+    T get();
+
+    /**
+     * If the underlying {@code Optional} does not have a value, set it to the
+     * {@code Optional} produced by the supplying function.
+     *
+     * @param supplier the supplying function that produces an {@code Optional}
+     * @return returns current value using {@link #asOptional()} if present,
+     *         otherwise value produced by the supplying function.
+     * @throws NullPointerException if the supplying function is {@code null} or
+     *                              produces a {@code null} result
+     */
+    default Optional<T> or(Supplier<? extends Optional<T>> supplier) {
+        return asOptional().or(supplier);
+    }
+
+    /**
+     * Return {@code true} if there is a value present, otherwise {@code false}.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @return {@code true} if there is a value present, otherwise {@code false}
+     * @see java.util.Optional#isPresent()
+     */
+    default boolean isPresent() {
+        return asOptional().isPresent();
+    }
+
+    /**
+     * Return {@code false} if there is a value present, otherwise {@code true}.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @return {@code false} if there is a value present, otherwise {@code true}
+     * @see java.util.Optional#isEmpty() ()
+     */
+    default boolean isEmpty() {
+        return asOptional().isEmpty();
+    }
+
+    /**
+     * If a value is present, performs the given action with the value,
+     * otherwise performs the given empty-based action.
+     *
+     * @param action      the action to be performed, if a value is present
+     * @param emptyAction the empty-based action to be performed, if no value is
+     *                    present
+     * @throws NullPointerException if a value is present and the given action
+     *                              is {@code null}, or no value is present and the given empty-based
+     *                              action is {@code null}.
+     */
+    default void ifPresentOrElse(Consumer<T> action, Runnable emptyAction) {
+        asOptional().ifPresentOrElse(action, emptyAction);
+    }
+
+    /**
+     * If a value is present, invoke the specified consumer with the value,
+     * otherwise do nothing.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param consumer block to be executed if a value is present
+     * @throws NullPointerException if value is present and {@code consumer} is
+     *                              null
+     * @see Optional#ifPresent(Consumer)
+     */
+    default void ifPresent(Consumer<? super T> consumer) {
+        asOptional().ifPresent(consumer);
+    }
+
+    /**
+     * If a value is present, apply the provided mapping function to it,
+     * and if the result is non-null, return an {@code Optional} describing the
+     * result.  Otherwise return an empty {@code Optional}.
+     *
+     * @param <U>    The type of the result of the mapping function
+     * @param mapper a mapping function to apply to the value, if present
+     * @return an {@code Optional} describing the result of applying a mapping
+     *         function to the value of this {@code Optional}, if a value is present,
+     *         otherwise an empty {@code Optional}
+     * @throws NullPointerException if the mapping function is null
+     *
+     *                              <p>
+     *                              Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     * @see Optional#map(Function)
+     */
+    default <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
+        return asOptional().map(mapper);
+    }
+
+    /**
+     * Return the value if present, otherwise return {@code other}.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param other the value to be returned if there is no value present, may
+     *              be null
+     * @return the value, if present, otherwise {@code other}
+     * @see Optional#orElse(Object)
+     */
+    default T orElse(T other) {
+        return asOptional().orElse(other);
+    }
+
+    /**
+     * Return the value if present, otherwise invoke {@code other} and return
+     * the result of that invocation.
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param other a {@code Supplier} whose result is returned if no value
+     *              is present
+     * @return the value if present otherwise the result of {@code other.get()}
+     * @throws NullPointerException if value is not present and {@code other} is
+     *                              null
+     * @see Optional#orElseGet(Supplier)
+     */
+    default T orElseGet(Supplier<? extends T> other) {
+        return asOptional().orElseGet(other);
+    }
+
+    /**
+     * Return the contained value, if present, otherwise throw an exception
+     * to be created by the provided supplier.
+     *
+     * <p>
+     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
+     *
+     * @param <X>               Type of the exception to be thrown
+     * @param exceptionSupplier The supplier which will return the exception to
+     *                          be thrown
+     * @return the present value
+     * @throws X                    if there is no value present
+     * @throws NullPointerException if no value is present and
+     *                              {@code exceptionSupplier} is null
+     * @see Optional#orElseThrow(Supplier)
+     */
+    default <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+        return asOptional().orElseThrow(exceptionSupplier);
+    }
+
+    /**
+     * If a value is present, returns the value, otherwise throws
+     * {@code NoSuchElementException}.
+     *
+     * @return the non-{@code null} value described by this value
+     * @throws NoSuchElementException if no value is present
+     */
+    default T orElseThrow() {
+        return orElseThrow(() -> new NoSuchElementException("No value present for " + name()));
+    }
+
+    // shortcut methods for commonly used types
+    @Override
+    default OptionalValue<Boolean> asBoolean() {
+        return as(Boolean.class);
+    }
+
+    @Override
+    default OptionalValue<String> asString() {
+        return as(String.class);
+    }
+
+    @Override
+    default OptionalValue<Integer> asInt() {
+        return as(Integer.class);
+    }
+
+    @Override
+    default OptionalValue<Long> asLong() {
+        return as(Long.class);
+    }
+
+    @Override
+    default OptionalValue<Double> asDouble() {
+        return as(Double.class);
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import io.helidon.common.GenericType;
+
+/**
+ * A typed value with support for mapping (conversion) to other types.
+ * For values not backed by an data, see {@link io.helidon.common.mapper.OptionalValue}.
+ *
+ * @param <T> type of the value
+ */
+public interface Value<T> {
+    /**
+     * Create a value backed by data. The type of the value is "guessed" from the instance provided.
+     *
+     * @param mapperManager mapper manager to use for mapping types
+     * @param name          name of the value
+     * @param value         value, must not be null
+     * @param qualifiers    qualifiers of the mapper
+     * @param <T>           type of the value
+     * @return a value backed by data
+     */
+    static <T> Value<T> create(MapperManager mapperManager, String name, T value, String... qualifiers) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        return new ValueBacked<>(mapperManager, name, value, qualifiers);
+    }
+
+    /**
+     * Create a value backed by data.
+     *
+     * @param mapperManager mapper manager to use for mapping types
+     * @param name          name of the value
+     * @param value         value, must not be null
+     * @param type          a more precise type that could be guessed form an instance
+     * @param qualifiers    qualifiers of the mapper
+     * @param <T>           type of the value
+     * @return a value backed by data
+     */
+    static <T> Value<T> create(MapperManager mapperManager, String name, T value, GenericType<T> type, String... qualifiers) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        return new ValueBacked<>(mapperManager, name, value, type, qualifiers);
+    }
+
+    /**
+     * Name of this value, to potentially troubleshoot the source of it.
+     *
+     * @return name of this value, such as "QueryParam("param-name")"
+     */
+    String name();
+
+    /**
+     * Typed value.
+     *
+     * @return direct value
+     */
+    T get();
+
+    /**
+     * Convert this value to a different type using a mapper.
+     *
+     * @param type type to convert to
+     * @return converted value
+     * @param <N> type we expect
+     * @throws io.helidon.common.mapper.MapperException in case the value cannot be converted
+     * @throws java.util.NoSuchElementException in case the value does not exist
+     */
+    default <N> N get(Class<N> type) throws MapperException, NoSuchElementException {
+        return as(type).get();
+    }
+
+    /**
+     * Convert this value to a different type using a mapper.
+     *
+     * @param type type to convert to
+     * @return converted value
+     * @param <N> type we expect
+     */
+    default <N> N get(GenericType<N> type) throws MapperException, NoSuchElementException {
+        return as(type).get();
+    }
+
+    /**
+     * Convert this value to a different type using a mapper.
+     *
+     * @param type type to convert to
+     * @return converted value
+     * @param <N> type we expect
+     * @throws io.helidon.common.mapper.MapperException in case the value cannot be converted
+     */
+    <N> Value<N> as(Class<N> type) throws MapperException;
+
+    /**
+     * Convert this value to a different type using a mapper.
+     *
+     * @param type type to convert to
+     * @return converted value
+     * @param <N> type we expect
+     */
+    <N> Value<N> as(GenericType<N> type) throws MapperException;
+
+    /**
+     * Convert this {@code Value} to a different type using a mapper function.
+     *
+     * @param mapper mapper to map the type of this {@code Value} to a type of the returned {@code Value}
+     * @param <N>    type of the returned {@code Value}
+     * @return a new value with the new type
+     */
+    <N> Value<N> as(Function<? super T, ? extends N> mapper);
+
+    /**
+     * Typed value as {@link java.util.Optional}.
+     * Returns a {@link java.util.Optional#empty() empty} if this value does not have a backing value present.
+     * As this class implements all methods of {@link java.util.Optional}, this is only a utility method if an actual
+     * {@link java.util.Optional} instance is needed ({@code Optional} itself is {code final}).
+     *
+     * @return value as {@link java.util.Optional}, {@link java.util.Optional#empty() empty} in case the value does not have
+     *         a direct value
+     * @throws io.helidon.common.mapper.MapperException in case the value cannot be converted to the expected type
+     * @see #get()
+     */
+    Optional<T> asOptional() throws MapperException;
+
+    // it is a pity that Optional is not an interface :(
+
+    /**
+     * If a value is present, and the value matches the given predicate,
+     * return an {@code Optional} describing the value, otherwise return an
+     * empty {@code Optional}.
+     * <p>
+     *
+     * @param predicate a predicate to apply to the value, if present
+     * @return an {@code Optional} describing the value of this {@code Optional}
+     *         if a value is present and the value matches the given predicate,
+     *         otherwise an empty {@code Optional}
+     * @throws NullPointerException if the predicate is null
+     * @see java.util.Optional#filter(java.util.function.Predicate)
+     */
+    default Optional<T> filter(Predicate<? super T> predicate) {
+        return asOptional().filter(predicate);
+    }
+
+    /**
+     * Apply the provided {@code Optional}-bearing
+     * mapping function to this value, return that result.
+     *
+     * @param <U>    The type parameter to the {@code Optional} returned by
+     * @param mapper a mapping function to apply to the value, if present
+     *               the mapping function
+     * @return the result of applying an {@code Optional}-bearing mapping
+     *         function to this value
+     * @throws NullPointerException if the mapping function is null or returns
+     *                              a null result
+     * @see java.util.Optional#flatMap(java.util.function.Function)
+     */
+    default <U> Optional<U> flatMap(Function<? super T, Optional<? extends U>> mapper) {
+        return asOptional().flatMap(mapper);
+    }
+
+    /**
+     * If a value is present, returns a sequential {@link java.util.stream.Stream} containing
+     * only that value, otherwise returns an empty {@code Stream}.
+     *
+     * @return the optional value as a {@code Stream}
+     */
+    default Stream<T> stream() {
+        return asOptional().stream();
+    }
+
+    // shortcut methods for commonly used types
+    /**
+     * Boolean typed value.
+     *
+     * @return typed value
+     */
+    Value<Boolean> asBoolean();
+
+    /**
+     * Boolean typed value.
+     *
+     * @return boolean value
+     */
+    default boolean getBoolean() {
+        return get(Boolean.class);
+    }
+
+    /**
+     * String typed value.
+     *
+     * @return typed value
+     */
+    Value<String> asString();
+
+    /**
+     * String typed value.
+     *
+     * @return string value
+     */
+    default String getString() {
+        return get(String.class);
+    }
+
+    /**
+     * Integer typed value.
+     *
+     * @return typed value
+     */
+    Value<Integer> asInt();
+
+    /**
+     * Integer typed value.
+     *
+     * @return integer value
+     */
+    default int getInt() {
+        return get(Integer.class);
+    }
+
+    /**
+     * Long typed value.
+     *
+     * @return typed value
+     */
+    Value<Long> asLong();
+
+    /**
+     * Long typed value.
+     *
+     * @return long value
+     */
+    default long getLong() {
+        return get(Long.class);
+    }
+
+    /**
+     * Double typed value.
+     *
+     * @return typed value
+     */
+    Value<Double> asDouble();
+
+    /**
+     * Double typed value.
+     *
+     * @return double value
+     */
+    default double getDouble() {
+        return get(Double.class);
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/ValueBacked.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/ValueBacked.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.helidon.common.GenericType;
+
+class ValueBacked<T> implements OptionalValue<T> {
+    private final MapperManager mapperManager;
+    private final String name;
+    private final T value;
+    private final GenericType<T> type;
+    private final String[] qualifiers;
+
+    ValueBacked(MapperManager mapperManager, String name, T value, GenericType<T> type, String[] qualifiers) {
+        Objects.requireNonNull(mapperManager);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(value);
+
+        this.name = name;
+        this.mapperManager = mapperManager;
+        this.value = value;
+        this.type = type;
+        this.qualifiers = qualifiers;
+    }
+
+    ValueBacked(MapperManager mapperManager, String name, T value, String[] qualifiers) {
+        this(mapperManager, name, value, null, qualifiers);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Optional<T> asOptional() throws MapperException {
+        return Optional.of(value);
+    }
+
+    @Override
+    public <N> OptionalValue<N> as(Function<? super T, ? extends N> mapper) {
+        N result = mapper.apply(value);
+        return new ValueBacked<>(mapperManager, name(), result, qualifiers);
+    }
+
+    @Override
+    public <N> OptionalValue<N> as(Class<N> type) throws MapperException {
+        GenericType<T> myType = this.type == null ? GenericType.create(value) : this.type;
+        return OptionalValue.create(mapperManager, name, mapperManager.map(value, myType, GenericType.create(type), qualifiers));
+    }
+
+    @Override
+    public <N> OptionalValue<N> as(GenericType<N> type) throws MapperException {
+        GenericType<T> myType = this.type == null ? GenericType.create(value) : this.type;
+        return OptionalValue.create(mapperManager, name, mapperManager.map(value, myType, type, qualifiers));
+    }
+
+    @Override
+    public T get() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Value<?> other)) {
+            return false;
+        }
+
+        return Objects.equals(name(), other.name())
+                && Objects.equals(asOptional(), other.asOptional());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value);
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/ValueEmpty.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/ValueEmpty.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.helidon.common.GenericType;
+
+class ValueEmpty<T> implements OptionalValue<T> {
+    private final MapperManager mapperManager;
+    private final GenericType<T> type;
+    private final String name;
+    private final String[] qualifiers;
+
+    ValueEmpty(MapperManager mapperManager, GenericType<T> type, String name, String[] qualifiers) {
+        this.mapperManager = mapperManager;
+        this.type = type;
+        this.name = name;
+        this.qualifiers = qualifiers;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Optional<T> asOptional() throws MapperException {
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <N> OptionalValue<N> as(Function<? super T, ? extends N> mapper) {
+        return (OptionalValue<N>) this;
+    }
+
+    @Override
+    public <N> OptionalValue<N> as(Class<N> type) throws MapperException {
+        GenericType<N> wantedType = GenericType.create(type);
+        if (mapperManager.mapper(this.type, wantedType, qualifiers).isPresent()) {
+            return new ValueEmpty<>(mapperManager, wantedType, name, qualifiers);
+        }
+        throw new MapperException(this.type, wantedType, "Cannot find mapper for " + name());
+    }
+
+    @Override
+    public <N> OptionalValue<N> as(GenericType<N> type) throws MapperException {
+        if (mapperManager.mapper(this.type, type, qualifiers).isPresent()) {
+            return new ValueEmpty<>(mapperManager, type, name, qualifiers);
+        }
+        throw new MapperException(this.type, type, "Cannot find mapper for " + name());
+    }
+
+    @Override
+    public T get() {
+        throw new NoSuchElementException("No value present for " + name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof OptionalValue<?> other)) {
+            return false;
+        }
+
+        return Objects.equals(name(), other.name())
+                && Objects.equals(asOptional(), other.asOptional());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/common/mapper/src/main/java/io/helidon/common/mapper/spi/MapperProvider.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/spi/MapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.common.mapper.spi;
 
 import io.helidon.common.GenericType;
@@ -20,7 +21,7 @@ import io.helidon.common.mapper.Mapper;
 
 /**
  * Java Service loader service to get mappers.
- *
+ * <p>
  * Mapper provider provides mappers based on the source and target types and a qualifier.
  * Generic mappers should always return {@link io.helidon.common.mapper.spi.MapperProvider.Support#COMPATIBLE}, so specific mappers
  * can be created for qualified usages. This is to support a different date/time mapper depending on usage. For this
@@ -36,7 +37,7 @@ public interface MapperProvider {
      *
      * @param sourceClass class of the source
      * @param targetClass class of the target
-     * @param qualifier   qualifiers of this mapping (such as {@code config} or {@code http-headers}
+     * @param qualifier   qualifiers of this mapping (such as {@code config} or {@code http-headers}, may be empty for default
      * @return a mapper that is capable of mapping (or converting) sources to targets
      */
     ProviderResponse mapper(Class<?> sourceClass, Class<?> targetClass, String qualifier);

--- a/common/mapper/src/main/java/module-info.java
+++ b/common/mapper/src/main/java/module-info.java
@@ -18,7 +18,6 @@
  * Helidon Common Mapper.
  */
 module io.helidon.common.mapper {
-
     requires transitive io.helidon.common;
 
     exports io.helidon.common.mapper;

--- a/common/parameters/pom.xml
+++ b/common/parameters/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-mapper</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/parameters/src/main/java/io/helidon/common/parameters/ParametersEmpty.java
+++ b/common/parameters/src/main/java/io/helidon/common/parameters/ParametersEmpty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.OptionalValue;
+
 class ParametersEmpty implements Parameters {
     private final String component;
 
@@ -33,7 +37,7 @@ class ParametersEmpty implements Parameters {
     }
 
     @Override
-    public String value(String name) throws NoSuchElementException {
+    public String get(String name) throws NoSuchElementException {
         throw new NoSuchElementException("This " + component + " does not contain parameter named \"" + name + "\"");
     }
 
@@ -60,5 +64,10 @@ class ParametersEmpty implements Parameters {
     @Override
     public String toString() {
         return component + ": <empty>";
+    }
+
+    @Override
+    public OptionalValue<String> first(String name) {
+        return OptionalValue.create(MapperManager.global(), name, GenericType.STRING);
     }
 }

--- a/common/parameters/src/main/java/io/helidon/common/parameters/ParametersMap.java
+++ b/common/parameters/src/main/java/io/helidon/common/parameters/ParametersMap.java
@@ -22,11 +22,19 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.OptionalValue;
+
 class ParametersMap implements Parameters {
+    private final MapperManager mapperManager;
     private final String component;
     private final Map<String, List<String>> params;
+    private final String[] qualifiers;
 
-    ParametersMap(String component, Map<String, List<String>> params) {
+    ParametersMap(MapperManager mapperManager, String component, Map<String, List<String>> params) {
+        this.qualifiers = component.split("/");
+        this.mapperManager = mapperManager;
         this.component = component;
         this.params = new LinkedHashMap<>(params);
     }
@@ -41,7 +49,7 @@ class ParametersMap implements Parameters {
     }
 
     @Override
-    public String value(String name) throws NoSuchElementException {
+    public String get(String name) throws NoSuchElementException {
         List<String> value = params.get(name);
         if (value == null) {
             throw new NoSuchElementException("This " + component + " does not contain parameter named \"" + name + "\"");
@@ -72,5 +80,13 @@ class ParametersMap implements Parameters {
     @Override
     public String toString() {
         return component + ": " + params;
+    }
+
+    @Override
+    public OptionalValue<String> first(String name) {
+        if (contains(name)) {
+            return OptionalValue.create(mapperManager, name, get(name), GenericType.STRING, qualifiers);
+        }
+        return OptionalValue.create(mapperManager, name, GenericType.STRING, qualifiers);
     }
 }

--- a/common/parameters/src/main/java/io/helidon/common/parameters/ParametersSingleValueMap.java
+++ b/common/parameters/src/main/java/io/helidon/common/parameters/ParametersSingleValueMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,19 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.OptionalValue;
+
 class ParametersSingleValueMap implements Parameters {
+    private final MapperManager mapperManager;
     private final String component;
     private final Map<String, String> params;
+    private final String[] qualifiers;
 
-    ParametersSingleValueMap(String component, Map<String, String> params) {
+    ParametersSingleValueMap(MapperManager mapperManager, String component, Map<String, String> params) {
+        this.qualifiers = component.split("/");
+        this.mapperManager = mapperManager;
         this.component = component;
         this.params = params;
     }
@@ -40,7 +48,7 @@ class ParametersSingleValueMap implements Parameters {
     }
 
     @Override
-    public String value(String name) throws NoSuchElementException {
+    public String get(String name) throws NoSuchElementException {
         String value = params.get(name);
         if (value == null) {
             throw new NoSuchElementException("This " + component + " does not contain parameter named \"" + name + "\"");
@@ -71,5 +79,13 @@ class ParametersSingleValueMap implements Parameters {
     @Override
     public String toString() {
         return component + ": " + params;
+    }
+
+    @Override
+    public OptionalValue<String> first(String name) {
+        if (contains(name)) {
+            return OptionalValue.create(mapperManager, name, get(name), GenericType.STRING, qualifiers);
+        }
+        return OptionalValue.create(mapperManager, name, GenericType.STRING, qualifiers);
     }
 }

--- a/common/parameters/src/main/java/module-info.java
+++ b/common/parameters/src/main/java/module-info.java
@@ -20,6 +20,8 @@ module io.helidon.common.parameters {
 
     // GenericType
     requires transitive io.helidon.common;
+    // OptionalValue
+    requires transitive io.helidon.common.mapper;
 
     exports io.helidon.common.parameters;
 

--- a/common/parameters/src/test/java/io/helidon/common/parameters/ParametersTest.java
+++ b/common/parameters/src/test/java/io/helidon/common/parameters/ParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.common.parameters;
 
 import java.util.List;
@@ -38,7 +39,7 @@ class ParametersTest {
         assertThat("Empty parameters should not contain anything", empty.contains("anything"), is(false));
         assertThat("Empty parameters should have size 0", empty.size(), is(0));
         assertThat("Empty parameters should have empty names", empty.names(), hasSize(0));
-        assertThrows(NoSuchElementException.class, () -> empty.value("anything"));
+        assertThrows(NoSuchElementException.class, () -> empty.get("anything"));
         assertThrows(NoSuchElementException.class, () -> empty.all("anything"));
         assertThat(empty.toString(), containsString(UNIT_TEST));
         assertThat("Empty parameters should be empty", empty.isEmpty(), is(true));
@@ -56,10 +57,10 @@ class ParametersTest {
         assertThat("Parameters should not contain \"anything\"", params.contains("anything"), is(false));
         assertThat("Parameters should have size 2", params.size(), is(2));
         assertThat("parameters should have correct names", params.names(), hasItems("something", "other"));
-        assertThrows(NoSuchElementException.class, () -> params.value("anything"));
+        assertThrows(NoSuchElementException.class, () -> params.get("anything"));
         assertThrows(NoSuchElementException.class, () -> params.all("anything"));
-        assertThat(params.value("something"), is("first"));
-        assertThat(params.value("other"), is("first"));
+        assertThat(params.get("something"), is("first"));
+        assertThat(params.get("other"), is("first"));
         assertThat(params.all("something"), hasItems("first"));
         assertThat(params.all("other"), hasItems("first", "second"));
         assertThat(params.toString(), containsString(UNIT_TEST));
@@ -78,10 +79,10 @@ class ParametersTest {
         assertThat("Parameters should not contain \"anything\"", params.contains("anything"), is(false));
         assertThat("Parameters should have size 2", params.size(), is(2));
         assertThat("parameters should have correct names", params.names(), hasItems("something", "other"));
-        assertThrows(NoSuchElementException.class, () -> params.value("anything"));
+        assertThrows(NoSuchElementException.class, () -> params.get("anything"));
         assertThrows(NoSuchElementException.class, () -> params.all("anything"));
-        assertThat(params.value("something"), is("first"));
-        assertThat(params.value("other"), is("first"));
+        assertThat(params.get("something"), is("first"));
+        assertThat(params.get("other"), is("first"));
         assertThat(params.all("something"), hasItems("first"));
         assertThat(params.all("other"), hasItems("first"));
         assertThat(params.toString(), containsString(UNIT_TEST));
@@ -101,10 +102,10 @@ class ParametersTest {
         assertThat("Parameters should not contain \"anything\"", params.contains("anything"), is(false));
         assertThat("Parameters should have size 2", params.size(), is(2));
         assertThat("parameters should have correct names", params.names(), hasItems("something", "other"));
-        assertThrows(NoSuchElementException.class, () -> params.value("anything"));
+        assertThrows(NoSuchElementException.class, () -> params.get("anything"));
         assertThrows(NoSuchElementException.class, () -> params.all("anything"));
-        assertThat(params.value("something"), is("first"));
-        assertThat(params.value("other"), is("first"));
+        assertThat(params.get("something"), is("first"));
+        assertThat(params.get("other"), is("first"));
         assertThat(params.all("something"), hasItems("first"));
         assertThat(params.all("other"), hasItems("first", "second"));
         assertThat(params.toString(), containsString(UNIT_TEST));

--- a/common/uri/src/main/java/io/helidon/common/uri/UriMatrixParameters.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriMatrixParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,15 +23,22 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.OptionalValue;
 import io.helidon.common.parameters.Parameters;
 
 import static io.helidon.common.uri.UriEncoding.decodeUri;
 
 class UriMatrixParameters implements Parameters {
-    private final Map<String, List<String>> matrixPatams;
+    private static final String COMPONENT = "uri/matrix";
+    private static final String[] QUALIFIERS = new String[] {"uri", "matrix"};
+    private final Map<String, List<String>> matrixParams;
+    private final MapperManager mapperManager;
 
-    private UriMatrixParameters(Map<String, List<String>> matrixPatams) {
-        this.matrixPatams = matrixPatams;
+    private UriMatrixParameters(Map<String, List<String>> matrixParams) {
+        this.matrixParams = matrixParams;
+        this.mapperManager = MapperManager.global();
     }
 
     static Parameters create(String rawPath) {
@@ -95,7 +102,7 @@ class UriMatrixParameters implements Parameters {
 
     @Override
     public List<String> all(String name) throws NoSuchElementException {
-        List<String> value = matrixPatams.get(name);
+        List<String> value = matrixParams.get(name);
         if (value == null) {
             throw new NoSuchElementException("This path does not contain parameter named \"" + name + "\"");
         }
@@ -103,8 +110,8 @@ class UriMatrixParameters implements Parameters {
     }
 
     @Override
-    public String value(String name) throws NoSuchElementException {
-        List<String> value = matrixPatams.get(name);
+    public String get(String name) throws NoSuchElementException {
+        List<String> value = matrixParams.get(name);
         if (value == null) {
             throw new NoSuchElementException("This path does not contain parameter named \"" + name + "\"");
         }
@@ -112,32 +119,41 @@ class UriMatrixParameters implements Parameters {
     }
 
     @Override
+    public OptionalValue<String> first(String name) {
+        List<String> value = matrixParams.get(name);
+        if (value == null) {
+            return OptionalValue.create(mapperManager, name, GenericType.STRING, QUALIFIERS);
+        }
+        return OptionalValue.create(mapperManager, name, value.get(0), GenericType.STRING, QUALIFIERS);
+    }
+
+    @Override
     public boolean contains(String name) {
-        return matrixPatams.containsKey(name);
+        return matrixParams.containsKey(name);
     }
 
     @Override
     public boolean isEmpty() {
-        return matrixPatams.isEmpty();
+        return matrixParams.isEmpty();
     }
 
     @Override
     public int size() {
-        return matrixPatams.size();
+        return matrixParams.size();
     }
 
     @Override
     public Set<String> names() {
-        return matrixPatams.keySet();
+        return matrixParams.keySet();
     }
 
     @Override
     public String component() {
-        return "uri-path-parameters";
+        return COMPONENT;
     }
 
     @Override
     public String toString() {
-        return component() + ": " + matrixPatams;
+        return component() + ": " + matrixParams;
     }
 }

--- a/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 import io.helidon.common.parameters.Parameters;
 
 class UriPathNoParam implements UriPath {
-    private static final Parameters EMPTY_PARAMS = Parameters.empty("path");
+    private static final Parameters EMPTY_PARAMS = Parameters.empty("uri/path");
 
     private final UriPath absolute;
     private final String rawPath;

--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryEmpty.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryEmpty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,10 @@ package io.helidon.common.uri;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.OptionalValue;
 
 final class UriQueryEmpty implements UriQuery {
     static final UriQuery INSTANCE = new UriQueryEmpty();
@@ -49,8 +53,13 @@ final class UriQueryEmpty implements UriQuery {
     }
 
     @Override
-    public String value(String name) {
+    public String get(String name) {
         throw new UnsupportedOperationException("Empty query");
+    }
+
+    @Override
+    public OptionalValue<String> first(String name) {
+        return OptionalValue.create(MapperManager.global(), name, GenericType.STRING, "uri", "query");
     }
 
     @Override

--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryImpl.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryImpl.java
@@ -25,6 +25,10 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.OptionalValue;
+
 import static io.helidon.common.uri.UriEncoding.decodeUri;
 
 // must be lazily populated to prevent perf overhead when queries are ignored
@@ -117,13 +121,24 @@ final class UriQueryImpl implements UriQuery {
     }
 
     @Override
-    public String value(String name) throws NoSuchElementException {
+    public String get(String name) throws NoSuchElementException {
         ensureDecoded();
         List<String> values = decodedQueryParams.get(name);
         if (values == null) {
             throw new NoSuchElementException("Query parameter \"" + name + "\" is not available");
         }
         return values.isEmpty() ? "" : values.iterator().next();
+    }
+
+    @Override
+    public OptionalValue<String> first(String name) {
+        ensureDecoded();
+        List<String> values = decodedQueryParams.get(name);
+        if (values == null) {
+            return OptionalValue.create(MapperManager.global(), name, GenericType.STRING, "uri", "query");
+        }
+        String value = values.isEmpty() ? "" : values.iterator().next();
+        return OptionalValue.create(MapperManager.global(), name, value, GenericType.STRING, "uri", "query");
     }
 
     @Override

--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryWriteableImpl.java
@@ -25,6 +25,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.OptionalValue;
+
 final class UriQueryWriteableImpl implements UriQueryWriteable {
     private final Map<String, List<String>> rawQueryParams = new HashMap<>();
     private final Map<String, List<String>> decodedQueryParams = new HashMap<>();
@@ -124,6 +128,16 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
     }
 
     @Override
+    public OptionalValue<String> first(String name) {
+        List<String> values = decodedQueryParams.get(name);
+        if (values == null) {
+            return OptionalValue.create(MapperManager.global(), name, GenericType.STRING, "uri", "query");
+        }
+        String value = values.isEmpty() ? "" : values.iterator().next();
+        return OptionalValue.create(MapperManager.global(), name, value, GenericType.STRING, "uri", "query");
+    }
+
+    @Override
     public String getRaw(String name) throws NoSuchElementException {
         List<String> values = rawQueryParams.get(name);
         if (values == null) {
@@ -151,7 +165,7 @@ final class UriQueryWriteableImpl implements UriQueryWriteable {
     }
 
     @Override
-    public String value(String name) throws NoSuchElementException {
+    public String get(String name) throws NoSuchElementException {
         List<String> values = decodedQueryParams.get(name);
         if (values == null) {
             throw new NoSuchElementException("Query parameter \"" + name + "\" is not available");

--- a/common/uri/src/test/java/io/helidon/common/uri/UriPathSegmentTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriPathSegmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,10 +46,10 @@ class UriPathSegmentTest {
 
         Parameters params = segment.matrixParameters();
         assertThat(params.isEmpty(), is(false));
-        assertThat(params.value("v"), is("1.0"));
-        assertThat(params.value("a"), is("b"));
-        assertThat(params.value("b"), is("1"));
-        assertThat(params.value("c"), is(""));
+        assertThat(params.get("v"), is("1.0"));
+        assertThat(params.get("a"), is("b"));
+        assertThat(params.get("b"), is("1"));
+        assertThat(params.get("c"), is(""));
     }
 
     @Test
@@ -63,9 +63,9 @@ class UriPathSegmentTest {
 
         Parameters params = segment.matrixParameters();
         assertThat(params.isEmpty(), is(false));
-        assertThat(params.value("v"), is("1.0"));
-        assertThat(params.value("a"), is("b"));
-        assertThat(params.value("b"), is("1"));
-        assertThat(params.value("c"), is(""));
+        assertThat(params.get("v"), is("1.0"));
+        assertThat(params.get("a"), is("b"));
+        assertThat(params.get("b"), is("1"));
+        assertThat(params.get("c"), is(""));
     }
 }

--- a/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
@@ -41,7 +41,7 @@ class UriQueryTest {
     @Test
     void testEncoded() throws UnsupportedEncodingException {
         UriQuery uriQuery = UriQuery.create("a=" + URLEncoder.encode("1&b=2", US_ASCII));
-        assertThat(uriQuery.value("a"), is("1&b=2"));
+        assertThat(uriQuery.get("a"), is("1&b=2"));
     }
 
     @Test
@@ -52,8 +52,8 @@ class UriQueryTest {
                    is("a=b%26c=d&e=f&e=g&h=x%63%23e%3c"));
 
         assertThat(uriQuery.all("e"), hasItems("f", "g"));
-        assertThat(uriQuery.value("h"), is("xc#e<"));
-        assertThat(uriQuery.value("a"), is("b&c=d"));
+        assertThat(uriQuery.get("h"), is("xc#e<"));
+        assertThat(uriQuery.get("a"), is("b&c=d"));
     }
     
     @Test

--- a/config/config-mp/src/main/java/io/helidon/config/mp/SeConfig.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/SeConfig.java
@@ -187,7 +187,7 @@ class SeConfig implements Config {
             return (ConfigValue<T>) as(genericType.rawType());
         }
 
-        return new SeConfigValue<>(key, () -> mapper.mapper().map(SeConfig.this, genericType));
+        return new SeConfigValue<>(this, key, () -> mapper.mapper().map(SeConfig.this, genericType));
     }
 
     @Override
@@ -200,7 +200,7 @@ class SeConfig implements Config {
                     .map(ConfigValues::simpleValue)
                     .orElseGet(ConfigValues::empty);
         } else {
-            return new SeConfigValue<>(key, () -> mapper.mapper().map(SeConfig.this, type));
+            return new SeConfigValue<>(this, key, () -> mapper.mapper().map(SeConfig.this, type));
         }
     }
 
@@ -355,7 +355,7 @@ class SeConfig implements Config {
     }
 
     private <T> ConfigValue<List<T>> asList(String configKey, Class<T> typeArg) {
-        return new SeConfigValue<>(key(), () -> toList(configKey, typeArg));
+        return new SeConfigValue<>(this, key(), () -> toList(configKey, typeArg));
     }
 
     private <T> List<T> toList(String configKey, Class<T> typeArg) {

--- a/config/config/src/main/java/io/helidon/config/ConfigValue.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.config;
 
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 /**
  * A typed value of a {@link Config} node.
@@ -84,19 +81,6 @@ public interface ConfigValue<T> extends io.helidon.common.config.ConfigValue<T> 
     }
 
     /**
-     * Returns a typed value as {@link Optional}.
-     * Returns a {@link Optional#empty() empty} for nodes without a value.
-     * As this class implements all methods of {@link Optional}, this is only a utility method if an actual {@link Optional}
-     * instance is needed.
-     *
-     * @return value as type instance as {@link Optional}, {@link Optional#empty() empty} in case the node does not have
-     * a direct value
-     * @throws ConfigMappingException in case the value cannot be converted to the expected type
-     * @see #get()
-     */
-    Optional<T> asOptional() throws ConfigMappingException;
-
-    /**
      * Typed value of the represented {@link Config} node.
      * Throws {@link MissingValueException} if the node is {@link Config.Type#MISSING} type.
      *
@@ -116,7 +100,7 @@ public interface ConfigValue<T> extends io.helidon.common.config.ConfigValue<T> 
      * @param <N>    type of the returned {@code ConfigValue}
      * @return a new value with the new type
      */
-    <N> ConfigValue<N> as(Function<T, N> mapper);
+    <N> ConfigValue<N> as(Function<? super T, ? extends N> mapper);
 
     /**
      * Returns a supplier of a typed value. The value provided from the supplier is the latest value available.
@@ -155,199 +139,4 @@ public interface ConfigValue<T> extends io.helidon.common.config.ConfigValue<T> 
      * @see #supplier()
      */
     Supplier<Optional<T>> optionalSupplier();
-
-    // it is a pity that Optional is not an interface :(
-
-    /**
-     * If the underlying {@code Optional} does not have a value, set it to the
-     * {@code Optional} produced by the supplying function.
-     *
-     * @param supplier the supplying function that produces an {@code Optional}
-     * @return returns current value using {@link #asOptional()} if present,
-     *   otherwise value produced by the supplying function.
-     * @throws NullPointerException if the supplying function is {@code null} or
-     *                              produces a {@code null} result
-     */
-    default Optional<T> or(Supplier<? extends Optional<T>> supplier) {
-        Objects.requireNonNull(supplier);
-
-        Optional<T> optional = asOptional();
-        if (optional.isEmpty()) {
-            Optional<T> supplied = supplier.get();
-            Objects.requireNonNull(supplied);
-            optional = supplied;
-        }
-        return optional;
-    }
-
-    /**
-     * Return {@code true} if there is a value present, otherwise {@code false}.
-     * <p>
-     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @return {@code true} if there is a value present, otherwise {@code false}
-     * @see Optional#isPresent()
-     */
-    default boolean isPresent() {
-        return asOptional().isPresent();
-    }
-
-    /**
-     * If a value is present, performs the given action with the value,
-     * otherwise performs the given empty-based action.
-     *
-     * @param action      the action to be performed, if a value is present
-     * @param emptyAction the empty-based action to be performed, if no value is
-     *                    present
-     * @throws NullPointerException if a value is present and the given action
-     *                              is {@code null}, or no value is present and the given empty-based
-     *                              action is {@code null}.
-     */
-    default void ifPresentOrElse(Consumer<T> action, Runnable emptyAction) {
-        Optional<T> optional = asOptional();
-        if (optional.isPresent()) {
-            action.accept(optional.get());
-        } else {
-            emptyAction.run();
-        }
-    }
-
-    /**
-     * If a value is present, invoke the specified consumer with the value,
-     * otherwise do nothing.
-     * <p>
-     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param consumer block to be executed if a value is present
-     * @throws NullPointerException if value is present and {@code consumer} is
-     *                              null
-     * @see Optional#ifPresent(Consumer)
-     */
-    default void ifPresent(Consumer<? super T> consumer) {
-        asOptional().ifPresent(consumer);
-    }
-
-    /**
-     * If a value is present, and the value matches the given predicate,
-     * return an {@code Optional} describing the value, otherwise return an
-     * empty {@code Optional}.
-     * <p>
-     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param predicate a predicate to apply to the value, if present
-     * @return an {@code Optional} describing the value of this {@code Optional}
-     * if a value is present and the value matches the given predicate,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the predicate is null
-     * @see Optional#filter(Predicate)
-     */
-    default Optional<T> filter(Predicate<? super T> predicate) {
-        return asOptional().filter(predicate);
-    }
-
-    /**
-     * If a value is present, apply the provided mapping function to it,
-     * and if the result is non-null, return an {@code Optional} describing the
-     * result.  Otherwise return an empty {@code Optional}.
-     *
-     * @param <U>    The type of the result of the mapping function
-     * @param mapper a mapping function to apply to the value, if present
-     * @return an {@code Optional} describing the result of applying a mapping
-     * function to the value of this {@code Optional}, if a value is present,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the mapping function is null
-     *
-     *                              <p>
-     *                              Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
-     * @see Optional#map(Function)
-     */
-    default <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
-        return asOptional().map(mapper);
-    }
-
-    /**
-     * If a value is present, apply the provided {@code Optional}-bearing
-     * mapping function to it, return that result, otherwise return an empty
-     * {@code Optional}.  This method is similar to {@link #map(Function)},
-     * but the provided mapper is one whose result is already an {@code Optional},
-     * and if invoked, {@code flatMap} does not wrap it with an additional
-     * {@code Optional}.
-     *
-     * <p>
-     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param <U>    The type parameter to the {@code Optional} returned by
-     * @param mapper a mapping function to apply to the value, if present
-     *               the mapping function
-     * @return the result of applying an {@code Optional}-bearing mapping
-     * function to the value of this {@code Optional}, if a value is present,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the mapping function is null or returns
-     *                              a null result
-     * @see Optional#flatMap(Function)
-     */
-    default <U> Optional<U> flatMap(Function<? super T, Optional<U>> mapper) {
-        return asOptional().flatMap(mapper);
-    }
-
-    /**
-     * Return the value if present, otherwise return {@code other}.
-     * <p>
-     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param other the value to be returned if there is no value present, may
-     *              be null
-     * @return the value, if present, otherwise {@code other}
-     * @see Optional#orElse(Object)
-     */
-    default T orElse(T other) {
-        return asOptional().orElse(other);
-    }
-
-    /**
-     * Return the value if present, otherwise invoke {@code other} and return
-     * the result of that invocation.
-     * <p>
-     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param other a {@code Supplier} whose result is returned if no value
-     *              is present
-     * @return the value if present otherwise the result of {@code other.get()}
-     * @throws NullPointerException if value is not present and {@code other} is
-     *                              null
-     * @see Optional#orElseGet(Supplier)
-     */
-    default T orElseGet(Supplier<? extends T> other) {
-        return asOptional().orElseGet(other);
-    }
-
-    /**
-     * Return the contained value, if present, otherwise throw an exception
-     * to be created by the provided supplier.
-     *
-     * <p>
-     * Copied from {@link Optional}. You can get real optional from {@link #asOptional()}.
-     *
-     * @param <X>               Type of the exception to be thrown
-     * @param exceptionSupplier The supplier which will return the exception to
-     *                          be thrown
-     * @return the present value
-     * @throws X                    if there is no value present
-     * @throws NullPointerException if no value is present and
-     *                              {@code exceptionSupplier} is null
-     * @see Optional#orElseThrow(Supplier)
-     */
-    default <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
-        return asOptional().orElseThrow(exceptionSupplier);
-    }
-
-    /**
-     * If a value is present, returns a sequential {@link Stream} containing
-     * only that value, otherwise returns an empty {@code Stream}.
-     *
-     * @return the optional value as a {@code Stream}
-     */
-    default Stream<T> stream() {
-        return asOptional().stream();
-    }
 }

--- a/config/config/src/test/java/io/helidon/config/ConfigValueTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.config;
 
 import java.util.List;
@@ -21,6 +22,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import io.helidon.common.GenericType;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -58,8 +61,18 @@ class ConfigValueTest {
             }
 
             @Override
-            public <N> ConfigValue<N> as(Function<CustomValue, N> mapper) {
+            public <N> ConfigValue<N> as(Function<? super CustomValue, ? extends N> mapper) {
                 return null;
+            }
+
+            @Override
+            public <N> io.helidon.common.config.ConfigValue<N> as(Class<N> type) {
+                throw new ConfigMappingException(key(), "test value cannot be mapped to other types.");
+            }
+
+            @Override
+            public <N> io.helidon.common.config.ConfigValue<N> as(GenericType<N> type) {
+                throw new ConfigMappingException(key(), "test value cannot be mapped to other types.");
             }
 
             @Override
@@ -89,8 +102,18 @@ class ConfigValueTest {
             }
 
             @Override
-            public <N> ConfigValue<N> as(Function<CustomValue, N> mapper) {
+            public <N> ConfigValue<N> as(Function<? super CustomValue, ? extends N> mapper) {
                 return null;
+            }
+
+            @Override
+            public <N> io.helidon.common.config.ConfigValue<N> as(Class<N> type) {
+                throw new ConfigMappingException(key(), "test value cannot be mapped to other types.");
+            }
+
+            @Override
+            public <N> io.helidon.common.config.ConfigValue<N> as(GenericType<N> type) {
+                throw new ConfigMappingException(key(), "test value cannot be mapped to other types.");
             }
 
             @Override

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbColumn.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbColumn.java
@@ -19,11 +19,12 @@ import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.mapper.MapperException;
+import io.helidon.common.mapper.Value;
 
 /**
  * Column data and metadata.
  */
-public interface DbColumn {
+public interface DbColumn extends Value<Object> {
 
     /**
      * Typed value of this column.
@@ -36,7 +37,8 @@ public interface DbColumn {
      * @throws io.helidon.common.mapper.MapperException in case the type is not the underlying {@link #javaType()} and
      *                         there is no mapper registered for it
      */
-    <T> T as(Class<T> type) throws MapperException;
+    @Override
+    <T> T get(Class<T> type) throws MapperException;
 
     /**
      * Value of this column as a generic type.
@@ -48,14 +50,16 @@ public interface DbColumn {
      * @return value mapped to the expected type if possible
      * @throws MapperException in case the mapping cannot be done
      */
-    <T> T as(GenericType<T> type) throws MapperException;
+    @Override
+    <T> T get(GenericType<T> type) throws MapperException;
 
     /**
      * Untyped value of this column, returns java type as provided by the underlying database driver.
      *
      * @return value of this column
      */
-    default Object value() {
+    @Override
+    default Object get() {
         return as(javaType());
     }
 
@@ -82,6 +86,7 @@ public interface DbColumn {
      *
      * @return name of this column
      */
+    @Override
     String name();
 
     /**

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbColumnBase.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbColumnBase.java
@@ -15,9 +15,13 @@
  */
 package io.helidon.dbclient;
 
+import java.util.Optional;
+import java.util.function.Function;
+
 import io.helidon.common.GenericType;
 import io.helidon.common.mapper.MapperException;
 import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.Value;
 
 /**
  * Base {@link DbColumn} implementation.
@@ -51,7 +55,7 @@ public abstract class DbColumnBase implements DbColumn {
     }
 
     @Override
-    public <T> T as(Class<T> type) throws MapperException {
+    public <T> T get(Class<T> type) throws MapperException {
         if (null == value) {
             return null;
         }
@@ -62,7 +66,7 @@ public abstract class DbColumnBase implements DbColumn {
     }
 
     @Override
-    public <T> T as(GenericType<T> type) throws MapperException {
+    public <T> T get(GenericType<T> type) throws MapperException {
         if (null == value) {
             return null;
         }
@@ -73,6 +77,51 @@ public abstract class DbColumnBase implements DbColumn {
             }
         }
         return map(value, type);
+    }
+
+    @Override
+    public <N> Value<N> as(Class<N> type) throws MapperException {
+        return Value.create(mapperManager, name(), get(type), "dbclient", "column");
+    }
+
+    @Override
+    public <N> Value<N> as(GenericType<N> type) throws MapperException {
+        return Value.create(mapperManager, name(), get(type), "dbclient", "column");
+    }
+
+    @Override
+    public <N> Value<N> as(Function<? super Object, ? extends N> mapper) {
+        return Value.create(mapperManager, name(), mapper.apply(value), "dbclient", "column");
+    }
+
+    @Override
+    public Optional<Object> asOptional() throws MapperException {
+        return Optional.of(value);
+    }
+
+    @Override
+    public Value<Boolean> asBoolean() {
+        return as(Boolean.class);
+    }
+
+    @Override
+    public Value<String> asString() {
+        return as(String.class);
+    }
+
+    @Override
+    public Value<Integer> asInt() {
+        return as(Integer.class);
+    }
+
+    @Override
+    public Value<Long> asLong() {
+        return as(Long.class);
+    }
+
+    @Override
+    public Value<Double> asDouble() {
+        return as(Double.class);
     }
 
     /**

--- a/dbclient/jsonp/src/main/java/io/helidon/dbclient/jsonp/JsonProcessingMapper.java
+++ b/dbclient/jsonp/src/main/java/io/helidon/dbclient/jsonp/JsonProcessingMapper.java
@@ -86,7 +86,7 @@ public final class JsonProcessingMapper implements DbMapper<JsonObject> {
     @Override
     public JsonObject read(DbRow row) {
         JsonObjectBuilder objectBuilder = JSON.createObjectBuilder();
-        row.forEach(dbCol -> toJson(objectBuilder, dbCol.name(), dbCol.javaType(), dbCol.value()));
+        row.forEach(dbCol -> toJson(objectBuilder, dbCol.name(), dbCol.javaType(), dbCol.get()));
         return objectBuilder.build();
     }
 

--- a/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbRow.java
+++ b/dbclient/mongodb/src/main/java/io/helidon/dbclient/mongodb/MongoDbRow.java
@@ -121,7 +121,7 @@ final class MongoDbRow implements DbRow {
             }
             sb.append(col.name());
             sb.append(':');
-            sb.append(col.value().toString());
+            sb.append(col.get().toString());
         }
         sb.append('}');
         return sb.toString();

--- a/examples/cors/src/main/java/io/helidon/examples/cors/GreetService.java
+++ b/examples/cors/src/main/java/io/helidon/examples/cors/GreetService.java
@@ -87,7 +87,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/dbclient/common/src/main/java/io/helidon/examples/dbclient/common/AbstractPokemonService.java
+++ b/examples/dbclient/common/src/main/java/io/helidon/examples/dbclient/common/AbstractPokemonService.java
@@ -103,7 +103,7 @@ public abstract class AbstractPokemonService implements HttpService {
     private void insertPokemonSimple(ServerRequest req, ServerResponse res) {
         Parameters params = req.path().pathParameters();
         // Test Pokémon POJO mapper
-        Pokemon pokemon = new Pokemon(params.value("name"), params.value("type"));
+        Pokemon pokemon = new Pokemon(params.get("name"), params.get("type"));
 
         long count = dbClient.execute().createNamedInsert("insert2")
                 .namedParam(pokemon)
@@ -118,7 +118,7 @@ public abstract class AbstractPokemonService implements HttpService {
      * @param res server response
      */
     private void getPokemon(ServerRequest req, ServerResponse res) {
-        String pokemonName = req.path().pathParameters().value("name");
+        String pokemonName = req.path().pathParameters().get("name");
         res.send(dbClient.execute()
                 .namedGet("select-one", pokemonName)
                 .orElseThrow(() -> new NotFoundException("Pokemon " + pokemonName + " not found"))
@@ -146,8 +146,8 @@ public abstract class AbstractPokemonService implements HttpService {
      */
     private void updatePokemonType(ServerRequest req, ServerResponse res) {
         Parameters params = req.path().pathParameters();
-        String name = params.value("name");
-        String type = params.value("type");
+        String name = params.get("name");
+        String type = params.get("type");
         long count = dbClient.execute()
                 .createNamedUpdate("update")
                 .addParam("name", name)
@@ -182,7 +182,7 @@ public abstract class AbstractPokemonService implements HttpService {
      * @param res the server response
      */
     private void deletePokemon(ServerRequest req, ServerResponse res) {
-        String name = req.path().pathParameters().value("name");
+        String name = req.path().pathParameters().get("name");
         long count = dbClient.execute().namedDelete("delete", name);
         res.send("Deleted: " + count + " values");
     }

--- a/examples/dbclient/common/src/main/java/io/helidon/examples/dbclient/common/PokemonMapper.java
+++ b/examples/dbclient/common/src/main/java/io/helidon/examples/dbclient/common/PokemonMapper.java
@@ -38,7 +38,7 @@ public class PokemonMapper implements DbMapper<Pokemon> {
         }
 
         DbColumn type = row.column("type");
-        return new Pokemon(name.as(String.class), type.as(String.class));
+        return new Pokemon(name.get(String.class), type.get(String.class));
     }
 
     @Override

--- a/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonMapper.java
+++ b/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonMapper.java
@@ -34,7 +34,7 @@ public class PokemonMapper implements DbMapper<Pokemon> {
         DbColumn id = row.column("id");
         DbColumn name = row.column("name");
         DbColumn type = row.column("idType");
-        return new Pokemon(id.as(Integer.class), name.as(String.class), type.as(Integer.class));
+        return new Pokemon(id.get(Integer.class), name.get(String.class), type.get(Integer.class));
     }
 
     @Override

--- a/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonService.java
+++ b/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonService.java
@@ -129,7 +129,7 @@ public class PokemonService implements HttpService {
     private void getPokemonById(ServerRequest request, ServerResponse response) {
         int pokemonId = Integer.parseInt(request.path()
                 .pathParameters()
-                .value("id"));
+                .get("id"));
 
         response.send(dbClient.execute().createNamedGet("select-pokemon-by-id")
                 .addParam("id", pokemonId)
@@ -145,7 +145,7 @@ public class PokemonService implements HttpService {
      * @param response server response
      */
     private void getPokemonByName(ServerRequest request, ServerResponse response) {
-        String pokemonName = request.path().pathParameters().value("name");
+        String pokemonName = request.path().pathParameters().get("name");
         response.send(dbClient.execute().namedGet("select-pokemon-by-name", pokemonName)
                 .orElseThrow(() -> new NotFoundException("Pokemon " + pokemonName + " not found"))
                 .as(JsonObject.class));

--- a/examples/employee-app/src/main/java/io/helidon/examples/employee/EmployeeRepositoryImplDB.java
+++ b/examples/employee-app/src/main/java/io/helidon/examples/employee/EmployeeRepositoryImplDB.java
@@ -154,14 +154,14 @@ final class EmployeeRepositoryImplDB implements EmployeeRepository {
         static Employee read(DbRow row) {
             // map named columns to an object
             return Employee.of(
-                    row.column("ID").as(String.class),
-                    row.column("FIRSTNAME").as(String.class),
-                    row.column("LASTNAME").as(String.class),
-                    row.column("EMAIL").as(String.class),
-                    row.column("PHONE").as(String.class),
-                    row.column("BIRTHDATE").as(String.class),
-                    row.column("TITLE").as(String.class),
-                    row.column("DEPARTMENT").as(String.class)
+                    row.column("ID").get(String.class),
+                    row.column("FIRSTNAME").get(String.class),
+                    row.column("LASTNAME").get(String.class),
+                    row.column("EMAIL").get(String.class),
+                    row.column("PHONE").get(String.class),
+                    row.column("BIRTHDATE").get(String.class),
+                    row.column("TITLE").get(String.class),
+                    row.column("DEPARTMENT").get(String.class)
             );
         }
     }

--- a/examples/employee-app/src/main/java/io/helidon/examples/employee/EmployeeService.java
+++ b/examples/employee-app/src/main/java/io/helidon/examples/employee/EmployeeService.java
@@ -83,7 +83,7 @@ public class EmployeeService implements HttpService {
     private void getByLastName(ServerRequest request, ServerResponse response) {
         LOGGER.fine("getByLastName");
 
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         // Invalid query strings handled in isValidQueryStr. Keeping DRY
         if (isValidQueryStr(response, name)) {
             response.send(employees.getByLastName(name));
@@ -99,7 +99,7 @@ public class EmployeeService implements HttpService {
     private void getByTitle(ServerRequest request, ServerResponse response) {
         LOGGER.fine("getByTitle");
 
-        String title = request.path().pathParameters().value("name");
+        String title = request.path().pathParameters().get("name");
         if (isValidQueryStr(response, title)) {
             response.send(employees.getByTitle(title));
         }
@@ -114,7 +114,7 @@ public class EmployeeService implements HttpService {
     private void getByDepartment(ServerRequest request, ServerResponse response) {
         LOGGER.fine("getByDepartment");
 
-        String department = request.path().pathParameters().value("name");
+        String department = request.path().pathParameters().get("name");
         if (isValidQueryStr(response, department)) {
             response.send(employees.getByDepartment(department));
         }
@@ -129,7 +129,7 @@ public class EmployeeService implements HttpService {
     private void getEmployeeById(ServerRequest request, ServerResponse response) {
         LOGGER.fine("getEmployeeById");
 
-        String id = request.path().pathParameters().value("id");
+        String id = request.path().pathParameters().get("id");
         // If invalid, response handled in isValidId. Keeping DRY
         if (isValidQueryStr(response, id)) {
             employees.getById(id)
@@ -167,7 +167,7 @@ public class EmployeeService implements HttpService {
     private void update(ServerRequest request, ServerResponse response) {
         LOGGER.fine("update");
 
-        String id = request.path().pathParameters().value("id");
+        String id = request.path().pathParameters().get("id");
         if (isValidQueryStr(response, id)) {
             if (employees.update(request.content().as(Employee.class), id) == 0) {
                 response.status(404).send();
@@ -186,7 +186,7 @@ public class EmployeeService implements HttpService {
     private void delete(ServerRequest request, ServerResponse response) {
         LOGGER.fine("delete");
 
-        String id = request.path().pathParameters().value("id");
+        String id = request.path().pathParameters().get("id");
         if (isValidQueryStr(response, id)) {
             if (employees.deleteById(id) == 0) {
                 response.status(404).send();

--- a/examples/integrations/microstream/greetings-se/src/main/java/io/helidon/examples/integrations/microstream/greetings/se/GreetingService.java
+++ b/examples/integrations/microstream/greetings-se/src/main/java/io/helidon/examples/integrations/microstream/greetings/se/GreetingService.java
@@ -105,7 +105,7 @@ public class GreetingService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/integrations/oci/objectstorage/src/main/java/io/helidon/examples/integrations/oci/objecstorage/ObjectStorageService.java
+++ b/examples/integrations/oci/objectstorage/src/main/java/io/helidon/examples/integrations/oci/objecstorage/ObjectStorageService.java
@@ -90,7 +90,7 @@ public class ObjectStorageService implements HttpService {
      * @param response response
      */
     public void download(ServerRequest request, ServerResponse response) {
-        String fileName = request.path().pathParameters().value("file-name");
+        String fileName = request.path().pathParameters().get("file-name");
         GetObjectResponse getObjectResponse =
                 objectStorageClient.getObject(
                         GetObjectRequest.builder()
@@ -127,7 +127,7 @@ public class ObjectStorageService implements HttpService {
      * @param response response
      */
     public void upload(ServerRequest request, ServerResponse response) {
-        String fileName = request.path().pathParameters().value("fileName");
+        String fileName = request.path().pathParameters().get("fileName");
         PutObjectRequest putObjectRequest;
         try (InputStream stream = new FileInputStream(System.getProperty("user.dir") + File.separator + fileName)) {
             byte[] contents = stream.readAllBytes();
@@ -158,7 +158,7 @@ public class ObjectStorageService implements HttpService {
      * @param response response
      */
     public void delete(ServerRequest request, ServerResponse response) {
-        String fileName = request.path().pathParameters().value("file-name");
+        String fileName = request.path().pathParameters().get("file-name");
         DeleteObjectResponse deleteObjectResponse = objectStorageClient.deleteObject(DeleteObjectRequest.builder()
                 .namespaceName(namespaceName)
                 .bucketName(bucketName)

--- a/examples/integrations/oci/vault/src/main/java/io/helidon/examples/integrations/oci/vault/VaultService.java
+++ b/examples/integrations/oci/vault/src/main/java/io/helidon/examples/integrations/oci/vault/VaultService.java
@@ -103,7 +103,7 @@ class VaultService implements HttpService {
     private void getSecret(ServerRequest req, ServerResponse res) {
         ociHandler(response -> {
             GetSecretBundleResponse id = secrets.getSecretBundle(GetSecretBundleRequest.builder()
-                    .secretId(req.path().pathParameters().value("id"))
+                    .secretId(req.path().pathParameters().get("id"))
                     .build());
             SecretBundleContentDetails content = id.getSecretBundle().getSecretBundleContent();
             if (content instanceof Base64SecretBundleContentDetails) {
@@ -121,7 +121,7 @@ class VaultService implements HttpService {
         ociHandler(response -> {
             // has to be for quite a long period of time - did not work with less than 30 days
             Date deleteTime = Date.from(Instant.now().plus(30, ChronoUnit.DAYS));
-            String secretOcid = req.path().pathParameters().value("id");
+            String secretOcid = req.path().pathParameters().get("id");
             vaults.scheduleSecretDeletion(ScheduleSecretDeletionRequest.builder()
                     .secretId(secretOcid)
                     .scheduleSecretDeletionDetails(ScheduleSecretDeletionDetails.builder()
@@ -141,7 +141,7 @@ class VaultService implements HttpService {
                     .build();
             CreateSecretResponse vaultsSecret = vaults.createSecret(CreateSecretRequest.builder()
                     .createSecretDetails(CreateSecretDetails.builder()
-                            .secretName(req.path().pathParameters().value("name"))
+                            .secretName(req.path().pathParameters().get("name"))
                             .vaultId(vaultOcid)
                             .compartmentId(compartmentOcid)
                             .keyId(encryptionKeyOcid)
@@ -156,7 +156,7 @@ class VaultService implements HttpService {
 
 
         ociHandler(response -> {
-            String text = req.path().pathParameters().value("text");
+            String text = req.path().pathParameters().get("text");
             String signature = req.content().as(String.class);
             VerifyDataDetails.SigningAlgorithm algorithm = VerifyDataDetails.SigningAlgorithm.Sha224RsaPkcsPss;
             VerifyResponse verifyResponse = crypto.verify(VerifyRequest.builder()
@@ -179,7 +179,7 @@ class VaultService implements HttpService {
                             .keyId(signatureKeyOcid)
                             .signingAlgorithm(SignDataDetails.SigningAlgorithm.Sha224RsaPkcsPss)
                             .message(Base64Value.create(req.path()
-                                    .pathParameters().value("text")).toBase64())
+                                    .pathParameters().get("text")).toBase64())
                             .build())
                     .build());
             response.send(signResponse.getSignedData().getSignature());
@@ -192,7 +192,7 @@ class VaultService implements HttpService {
                     .encryptDataDetails(EncryptDataDetails.builder()
                             .keyId(encryptionKeyOcid)
                             .plaintext(Base64Value.create(req.path()
-                                    .pathParameters().value("text")).toBase64())
+                                    .pathParameters().get("text")).toBase64())
                             .build())
                     .build());
             response.send(encryptResponse.getEncryptedData().getCiphertext());
@@ -205,7 +205,7 @@ class VaultService implements HttpService {
                     .decryptDataDetails(DecryptDataDetails.builder()
                             .keyId(encryptionKeyOcid)
                             .ciphertext(req.path()
-                                    .pathParameters().value("text"))
+                                    .pathParameters().get("text"))
                             .build())
                     .build());
             response.send(Base64Value.createFromEncoded(decryptResponse.getDecryptedData().getPlaintext())

--- a/examples/integrations/vault/hcp/src/main/java/io/helidon/examples/integrations/vault/hcp/CubbyholeService.java
+++ b/examples/integrations/vault/hcp/src/main/java/io/helidon/examples/integrations/vault/hcp/CubbyholeService.java
@@ -49,7 +49,7 @@ class CubbyholeService implements HttpService {
     }
 
     private void getSecret(ServerRequest req, ServerResponse res) {
-        String path = req.path().pathParameters().value("path");
+        String path = req.path().pathParameters().get("path");
         Optional<Secret> secret = secrets.get(path);
         if (secret.isPresent()) {
             // using toString so we do not need to depend on JSON-B

--- a/examples/integrations/vault/hcp/src/main/java/io/helidon/examples/integrations/vault/hcp/Kv1Service.java
+++ b/examples/integrations/vault/hcp/src/main/java/io/helidon/examples/integrations/vault/hcp/Kv1Service.java
@@ -62,13 +62,13 @@ class Kv1Service implements HttpService {
     }
 
     private void deleteSecret(ServerRequest req, ServerResponse res) {
-        String path = req.path().pathParameters().value("path");
+        String path = req.path().pathParameters().get("path");
         secrets.delete(path);
         res.send("Deleted secret on path " + path);
     }
 
     private void getSecret(ServerRequest req, ServerResponse res) {
-        String path = req.path().pathParameters().value("path");
+        String path = req.path().pathParameters().get("path");
 
         Optional<Secret> secret = secrets.get(path);
         if (secret.isPresent()) {

--- a/examples/integrations/vault/hcp/src/main/java/io/helidon/examples/integrations/vault/hcp/Kv2Service.java
+++ b/examples/integrations/vault/hcp/src/main/java/io/helidon/examples/integrations/vault/hcp/Kv2Service.java
@@ -50,13 +50,13 @@ class Kv2Service implements HttpService {
     }
 
     private void deleteSecret(ServerRequest req, ServerResponse res) {
-        String path = req.path().pathParameters().value("path");
+        String path = req.path().pathParameters().get("path");
         secrets.deleteAll(path);
         res.send("Deleted secret on path " + path);
     }
 
     private void getSecret(ServerRequest req, ServerResponse res) {
-        String path = req.path().pathParameters().value("path");
+        String path = req.path().pathParameters().get("path");
 
         Optional<Kv2Secret> secret = secrets.get(path);
         if (secret.isPresent()) {

--- a/examples/integrations/vault/hcp/src/main/java/io/helidon/examples/integrations/vault/hcp/TransitService.java
+++ b/examples/integrations/vault/hcp/src/main/java/io/helidon/examples/integrations/vault/hcp/TransitService.java
@@ -97,7 +97,7 @@ class TransitService implements HttpService {
     }
 
     private void decryptSecret(ServerRequest req, ServerResponse res) {
-        String encrypted = req.path().pathParameters().value("text");
+        String encrypted = req.path().pathParameters().get("text");
 
         Decrypt.Response decryptResponse = secrets.decrypt(Decrypt.Request.builder()
                                                                           .encryptionKeyName(ENCRYPTION_KEY)
@@ -107,7 +107,7 @@ class TransitService implements HttpService {
     }
 
     private void encryptSecret(ServerRequest req, ServerResponse res) {
-        String secret = req.path().pathParameters().value("text");
+        String secret = req.path().pathParameters().get("text");
 
         Encrypt.Response encryptResponse = secrets.encrypt(Encrypt.Request.builder()
                                                                           .encryptionKeyName(ENCRYPTION_KEY)
@@ -133,7 +133,7 @@ class TransitService implements HttpService {
     }
 
     private void verifyHmac(ServerRequest req, ServerResponse res) {
-        String hmac = req.path().pathParameters().value("text");
+        String hmac = req.path().pathParameters().get("text");
 
         Verify.Response verifyResponse = secrets.verify(Verify.Request.builder()
                                                               .digestKeyName(ENCRYPTION_KEY)
@@ -144,7 +144,7 @@ class TransitService implements HttpService {
     }
 
     private void verify(ServerRequest req, ServerResponse res) {
-        String signature = req.path().pathParameters().value("text");
+        String signature = req.path().pathParameters().get("text");
 
         Verify.Response verifyResponse = secrets.verify(Verify.Request.builder()
                                                               .digestKeyName(SIGNATURE_KEY)

--- a/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileService.java
+++ b/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileService.java
@@ -107,7 +107,7 @@ public final class FileService implements HttpService {
     }
 
     private void download(ServerRequest req, ServerResponse res) {
-        Path filePath = storage.resolve(req.path().pathParameters().value("fname"));
+        Path filePath = storage.resolve(req.path().pathParameters().get("fname"));
         if (!filePath.getParent().equals(storage)) {
             res.status(BAD_REQUEST_400).send("Invalid file name");
             return;

--- a/examples/messaging/jms-websocket-se/src/main/java/io/helidon/examples/messaging/se/SendingService.java
+++ b/examples/messaging/jms-websocket-se/src/main/java/io/helidon/examples/messaging/se/SendingService.java
@@ -77,7 +77,7 @@ class SendingService implements HttpService {
         // Listen for GET /example/send/{msg}
         // to send it through messaging to Jms
         rules.get("/send/{msg}", (req, res) -> {
-            String msg = req.path().pathParameters().value("msg");
+            String msg = req.path().pathParameters().get("msg");
             System.out.println("Emitting: " + msg);
             emitter.send(msg);
             res.send();

--- a/examples/messaging/kafka-websocket-se/src/main/java/io/helidon/examples/messaging/se/SendingService.java
+++ b/examples/messaging/kafka-websocket-se/src/main/java/io/helidon/examples/messaging/se/SendingService.java
@@ -76,7 +76,7 @@ class SendingService implements HttpService {
         // Listen for GET /example/send/{msg}
         // to send it thru messaging to Kafka
         rules.get("/send/{msg}", (req, res) -> {
-            String msg = req.path().pathParameters().value("msg");
+            String msg = req.path().pathParameters().get("msg");
             System.out.println("Emitting: " + msg);
             emitter.send(msg);
             res.send();

--- a/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
+++ b/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
@@ -104,7 +104,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/GreetService.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/GreetService.java
@@ -100,7 +100,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/GreetService.java
+++ b/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/GreetService.java
@@ -86,7 +86,7 @@ public class GreetService implements HttpService {
      * @param response the server response
      */
     private void getMessageHandler(ServerRequest request, ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusService.java
+++ b/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusService.java
@@ -33,7 +33,7 @@ public class StatusService implements HttpService {
     }
 
     private void respondWithRequestedStatus(ServerRequest request, ServerResponse response) {
-        String statusText = request.path().pathParameters().value("status");
+        String statusText = request.path().pathParameters().get("status");
         int status;
         String msg;
         try {

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
@@ -105,7 +105,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetService.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetService.java
@@ -87,7 +87,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -87,7 +87,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -87,7 +87,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/security/vaults/src/main/java/io/helidon/examples/security/vaults/DigestService.java
+++ b/examples/security/vaults/src/main/java/io/helidon/examples/security/vaults/DigestService.java
@@ -39,16 +39,16 @@ class DigestService implements HttpService {
     }
 
     private void digest(ServerRequest req, ServerResponse res) {
-        String configName = req.path().pathParameters().value("config");
-        String text = req.path().pathParameters().value("text");
+        String configName = req.path().pathParameters().get("config");
+        String text = req.path().pathParameters().get("text");
 
         res.send(security.digest(configName, text.getBytes(UTF_8)));
     }
 
     private void verify(ServerRequest req, ServerResponse res) {
-        String configName = req.path().pathParameters().value("config");
-        String text = req.path().pathParameters().value("text");
-        String digest = req.path().pathParameters().value("digest");
+        String configName = req.path().pathParameters().get("config");
+        String text = req.path().pathParameters().get("text");
+        String digest = req.path().pathParameters().get("digest");
 
         boolean valid = security.verifyDigest(configName, text.getBytes(UTF_8), digest);
         res.send(valid ? "Valid" : "Invalid");

--- a/examples/security/vaults/src/main/java/io/helidon/examples/security/vaults/EncryptionService.java
+++ b/examples/security/vaults/src/main/java/io/helidon/examples/security/vaults/EncryptionService.java
@@ -39,15 +39,15 @@ class EncryptionService implements HttpService {
     }
 
     private void encrypt(ServerRequest req, ServerResponse res) {
-        String configName = req.path().pathParameters().value("config");
-        String text = req.path().pathParameters().value("text");
+        String configName = req.path().pathParameters().get("config");
+        String text = req.path().pathParameters().get("text");
 
         res.send(security.encrypt(configName, text.getBytes(UTF_8)));
     }
 
     private void decrypt(ServerRequest req, ServerResponse res) {
-        String configName = req.path().pathParameters().value("config");
-        String cipherText = req.path().pathParameters().value("cipherText");
+        String configName = req.path().pathParameters().get("config");
+        String cipherText = req.path().pathParameters().get("cipherText");
 
         res.send(security.decrypt(configName, cipherText));
     }

--- a/examples/security/vaults/src/main/java/io/helidon/examples/security/vaults/SecretsService.java
+++ b/examples/security/vaults/src/main/java/io/helidon/examples/security/vaults/SecretsService.java
@@ -36,7 +36,7 @@ class SecretsService implements HttpService {
     }
 
     private void secret(ServerRequest req, ServerResponse res) {
-        String secretName = req.path().pathParameters().value("name");
+        String secretName = req.path().pathParameters().get("name");
         res.send(security.secret(secretName, "default-" + secretName));
     }
 }

--- a/examples/todo-app/frontend/src/main/java/io/helidon/examples/todos/frontend/TodoService.java
+++ b/examples/todo-app/frontend/src/main/java/io/helidon/examples/todos/frontend/TodoService.java
@@ -109,7 +109,7 @@ public final class TodoService implements HttpService {
      * @param res the server response
      */
     private void update(ServerRequest req, ServerResponse res) {
-        String id = req.path().pathParameters().value("id");
+        String id = req.path().pathParameters().get("id");
         JsonObject jsonObject = bsc.update(id, req.content().as(JsonObject.class));
         updateCounter.increment();
         res.send(jsonObject);
@@ -122,7 +122,7 @@ public final class TodoService implements HttpService {
      * @param res the server response
      */
     private void delete(ServerRequest req, ServerResponse res) {
-        String id = req.path().pathParameters().value("id");
+        String id = req.path().pathParameters().get("id");
         JsonObject jsonObject = bsc.deleteSingle(id);
         deleteCounter.increment();
         res.send(jsonObject);
@@ -135,7 +135,7 @@ public final class TodoService implements HttpService {
      * @param res the server response
      */
     private void get(ServerRequest req, ServerResponse res) {
-        String id = req.path().pathParameters().value("id");
+        String id = req.path().pathParameters().get("id");
         res.send(bsc.get(id));
     }
 }

--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/GreetService.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/GreetService.java
@@ -104,7 +104,7 @@ public class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/examples/webserver/basics/src/main/java/io/helidon/examples/webserver/basics/Catalog.java
+++ b/examples/webserver/basics/src/main/java/io/helidon/examples/webserver/basics/Catalog.java
@@ -29,7 +29,7 @@ public class Catalog implements HttpService {
     @Override
     public void routing(HttpRules rules) {
         rules.get("/", this::list)
-                .get("/{id}", (req, res) -> getSingle(res, req.path().pathParameters().value("id")));
+                .get("/{id}", (req, res) -> getSingle(res, req.path().pathParameters().get("id")));
     }
 
     private void list(ServerRequest request, ServerResponse response) {

--- a/examples/webserver/basics/src/main/java/io/helidon/examples/webserver/basics/Main.java
+++ b/examples/webserver/basics/src/main/java/io/helidon/examples/webserver/basics/Main.java
@@ -143,7 +143,7 @@ public class Main {
                     .first("bar")
                     .ifPresent(v -> sb.append("bar: ").append(v).append("\n"));
             // Path parameters
-            sb.append("id: ").append(req.path().pathParameters().value("id"));
+            sb.append("id: ").append(req.path().pathParameters().get("id"));
             // Response headers
             res.headers().contentType(MediaTypes.TEXT_PLAIN);
             // Response entity (payload)
@@ -242,7 +242,7 @@ public class Main {
                         res.send(JSON.createObjectBuilder()
                                 .add("message", "Hello " + req.path()
                                         .pathParameters()
-                                        .value("what"))
+                                        .get("what"))
                                 .build()));
         mediaContext.addMediaSupport(JsonpSupport.create());
     }

--- a/examples/webserver/comment-aas/src/main/java/io/helidon/examples/webserver/comments/CommentsService.java
+++ b/examples/webserver/comment-aas/src/main/java/io/helidon/examples/webserver/comments/CommentsService.java
@@ -42,13 +42,13 @@ public class CommentsService implements HttpService {
     }
 
     private void handleListComments(ServerRequest req, ServerResponse resp) {
-        String topic = req.path().pathParameters().value("topic");
+        String topic = req.path().pathParameters().get("topic");
         resp.headers().contentType(HttpMediaTypes.PLAINTEXT_UTF_8);
         resp.send(listComments(topic));
     }
 
     private void handleAddComment(ServerRequest req, ServerResponse res) {
-        String topic = req.path().pathParameters().value("topic");
+        String topic = req.path().pathParameters().get("topic");
         String userName = req.context().get("user", String.class).orElse("anonymous");
         String msg = req.content().as(String.class);
         addComment(msg, userName, topic);

--- a/examples/webserver/echo/src/main/java/io/helidon/examples/webserver/echo/EchoMain.java
+++ b/examples/webserver/echo/src/main/java/io/helidon/examples/webserver/echo/EchoMain.java
@@ -65,11 +65,11 @@ public class EchoMain {
         Set<String> queryNames = query.names();
 
         for (String pathParamName : pathParams.names()) {
-            res.header("R-PATH_PARAM_" + pathParamName, pathParams.value(pathParamName));
+            res.header("R-PATH_PARAM_" + pathParamName, pathParams.get(pathParamName));
         }
 
         for (String paramName : templateParams.names()) {
-            res.header("R-PATH_" + paramName, templateParams.value(paramName));
+            res.header("R-PATH_" + paramName, templateParams.get(paramName));
         }
 
         for (String queryName : queryNames) {

--- a/examples/webserver/fault-tolerance/src/main/java/io/helidon/examples/webserver/faulttolerance/FtService.java
+++ b/examples/webserver/fault-tolerance/src/main/java/io/helidon/examples/webserver/faulttolerance/FtService.java
@@ -73,12 +73,12 @@ public class FtService implements HttpService {
     }
 
     private void timeoutHandler(ServerRequest request, ServerResponse response) {
-        long sleep = Long.parseLong(request.path().pathParameters().value("millis"));
+        long sleep = Long.parseLong(request.path().pathParameters().get("millis"));
         response.send(timeout.invoke(() -> sleep(sleep)));
     }
 
     private void retryHandler(ServerRequest request, ServerResponse response) {
-        int count = Integer.parseInt(request.path().pathParameters().value("count"));
+        int count = Integer.parseInt(request.path().pathParameters().get("count"));
 
         AtomicInteger call = new AtomicInteger(1);
         AtomicInteger failures = new AtomicInteger();
@@ -95,7 +95,7 @@ public class FtService implements HttpService {
     }
 
     private void fallbackHandler(ServerRequest request, ServerResponse response) {
-        boolean success = "true".equalsIgnoreCase(request.path().pathParameters().value("success"));
+        boolean success = "true".equalsIgnoreCase(request.path().pathParameters().get("success"));
         if (success) {
             response.send(fallback.invoke(this::data));
         } else {
@@ -104,7 +104,7 @@ public class FtService implements HttpService {
     }
 
     private void circuitBreakerHandler(ServerRequest request, ServerResponse response) {
-        boolean success = "true".equalsIgnoreCase(request.path().pathParameters().value("success"));
+        boolean success = "true".equalsIgnoreCase(request.path().pathParameters().get("success"));
         if (success) {
             response.send(breaker.invoke(this::data));
         } else {
@@ -113,7 +113,7 @@ public class FtService implements HttpService {
     }
 
     private void bulkheadHandler(ServerRequest request, ServerResponse response) {
-        long sleep = Long.parseLong(request.path().pathParameters().value("millis"));
+        long sleep = Long.parseLong(request.path().pathParameters().get("millis"));
         response.send(bulkhead.invoke(() -> sleep(sleep)));
     }
 

--- a/examples/webserver/tutorial/src/main/java/io/helidon/examples/webserver/tutorial/CommentService.java
+++ b/examples/webserver/tutorial/src/main/java/io/helidon/examples/webserver/tutorial/CommentService.java
@@ -41,7 +41,7 @@ class CommentService implements HttpService {
     }
 
     private void getComments(ServerRequest req, ServerResponse resp) {
-        String roomId = req.path().pathParameters().value("room-id");
+        String roomId = req.path().pathParameters().get("room-id");
         resp.headers().contentType(HttpMediaTypes.PLAINTEXT_UTF_8);
         resp.send(getComments(roomId));
     }
@@ -62,7 +62,7 @@ class CommentService implements HttpService {
     }
 
     private void addComment(ServerRequest req, ServerResponse res) {
-        String roomId = req.path().pathParameters().value("room-id");
+        String roomId = req.path().pathParameters().get("room-id");
         User user = req.context().get(User.class).orElse(User.ANONYMOUS);
         String msg = req.content().as(String.class);
         addComment(roomId, user, msg);

--- a/http/http/src/main/java/io/helidon/http/ClientResponseHeaders.java
+++ b/http/http/src/main/java/io/helidon/http/ClientResponseHeaders.java
@@ -80,7 +80,7 @@ public interface ClientResponseHeaders extends Headers {
     default Optional<URI> location() {
         if (contains(LOCATION)) {
             return Optional.of(get(LOCATION))
-                    .map(Http.Header::value)
+                    .map(Http.Header::get)
                     .map(URI::create);
         }
         return Optional.empty();
@@ -96,7 +96,7 @@ public interface ClientResponseHeaders extends Headers {
     default Optional<ZonedDateTime> lastModified() {
         if (contains(LAST_MODIFIED)) {
             return Optional.of(get(LAST_MODIFIED))
-                    .map(Http.Header::value)
+                    .map(Http.Header::get)
                     .map(DateTime::parse);
         }
         return Optional.empty();
@@ -112,7 +112,7 @@ public interface ClientResponseHeaders extends Headers {
     default Optional<ZonedDateTime> expires() {
         if (contains(EXPIRES)) {
             return Optional.of(get(EXPIRES))
-                    .map(Http.Header::value)
+                    .map(Http.Header::get)
                     .map(DateTime::parse);
         }
         return Optional.empty();

--- a/http/http/src/main/java/io/helidon/http/ContentDisposition.java
+++ b/http/http/src/main/java/io/helidon/http/ContentDisposition.java
@@ -25,10 +25,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperException;
 import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.Value;
 
 /**
  * A generic representation of the {@code Content-Disposition} header.
@@ -54,7 +58,6 @@ public class ContentDisposition implements Http.Header {
     private static final String MODIFICATION_DATE_PARAMETER = "modification-date";
     private static final String READ_DATE_PARAMETER = "read-date";
     private static final String SIZE_PARAMETER = "size";
-    private static final MapperManager MAPPER_MANAGER = MapperManager.create();
     private static final ContentDisposition EMPTY = ContentDisposition.builder()
             .type("")
             .build();
@@ -135,7 +138,7 @@ public class ContentDisposition implements Http.Header {
     }
 
     @Override
-    public String value() {
+    public String get() {
         if (value == null) {
             StringBuilder sb = new StringBuilder();
             sb.append(type);
@@ -157,13 +160,53 @@ public class ContentDisposition implements Http.Header {
     }
 
     @Override
-    public <T> T value(Class<T> type) {
-        return MAPPER_MANAGER.map(value(), String.class, type, "http-header");
+    public <N> Value<N> as(Class<N> type) throws MapperException {
+        return asString().as(type);
+    }
+
+    @Override
+    public <N> Value<N> as(GenericType<N> type) throws MapperException {
+        return asString().as(type);
+    }
+
+    @Override
+    public <N> Value<N> as(Function<? super String, ? extends N> mapper) {
+        return asString().as(mapper);
+    }
+
+    @Override
+    public Optional<String> asOptional() throws MapperException {
+        return asString().asOptional();
+    }
+
+    @Override
+    public Value<Boolean> asBoolean() {
+        return asString().asBoolean();
+    }
+
+    @Override
+    public Value<String> asString() {
+        return Value.create(MapperManager.global(), name(), get(), GenericType.STRING, "http", "header");
+    }
+
+    @Override
+    public Value<Integer> asInt() {
+        return asString().asInt();
+    }
+
+    @Override
+    public Value<Long> asLong() {
+        return asString().asLong();
+    }
+
+    @Override
+    public Value<Double> asDouble() {
+        return asString().asDouble();
     }
 
     @Override
     public List<String> allValues() {
-        return List.of(value());
+        return List.of(get());
     }
 
     @Override
@@ -183,7 +226,7 @@ public class ContentDisposition implements Http.Header {
 
     @Override
     public String toString() {
-        return value();
+        return get();
     }
 
     /**

--- a/http/http/src/main/java/io/helidon/http/CookieParser.java
+++ b/http/http/src/main/java/io/helidon/http/CookieParser.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import io.helidon.common.parameters.Parameters;
 
 final class CookieParser {
-    private static final Parameters EMPTY_COOKIES = Parameters.empty("cookies");
+    private static final Parameters EMPTY_COOKIES = Parameters.empty("http/cookies");
 
     private static final String RFC2965_VERSION = "$Version";
     private static final String RFC2965_PATH = "$Path";
@@ -51,7 +51,7 @@ final class CookieParser {
         if (allCookies.isEmpty()) {
             return EMPTY_COOKIES;
         }
-        return Parameters.create("cookies", allCookies);
+        return Parameters.create("http/cookies", allCookies);
     }
 
     static Parameters empty() {

--- a/http/http/src/main/java/io/helidon/http/HeaderValueBase.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueBase.java
@@ -17,13 +17,17 @@
 package io.helidon.http;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.MapperException;
 import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.Value;
 import io.helidon.http.Http.HeaderName;
 
 abstract class HeaderValueBase implements Http.HeaderValueWriteable {
-    private static final MapperManager MAPPER_MANAGER = MapperManager.create();
-
+    private static final String[] QUALIFIER = new String[] {"http", "header"};
     private final HeaderName name;
     private final String actualName;
     private final String firstValue;
@@ -52,13 +56,58 @@ abstract class HeaderValueBase implements Http.HeaderValueWriteable {
     }
 
     @Override
-    public String value() {
+    public String get() {
         return firstValue;
     }
 
     @Override
-    public <T> T value(Class<T> type) {
-        return MAPPER_MANAGER.map(value(), String.class, type, "http-header");
+    public <T> T get(Class<T> type) {
+        return MapperManager.global().map(get(), String.class, type, QUALIFIER);
+    }
+
+    @Override
+    public <N> Value<N> as(Function<? super String, ? extends N> mapper) {
+        return Value.create(MapperManager.global(), name(), mapper.apply(get()), QUALIFIER);
+    }
+
+    @Override
+    public <N> Value<N> as(Class<N> type) throws MapperException {
+        return asString().as(type);
+    }
+
+    @Override
+    public Value<String> asString() {
+        return Value.create(MapperManager.global(), name(), get(), GenericType.STRING, QUALIFIER);
+    }
+
+    @Override
+    public <N> Value<N> as(GenericType<N> type) throws MapperException {
+        return asString().as(type);
+    }
+
+    @Override
+    public Optional<String> asOptional() throws MapperException {
+        return asString().asOptional();
+    }
+
+    @Override
+    public Value<Boolean> asBoolean() {
+        return asString().asBoolean();
+    }
+
+    @Override
+    public Value<Integer> asInt() {
+        return asString().asInt();
+    }
+
+    @Override
+    public Value<Long> asLong() {
+        return asString().asLong();
+    }
+
+    @Override
+    public Value<Double> asDouble() {
+        return asString().asDouble();
     }
 
     @Override

--- a/http/http/src/main/java/io/helidon/http/HeaderValueCopy.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueCopy.java
@@ -24,7 +24,7 @@ class HeaderValueCopy extends HeaderValueBase {
     private List<String> values;
 
     HeaderValueCopy(Http.Header header) {
-        super(header.headerName(), header.changing(), header.sensitive(), header.value());
+        super(header.headerName(), header.changing(), header.sensitive(), header.get());
 
         this.original = header;
     }

--- a/http/http/src/main/java/io/helidon/http/HeaderValueLazy.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueLazy.java
@@ -42,7 +42,7 @@ class HeaderValueLazy extends HeaderValueBase {
     }
 
     @Override
-    public String value() {
+    public String get() {
         return value.stripOws();
     }
 

--- a/http/http/src/main/java/io/helidon/http/Headers.java
+++ b/http/http/src/main/java/io/helidon/http/Headers.java
@@ -112,7 +112,7 @@ public interface Headers extends Iterable<Http.Header> {
      */
     default Optional<String> first(Http.HeaderName headerName) {
         if (contains(headerName)) {
-            return Optional.of(get(headerName).value());
+            return Optional.of(get(headerName).get());
         }
         return Optional.empty();
     }
@@ -148,7 +148,7 @@ public interface Headers extends Iterable<Http.Header> {
      */
     default OptionalLong contentLength() {
         if (contains(HeaderNameEnum.CONTENT_LENGTH)) {
-            return OptionalLong.of(get(HeaderNameEnum.CONTENT_LENGTH).value(long.class));
+            return OptionalLong.of(get(HeaderNameEnum.CONTENT_LENGTH).get(long.class));
         }
         return OptionalLong.empty();
     }
@@ -162,7 +162,7 @@ public interface Headers extends Iterable<Http.Header> {
     default Optional<HttpMediaType> contentType() {
         if (contains(HeaderNameEnum.CONTENT_TYPE)) {
             return Optional.of(HttpMediaType.create(get(HeaderNameEnum.CONTENT_TYPE)
-                                                            .value()));
+                                                            .get()));
         }
         return Optional.empty();
     }

--- a/http/http/src/main/java/io/helidon/http/HeadersImpl.java
+++ b/http/http/src/main/java/io/helidon/http/HeadersImpl.java
@@ -73,7 +73,7 @@ class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
         }
         if (headerWithValue.valueCount() == 1 && headerValue.valueCount() == 1) {
             // just a string compare instead of list compare
-            return headerWithValue.value().equals(headerValue.value());
+            return headerWithValue.get().equals(headerValue.get());
         }
         return headerWithValue.allValues().equals(headerValue.allValues());
     }

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -28,6 +28,7 @@ import java.util.function.Predicate;
 import io.helidon.common.buffers.Ascii;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.LazyString;
+import io.helidon.common.mapper.Value;
 
 /**
  * HTTP protocol related constants and utilities.
@@ -803,7 +804,7 @@ public final class Http {
      *
      * @see io.helidon.http.Http.Headers
      */
-    public interface Header {
+    public interface Header extends Value<String> {
 
         /**
          * Name of the header as configured by user
@@ -811,7 +812,19 @@ public final class Http {
          *
          * @return header name, always lower case for HTTP/2 headers
          */
+        @Override
         String name();
+
+        /**
+         * Value of the header.
+         *
+         * @return header value
+         * @deprecated use {@link #get()}
+         */
+        @Deprecated(forRemoval = true, since = "4.0.0")
+        default String value() {
+            return get();
+        }
 
         /**
          * Header name for the header.
@@ -819,22 +832,6 @@ public final class Http {
          * @return header name
          */
         HeaderName headerName();
-
-        /**
-         * First value of this header.
-         *
-         * @return the first value
-         */
-        String value();
-
-        /**
-         * Value mapped using a {@link io.helidon.common.mapper.MapperManager}.
-         *
-         * @param type class of the value
-         * @param <T>  type of the value
-         * @return typed value
-         */
-        <T> T value(Class<T> type);
 
         /**
          * All values concatenated using a comma.
@@ -903,7 +900,7 @@ public final class Http {
          * @return value bytes
          */
         default byte[] valueBytes() {
-            return value().getBytes(StandardCharsets.US_ASCII);
+            return get().getBytes(StandardCharsets.US_ASCII);
         }
 
         /**

--- a/http/http/src/main/java/io/helidon/http/PathMatchers.java
+++ b/http/http/src/main/java/io/helidon/http/PathMatchers.java
@@ -461,7 +461,7 @@ public final class PathMatchers {
                     params.put(entry.getKey(), paramValue);
                 }
             }
-            return Parameters.createSingleValueMap("path-template", params);
+            return Parameters.createSingleValueMap("http/path", params);
         }
     }
 
@@ -513,7 +513,7 @@ public final class PathMatchers {
 
     // path without parameters
     private static class NoParamRoutedPath implements RoutedPath, Supplier<RoutedPath> {
-        private static final Parameters EMPTY_PARAMS = Parameters.empty("path-template");
+        private static final Parameters EMPTY_PARAMS = Parameters.empty("http/path");
         private final UriPath path;
 
         NoParamRoutedPath(UriPath path) {

--- a/http/media/multipart/src/main/java/io/helidon/http/media/multipart/MultiPartImpl.java
+++ b/http/media/multipart/src/main/java/io/helidon/http/media/multipart/MultiPartImpl.java
@@ -88,7 +88,7 @@ class MultiPartImpl extends MultiPart {
                                               headers,
                                               dataReader,
                                               index++,
-                                              headers.get(HeaderNames.CONTENT_LENGTH).value(long.class));
+                                              headers.get(HeaderNames.CONTENT_LENGTH).get(long.class));
                 return true;
             } else {
                 next = new ReadablePartNoLength(context, headers, dataReader, index++, boundary, endBoundary);

--- a/http/processor/src/main/java/io/helidon/http/processor/HttpMethodCreator.java
+++ b/http/processor/src/main/java/io/helidon/http/processor/HttpMethodCreator.java
@@ -209,7 +209,7 @@ public class HttpMethodCreator extends HttpCreatorBase implements CustomAnnotati
 
         // todo now we only support String for query, path and header -> add conversions
         switch (httpAnnotation.typeName().resolvedName()) {
-        case PATH_PARAM_ANNOTATION -> parameters.add("req.path().pathParameters().value(\"" + httpAnnotation.value().orElseThrow()
+        case PATH_PARAM_ANNOTATION -> parameters.add("req.path().pathParameters().get(\"" + httpAnnotation.value().orElseThrow()
                                                              + "\"),");
         case (ENTITY_PARAM_ANNOTATION) -> parameters.add("req.content().as(" + type + ".class),");
         case (HEADER_PARAM_ANNOTATION) -> {

--- a/http/processor/src/main/resources/templates/inject/helidon/http-method.java.hbs
+++ b/http/processor/src/main/resources/templates/inject/helidon/http-method.java.hbs
@@ -88,14 +88,12 @@ class {{className}} implements GeneratedHandler {
     private <T> T query(ServerRequest req, ServerResponse res, String name, String defaultValue, Class<T> type) {
         UriQuery query = req.query();
         if (query.contains(name)) {
-            // todo hardcoded type
-            return (T) query.value(name);
+            return query.first(name).get(type);
         }
         if (defaultValue == null) {
             throw new HttpException("Query parameter \"" + name + "\" is required", Http.Status.BAD_REQUEST_400, true);
         }
-        // todo also hardcoded type
-        return (T) defaultValue;
+        return io.helidon.common.mapper.MapperManager.global().map(defaultValue, String.class, type, "http", "endpoint");
     }
 {{/if}}
 }

--- a/jersey/tests/connector/src/test/java/io/helidon/jersey/connector/JerseyConnectorTest.java
+++ b/jersey/tests/connector/src/test/java/io/helidon/jersey/connector/JerseyConnectorTest.java
@@ -19,13 +19,13 @@ package io.helidon.jersey.connector;
 import java.util.Arrays;
 
 import io.helidon.http.Http;
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpRoute;
-
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
@@ -34,7 +34,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientConfig;
-
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -80,8 +79,8 @@ class JerseyConnectorTest {
     }
 
     static void basicGetQuery(ServerRequest request, ServerResponse response) {
-        String first = request.query().value("first");
-        String second = request.query().value("second");
+        String first = request.query().get("first");
+        String second = request.query().get("second");
         response.status(Http.Status.OK_200).send(first + second);
     }
 

--- a/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/CoordinatorService.java
+++ b/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/CoordinatorService.java
@@ -187,7 +187,7 @@ public class CoordinatorService implements HttpService {
      * @param res HTTP Response
      */
     private void close(ServerRequest req, ServerResponse res) {
-        String lraId = req.path().pathParameters().value("LraId");
+        String lraId = req.path().pathParameters().get("LraId");
         Lra lra = lraPersistentRegistry.get(lraId);
         if (lra == null) {
             res.status(NOT_FOUND_404).send();
@@ -209,7 +209,7 @@ public class CoordinatorService implements HttpService {
      * @param res HTTP Response
      */
     private void cancel(ServerRequest req, ServerResponse res) {
-        String lraId = req.path().pathParameters().value("LraId");
+        String lraId = req.path().pathParameters().get("LraId");
         Lra lra = lraPersistentRegistry.get(lraId);
         if (lra == null) {
             res.status(NOT_FOUND_404).send();
@@ -227,7 +227,7 @@ public class CoordinatorService implements HttpService {
      */
     private void join(ServerRequest req, ServerResponse res) {
 
-        String lraId = req.path().pathParameters().value("LraId");
+        String lraId = req.path().pathParameters().get("LraId");
         String compensatorLink = req.headers().first(Http.HeaderNames.LINK).orElse("");
 
         Lra lra = lraPersistentRegistry.get(lraId);
@@ -255,7 +255,7 @@ public class CoordinatorService implements HttpService {
      * @param res HTTP Response
      */
     private void status(ServerRequest req, ServerResponse res) {
-        String lraId = req.path().pathParameters().value("LraId");
+        String lraId = req.path().pathParameters().get("LraId");
         Lra lra = lraPersistentRegistry.get(lraId);
         if (lra == null) {
             res.status(NOT_FOUND_404).send();
@@ -274,7 +274,7 @@ public class CoordinatorService implements HttpService {
      * @param res HTTP Response
      */
     private void leave(ServerRequest req, ServerResponse res) {
-        String lraId = req.path().pathParameters().value("LraId");
+        String lraId = req.path().pathParameters().get("LraId");
         String compensatorLinks = req.content().as(String.class);
 
         Lra lra = lraPersistentRegistry.get(lraId);
@@ -296,7 +296,7 @@ public class CoordinatorService implements HttpService {
         nextRecoveryCycle();
 
         Optional<String> lraUUID = req.query().first("lraId")
-                .or(() -> req.path().pathParameters().first("LraId"))
+                .or(() -> req.path().pathParameters().first("LraId").asOptional())
                 .map(l -> {
                     if (l.lastIndexOf("/") != -1 && l.lastIndexOf("/") + 1 < l.length()) {
                         return l.substring(l.lastIndexOf("/") + 1);
@@ -339,7 +339,7 @@ public class CoordinatorService implements HttpService {
 
     private void get(ServerRequest req, ServerResponse res) {
         Optional<String> lraId = req.path().pathParameters().first("LraId")
-                .or(() -> req.query().first("lraId"));
+                .or(() -> req.query().first("lraId").asOptional());
 
         JsonArray array = lraPersistentRegistry
                 .stream()

--- a/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/LraDatabasePersistentRegistry.java
+++ b/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/LraDatabasePersistentRegistry.java
@@ -76,26 +76,26 @@ class LraDatabasePersistentRegistry implements LraPersistentRegistry {
     public void load(CoordinatorService coordinatorService) {
         DbExecute tx = dbClient.execute();
         tx.namedQuery("load").forEach(row -> {
-            String lraId = row.column("ID").as(String.class);
-            String parentId = row.column("PARENT_ID").as(String.class);
-            Long timeout = row.column("TIMEOUT").as(Long.class);
-            String lraStatus = row.column("STATUS").as(String.class);
-            Boolean isChild = row.column("IS_CHILD").as(Boolean.class);
-            Long whenReadyToDelete = row.column("WHEN_READY_TO_DELETE").as(Long.class);
+            String lraId = row.column("ID").get(String.class);
+            String parentId = row.column("PARENT_ID").get(String.class);
+            Long timeout = row.column("TIMEOUT").get(Long.class);
+            String lraStatus = row.column("STATUS").get(String.class);
+            Boolean isChild = row.column("IS_CHILD").get(Boolean.class);
+            Long whenReadyToDelete = row.column("WHEN_READY_TO_DELETE").get(Long.class);
 
-            String completeLink = row.column("COMPLETE_LINK").as(String.class);
-            String compensateLink = row.column("COMPENSATE_LINK").as(String.class);
-            String afterLink = row.column("AFTER_LINK").as(String.class);
-            String forgetLink = row.column("FORGET_LINK").as(String.class);
-            String statusLink = row.column("STATUS_LINK").as(String.class);
-            String participantStatus = row.column("PARTICIPANT_STATUS").as(String.class);
-            String compensateStatus = row.column("COMPENSATE_STATUS").as(String.class);
-            String forgetStatus = row.column("FORGET_STATUS").as(String.class);
-            String afterStatus = row.column("AFTER_LRA_STATUS").as(String.class);
-            String sendingStatus = row.column("SENDING_STATUS").as(String.class);
+            String completeLink = row.column("COMPLETE_LINK").get(String.class);
+            String compensateLink = row.column("COMPENSATE_LINK").get(String.class);
+            String afterLink = row.column("AFTER_LINK").get(String.class);
+            String forgetLink = row.column("FORGET_LINK").get(String.class);
+            String statusLink = row.column("STATUS_LINK").get(String.class);
+            String participantStatus = row.column("PARTICIPANT_STATUS").get(String.class);
+            String compensateStatus = row.column("COMPENSATE_STATUS").get(String.class);
+            String forgetStatus = row.column("FORGET_STATUS").get(String.class);
+            String afterStatus = row.column("AFTER_LRA_STATUS").get(String.class);
+            String sendingStatus = row.column("SENDING_STATUS").get(String.class);
 
-            Integer remainingCloseAttempts = row.column("REMAINING_CLOSE_ATTEMPTS").as(Integer.class);
-            Integer remainingAfterAttempts = row.column("REMAINING_AFTER_ATTEMPTS").as(Integer.class);
+            Integer remainingCloseAttempts = row.column("REMAINING_CLOSE_ATTEMPTS").get(Integer.class);
+            Integer remainingAfterAttempts = row.column("REMAINING_AFTER_ATTEMPTS").get(Integer.class);
             Lra lra = lraMap.get(lraId);
             if (lra == null) {
                 lra = new Lra(coordinatorService, lraId,

--- a/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/NonJaxRsResource.java
+++ b/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/NonJaxRsResource.java
@@ -108,9 +108,9 @@ class NonJaxRsResource {
 
         PropagatedHeaders propagatedHeaders = participantService.prepareCustomHeaderPropagation(headers.toMap());
 
-        String fqdn = path.value("fqdn");
-        String method = path.value("methodName");
-        String type = path.value("type");
+        String fqdn = path.get("fqdn");
+        String method = path.get("methodName");
+        String type = path.get("type");
 
         try {
             handleRequest(req, res, type, fqdn, method, lraId, parentId, propagatedHeaders);

--- a/microprofile/lra/jax-rs/src/test/java/io/helidon/microprofile/lra/CoordinatorHeaderPropagationTest.java
+++ b/microprofile/lra/jax-rs/src/test/java/io/helidon/microprofile/lra/CoordinatorHeaderPropagationTest.java
@@ -157,7 +157,7 @@ class CoordinatorHeaderPropagationTest {
                     closeHeadersCoordinator.putAll(req.headers().toMap());
                     String lraId = "http://localhost:" + port + "/lra-coordinator/" + req.path()
                             .pathParameters()
-                            .value("lraId");
+                            .get("lraId");
                     if (lraMap.get(lraId).get("complete") == null) {
                         //no complete resource
                         // after lra
@@ -204,7 +204,7 @@ class CoordinatorHeaderPropagationTest {
                     closeHeadersCoordinator.putAll(req.headers().toMap());
                     String lraId = "http://localhost:" + port + "/lra-coordinator/" + req.path()
                             .pathParameters()
-                            .value("lraId");
+                            .get("lraId");
 
                     try (Http1ClientResponse clientResponse = Http1Client.builder()
                             .baseUri(lraMap.get(lraId).get("compensate").toASCIIString())
@@ -227,7 +227,7 @@ class CoordinatorHeaderPropagationTest {
                     joinHeadersCoordinator.putAll(req.headers().toMap());
                     String lraId = "http://localhost:" + port + "/lra-coordinator/" + req.path()
                             .pathParameters()
-                            .value("lraId");
+                            .get("lraId");
                     String content = req.content().as(String.class);
 
                     for (String part : content.split(",")) {

--- a/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+import io.helidon.common.mapper.OptionalValue;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
@@ -373,7 +374,7 @@ public abstract class OpenApiFeature extends HelidonFeatureSupport {
          * Response media type default is application/vnd.oai.openapi (YAML)
          * unless otherwise specified.
          */
-        Optional<String> queryParameterFormat = req.query()
+        OptionalValue<String> queryParameterFormat = req.query()
                 .first(OPENAPI_ENDPOINT_FORMAT_QUERY_PARAMETER);
         if (queryParameterFormat.isPresent()) {
             String queryParameterFormatValue = queryParameterFormat.get();

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
@@ -166,7 +166,7 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         Optional<String> tenantId = Optional.empty();
         missingLocations.add("tenant-id-finder");
         if (oidcConfig.useParam()) {
-            tenantId = providerRequest.env().queryParams().first(oidcConfig.tenantParamName());
+            tenantId = providerRequest.env().queryParams().first(oidcConfig.tenantParamName()).asOptional();
 
             if (tenantId.isEmpty()) {
                 missingLocations.add("query-param");

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -187,7 +187,7 @@ class TenantAuthenticationHandler {
                 token = token.or(() -> PARAM_HEADER_HANDLER.extractToken(providerRequest.env().headers()));
 
                 if (token.isEmpty()) {
-                    token = token.or(() -> providerRequest.env().queryParams().first(oidcConfig.paramName()));
+                    token = token.or(() -> providerRequest.env().queryParams().first(oidcConfig.paramName()).asOptional());
                 }
 
                 if (token.isEmpty()) {

--- a/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/BookService.java
+++ b/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/BookService.java
@@ -18,15 +18,15 @@ package io.helidon.tests.apps.bookstore.se;
 
 import java.util.Collection;
 
-import io.helidon.http.Http;
 import io.helidon.config.Config;
+import io.helidon.http.Http;
+import io.helidon.tests.apps.bookstore.common.Book;
+import io.helidon.tests.apps.bookstore.common.BookMapper;
+import io.helidon.tests.apps.bookstore.common.BookStore;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
-import io.helidon.tests.apps.bookstore.common.Book;
-import io.helidon.tests.apps.bookstore.common.BookMapper;
-import io.helidon.tests.apps.bookstore.common.BookStore;
 
 import jakarta.json.JsonObject;
 
@@ -101,7 +101,7 @@ public class BookService implements HttpService {
     }
 
     private void getBook(ServerRequest request, ServerResponse response) {
-        String isbn = request.path().pathParameters().value(ISBN_PARAM);
+        String isbn = request.path().pathParameters().get(ISBN_PARAM);
         Book book = BOOK_STORE.find(isbn);
 
         if (book == null) {
@@ -148,7 +148,7 @@ public class BookService implements HttpService {
     }
 
     private void deleteBook(ServerRequest request, ServerResponse response) {
-        String isbn = request.path().pathParameters().value(ISBN_PARAM);
+        String isbn = request.path().pathParameters().get(ISBN_PARAM);
         if (BOOK_STORE.contains(isbn)) {
             BOOK_STORE.remove(isbn);
             response.send();

--- a/tests/integration/dbclient/app/src/main/java/io/helidon/tests/integration/dbclient/app/VerifyService.java
+++ b/tests/integration/dbclient/app/src/main/java/io/helidon/tests/integration/dbclient/app/VerifyService.java
@@ -18,12 +18,12 @@ package io.helidon.tests.integration.dbclient.app;
 import io.helidon.config.Config;
 import io.helidon.dbclient.DbClient;
 import io.helidon.dbclient.DbExecute;
+import io.helidon.tests.integration.dbclient.app.tests.AbstractService;
+import io.helidon.tests.integration.dbclient.app.tools.QueryParams;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
-import io.helidon.tests.integration.dbclient.app.tests.AbstractService;
-import io.helidon.tests.integration.dbclient.app.tools.QueryParams;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
@@ -59,8 +59,8 @@ public class VerifyService implements HttpService {
         JsonObject jsonObject = exec
                 .namedGet("get-pokemon-by-id", id)
                 .map(row -> Json.createObjectBuilder()
-                        .add("name", row.column("name").as(String.class))
-                        .add("id", row.column("id").as(Integer.class))
+                        .add("name", row.column("name").getString())
+                        .add("id", row.column("id").getInt())
                         .add("types", exec.namedQuery("get-pokemon-types", id)
                                 .map(typeRow -> typeRow.as(JsonObject.class))
                                 .collect(

--- a/tests/integration/dbclient/app/src/main/java/io/helidon/tests/integration/dbclient/app/dbmapper/DbRowToJsonObjectMapper.java
+++ b/tests/integration/dbclient/app/src/main/java/io/helidon/tests/integration/dbclient/app/dbmapper/DbRowToJsonObjectMapper.java
@@ -52,17 +52,17 @@ public class DbRowToJsonObjectMapper implements DbMapper<JsonObject> {
     public static final SimpleDateFormat DATE_TIME_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     static {
-        MAPPERS.put(Byte.class, (job, column) -> job.add(column.name(), column.as(Byte.class).intValue()));
-        MAPPERS.put(Short.class, (job, column) -> job.add(column.name(), column.as(Short.class).intValue()));
-        MAPPERS.put(Integer.class, (job, column) -> job.add(column.name(), column.as(Integer.class).intValue()));
-        MAPPERS.put(Long.class, (job, column) -> job.add(column.name(), column.as(Long.class).longValue()));
-        MAPPERS.put(Float.class, (job, column) -> job.add(column.name(), column.as(Float.class).doubleValue()));
-        MAPPERS.put(Double.class, (job, column) -> job.add(column.name(), column.as(Double.class).doubleValue()));
-        MAPPERS.put(BigInteger.class, (job, column) -> job.add(column.name(), column.as(BigInteger.class)));
-        MAPPERS.put(BigDecimal.class, (job, column) -> job.add(column.name(), column.as(BigDecimal.class)));
-        MAPPERS.put(String.class, (job, column) -> job.add(column.name(), column.as(String.class)));
-        MAPPERS.put(Character.class, (job, column) -> job.add(column.name(), column.as(Character.class).toString()));
-        MAPPERS.put(Boolean.class, (job, column) -> job.add(column.name(), column.as(Boolean.class)));
+        MAPPERS.put(Byte.class, (job, column) -> job.add(column.name(), column.get(Byte.class).intValue()));
+        MAPPERS.put(Short.class, (job, column) -> job.add(column.name(), column.get(Short.class).intValue()));
+        MAPPERS.put(Integer.class, (job, column) -> job.add(column.name(), column.get(Integer.class)));
+        MAPPERS.put(Long.class, (job, column) -> job.add(column.name(), column.get(Long.class)));
+        MAPPERS.put(Float.class, (job, column) -> job.add(column.name(), column.get(Float.class).doubleValue()));
+        MAPPERS.put(Double.class, (job, column) -> job.add(column.name(), column.get(Double.class)));
+        MAPPERS.put(BigInteger.class, (job, column) -> job.add(column.name(), column.get(BigInteger.class)));
+        MAPPERS.put(BigDecimal.class, (job, column) -> job.add(column.name(), column.get(BigDecimal.class)));
+        MAPPERS.put(String.class, (job, column) -> job.add(column.name(), column.get(String.class)));
+        MAPPERS.put(Character.class, (job, column) -> job.add(column.name(), column.get(Character.class).toString()));
+        MAPPERS.put(Boolean.class, (job, column) -> job.add(column.name(), column.get(Boolean.class)));
         MAPPERS.put(java.sql.Date.class, (job, column) -> job.add(column.name(), DATE_FORMATTER.format(column.as(java.sql.Date.class))));
         MAPPERS.put(java.sql.Time.class, (job, column) -> job.add(column.name(), TIME_FORMATTER.format(column.as(java.sql.Time.class))));
         MAPPERS.put(java.sql.Timestamp.class, (job, column) -> job.add(column.name(), DATE_TIME_FORMATTER.format(column.as(java.sql.Timestamp.class))));
@@ -81,7 +81,7 @@ public class DbRowToJsonObjectMapper implements DbMapper<JsonObject> {
             if (mapper != null) {
                 mapper.accept(job, dbColumn);
             } else {
-                job.add(dbColumn.name(), dbColumn.value().toString());
+                job.add(dbColumn.name(), dbColumn.get().toString());
             }
         });
         return job.build();

--- a/tests/integration/dbclient/app/src/main/java/io/helidon/tests/integration/dbclient/app/tests/FlowControlService.java
+++ b/tests/integration/dbclient/app/src/main/java/io/helidon/tests/integration/dbclient/app/tests/FlowControlService.java
@@ -22,11 +22,11 @@ import java.util.stream.Stream;
 
 import io.helidon.dbclient.DbClient;
 import io.helidon.dbclient.DbRow;
+import io.helidon.tests.integration.dbclient.common.model.Type;
+import io.helidon.tests.integration.harness.RemoteTestException;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
-import io.helidon.tests.integration.dbclient.common.model.Type;
-import io.helidon.tests.integration.harness.RemoteTestException;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -76,8 +76,8 @@ public class FlowControlService extends AbstractService {
             throw new RemoteTestException("Rows list size shall be 18.");
         }
         for (DbRow row : list) {
-            Integer id = row.column(1).as(Integer.class);
-            String name = row.column(2).as(String.class);
+            Integer id = row.column(1).get(Integer.class);
+            String name = row.column(2).get(String.class);
             Type type = new Type(id, name);
             if (!Type.TYPES.get(id).name().equals(name)) {
                 throw new RemoteTestException("Expected type name \"%s\", but got \"%s\".",

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/model/Pokemon.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/model/Pokemon.java
@@ -44,7 +44,7 @@ public class Pokemon {
 
         @Override
         public Pokemon read(DbRow row) {
-            return new Pokemon(row.column("id").as(Integer.class), row.column("name").as(String.class));
+            return new Pokemon(row.column("id").get(Integer.class), row.column("name").get(String.class));
         }
 
         @Override

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/FlowControlIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/FlowControlIT.java
@@ -21,8 +21,8 @@ import java.util.stream.Stream;
 
 import io.helidon.dbclient.DbClient;
 import io.helidon.dbclient.DbRow;
-
 import io.helidon.tests.integration.dbclient.common.model.Type;
+
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.tests.integration.dbclient.common.model.Type.TYPES;
@@ -57,8 +57,8 @@ public class FlowControlIT {
         assertThat(list, not(empty()));
         assertThat(list.size(), equalTo(18));
         for (DbRow row : list) {
-            Integer id = row.column(1).as(Integer.class);
-            String name = row.column(2).as(String.class);
+            Integer id = row.column(1).get(Integer.class);
+            String name = row.column(2).get(String.class);
             Type type = new Type(id, name);
             assertThat(name, TYPES.get(id).name().equals(name));
             LOGGER.log(Level.DEBUG, () -> String.format("Type: %s", type));

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/utils/VerifyData.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/utils/VerifyData.java
@@ -58,8 +58,8 @@ public class VerifyData {
         List<DbRow> rowsList = rows.toList();
         assertThat(rowsList, hasSize(valid.size()));
         for (DbRow row : rowsList) {
-            Integer id = row.column(1).as(Integer.class);
-            String name = row.column(2).as(String.class);
+            Integer id = row.column(1).get(Integer.class);
+            String name = row.column(2).get(String.class);
             LOGGER.log(Level.INFO, () -> String.format("Pokemon id=%d, name=%s", id, name));
             assertThat(valid.containsKey(id), equalTo(true));
             assertThat(name, equalTo(valid.get(id).getName()));
@@ -77,8 +77,8 @@ public class VerifyData {
         Map<Integer, Pokemon> valid = range(idMin, idMax);
         assertThat(maybeRow.isPresent(), equalTo(true));
         DbRow row = maybeRow.get();
-        Integer id = row.column(1).as(Integer.class);
-        String name = row.column(2).as(String.class);
+        Integer id = row.column(1).get(Integer.class);
+        String name = row.column(2).get(String.class);
         assertThat(valid.containsKey(id), equalTo(true));
         assertThat(name, equalTo(valid.get(id).getName()));
     }
@@ -93,8 +93,8 @@ public class VerifyData {
         assertThat(rows, notNullValue());
         assertThat(rows, hasSize(1));
         DbRow row = rows.get(0);
-        Integer id = row.column(1).as(Integer.class);
-        String name = row.column(2).as(String.class);
+        Integer id = row.column(1).get(Integer.class);
+        String name = row.column(2).get(String.class);
         assertThat(id, equalTo(expected.getId()));
         assertThat(name, expected.getName().equals(name));
     }
@@ -119,8 +119,8 @@ public class VerifyData {
     public static void verifyPokemon(Optional<DbRow> maybeRow, Pokemon expected) {
         assertThat(maybeRow.isPresent(), equalTo(true));
         DbRow row = maybeRow.get();
-        Integer id = row.column(1).as(Integer.class);
-        String name = row.column(2).as(String.class);
+        Integer id = row.column(1).get(Integer.class);
+        String name = row.column(2).get(String.class);
         assertThat(id, equalTo(expected.getId()));
         assertThat(name, expected.getName().equals(name));
     }
@@ -150,8 +150,8 @@ public class VerifyData {
 
         assertThat(maybeRow.isPresent(), equalTo(true));
         DbRow row = maybeRow.get();
-        Integer id = row.column("id").as(Integer.class);
-        String name = row.column("name").as(String.class);
+        Integer id = row.column("id").get(Integer.class);
+        String name = row.column("name").get(String.class);
         assertThat(id, equalTo(data.getId()));
         assertThat(name, data.getName().equals(name));
     }

--- a/tests/integration/gh-5792/src/main/java/io/helidon/tests/integration/yamlparsing/GreetService.java
+++ b/tests/integration/gh-5792/src/main/java/io/helidon/tests/integration/yamlparsing/GreetService.java
@@ -87,7 +87,7 @@ class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
         sendResponse(response, name);
     }
 

--- a/tests/integration/native-image/se-1/src/main/java/io/helidon/tests/integration/nativeimage/se1/GreetService.java
+++ b/tests/integration/native-image/se-1/src/main/java/io/helidon/tests/integration/nativeimage/se1/GreetService.java
@@ -20,8 +20,8 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import io.helidon.http.Http;
 import io.helidon.config.Config;
+import io.helidon.http.Http;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.ServerRequest;
@@ -93,7 +93,7 @@ class GreetService implements HttpService {
      */
     private void getMessageHandler(ServerRequest request,
                                    ServerResponse response) {
-        String name = request.path().pathParameters().value("name");
+        String name = request.path().pathParameters().get("name");
 
         sendResponse(response, name);
     }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientUriTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientUriTest.java
@@ -20,6 +20,7 @@ import java.net.URI;
 
 import io.helidon.common.uri.UriPath;
 import io.helidon.common.uri.UriQueryWriteable;
+
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -70,9 +71,9 @@ class ClientUriTest {
         assertThat(helper.path(), is(UriPath.create("/loom/quick")));
         assertThat(helper.port(), is(8080));
         assertThat(helper.scheme(), is("http"));
-        assertThat(helper.query().value("p1"), is("v1"));
-        assertThat(helper.query().value("p2"), is("v2"));
-        assertThat(helper.query().value("p3"), is("//v3//"));
+        assertThat(helper.query().get("p1"), is("v1"));
+        assertThat(helper.query().get("p2"), is("v2"));
+        assertThat(helper.query().get("p3"), is("//v3//"));
         assertThat(helper.query().getRaw("p3"), is("%2F%2Fv3%2F%2F"));
     }
 

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -784,7 +784,7 @@ class Http1ClientTest {
                         entitySize += chunkLength;
                     }
                 } else if (reqHeaders.contains(Http.HeaderNames.CONTENT_LENGTH)) {
-                    entitySize = reqHeaders.get(Http.HeaderNames.CONTENT_LENGTH).value(int.class);
+                    entitySize = reqHeaders.get(Http.HeaderNames.CONTENT_LENGTH).get(int.class);
                     if (entitySize > 0) {
                         entity.write(serverReader.getBuffer(entitySize));
                     }
@@ -800,7 +800,7 @@ class Http1ClientTest {
                     resHeaders.set(REQ_EXPECT_100_HEADER_NAME);
                 }
                 if (reqHeaders.contains(Http.HeaderNames.CONTENT_LENGTH)) {
-                    resHeaders.set(REQ_CONTENT_LENGTH_HEADER_NAME, reqHeaders.get(Http.HeaderNames.CONTENT_LENGTH).value());
+                    resHeaders.set(REQ_CONTENT_LENGTH_HEADER_NAME, reqHeaders.get(Http.HeaderNames.CONTENT_LENGTH).get());
                 }
                 if (reqHeaders.contains(Http.Headers.TRANSFER_ENCODING_CHUNKED)) {
                     resHeaders.set(REQ_CHUNKED_HEADER);
@@ -820,7 +820,7 @@ class Http1ClientTest {
             resHeaders.add(Http.HeaderNames.CONTENT_LENGTH, Integer.toString(entitySize));
             BufferData entityBuffer = BufferData.growing(128);
             for (Http.Header header : resHeaders) {
-                header.writeHttp1Header(entityBuffer);
+header.writeHttp1Header(entityBuffer);
             }
             entityBuffer.write(Bytes.CR_BYTE);
             entityBuffer.write(Bytes.LF_BYTE);

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WebClientTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2WebClientTest.java
@@ -31,22 +31,19 @@ import java.util.stream.Stream;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.configurable.Resource;
-import io.helidon.http.Http;
 import io.helidon.common.pki.Keys;
 import io.helidon.common.tls.Tls;
+import io.helidon.http.Http;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http1.Http1Route;
 import io.helidon.webserver.http2.Http2Config;
 import io.helidon.webserver.http2.Http2ConnectionSelector;
 import io.helidon.webserver.http2.Http2Route;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpServer;
-import io.helidon.webserver.WebServer;
-import io.helidon.webserver.WebServerConfig;
-import io.helidon.webserver.http1.Http1Route;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -137,24 +134,24 @@ class Http2WebClientTest {
                         .route(Http1Route.route(GET, "/versionspecific", (req, res) -> res.send("HTTP/1.1 route")))
                         .route(Http2Route.route(GET, "/versionspecific", (req, res) -> {
                             res.header(CLIENT_USER_AGENT_HEADER_NAME, req.headers().get(USER_AGENT).value());
-                            res.header(SERVER_HEADER_FROM_PARAM_NAME, req.query().value("custQueryParam"));
+                            res.header(SERVER_HEADER_FROM_PARAM_NAME, req.query().get("custQueryParam"));
                             res.send("HTTP/2 route");
                         }))
                         .route(Http2Route.route(PUT, "/versionspecific", (req, res) -> {
                             res.header(SERVER_CUSTOM_HEADER_NAME, req.headers().get(CLIENT_CUSTOM_HEADER_NAME).value());
                             res.header(CLIENT_USER_AGENT_HEADER_NAME, req.headers().get(USER_AGENT).value());
-                            res.header(SERVER_HEADER_FROM_PARAM_NAME, req.query().value("custQueryParam"));
+                            res.header(SERVER_HEADER_FROM_PARAM_NAME, req.query().get("custQueryParam"));
                             res.send("PUT " + req.content().as(String.class));
                         }))
                         .route(Http2Route.route(POST, "/versionspecific", (req, res) -> {
                             res.header(SERVER_CUSTOM_HEADER_NAME, req.headers().get(CLIENT_CUSTOM_HEADER_NAME).value());
                             res.header(CLIENT_USER_AGENT_HEADER_NAME, req.headers().get(USER_AGENT).value());
-                            res.header(SERVER_HEADER_FROM_PARAM_NAME, req.query().value("custQueryParam"));
+                            res.header(SERVER_HEADER_FROM_PARAM_NAME, req.query().get("custQueryParam"));
                             res.send("POST " + req.content().as(String.class));
                         }))
                         .route(Http2Route.route(GET, "/versionspecific/h2streaming", (req, res) -> {
                             res.status(Http.Status.OK_200);
-                            String execId = req.query().value("execId");
+                            String execId = req.query().get("execId");
                             try (OutputStream os = res.outputStream()) {
                                 for (int i = 0; i < 5; i++) {
                                     os.write(String.format(execId + "BAF%03d", i).getBytes());

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -36,9 +36,6 @@ import io.helidon.http.media.EntityReader;
 import io.helidon.http.media.EntityWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaContextConfig;
-import io.helidon.webclient.http2.Http2Client;
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.api.HttpClientRequest;
@@ -49,6 +46,8 @@ import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import org.junit.jupiter.api.Test;
 
@@ -83,7 +82,7 @@ class Http1ClientTest {
 
     Http1ClientTest(WebServer webServer, WebClient client) {
         baseURI = "http://localhost:" + webServer.port();
-        this.plainPort = webServer.port();
+        plainPort = webServer.port();
         injectedHttp1client = client;
     }
 
@@ -480,7 +479,7 @@ class Http1ClientTest {
             res.headers().set(REQ_EXPECT_100_HEADER_NAME);
         }
         if (reqHeaders.contains(Http.HeaderNames.CONTENT_LENGTH)) {
-            res.headers().set(REQ_CONTENT_LENGTH_HEADER_NAME, reqHeaders.get(Http.HeaderNames.CONTENT_LENGTH).value());
+            res.headers().set(REQ_CONTENT_LENGTH_HEADER_NAME, reqHeaders.get(Http.HeaderNames.CONTENT_LENGTH).get());
         }
         if (reqHeaders.contains(Http.Headers.TRANSFER_ENCODING_CHUNKED)) {
             res.headers().set(REQ_CHUNKED_HEADER);

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/SharedCacheTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/SharedCacheTest.java
@@ -95,13 +95,13 @@ class SharedCacheTest {
 
             Integer firstReqClientPort;
             try (var res = webClient.post().submit("WHATEVER")) {
-                firstReqClientPort = res.headers().get(clientPortHeader).value(Integer.TYPE);
+                firstReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
                 assertThat(res.status(), is(Http.Status.OK_200));
             }
 
             Integer secondReqClientPort;
             try (var res = webClient.post().submit("WHATEVER")) {
-                secondReqClientPort = res.headers().get(clientPortHeader).value(Integer.TYPE);
+                secondReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
                 assertThat(res.status(), is(Http.Status.OK_200));
             }
 

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/StatusLineTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/StatusLineTest.java
@@ -16,13 +16,13 @@
 
 package io.helidon.webclient.tests;
 
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,12 +45,12 @@ class StatusLineTest {
     static void routing(HttpRules rules) {
         rules.get("/status/{code}", (
                         (req, res) -> {
-                            int code = Integer.parseInt(req.path().pathParameters().value("code"));
+                            int code = Integer.parseInt(req.path().pathParameters().get("code"));
                             res.status(code);
                             res.send();
                         }))
                 .get("/{code}", (req, res) -> {
-                    int code = Integer.parseInt(req.path().pathParameters().value("code"));
+                    int code = Integer.parseInt(req.path().pathParameters().get("code"));
                     try (HttpClientResponse clientRes = client.get("/status/" + code).request()) {
                         res.send("got : " + clientRes.status().code());
                     }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -356,7 +356,7 @@ public class Http2ServerStream implements Runnable, Http2Stream {
     private void handle() {
         Headers httpHeaders = headers.httpHeaders();
         if (httpHeaders.contains(Http.HeaderNames.CONTENT_LENGTH)) {
-            this.expectedLength = httpHeaders.get(HeaderNames.CONTENT_LENGTH).value(long.class);
+            this.expectedLength = httpHeaders.get(HeaderNames.CONTENT_LENGTH).get(long.class);
         }
 
         subProtocolHandler = null;
@@ -383,7 +383,7 @@ public class Http2ServerStream implements Runnable, Http2Stream {
             ContentDecoder decoder;
             if (contentEncodingContext.contentDecodingEnabled()) {
                 if (httpHeaders.contains(Http.HeaderNames.CONTENT_ENCODING)) {
-                    String contentEncoding = httpHeaders.get(Http.HeaderNames.CONTENT_ENCODING).value();
+                    String contentEncoding = httpHeaders.get(Http.HeaderNames.CONTENT_ENCODING).get();
                     if (contentEncodingContext.contentDecodingSupported(contentEncoding)) {
                         decoder = contentEncodingContext.decoder(contentEncoding);
                     } else {

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigService.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigService.java
@@ -92,7 +92,7 @@ class ConfigService implements HttpService {
     }
 
     private void value(ServerRequest req, ServerResponse res) {
-        String name = req.path().pathParameters().value("name");
+        String name = req.path().pathParameters().get("name");
 
         ConfigValue<String> value = GlobalConfig.config().get(name).asString();
         if (value.isPresent()) {

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/SingleCheckHandler.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/SingleCheckHandler.java
@@ -57,7 +57,7 @@ class SingleCheckHandler implements Handler {
 
     @Override
     public void handle(ServerRequest req, ServerResponse res) {
-        String name = req.path().pathParameters().value("name");
+        String name = req.path().pathParameters().get("name");
         HealthCheck check = checks.get(name);
         if (check == null) {
             throw new NotFoundException(name);

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoService.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoService.java
@@ -56,7 +56,7 @@ class InfoService implements HttpService {
     }
 
     private void namedInfo(ServerRequest req, ServerResponse res) {
-        String name = req.path().pathParameters().value("name");
+        String name = req.path().pathParameters().get("name");
 
         Object value = info.get(name);
         if (value == null) {

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -348,7 +348,7 @@ public class MetricsFeature extends HelidonFeatureSupport {
         }
 
         private void optionsByName(ServerRequest req, ServerResponse res, Iterable<String> scopeSelection) {
-            String metricName = req.path().pathParameters().value("metric");
+            String metricName = req.path().pathParameters().get("metric");
             optionsMatching(req, res, scopeSelection, Set.of(metricName));
         }
 

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -330,7 +330,7 @@ public class MetricsFeature extends HelidonFeatureSupport {
     }
 
     private void getByName(ServerRequest req, ServerResponse res, Iterable<String> scopeSelection) {
-        String metricName = req.path().pathParameters().value("metric");
+        String metricName = req.path().pathParameters().get("metric");
         getMatching(req, res, scopeSelection, Set.of(metricName));
     }
 

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -25,16 +25,16 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.configurable.LruCache;
+import io.helidon.common.parameters.Parameters;
+import io.helidon.common.uri.UriFragment;
+import io.helidon.common.uri.UriPath;
+import io.helidon.common.uri.UriQuery;
 import io.helidon.http.Http;
 import io.helidon.http.HttpException;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.ServerResponseHeaders;
-import io.helidon.common.parameters.Parameters;
-import io.helidon.common.uri.UriFragment;
-import io.helidon.common.uri.UriPath;
-import io.helidon.common.uri.UriQuery;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
@@ -236,7 +236,7 @@ class StaticContentHandlerTest {
         when(request.path()).thenReturn(new RoutedPath() {
             @Override
             public Parameters pathParameters() {
-                return Parameters.empty("unit-template-params");
+                return Parameters.empty("http/path");
             }
 
             @Override

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ServerTest.java
@@ -25,15 +25,11 @@ import java.time.Duration;
 import java.util.Optional;
 
 import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.Keys;
+import io.helidon.common.tls.Tls;
 import io.helidon.http.Http;
 import io.helidon.http.Http.Header;
 import io.helidon.http.Http.HeaderNames;
-import io.helidon.common.pki.Keys;
-import io.helidon.common.tls.Tls;
-import io.helidon.webserver.http2.Http2Route;
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpRoute;
-import io.helidon.webserver.testing.junit5.SetUpServer;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServer;
@@ -41,6 +37,10 @@ import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -178,6 +178,6 @@ class Http2ServerTest {
     }
 
     private static void queryEndpoint(ServerRequest req, ServerResponse res) {
-        res.send(req.query().value("param"));
+        res.send(req.query().get("param"));
     }
 }

--- a/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
+++ b/webserver/tests/upgrade/src/test/java/io/helidon/webserver/tests/upgrade/test/SharedHttp2CacheTest.java
@@ -78,7 +78,7 @@ class SharedHttp2CacheTest {
 
             Integer firstReqClientPort;
             try (var res = webClient.post().submit("WHATEVER")) {
-                firstReqClientPort = res.headers().get(clientPortHeader).value(Integer.TYPE);
+                firstReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
                 assertThat(res.status(), is(Http.Status.OK_200));
             }
 
@@ -94,7 +94,7 @@ class SharedHttp2CacheTest {
 
             Integer secondReqClientPort;
             try (var res = webClient.post().submit("WHATEVER")) {
-                secondReqClientPort = res.headers().get(clientPortHeader).value(Integer.TYPE);
+                secondReqClientPort = res.headers().get(clientPortHeader).get(Integer.TYPE);
                 assertThat(res.status(), is(Http.Status.OK_200));
             }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ResponseOrderingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ResponseOrderingTest.java
@@ -24,10 +24,10 @@ import java.util.ArrayList;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import io.helidon.http.Http;
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import org.junit.jupiter.api.Test;
 
@@ -56,7 +56,7 @@ class ResponseOrderingTest {
     @SetUpRoute
     static void routing(HttpRules rules) {
         rules.any("/multi", (req, res) -> {
-                    long requestId = Long.parseLong(req.query().value("id"));
+                    long requestId = Long.parseLong(req.query().get("id"));
                     queue.add(requestId);
                     res.status(Http.Status.CREATED_201)
                             .send("" + requestId);

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/UriEncodingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/UriEncodingTest.java
@@ -16,12 +16,12 @@
 
 package io.helidon.webserver.tests;
 
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.Http;
-import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
-import io.helidon.webserver.http.HttpRules;
 
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +40,7 @@ class UriEncodingTest {
     @SetUpRoute
     static void routing(HttpRules rules) {
         rules.get("/foo", (req, res) -> res.send("It works!"))
-                .get("/foo/{bar}", (req, res) -> res.send(req.path().pathParameters().value("bar")));
+                .get("/foo/{bar}", (req, res) -> res.send(req.path().pathParameters().get("bar")));
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -33,6 +33,7 @@ public interface WebServer extends RuntimeType.Api<WebServerConfig> {
      * The default server socket configuration name. All the default server socket
      * configuration such as {@link WebServer#port(String)}
      * is accessible using this name.
+     * The value is {@value}.
      */
     String DEFAULT_SOCKET_NAME = "@default";
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/Filters.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/Filters.java
@@ -130,7 +130,7 @@ public final class Filters implements ServerLifecycle {
     }
 
     private static final class FilterRoutedPath implements RoutedPath {
-        private static final Parameters EMPTY_PARAMS = Parameters.empty("filter-path-template");
+        private static final Parameters EMPTY_PARAMS = Parameters.empty("http/path");
 
         private final UriPath uriPath;
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RouteCrawler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RouteCrawler.java
@@ -144,7 +144,7 @@ class RouteCrawler {
                 newParams.put(paramName, params.all(paramName));
             }
             newParams.replaceAll((name, values) -> List.copyOf(values));
-            RoutedPath result = new CrawlerRoutedPath(path, Parameters.create("path-template-parameters", newParams));
+            RoutedPath result = new CrawlerRoutedPath(path, Parameters.create("http/path", newParams));
             return new CrawlerItem(result, handler);
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -145,7 +145,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
 
                 if (canUpgrade) {
                     if (headers.contains(Http.HeaderNames.UPGRADE)) {
-                        Http1Upgrader upgrader = upgradeProviderMap.get(headers.get(Http.HeaderNames.UPGRADE).value());
+                        Http1Upgrader upgrader = upgradeProviderMap.get(headers.get(Http.HeaderNames.UPGRADE).get());
                         if (upgrader != null) {
                             ServerConnection upgradeConnection = upgrader.upgrade(ctx, prologue, headers);
                             // upgrader may decide not to upgrade this connection
@@ -292,7 +292,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
             this.currentEntitySize = -1;
         } else if (headers.contains(Http.HeaderNames.CONTENT_LENGTH)) {
             try {
-                this.currentEntitySize = headers.get(Http.HeaderNames.CONTENT_LENGTH).value(long.class);
+                this.currentEntitySize = headers.get(Http.HeaderNames.CONTENT_LENGTH).get(long.class);
                 if (maxPayloadSize != -1 && currentEntitySize > maxPayloadSize) {
                     throw RequestException.builder()
                             .type(EventType.BAD_REQUEST)
@@ -346,7 +346,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         if (contentEncodingContext.contentDecodingEnabled()) {
             // there may be some decoder used
             if (headers.contains(Http.HeaderNames.CONTENT_ENCODING)) {
-                String contentEncoding = headers.get(Http.HeaderNames.CONTENT_ENCODING).value();
+                String contentEncoding = headers.get(Http.HeaderNames.CONTENT_ENCODING).get();
                 if (contentEncodingContext.contentDecodingSupported(contentEncoding)) {
                     decoder = contentEncodingContext.decoder(contentEncoding);
                 } else {


### PR DESCRIPTION
### Description
Resolves #1897 (mappable query params and path params)
Related to #1789 (align mappers)

### Documentation
This change introduces a few API changes that are needed to align method names and to implement the same interfaces.

#### New types
- `io.helidon.common.mapper.Value<T>` - a value, that supports mapping and a subset of `Optional` methods
- `io.helidon.common.mapper.OptionalValue<T>` - a value that may be empty, that supports mapping and full set of `Optional` methods (also extends `Value<T>`)

#### Modified types
- `io.helidon.common.config.ConfigValue` now extends `OptionalValue` (transitive impact on `io.helidon.config.ConfigValue`)
- `io.helidon.common.parameters.Parameters` now return `OptionalValue` instead of `Optional` in method `first`
- `io.helidon.common.parameters.Parameters` - renamed method `value` to `get`
- `Parameters` changes have transitive impact on `UriQuery`, `Uri` matrix parameters, `Uri` path parameters
- `io.helidon.dbclient.DbColumn` now implements `Value<String>` - as a result, methods `as(..)` are now renamed to `get(...)`, as they return an actual value, and method `value` is renamed to `get` (inherited from `Value`)

A very important change:
`io.helidon.http.Http.Header`:
- now extends `Value<String>`
- method `value()` will be removed, all usages should be replaced wil `.get()` (will create a follow up)
- method `value(Class<T>)` is removed

Example code:

HTTP headers (header once retrieved must have a value):
`req.headers().get(CONTENT_LENGTH).getLong()`

Query parameters (optional value):
`req.query().first("count").asInt().orElse(10)`

