### PR TITLE
2.x: Upgrade jgit to 6.7.0

### DIFF
--- a/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
+++ b/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.config.git;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.rules.TestName;
 
 import static io.helidon.config.PollingStrategies.regular;
 import static io.helidon.config.testing.ValueNodeMatcher.valueNode;
@@ -62,6 +64,17 @@ public class GitConfigSourceBuilderTest extends RepositoryTestCase {
 
     @BeforeEach
     public void setUp(TestInfo testInfo) throws Exception {
+        String testMethodName = testInfo.getTestMethod()
+                .map(Method::getName)
+                .orElse(this.getClass().getName());
+        /* Hack to let us re-use setup from jgit 6's LocalDiskRepositoryTestCase */
+        super.currentTest = new TestName() {
+            @Override
+            public String getMethodName() {
+                return testMethodName;
+            }
+        };
+
         super.setUp();
 
         git = new Git(db);

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -87,7 +87,7 @@
         <version.lib.jaxb-runtime>2.3.3</version.lib.jaxb-runtime>
         <version.lib.jedis>3.6.3</version.lib.jedis>
         <version.lib.jersey>2.40</version.lib.jersey>
-        <version.lib.jgit>5.11.1.202105131744-r</version.lib.jgit>
+        <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
         <version.lib.jms-api>2.0</version.lib.jms-api>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>


### PR DESCRIPTION
### Description

Upgrades jgit to 6.7.0. Some testing base classes changed in jgit that broke our tests and require a work-around.
Documentation

### Documentation

No impact