### PR TITLE
4.x: Introducing request and response stream filters to server.

### DIFF
--- a/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncoding.java
+++ b/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncoding.java
@@ -87,7 +87,7 @@ public class DeflateEncoding implements ContentEncoding {
     public ContentEncoder encoder() {
         return new ContentEncoder() {
             @Override
-            public OutputStream encode(OutputStream network) {
+            public OutputStream apply(OutputStream network) {
                 return new DeflaterOutputStream(network);
             }
 

--- a/http/encoding/encoding/src/main/java/io/helidon/http/encoding/ContentDecoder.java
+++ b/http/encoding/encoding/src/main/java/io/helidon/http/encoding/ContentDecoder.java
@@ -17,13 +17,13 @@
 package io.helidon.http.encoding;
 
 import java.io.InputStream;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * Content decoder.
  */
 @FunctionalInterface
-public interface ContentDecoder extends Function<InputStream, InputStream> {
+public interface ContentDecoder extends UnaryOperator<InputStream> {
     /**
      * No op content decoder.
      */

--- a/http/encoding/encoding/src/main/java/io/helidon/http/encoding/ContentEncoder.java
+++ b/http/encoding/encoding/src/main/java/io/helidon/http/encoding/ContentEncoder.java
@@ -17,13 +17,14 @@
 package io.helidon.http.encoding;
 
 import java.io.OutputStream;
+import java.util.function.UnaryOperator;
 
 import io.helidon.http.WritableHeaders;
 
 /**
  * Content encoder.
  */
-public interface ContentEncoder {
+public interface ContentEncoder extends UnaryOperator<OutputStream> {
     /**
      * No-op content encoder.
      */
@@ -35,7 +36,8 @@ public interface ContentEncoder {
      * @param network output stream to be written over the network
      * @return output stream to write plain data (to compress, encrypt)
      */
-    OutputStream encode(OutputStream network);
+    @Override
+    OutputStream apply(OutputStream network);
 
     /**
      * Update headers.

--- a/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncoding.java
+++ b/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncoding.java
@@ -87,7 +87,7 @@ public class GzipEncoding implements ContentEncoding {
     public ContentEncoder encoder() {
         return new ContentEncoder() {
             @Override
-            public OutputStream encode(OutputStream network) {
+            public OutputStream apply(OutputStream network) {
                 try {
                     return new GZIPOutputStream(network);
                 } catch (IOException e) {

--- a/tracing/tests/it-tracing-client-zipkin/src/test/java/io/helidon/tracing/tests/it1/OpenTraceableClientE2ETest.java
+++ b/tracing/tests/it-tracing-client-zipkin/src/test/java/io/helidon/tracing/tests/it1/OpenTraceableClientE2ETest.java
@@ -26,15 +26,15 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
-import io.helidon.webserver.WebServer;
-import io.helidon.webserver.WebServerConfig;
-import io.helidon.webserver.tracing.TracingFeature;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.jersey.client.ClientTracingFilter;
 import io.helidon.tracing.providers.opentracing.OpenTracing;
 import io.helidon.tracing.providers.zipkin.ZipkinTracer;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.tracing.TracingFeature;
 
 import brave.Tracing;
 import brave.opentracing.BraveSpanContext;
@@ -47,7 +47,6 @@ import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -68,7 +67,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  *
  */
 @ServerTest
-@Disabled("https://github.com/helidon-io/helidon/issues/7203")
 class OpenTraceableClientE2ETest {
     /**
      * We expect two client spans and two server spans.
@@ -129,7 +127,9 @@ class OpenTraceableClientE2ETest {
             fail("Timed out waiting to detect expected "
                     + EXPECTED_TRACE_EVENTS_COUNT
                     + "; remaining latch count: "
-                    + eventsLatch.getCount());
+                    + eventsLatch.getCount()
+                    + ", server spans: " + printSpans(SERVER_SPANS)
+                    + ", client spans: " + printSpans(CLIENT_SPANS));
         }
 
         assertThat("Client spans reported. Client: " + printSpans(CLIENT_SPANS) + ", Server: " + printSpans(SERVER_SPANS),

--- a/tracing/tests/it-tracing-client-zipkin/src/test/resources/logging.properties
+++ b/tracing/tests/it-tracing-client-zipkin/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,19 +14,9 @@
 # limitations under the License.
 #
 
-# Example Logging Configuration File
-# For more information see $JAVA_HOME/jre/lib/logging.properties
-
-# Send messages to the console
 handlers=io.helidon.logging.jul.HelidonConsoleHandler
-
-# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-# Global logging level. Can be overridden by specific loggers
 .level=WARNING
 
 io.helidon.level=INFO
-io.helidon.faulttolerance.level=INFO
-
-

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/TracingPropagationTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/TracingPropagationTest.java
@@ -64,7 +64,7 @@ class TracingPropagationTest {
     private final URI uri;
 
     TracingPropagationTest(URI uri) {
-        Tracer tracer = OpenTracing.create(this.tracer);
+        Tracer tracer = OpenTracing.create(TracingPropagationTest.tracer);
         this.uri = uri.resolve("/greet");
         this.client = Http1Client.builder()
                 .baseUri(this.uri)
@@ -111,7 +111,8 @@ class TracingPropagationTest {
 
         // the server traces asynchronously, some spans may be written after we receive the response.
         // we need to try to wait for such spans
-        assertThat("There should be 2 spans reported", tracer.finishedSpans(), hasSize(2));
+        // re-introduced content-write span
+        assertThat("There should be 3 spans reported", tracer.finishedSpans(), hasSize(3));
 
 
         // we need the first span - parentId 0

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
@@ -16,7 +16,10 @@
 
 package io.helidon.webserver.http2;
 
+import java.io.InputStream;
+import java.util.Objects;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.buffers.BufferData;
@@ -60,6 +63,7 @@ class Http2ServerRequest implements RoutingRequest {
     private Context context;
     // preparation for continue support in HTTP/2
     private boolean continueSent;
+    private UnaryOperator<InputStream> streamFilter = UnaryOperator.identity();
 
     Http2ServerRequest(ConnectionContext ctx,
                        HttpSecurity security,
@@ -76,7 +80,8 @@ class Http2ServerRequest implements RoutingRequest {
         this.requestId = requestId;
         this.authority = headers.authority();
 
-        this.entity = LazyValue.create(() -> Http2ServerRequestEntity.create(decoder,
+        this.entity = LazyValue.create(() -> Http2ServerRequestEntity.create(streamFilter,
+                                                                             decoder,
                                                                              it -> entitySupplier.get(),
                                                                              NO_OP_RUNNABLE,
                                                                              this.headers,
@@ -206,6 +211,13 @@ class Http2ServerRequest implements RoutingRequest {
     @Override
     public boolean continueSent() {
         return continueSent;
+    }
+
+    @Override
+    public void streamFilter(UnaryOperator<InputStream> filterFunction) {
+        Objects.requireNonNull(filterFunction);
+        UnaryOperator<InputStream> current = this.streamFilter;
+        this.streamFilter = it -> filterFunction.apply(current.apply(it));
     }
 
     private UriInfo createUriInfo() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerRequest.java
@@ -16,6 +16,9 @@
 
 package io.helidon.webserver.http;
 
+import java.io.InputStream;
+import java.util.function.UnaryOperator;
+
 import io.helidon.common.context.Context;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.media.ReadableEntity;
@@ -100,4 +103,11 @@ public interface ServerRequest extends HttpRequest {
      * @return whether 100-Continue was sent back to client
      */
     boolean continueSent();
+
+    /**
+     * Configure a custom input stream to wrap the input stream of the request.
+     *
+     * @param filterFunction the function to replace input stream of this request with a user provided one
+     */
+    void streamFilter(UnaryOperator<InputStream> filterFunction);
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -18,6 +18,7 @@ package io.helidon.webserver.http;
 
 import java.io.OutputStream;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.uri.UriQuery;
@@ -218,4 +219,11 @@ public interface ServerResponse {
     default <T extends Sink<?>> T sink(GenericType<T> sinkType) {
         throw new UnsupportedOperationException("No sink available for type " + sinkType);
     }
+
+    /**
+     * Configure a custom output stream to wrap the output stream of the response.
+     *
+     * @param filterFunction the function to replace output stream of this response with a user provided one
+     */
+    void streamFilter(UnaryOperator<OutputStream> filterFunction);
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -91,7 +91,6 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         send(BufferData.EMPTY_BYTES);
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void send(Object entity) {
         if (entity instanceof byte[] bytes) {
@@ -193,7 +192,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
             ContentEncoder encoder = contentEncodingContext.encoder(requestHeaders);
             // we want to preserve optimization here, let's create a new byte array
             ByteArrayOutputStream baos = new ByteArrayOutputStream(entity.length);
-            OutputStream os = encoder.encode(baos);
+            OutputStream os = encoder.apply(baos);
             try {
                 os.write(entity);
                 os.close();
@@ -217,7 +216,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
             ContentEncoder encoder = contentEncodingContext.encoder(requestHeaders);
             encoder.headers(headers());
 
-            return encoder.encode(outputStream);
+            return encoder.apply(outputStream);
         }
         return outputStream;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequestNoEntity.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequestNoEntity.java
@@ -16,6 +16,9 @@
 
 package io.helidon.webserver.http1;
 
+import java.io.InputStream;
+import java.util.function.UnaryOperator;
+
 import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.media.ReadableEntity;
@@ -44,5 +47,9 @@ class Http1ServerRequestNoEntity extends Http1ServerRequest {
     public boolean continueSent() {
         // we do not have a request entity, so we did not sent expect continue, and we do not need to drain it
         return false;
+    }
+
+    @Override
+    public void streamFilter(UnaryOperator<InputStream> filterFunction) {
     }
 }


### PR DESCRIPTION
### Description
Resolves #7203 
For the need of tracing of entity writes, this PR introduces a stream filter to server response (and to have symmetry, also to server request).
The tracing test could be fixed as a result of this feature - tracing feature now registers such a filter for response stream

### Documentation
New API on `ServerRequest` and `ServerResponse` that allows filters to also add stream filters to request and/or response