### PR TITLE
4.x: Fix source and javadoc jars required for oss staging

### DIFF
--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -35,7 +35,6 @@
 
     <properties>
         <spotbugs.skip>true</spotbugs.skip>
-        <maven.source.skip>true</maven.source.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
@@ -161,6 +160,30 @@
                                 <helidon.histogram.tolerance>0.25</helidon.histogram.tolerance>
                             </systemPropertyVariables>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>releaseX</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>empty-javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.build.directory}/javadoc</classesDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -165,7 +165,7 @@
             </build>
         </profile>
         <profile>
-            <id>releaseX</id>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>

--- a/metrics/provider-tests/pom.xml
+++ b/metrics/provider-tests/pom.xml
@@ -29,6 +29,8 @@
     <name>Helidon Metrics Provider Tests</name>
 
     <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.sources.skip>true</maven.sources.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 

--- a/webclient/webclient/pom.xml
+++ b/webclient/webclient/pom.xml
@@ -28,7 +28,6 @@
     <name>Helidon WebClient</name>
 
     <properties>
-        <maven.sources.skip>true</maven.sources.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <spotbugs.skip>true</spotbugs.skip>
     </properties>
@@ -43,4 +42,32 @@
             <artifactId>helidon-webclient-http1</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>empty-javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.build.directory}/javadoc</classesDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
### Description

Fixes issues with release which requires javadoc and source jar files.
* Ensure new `metrics/metrics` has source and (empty) javadoc jar
* Ensure `webclient/webclient` has (empty) javadoc jar
* Don't deploy `metrics/provider-tests`

### Documentation

No impact