### PR TITLE
4.x: Upgrade io.dropwizard.metrics:metrics-core to 4.1.36

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -45,7 +45,7 @@
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
-        <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
+        <version.lib.dropwizard.metrics>4.1.36</version.lib.dropwizard.metrics>
         <version.lib.eclipselink>4.0.2</version.lib.eclipselink>
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>


### PR DESCRIPTION
### Description

Upgrades io.dropwizard.metrics:metrics-core to 4.1.36

### Documentation

No impact