### PR TITLE
[3.x] Fix bug with empty Accept header

### DIFF
--- a/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
@@ -549,7 +549,7 @@ public abstract class OpenAPISupport implements Service {
 
         RequestHeaders headers = req.headers();
         if (headers.acceptedTypes().isEmpty()) {
-            headers.add(Http.Header.ACCEPT, DEFAULT_RESPONSE_MEDIA_TYPE.toString());
+            return Optional.of(DEFAULT_RESPONSE_MEDIA_TYPE);
         }
         return headers
                 .bestAccepted(preferredMediaTypeOrdering);

--- a/openapi/src/test/java/io/helidon/openapi/ServerTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
Resolves #7311

If a request for the OpenAPI endpoint specifies an empty `Accept` header, then the code would attempt to modify the request headers by adding a "default" `Accept`. But the request headers are read-only at that point, so the attempt would thrown an exception.

This PR changes that flow so it simply returns the default media type for OpenAPI content if the incoming `Accept` is empty.

Includes a test that reproduces the original problem and verifies the fix.


### Documentation
No doc impact.