### PR TITLE
4.x: Upgrade mongodb driver to 4.10.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -123,7 +123,7 @@
         <version.lib.microprofile-tracing>3.0</version.lib.microprofile-tracing>
         <version.lib.microprofile-lra-api>2.0</version.lib.microprofile-lra-api>
         <version.lib.microstream>05.00.02-MS-GA</version.lib.microstream>
-        <version.lib.mongodb>4.9.1</version.lib.mongodb>
+        <version.lib.mongodb>4.10.2</version.lib.mongodb>
         <version.lib.mssql-jdbc>8.4.1.jre8</version.lib.mssql-jdbc>
         <version.lib.mysql-connector-java>8.0.28</version.lib.mysql-connector-java>
         <version.lib.narayana>5.13.1.Final</version.lib.narayana>


### PR DESCRIPTION
### Description

Upgrades mongodb driver to 4.10.2

### Documentation

No impact