### PR TITLE
4.x: Upgrade zipkin-sender-urlconnection to 2.16.4

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -155,7 +155,7 @@
         <version.lib.weld-api>5.0.SP3</version.lib.weld-api>
         <version.lib.weld>5.1.0.Final</version.lib.weld>
         <version.lib.yasson>2.0.4</version.lib.yasson>
-        <version.lib.zipkin.sender-urlconnection>2.12.0</version.lib.zipkin.sender-urlconnection>
+        <version.lib.zipkin.sender-urlconnection>2.16.4</version.lib.zipkin.sender-urlconnection>
         <version.lib.zipkin>2.12.5</version.lib.zipkin>
         <version.lib.zookeeper>3.5.7</version.lib.zookeeper>
     </properties>


### PR DESCRIPTION
### Description

Upgrade zipkin-sender-urlconnection to 2.16.4

### Documentation

No impact