### PR TITLE
2.x: Upgrade jboss logging to 3.5.3.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -80,7 +80,7 @@
         <version.lib.jaxb-impl>2.3.5</version.lib.jaxb-impl>
         <version.lib.jaxrs-api>2.1.6</version.lib.jaxrs-api>
         <version.lib.jboss.classfilewriter>1.2.5.Final</version.lib.jboss.classfilewriter>
-        <version.lib.jboss.logging>3.2.1.Final</version.lib.jboss.logging>
+        <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
         <version.lib.jboss.transaction-api>1.0.0.Final</version.lib.jboss.transaction-api>
         <version.lib.jboss.transaction-spi>7.6.1.Final</version.lib.jboss.transaction-spi>
         <!-- Force upgrade version used by maven-jaxb2-plugin. Needed to support Java 16 -->

--- a/microprofile/cdi/src/main/java/module-info.java
+++ b/microprofile/cdi/src/main/java/module-info.java
@@ -40,6 +40,9 @@ module io.helidon.microprofile.cdi {
     requires jakarta.inject.api;
     requires microprofile.config.api;
 
+    // Needed by weld
+    requires org.jboss.logging;
+
     exports io.helidon.microprofile.cdi;
 
     uses javax.enterprise.inject.spi.Extension;


### PR DESCRIPTION
### Description

Upgrades jboss logging to 3.5.3

Had to add `requires org.jboss.logging;` because it is now a well formed module and must be in module graph.

### Documentation

No impact