### PR TITLE
4.x: Mark inject processor as preview (warning when executed).

### DIFF
--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -115,6 +115,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs>
+                        <arg>-Ainject.acceptPreview=true</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.common.features</groupId>

--- a/config/tests/service-registry/pom.xml
+++ b/config/tests/service-registry/pom.xml
@@ -70,6 +70,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgs>
+                        <arg>-Ainject.acceptPreview=true</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.inject</groupId>

--- a/examples/inject/basics/pom.xml
+++ b/examples/inject/basics/pom.xml
@@ -63,6 +63,7 @@
                     <compilerArgs>
                         <arg>-Ainject.autoAddNonContractInterfaces=false</arg> <!-- this setting can be used to avoid the need for @Contract -->
                         <arg>-Ainject.debug=false</arg>
+                        <arg>-Ainject.acceptPreview=true</arg>
                     </compilerArgs>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <annotationProcessorPaths>

--- a/examples/inject/interceptors/pom.xml
+++ b/examples/inject/interceptors/pom.xml
@@ -68,6 +68,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                    <compilerArgs>
+                        <arg>-Ainject.acceptPreview=true</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.inject</groupId>

--- a/examples/inject/providers/pom.xml
+++ b/examples/inject/providers/pom.xml
@@ -71,6 +71,7 @@
                     <compilerArgs>
                         <arg>-Ainject.autoAddNonContractInterfaces=true</arg> <!-- this setting can be used to avoid the need for @Contract -->
                         <arg>-Ainject.debug=false</arg>
+                        <arg>-Ainject.acceptPreview=true</arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <path>

--- a/inject/processor/src/main/java/io/helidon/inject/processor/BaseAnnotationProcessor.java
+++ b/inject/processor/src/main/java/io/helidon/inject/processor/BaseAnnotationProcessor.java
@@ -19,18 +19,22 @@ package io.helidon.inject.processor;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
 
 import io.helidon.common.types.TypeName;
