### PR TITLE
3.x: Upgrade jgit to 6.7.0

### DIFF
--- a/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
+++ b/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
+++ b/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
@@ -18,6 +18,7 @@ package io.helidon.config.git;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.rules.TestName;
 
 import static io.helidon.config.PollingStrategies.regular;
 import static io.helidon.config.testing.ValueNodeMatcher.valueNode;
@@ -62,6 +64,17 @@ public class GitConfigSourceBuilderTest extends RepositoryTestCase {
 
     @BeforeEach
     public void setUp(TestInfo testInfo) throws Exception {
+        String testMethodName = testInfo.getTestMethod()
+                .map(Method::getName)
+                .orElse(this.getClass().getName());
+        /* Hack to let us re-use setup from jgit 6's LocalDiskRepositoryTestCase */
+        super.currentTest = new TestName() {
+            @Override
+            public String getMethodName() {
+                return testMethodName;
+            }
+        };
+
         super.setUp();
 
         git = new Git(db);

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -96,7 +96,7 @@
         <version.lib.jaxb-runtime>3.0.2</version.lib.jaxb-runtime>
         <version.lib.jedis>3.6.3</version.lib.jedis>
         <version.lib.jersey>3.0.11</version.lib.jersey>
-        <version.lib.jgit>5.11.1.202105131744-r</version.lib.jgit>
+        <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
         <version.lib.jsonp-impl>2.0.1</version.lib.jsonp-impl>
         <version.lib.junit>5.7.0</version.lib.junit>
         <version.lib.kafka>3.4.0</version.lib.kafka>


### PR DESCRIPTION
### Description

Upgrades jgit to 6.7.0. Some testing base classes changed in jgit that broke our tests and require a work-around.

### Documentation

No impact