### PR TITLE
Add missing permutations in archetype integration tests

### DIFF
--- a/archetypes/helidon/filters.properties
+++ b/archetypes/helidon/filters.properties
@@ -36,9 +36,6 @@ health=!${health} || (${health.builtin})
 # force metrics.builtin=true
 metrics=!${metrics} || (${metrics.builtin})
 
-# force metrics.provider='microprofile' when tracing=true
-tracing=!${tracing} || (${tracing} && ${metrics.provider} == 'microprofile')
-
 # group extra options
 extra=${extra} == [] || ${extra} == ['cors', 'fault-tolerance'] || \
   (${flavor} == 'se' && ${extra} == ['webclient', 'cors', 'fault-tolerance'])


### PR DESCRIPTION
### Description

Update archetype filter to add missing tests.
fix #7508 

### Documentation

no impact
