### PR TITLE
2.x: Adds zero-argument non-private constructors to NonTransactionalEntityManager and ExtendedEntityManager

### DIFF
--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ExtendedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ExtendedEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import javax.persistence.EntityManager;
  * A {@link DelegatingEntityManager} created to support extended
  * persistence contexts.
  */
-final class ExtendedEntityManager extends DelegatingEntityManager {
+class ExtendedEntityManager extends DelegatingEntityManager {
 
 
     /*
@@ -59,6 +59,39 @@ final class ExtendedEntityManager extends DelegatingEntityManager {
      */
 
 
+    /**
+     * Creates a new {@link ExtendedEntityManager}.
+     *
+     * <p>This constructor exists only for proxiable type requirements imposed by CDI. Using it for any other purpose
+     * will result in undefined behavior.</p>
+     *
+     * @deprecated For use by CDI only.
+     */
+    @Deprecated // For use by CDI only.
+    ExtendedEntityManager() {
+        super();
+        this.transactionSupport = null;
+        this.suppliedQualifiers = null;
+        this.isSynchronized = false;
+        this.instance = null;
+        this.beanManager = null;
+    }
+
+    /**
+     * Creates a new {@link ExtendedEntityManager}.
+     *
+     * @param instance an {@link Instance} representing the CDI
+     * container
+     *
+     * @param suppliedQualifiers a {@link Set} of qualifier {@link
+     * Annotation}s; must not be {@code null}
+     *
+     * @param beanManager a {@link BeanManager}; must not be {@code
+     * null}
+     *
+     * @exception NullPointerException if any parameter value is
+     * {@code null}
+     */
     ExtendedEntityManager(final Instance<Object> instance,
                           final Set<? extends Annotation> suppliedQualifiers,
                           final BeanManager beanManager) {

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/NonTransactionalEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/NonTransactionalEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,16 @@ class NonTransactionalEntityManager extends DelegatingEntityManager {
      * Constructors.
      */
 
+
+    /**
+     * Creates a new {@link NonTransactionalEntityManager}.
+     *
+     * @deprecated For use by CDI only.
+     */
+    @Deprecated // For use by CDI only
+    NonTransactionalEntityManager() {
+        super();
+    }
 
     /**
      * Creates a new {@link NonTransactionalEntityManager}.


### PR DESCRIPTION
Addresses #7558.