### PR TITLE
1.x: Upgrade jgit to 6.7.0

### DIFF
--- a/config/git/pom.xml
+++ b/config/git/pom.xml
@@ -95,5 +95,11 @@
             <artifactId>slf4j-jdk14</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.lib.junit4}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
+++ b/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.config.git;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,6 +49,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.rules.TestName;
 
 import static io.helidon.config.PollingStrategies.regular;
 import static io.helidon.config.testing.ValueNodeMatcher.valueNode;
@@ -71,6 +73,16 @@ public class GitConfigSourceBuilderTest extends RepositoryTestCase {
 
     @BeforeEach
     public void setUp(TestInfo testInfo) throws Exception {
+        String testMethodName = testInfo.getTestMethod()
+                .map(Method::getName)
+                .orElse(this.getClass().getName());
+        /* Hack to let us re-use setup from jgit 6's LocalDiskRepositoryTestCase */
+        super.currentTest = new TestName() {
+            @Override
+            public String getMethodName() {
+                return testMethodName;
+            }
+        };
         super.setUp();
 
         git = new Git(db);

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <version.lib.checkstyle>8.29</version.lib.checkstyle>
         <version.lib.classfilewriter>1.2.4.Final</version.lib.classfilewriter>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
-        <version.lib.jgit>4.9.9.201903122025-r</version.lib.jgit>
+        <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
         <version.lib.jsch>0.1.55</version.lib.jsch>
         <version.lib.netty.tcnative>2.0.54.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>


### PR DESCRIPTION
### Description

Upgrades jgit to 6.7.0. Some testing base classes changed in jgit that broke our tests and require a work-around.
Documentation

### Documentation

No impact
