### PR TITLE
4.x: introduce AfterStop annotation

### DIFF
--- a/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/AfterStop.java
+++ b/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/AfterStop.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Mark a static method to be executed after the container is stopped.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AfterStop {
+}

--- a/microprofile/tests/server/pom.xml
+++ b/microprofile/tests/server/pom.xml
@@ -20,41 +20,45 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://maven.apache.org/POM/4.0.0"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.microprofile</groupId>
-        <artifactId>helidon-microprofile-project</artifactId>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tests-project</artifactId>
         <version>4.0.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
-    <groupId>io.helidon.microprofile.tests</groupId>
-    <artifactId>tests-project</artifactId>
-    <name>Helidon Microprofile Tests</name>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>helidon-microprofile-tests-server</artifactId>
+    <name>Helidon Microprofile Tests Server</name>
+
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.sources.skip>true</maven.sources.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <spotbugs.skip>true</spotbugs.skip>
+        <checkstyle.skip>true</checkstyle.skip>
         <dependency-check.skip>true</dependency-check.skip>
         <helidon.services.skip>true</helidon.services.skip>
     </properties>
 
-    <modules>
-        <module>arquillian</module>
-        <module>junit5</module>
-        <module>junit5-tests</module>
-        <module>testng</module>
-        <module>testng-tests</module>
-        <module>server</module>
-    </modules>
-
-    <profiles>
-        <profile>
-            <id>tck</id>
-            <modules>
-                <module>tck</module>
-            </modules>
-        </profile>
-    </profiles>
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/microprofile/tests/server/src/test/resources/application.yaml
+++ b/microprofile/tests/server/src/test/resources/application.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mp.initializer:
+  allow: true
+  no-warn: true

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/AfterStop.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/AfterStop.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.testing.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Mark a static method to be executed after the container is stopped.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AfterStop {
+}

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.testing.junit5;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+abstract class JunitExtensionBase implements AfterAllCallback {
+    private Class<?> testClass;
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        callAfterStop();
+    }
+
+    void testClass(Class<?> testClass) {
+        this.testClass = testClass;
+    }
+
+    Class<?> testClass() {
+        return testClass;
+    }
+
+    private void callAfterStop() {
+        if (testClass == null) {
+            return;
+        }
+
+        List<Method> toInvoke = new ArrayList<>();
+
+        Method[] methods = testClass.getMethods();
+        for (Method method : methods) {
+            AfterStop annotation = method.getAnnotation(AfterStop.class);
+            if (annotation != null) {
+                if (method.getParameterCount() != 0) {
+                    throw new IllegalStateException("Method " + method + " is annotated with @AfterStop, but it has parameters");
+                }
+                if (Modifier.isStatic(method.getModifiers())) {
+                    method.setAccessible(true);
+                    toInvoke.add(method);
+                } else {
+                    throw new IllegalStateException("Method " + method + " is annotated with @AfterStop, but it is not static");
+                }
+            }
+        }
+
+        for (Method method : toInvoke) {
+            try {
+                method.invoke(testClass);
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to invoke method: " + method, e);
+            }
+        }
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/LifecycleMethodAnnotatedTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/LifecycleMethodAnnotatedTest.java
@@ -1,0 +1,68 @@
+package io.helidon.webserver.tests;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class LifecycleMethodAnnotatedTest {
+    private static final TestFeature FEATURE = new TestFeature();
+
+    @SetUpRoute
+    static void setUpRoute(HttpRouting.Builder http) {
+        http.addFeature(FEATURE);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        assertThat("Before start should only have been called on server startup", FEATURE.beforeStart.get(), is(1));
+        assertThat("After stop should have been called on server stop", FEATURE.afterStop.get(), is(1));
+    }
+
+    @Test
+    void testLifecycleMethodsCalled(WebClient webClient) {
+        ClientResponseTyped<String> request = webClient.get()
+                .request(String.class);
+
+        assertThat(request.entity(), is("works"));
+
+        assertThat("Before start should have been called on server startup", FEATURE.beforeStart.get(), is(1));
+        assertThat("After stop should not have been called on server startup", FEATURE.afterStop.get(), is(0));
+    }
+
+    private static final class TestFeature implements HttpFeature {
+        final AtomicInteger beforeStart = new AtomicInteger();
+        final AtomicInteger afterStop = new AtomicInteger();
+
+        @Override
+        public void setup(HttpRouting.Builder routing) {
+            routing.get("/", (req, res) -> res.send("works"));
+        }
+
+        @Override
+        public void beforeStart() {
+            beforeStart.incrementAndGet();
+        }
+
+        @Override
+        public void afterStop() {
+            afterStop.incrementAndGet();
+        }
+
+        void reset() {
+            beforeStart.set(0);
+            afterStop.set(0);
+        }
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/LifecycleMethodTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/LifecycleMethodTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.helidon.webserver.tests;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/LifecycleMethodTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/LifecycleMethodTest.java
@@ -1,0 +1,66 @@
+package io.helidon.webserver.tests;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRouting;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class LifecycleMethodTest {
+    private static final TestFeature FEATURE = new TestFeature();
+
+    static void setUpRoute(HttpRouting.Builder http) {
+        http.addFeature(FEATURE);
+    }
+
+    @BeforeEach
+    void resetCounter() {
+        FEATURE.reset();
+    }
+
+    @RepeatedTest(10)
+    void testLifecycleMethodsCalled() {
+        WebServer server = WebServer.builder()
+                .routing(LifecycleMethodTest::setUpRoute)
+                .build()
+                .start();
+        server.start();
+        assertThat("Before start should have been called on server startup", FEATURE.beforeStart.get(), is(1));
+        assertThat("After stop should not have been called on server startup", FEATURE.afterStop.get(), is(0));
+
+        server.stop();
+        assertThat("Before start should only have been called on server startup", FEATURE.beforeStart.get(), is(1));
+        assertThat("After stop should have been called on server stop", FEATURE.afterStop.get(), is(1));
+    }
+
+    private static final class TestFeature implements HttpFeature {
+        final AtomicInteger beforeStart = new AtomicInteger();
+        final AtomicInteger afterStop = new AtomicInteger();
+
+        @Override
+        public void setup(HttpRouting.Builder routing) {
+            routing.get("/", (req, res) -> res.send("works"));
+        }
+
+        @Override
+        public void beforeStart() {
+            beforeStart.incrementAndGet();
+        }
+
+        @Override
+        public void afterStop() {
+            afterStop.incrementAndGet();
+        }
+
+        void reset() {
+            beforeStart.set(0);
+            afterStop.set(0);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Resolves #7518 
We cannot validate tasks done on server shutdown (both SE and MP), as `@AfterAll` is called first on the test class, and then on our extension.

### Documentation
This PR introduces `@AfterStop` annotation, that can be placed on a static method and validate things that should be done during shutdown. This is valid both for our MP testing (`@HelidonTest` annotation), and SE testing (`@ServerTest`, and `@RoutingTest` annotations).

For MP: `io.helidon.microprofile.tests.junit5.AfterStop`
For SE: `io.helidon.webserver.testing.junit5.AfterStop`

Example of usage:
```java
@AfterStop
static void afterStop() {
    assertThat("Before start should only have been called on server startup", FEATURE.beforeStart.get(), is(1));
    assertThat("After stop should have been called on server stop", FEATURE.afterStop.get(), is(1));
}
```