### PR TITLE
4.x: Deprecate support for etcd v2

### DIFF
--- a/config/etcd/src/main/java/io/helidon/config/etcd/EtcdConfigSourceBuilder.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/EtcdConfigSourceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/etcd/src/main/java/io/helidon/config/etcd/EtcdConfigSourceBuilder.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/EtcdConfigSourceBuilder.java
@@ -59,9 +59,9 @@ public final class EtcdConfigSourceBuilder extends AbstractConfigSourceBuilder<E
                    Builder<EtcdConfigSourceBuilder, EtcdConfigSource> {
 
     /**
-     * Default Etcd API version ({@link io.helidon.config.etcd.EtcdConfigSourceBuilder.EtcdApi#v2}).
+     * Default Etcd API version ({@link io.helidon.config.etcd.EtcdConfigSourceBuilder.EtcdApi#v3}).
      */
-    public static final EtcdApi DEFAULT_VERSION = EtcdApi.v2;
+    public static final EtcdApi DEFAULT_VERSION = EtcdApi.v3;
     /**
      * Default Etcd endpoint ({@code http://localhost:2379}).
      */
@@ -195,12 +195,15 @@ public final class EtcdConfigSourceBuilder extends AbstractConfigSourceBuilder<E
      * {@code EtcdApi} determines which etcd API version will be used.
      * <p>
      * There are two API versions: {@code v2} and {@code v3}.
+     *
+     * Support for v2 of the API is deprecated
      */
     public enum EtcdApi {
 
         /**
          * Etcd API v2 version.
          */
+        @Deprecated(since = "4.0.0", forRemoval = true)
         v2(new EtcdV2ClientFactory()),
 
         /**

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2Client.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2Client.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2Client.java
@@ -41,6 +41,8 @@ import mousio.etcd4j.responses.EtcdKeysResponse;
 /**
  * Etcd API v2 client.
  */
+@Deprecated(since = "4.0.0", forRemoval = true)
+
 public class EtcdV2Client implements EtcdClient {
 
     private static final Logger LOGGER = Logger.getLogger(EtcdV2Client.class.getName());
@@ -52,6 +54,8 @@ public class EtcdV2Client implements EtcdClient {
      * Init client with specified target Etcd uri.
      *
      * @param uris target Etcd uris
+     *
+     * @deprecated
      */
     EtcdV2Client(URI... uris) {
         etcd = new mousio.etcd4j.EtcdClient(uris);

--- a/docs/se/config/supported-formats.adoc
+++ b/docs/se/config/supported-formats.adoc
@@ -269,7 +269,7 @@ Config config = Config.create(
 <1> Use the factory method `EtcdConfigSourceBuilder.create` to initialize the builder.
 <2> Specify the Etcd endpoint address.
 <3> Specify the Etcd key of the configuration document.
-<4> Version of the Etcd API to use; `v2` and `v3` are supported.
+<4> Version of the Etcd API to use; `v3` is supported. `v2` is deprecated.
 
 The config system will use the <<Config-ModuleYaml,YAML parser>> automatically in this example
 because the file type of the key is `.yaml`.
@@ -304,7 +304,7 @@ for the source:
 * `uri` (type `URI`) - Etcd endpoint URI.
 * `key` (type `String`) - Etcd key that is associated with the configuration.
 * `api` (type `EtcdConfigSourceBuilder.EtcdApi`, i.e. `v2` or `v3`) - Etcd API
- version.
+ version. `v2` is deprecated.
 
 Other optional `properties` are inherited from
  `AbstractParsableConfigSource.Builder`. (see


### PR DESCRIPTION
### Description

The last release of etcd v2 was over five years ago, and `org.mousio:etcd4j` which we use to implement support for v2 is also getting long in the tooth.  

This PR deprecates support for etcd v2.

### Documentation

Changes are included in this PR
