### PR TITLE
[4.x] Try to fix occasional test failures in pipeline

### DIFF
--- a/metrics/provider-tests/src/main/java/io/helidon/metrics/provider/tests/TestGlobalTags.java
+++ b/metrics/provider-tests/src/main/java/io/helidon/metrics/provider/tests/TestGlobalTags.java
@@ -24,6 +24,7 @@ import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Metrics;
 import io.helidon.metrics.api.MetricsConfig;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ class TestGlobalTags {
 
         Config config = Config.just(ConfigSources.create(settings));
 
-        MeterRegistry meterRegistry = Metrics.createMeterRegistry(
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry(
                 MetricsConfig.create(config.get("metrics")));
 
         Counter counter1 = meterRegistry.getOrCreate(Counter.builder("a")

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestCounter.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestCounter.java
@@ -35,10 +35,7 @@ class TestCounter {
 
     @BeforeAll
     static void prep() {
-        io.micrometer.core.instrument.Metrics.globalRegistry
-                .getMeters()
-                .forEach(io.micrometer.core.instrument.Metrics.globalRegistry::remove);
-        meterRegistry = Metrics.createMeterRegistry(MetricsConfig.create());
+        meterRegistry = Metrics.globalRegistry();
     }
 
     @Test

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestGauge.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestGauge.java
@@ -34,7 +34,7 @@ class TestGauge {
 
     @BeforeAll
     static void prep() {
-        meterRegistry = Metrics.createMeterRegistry(MetricsConfig.create());
+        meterRegistry = Metrics.globalRegistry();
     }
 
     @Test

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestTimer.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestTimer.java
@@ -35,7 +35,7 @@ class TestTimer {
 
     @BeforeAll
     static void prep() {
-        meterRegistry = Metrics.createMeterRegistry(MetricsConfig.create());
+        meterRegistry = Metrics.globalRegistry();
     }
 
     @Test


### PR DESCRIPTION
Resovles #7530 

### Description
A few pipeline jobs suffered intermittent failures in new Micrometer-based unit tests.

Tests should use the global registry and these did not. This might help the intermittent unit test failures.

### Documentation

No doc impact