### PR TITLE
4.x: Upgrade jboss logging to 3.5.3.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -88,7 +88,7 @@
         <version.lib.jaxb-core>4.0.3</version.lib.jaxb-core>
         <version.lib.jaxb-impl>4.0.3</version.lib.jaxb-impl>
         <version.lib.jboss.classfilewriter>1.2.5.Final</version.lib.jboss.classfilewriter>
-        <version.lib.jboss.logging>3.4.2.Final</version.lib.jboss.logging>
+        <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
         <version.lib.jboss.transaction-spi>7.6.1.Final</version.lib.jboss.transaction-spi>
         <!-- Force upgrade version used by maven-jaxb2-plugin. Needed to support Java 16 -->
         <version.lib.jaxb-runtime>4.0.3</version.lib.jaxb-runtime>

--- a/microprofile/cdi/src/main/java/module-info.java
+++ b/microprofile/cdi/src/main/java/module-info.java
@@ -52,6 +52,9 @@ module io.helidon.microprofile.cdi {
     requires weld.environment.common;
     requires weld.se.core;
 
+    // Need by weld
+    requires org.jboss.logging;
+
     exports io.helidon.microprofile.cdi;
 
     uses jakarta.enterprise.inject.spi.Extension;


### PR DESCRIPTION
### Description

Upgrades jboss logging to 3.5.3

Had to add `requires org.jboss.logging;` because it is now a well formed module and must be in module graph.

### Documentation

No impact