### PR TITLE
Use requested URI info in CORS decision-making

### DIFF
--- a/cors/src/main/java/io/helidon/cors/CorsRequestAdapter.java
+++ b/cors/src/main/java/io/helidon/cors/CorsRequestAdapter.java
@@ -19,6 +19,7 @@ package io.helidon.cors;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.uri.UriInfo;
 import io.helidon.http.HeaderName;
 
 /**
@@ -36,11 +37,11 @@ public interface CorsRequestAdapter<T> {
     String path();
 
     /**
-     * Authority of the request (host header, or obtained from forwarded header).
+     * Returns the {@link io.helidon.common.uri.UriInfo} for the request.
      *
-     * @return authority
+     * @return URI info for the request
      */
-    String authority();
+    UriInfo requestedUri();
 
     /**
      * Retrieves the first value for the specified header as a String.

--- a/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
+++ b/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
@@ -372,10 +372,10 @@ public class CorsSupportHelper<Q, R> {
     private boolean isRequestTypeNormal(CorsRequestAdapter<Q> requestAdapter, boolean silent) {
         // If no origin header or same as host, then just normal
         Optional<String> originOpt = requestAdapter.firstHeader(HeaderNames.ORIGIN);
-        Optional<String> hostOpt = requestAdapter.firstHeader(HeaderNames.HOST);
+        String host = requestAdapter.requestedUri().host();
 
-        boolean result = originOpt.isEmpty() || (hostOpt.isPresent() && originOpt.get().contains("://" + hostOpt.get()));
-        LogHelper.logIsRequestTypeNormal(result, silent, requestAdapter, originOpt, hostOpt);
+        boolean result = originOpt.isEmpty() || originOpt.get().contains("://" + host);
+        LogHelper.logIsRequestTypeNormal(result, silent, requestAdapter, originOpt, host);
         return result;
     }
 

--- a/cors/src/main/java/io/helidon/cors/LogHelper.java
+++ b/cors/src/main/java/io/helidon/cors/LogHelper.java
@@ -69,7 +69,7 @@ class LogHelper {
     }
 
     static <T> void logIsRequestTypeNormal(boolean result, boolean silent, CorsRequestAdapter<T> requestAdapter,
-            Optional<String> originOpt, Optional<String> hostOpt) {
+            Optional<String> originOpt, String host) {
         if (silent || !CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {
             return;
         }
@@ -84,21 +84,21 @@ class LogHelper {
             factorsWhyCrossHost.add(String.format("header %s is present (%s)", HeaderNames.ORIGIN, originOpt.get()));
         }
 
-        if (hostOpt.isEmpty()) {
+        if (host.isEmpty()) {
             reasonsWhyNormal.add("header " + HeaderNames.HOST + " is absent");
         } else {
-            factorsWhyCrossHost.add(String.format("header %s is present (%s)", HeaderNames.HOST, hostOpt.get()));
+            factorsWhyCrossHost.add(String.format("header %s is present (%s)", HeaderNames.HOST, host));
         }
 
-        if (hostOpt.isPresent() && originOpt.isPresent()) {
-            String partOfOriginMatchingHost = "://" + hostOpt.get();
+        if (originOpt.isPresent()) {
+            String partOfOriginMatchingHost = "://" + host;
             if (originOpt.get()
                     .contains(partOfOriginMatchingHost)) {
                 reasonsWhyNormal.add(String.format("header %s '%s' matches header %s '%s'", HeaderNames.ORIGIN,
-                                                   originOpt.get(), HeaderNames.HOST, hostOpt.get()));
+                                                   originOpt.get(), HeaderNames.HOST, host));
             } else {
                 factorsWhyCrossHost.add(String.format("header %s '%s' does not match header %s '%s'", HeaderNames.ORIGIN,
-                                                      originOpt.get(), HeaderNames.HOST, hostOpt.get()));
+                                                      originOpt.get(), HeaderNames.HOST, host));
             }
         }
 

--- a/docs/includes/cors.adoc
+++ b/docs/includes/cors.adoc
@@ -248,6 +248,21 @@ matches an incoming request's path pattern and HTTP method.
 // end::mapped-config-suffix[]
 // end::mapped-config[]
 
+// tag::cors-and-requested-uri-intro[]
+=== CORS and the Requested URI Feature
+The decisions the Helidon CORS feature makes depend on accurate information about each incoming request,
+particularly the host to which the request is sent.
+Conveyed as headers in the request, this information can be changed or overwritten by intermediate nodes--such as load
+balancers--between the origin of the request and your service.
+
+Well-behaved intermediate nodes preserve this important data in other headers, such as `Forwarded`.
+// end::cors-and-requested-uri-intro[]
+
+// tag::cors-and-requested-uri-wrapup[]
+The CORS support in Helidon uses the requested URI feature to discover the correct information about each request,
+according to your configuration, so it can make accurate decisions about whether to permit cross-origin accesses.
+// end::cors-and-requested-uri-wrapup[]
+
 // tag::understanding-cors-support-in-services[]
 === Using CORS Support in Built-in Helidon Services
 

--- a/docs/mp/cors/cors.adoc
+++ b/docs/mp/cors/cors.adoc
@@ -213,6 +213,11 @@ cors.paths.1.allow-origins=http://foo.com
 
 == Additional Information
 
+include::{rootdir}/includes/cors.adoc[tag=cors-and-requested-uri-intro]
+You can configure how the Helidon server handles these headers as described in the documentation for xref:{rootdir}/mp/server.adoc#_using_requested_uri_discovery[requested URI discovery].
+
+include::{rootdir}/includes/cors.adoc[tag=cors-and-requested-uri-wrapup]
+
 include::{rootdir}/includes/cors.adoc[tag=understanding-cors-support-in-services]
 
 include::{rootdir}/includes/cors.adoc[tag=builtin-getting-started]

--- a/docs/se/cors.adoc
+++ b/docs/se/cors.adoc
@@ -248,6 +248,11 @@ For a complete example, see {helidon-github-tree-url}/examples/cors[Helidon SE C
 
 == Additional Information
 
+include::{rootdir}/includes/cors.adoc[tag=cors-and-requested-uri-intro]
+You can configure how the Helidon server handles these headers as described in the documentation for xref:{rootdir}/se/webserver.adoc#_requested_uri_discovery[requested URI discovery].
+
+include::{rootdir}/includes/cors.adoc[tag=cors-and-requested-uri-wrapup]
+
 include::{rootdir}/includes/cors.adoc[tag=understanding-cors-support-in-services]
 include::{rootdir}/includes/cors.adoc[tag=builtin-getting-started]
 

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
@@ -20,12 +20,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import io.helidon.common.LazyValue;
+import io.helidon.common.uri.UriInfo;
 import io.helidon.cors.CorsRequestAdapter;
 import io.helidon.cors.CorsResponseAdapter;
 import io.helidon.cors.CorsSupportBase;
 import io.helidon.cors.CrossOriginConfig;
 import io.helidon.http.HeaderName;
-import io.helidon.http.HeaderNames;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
@@ -104,15 +105,17 @@ class CorsSupportMp extends CorsSupportBase<ContainerRequestContext, Response, C
     static class RequestAdapterMp implements CorsRequestAdapter<ContainerRequestContext> {
 
         private final ContainerRequestContext requestContext;
+        private final LazyValue<UriInfo> uriInfo;
 
+        @SuppressWarnings("unchecked")
         RequestAdapterMp(ContainerRequestContext requestContext) {
             this.requestContext = requestContext;
+            uriInfo = LazyValue.create(() -> ((Supplier<UriInfo>) requestContext.getProperty(UriInfo.class.getName())).get());
         }
 
         @Override
-        public String authority() {
-            // TODO we want authority - we should set it in integration with WebServer as request property
-            return firstHeader(HeaderNames.HOST).orElse("localhost");
+        public UriInfo requestedUri() {
+            return uriInfo.get();
         }
 
         @Override

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsServerRequestAdapter.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsServerRequestAdapter.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.cors;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.uri.UriInfo;
 import io.helidon.cors.CorsRequestAdapter;
 import io.helidon.http.HeaderName;
 import io.helidon.http.ServerRequestHeaders;
@@ -40,8 +41,8 @@ class CorsServerRequestAdapter implements CorsRequestAdapter<ServerRequest> {
     }
 
     @Override
-    public String authority() {
-        return request.authority();
+    public UriInfo requestedUri() {
+        return request.requestedUri();
     }
 
     @Override
@@ -52,7 +53,7 @@ class CorsServerRequestAdapter implements CorsRequestAdapter<ServerRequest> {
     @Override
     public Optional<String> firstHeader(HeaderName key) {
         if (headers.contains(key)) {
-            return Optional.of(headers.get(key).value());
+            return Optional.of(headers.get(key).get());
         }
         return Optional.empty();
     }


### PR DESCRIPTION
(also remove temporary workaround for now-fixed MP OpenAPI TCK bug)

Resolves #5786 and #3619 

### Description
Originally, the CORS decision-making used the `Host` header value from the incoming request. But intervening nodes--load balancers, etc.--might have overwritten that value making it useless for CORS.

We added requested URI support some time ago to work with the `Forwarded` (and the related non-standard  `X-Forwarded...` headers); this PR enhances the CORS logic to make use of it.

The original CORS code includes adapters around the SE and MP request types. Basically, those adapters are enhanced to expose the underlying request's URI info so CORS has access to it, and the CORS logic uses the host from that instead of directly from the `Host` header in making its decisions.

### Documentation

Revised doc files are part of this PR.
