### PR TITLE
[4.x] OciExtension refinements

### DIFF
--- a/integrations/oci/sdk/runtime/etc/spotbugs/exclude.xml
+++ b/integrations/oci/sdk/runtime/etc/spotbugs/exclude.xml
@@ -28,4 +28,10 @@
         <Bug pattern="PATH_TRAVERSAL_IN"/>
     </Match>
 
+    <Match>
+        <!-- Path comes from config or code -->
+        <Class name="io.helidon.integrations.oci.sdk.runtime.OciExtension"/>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+    </Match>
+
 </FindBugsFilter>

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAuthenticationDetailsProvider.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAuthenticationDetailsProvider.java
@@ -72,10 +72,10 @@ class OciAuthenticationDetailsProvider implements InjectionPointProvider<Abstrac
     static final String VAL_RESOURCE_PRINCIPAL = "resource-principal";
 
     // order is important here - see the tests and the docs
-    static final List<String> ALL_STRATEGIES = List.of(VAL_INSTANCE_PRINCIPALS,
-                                                       VAL_RESOURCE_PRINCIPAL,
-                                                       VAL_CONFIG,
-                                                       VAL_CONFIG_FILE);
+    static final List<String> ALL_STRATEGIES = List.of(VAL_CONFIG,
+                                                       VAL_CONFIG_FILE,
+                                                       VAL_INSTANCE_PRINCIPALS,
+                                                       VAL_RESOURCE_PRINCIPAL);
 
     OciAuthenticationDetailsProvider() {
     }

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciExtension.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciExtension.java
@@ -16,8 +16,6 @@
 
 package io.helidon.integrations.oci.sdk.runtime;
 