+import io.helidon.inject.tools.Options;
 
 /**
  * Abstract base for all Helidon annotation processing.
  */
 abstract class BaseAnnotationProcessor extends AbstractProcessor {
+    private static final AtomicBoolean LOGGED_WARNING = new AtomicBoolean();
     private final System.Logger logger = System.getLogger(getClass().getName());
 
     private ActiveProcessorUtils utils;
@@ -53,6 +57,15 @@ abstract class BaseAnnotationProcessor extends AbstractProcessor {
     public void init(ProcessingEnvironment processingEnv) {
         this.utils = new ActiveProcessorUtils(this, processingEnv);
         super.init(processingEnv);
+
+        if (!Options.isOptionEnabled(Options.TAG_ACCEPT_PREVIEW)
+                && LOGGED_WARNING.compareAndSet(false, true)) {
+            processingEnv.getMessager()
+                    .printMessage(Diagnostic.Kind.WARNING,
+                                  "Helidon Inject is a preview feature, and may introduce backward incompatible changes. "
+                                          + "It is a production quality code, but we may need to do fine tuning of APIs and SPIs."
+                                          + " This warning can be disabled by compiler argument -Ainject.acceptPreview=true");
+        }
     }
 
     @Override

--- a/inject/processor/src/main/java/io/helidon/inject/processor/BaseAnnotationProcessor.java
+++ b/inject/processor/src/main/java/io/helidon/inject/processor/BaseAnnotationProcessor.java
@@ -62,8 +62,8 @@ abstract class BaseAnnotationProcessor extends AbstractProcessor {
                 && LOGGED_WARNING.compareAndSet(false, true)) {
             processingEnv.getMessager()
                     .printMessage(Diagnostic.Kind.WARNING,
-                                  "Helidon Inject is a preview feature, and may introduce backward incompatible changes. "
-                                          + "It is a production quality code, but we may need to do fine tuning of APIs and SPIs."
+                                  "Helidon Inject is preview feature, and the API and SPI may be modified in a future"
+                                          + " revision. It is considered a production feature."
                                           + " This warning can be disabled by compiler argument -Ainject.acceptPreview=true");
         }
     }

--- a/inject/tests/interception/pom.xml
+++ b/inject/tests/interception/pom.xml
@@ -72,6 +72,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                    <compilerArgs>
+                        <arg>-Ainject.acceptPreview=true</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.inject</groupId>

--- a/inject/tests/resources-inject/pom.xml
+++ b/inject/tests/resources-inject/pom.xml
@@ -48,12 +48,6 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.inject</groupId>
-            <artifactId>helidon-inject-processor</artifactId>
-            <scope>provided</scope> <!-- reactor dependency ordering only -->
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.inject</groupId>
             <artifactId>helidon-inject-maven-plugin</artifactId>
             <scope>provided</scope> <!-- reactor dependency ordering only -->
             <optional>true</optional>
@@ -104,6 +98,7 @@
 <!--                        <arg>-XprintProcessorInfo</arg>-->
 <!--                        <arg>-XprintRounds</arg>-->
 <!--                        <arg>-verbose</arg>-->
+                        <arg>-Ainject.acceptPreview=true</arg>
                     </compilerArgs>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <annotationProcessorPaths>
@@ -130,6 +125,11 @@
                     </annotationProcessorPaths>
                 </configuration>
                 <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.inject</groupId>
+                        <artifactId>helidon-inject-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
 				    <dependency>
                         <groupId>io.helidon.common.processor</groupId>
                         <artifactId>helidon-common-processor-helidon-copyright</artifactId>

--- a/inject/tests/resources-inject/pom.xml
+++ b/inject/tests/resources-inject/pom.xml
@@ -130,7 +130,7 @@
                         <artifactId>helidon-inject-processor</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
-				    <dependency>
+                    <dependency>
                         <groupId>io.helidon.common.processor</groupId>
                         <artifactId>helidon-common-processor-helidon-copyright</artifactId>
                         <version>${helidon.version}</version>

--- a/inject/tools/src/main/java/io/helidon/inject/tools/Options.java
+++ b/inject/tools/src/main/java/io/helidon/inject/tools/Options.java
@@ -19,6 +19,7 @@ package io.helidon.inject.tools;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -36,6 +37,10 @@ public class Options {
      * Tag for putting Injection's annotation processing into debug mode.
      */
     public static final String TAG_DEBUG = InjectionServices.TAG_DEBUG;
+    /**
+     * Tag to accept this is a preview feature (so no warning is printed).
+     */
+    public static final String TAG_ACCEPT_PREVIEW = "inject.acceptPreview";
     /**
      * Treat all super types as a contract for a given service type being added.
      */
@@ -84,6 +89,7 @@ public class Options {
      * @param processingEnv the processing env
      */
     public static void init(ProcessingEnvironment processingEnv) {
+        Objects.requireNonNull(processingEnv);
         if (OPTS.isEmpty()) {
             OPTS.put(TAG_DEBUG,
                      String.valueOf(isOptionEnabled(TAG_DEBUG, processingEnv)));
@@ -105,6 +111,7 @@ public class Options {
                      getOption(TAG_IGNORE_UNSUPPORTED_ANNOTATIONS, null, processingEnv));
             OPTS.put(TAG_IGNORE_MODULE_USAGE,
                      getOption(TAG_IGNORE_MODULE_USAGE, null, processingEnv));
+            OPTS.put(TAG_ACCEPT_PREVIEW, getOption(TAG_ACCEPT_PREVIEW, null, processingEnv));
         }
     }
 
@@ -146,7 +153,7 @@ public class Options {
     /**
      * This only supports the subset of options that Injection cares about, and should not be generally used for options.
      *
-     * @param option the key (assumed to be meaningful to this class)
+     * @param option     the key (assumed to be meaningful to this class)
      * @param defaultVal the default value used if the associated value is null.
      * @return the option value
      */
@@ -158,11 +165,10 @@ public class Options {
 
     private static boolean isOptionEnabled(String option,
                                            ProcessingEnvironment processingEnv) {
-        if (processingEnv != null) {
-            String val = processingEnv.getOptions().get(option);
-            if (val != null) {
-                return Boolean.parseBoolean(val);
-            }
+
+        String val = processingEnv.getOptions().get(option);
+        if (val != null) {
+            return Boolean.parseBoolean(val);
         }
 
         return getOption(option, "", processingEnv).equals("true");
@@ -171,11 +177,9 @@ public class Options {
     private static String getOption(String option,
                                     String defaultVal,
                                     ProcessingEnvironment processingEnv) {
-        if (processingEnv != null) {
-            String val = processingEnv.getOptions().get(option);
-            if (val != null) {
-                return val;
-            }
+        String val = processingEnv.getOptions().get(option);
+        if (val != null) {
+            return val;
         }
 
         return defaultVal;


### PR DESCRIPTION
### Description
Resolves #7413 

Helidon inject processor will print a warning when configured in a project.
This can be disabled through `-Ainject.acceptPreview=true` compiler argument

### Documentation
Documentation should mention that `helidon-inject` and all related modules are in `preview` - we may need to do backward incompatible changes to these modules, so if customer uses them directly or through annotation processor, they need to be aware of this.