-import java.io.InputStream;
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciExtension.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciExtension.java
@@ -244,7 +244,7 @@ public final class OciExtension {
      * @see #configSupplier()
      */
     public static void configSupplier(Supplier<io.helidon.common.config.Config> configSupplier) {
-        ociConfigSupplier = configSupplier;
+        ociConfigSupplier = Objects.requireNonNull(configSupplier, "configSupplier");
     }
 
     /**
@@ -257,7 +257,7 @@ public final class OciExtension {
      * @see #configSupplier()
      */
     public static void fallbackConfigSupplier(Supplier<io.helidon.common.config.Config> configSupplier) {
-        fallbackConfigSupplier = configSupplier;
+        fallbackConfigSupplier = Objects.requireNonNull(configSupplier, "configSupplier");
     }
 
     /**

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciExtension.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciExtension.java
@@ -16,6 +16,10 @@
 
 package io.helidon.integrations.oci.sdk.runtime;
 
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -117,6 +121,9 @@ import static java.util.function.Predicate.not;
  * target="_top">Oracle Cloud Infrastructure Java SDK</a>
  */
 public final class OciExtension {
+    /**
+     * The name for the OCI bootstrap configuration file (value = {@value}).
+     */
     static final String DEFAULT_OCI_GLOBAL_CONFIG_FILE = "oci.yaml";
     static final System.Logger LOGGER = System.getLogger(OciExtension.class.getName());
     static final LazyValue<OciConfig> DEFAULT_OCI_CONFIG_BEAN = LazyValue.create(() -> OciConfig.builder()
@@ -127,6 +134,7 @@ public final class OciExtension {
             .build());
     private static String overrideOciConfigFile;
     private static volatile Supplier<io.helidon.common.config.Config> ociConfigSupplier;
+    private static volatile Supplier<io.helidon.common.config.Config> fallbackConfigSupplier;
 
     private OciExtension() {
     }
@@ -201,32 +209,56 @@ public final class OciExtension {
      * The supplier for the raw config-backed by the OCI config source(s).
      *
      * @return the supplier for the raw config-backed by the OCI config source(s)
-     * @see #ociAuthenticationProvider()
      * @see #configSupplier(Supplier)
+     * @see #fallbackConfigSupplier(Supplier)
+     * @see #ociAuthenticationProvider()
      */
     public static Supplier<io.helidon.common.config.Config> configSupplier() {
-        if (ociConfigSupplier == null) {
-            configSupplier(() -> {
-                // we do it this way to allow for any system and env vars to be used for the auth-strategy definition
-                // (not advertised in the javadoc)
-                String ociConfigFile = ociConfigFilename();
-                return Config.create(
-                        ConfigSources.classpath(ociConfigFile).optional(),
-                        ConfigSources.file(ociConfigFile).optional());
-            });
+        if (ociConfigSupplier != null) {
+            return ociConfigSupplier;
         }
+
+        String ociConfigFile = ociConfigFilename();
+        Path ociConfigFilePath = Paths.get(ociConfigFilename());
+        boolean ociConfigResourceExists = (OciExtension.class.getClassLoader().getResource(ociConfigFile) != null);
+        if (fallbackConfigSupplier != null
+                && !(ociConfigResourceExists || ociConfigFilePath.toFile().exists())) {
+            return fallbackConfigSupplier;
+        }
+
+        configSupplier(() -> {
+            // we do it this way to allow for any system and env vars to be used for the auth-strategy definition
+            // (not advertised in the javadoc)
+            return Config.create(
+                    ConfigSources.classpath(ociConfigFile).optional(),
+                    ConfigSources.file(ociConfigFilePath).optional());
+        });
 
         return ociConfigSupplier;
     }
 
     /**
-     * Establishes the supplier for the raw config-backed by the OCI config source(s).
+     * Establishes the supplier for the raw config-backed by the OCI config source(s). Setting this will override the usage of
+     * the {@link #DEFAULT_OCI_GLOBAL_CONFIG_FILE} as the backing configuration file.
      *
      * @param configSupplier the config supplier
      * @see #configSupplier()
      */
     public static void configSupplier(Supplier<io.helidon.common.config.Config> configSupplier) {
         ociConfigSupplier = configSupplier;
+    }
+
+    /**
+     * Establishes the fallback config supplier used only when the {@link #DEFAULT_OCI_GLOBAL_CONFIG_FILE} is not physically
+     * present, and there has been no config supplier explicitly established via {@link #configSupplier(Supplier)}.
+     * <p>
+     * This method is typically used when running in CDI in order to allow for the fallback of using microprofile configuration.
+     *
+     * @param configSupplier the fallback config supplier
+     * @see #configSupplier()
+     */
+    public static void fallbackConfigSupplier(Supplier<io.helidon.common.config.Config> configSupplier) {
+        fallbackConfigSupplier = configSupplier;
     }
 
     /**
@@ -246,6 +278,7 @@ public final class OciExtension {
     static void ociConfigFileName(String fileName) {
         overrideOciConfigFile = fileName;
         ociConfigSupplier = null;
+        fallbackConfigSupplier = null;
     }
 
     // in support for testing a variant of oci.yaml

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciExtension.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciExtension.java
@@ -16,6 +16,7 @@
 
 package io.helidon.integrations.oci.sdk.runtime;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -220,7 +221,7 @@ public final class OciExtension {
         Path ociConfigFilePath = Paths.get(ociConfigFilename());
         boolean ociConfigResourceExists = (OciExtension.class.getClassLoader().getResource(ociConfigFile) != null);
         if (fallbackConfigSupplier != null
-                && !(ociConfigResourceExists || ociConfigFilePath.toFile().exists())) {
+                && !(ociConfigResourceExists || Files.exists(ociConfigFilePath))) {
             return fallbackConfigSupplier;
         }
 

--- a/integrations/oci/sdk/runtime/src/test/java/io/helidon/integrations/oci/sdk/runtime/OciExtensionTest.java
+++ b/integrations/oci/sdk/runtime/src/test/java/io/helidon/integrations/oci/sdk/runtime/OciExtensionTest.java
@@ -31,6 +31,7 @@ import io.helidon.inject.api.InjectionServices;
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,19 +78,19 @@ class OciExtensionTest {
                 .get(OciConfig.CONFIG_KEY);
         OciConfig cfg = OciConfig.create(config);
         assertThat(cfg.potentialAuthStrategies(),
-                   contains("instance-principals", "resource-principal", "config", "config-file"));
+                   contains("config", "config-file", "instance-principals", "resource-principal"));
 
         config = createTestConfig(ociAuthConfigStrategies("auto"))
                 .get(OciConfig.CONFIG_KEY);
         cfg = OciConfig.create(config);
         assertThat(cfg.potentialAuthStrategies(),
-                   contains("instance-principals", "resource-principal", "config", "config-file"));
+                   contains( "config", "config-file", "instance-principals", "resource-principal"));
 
         config = createTestConfig(ociAuthConfigStrategies(null, "instance-principals", "auto"))
                 .get(OciConfig.CONFIG_KEY);
         cfg = OciConfig.create(config);
         assertThat(cfg.potentialAuthStrategies(),
-                   contains("instance-principals", "resource-principal", "config", "config-file"));
+                   contains("config", "config-file", "instance-principals", "resource-principal"));
 
         config = createTestConfig(ociAuthConfigStrategies(null, "instance-principals", "resource-principal"))
                 .get(OciConfig.CONFIG_KEY);
@@ -284,6 +285,25 @@ class OciExtensionTest {
         assertSame(Objects.requireNonNull(OciExtension.configSupplier()),
                    OciExtension.configSupplier(),
                    "The oci configuration from the config source should be cached");
+    }
+
+    @Test
+    void fallbackConfigSupplier() {
+        Config fallbackCfg = Config.just(
+                        ConfigSources.create(
+                                Map.of("oci.auth", "config"),
+                                "test-fallback-cfg"));
+        OciExtension.fallbackConfigSupplier(() -> fallbackCfg);
+
+        assertThat("when there is no oci.yaml present then we should be looking at the fallback config",
+                   OciExtension.configuredAuthenticationDetailsProvider(false),
+                   equalTo(SimpleAuthenticationDetailsProvider.class));
+
+        OciExtension.ociConfigFileName("test-oci-resource-principal.yaml");
+        OciExtension.fallbackConfigSupplier(() -> fallbackCfg);
+        assertThat("when there is an oci.yaml present then we should NOT be looking at the fallback config",
+                   OciExtension.configuredAuthenticationDetailsProvider(false),
+                   equalTo(ResourcePrincipalAuthenticationDetailsProvider.class));
     }
 
     static Config createTestConfig(MapConfigSource.Builder... builders) {


### PR DESCRIPTION
Fix for #7562.

This change, in conjunction with the upcoming work in https://github.com/helidon-io/helidon/pull/7373 will make oci auth integration backwards compatible with 3.x behavior.