### PR TITLE
2.x - Support Jersey Multipart feature by Helidon Connector

### DIFF
--- a/jersey/connector/pom.xml
+++ b/jersey/connector/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jersey/connector/pom.xml
+++ b/jersey/connector/pom.xml
@@ -51,11 +51,6 @@
             <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
             <scope>test</scope>
@@ -63,11 +58,6 @@
         <dependency>
             <groupId>io.helidon.microprofile.tests</groupId>
             <artifactId>helidon-microprofile-tests-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile.cdi</groupId>
-            <artifactId>helidon-microprofile-cdi</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jersey/connector/pom.xml
+++ b/jersey/connector/pom.xml
@@ -51,6 +51,31 @@
             <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.cdi</groupId>
+            <artifactId>helidon-microprofile-cdi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonConnector.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonConnector.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ import org.glassfish.jersey.spi.ExecutorServiceProvider;
 class HelidonConnector implements Connector {
 
     private static final String HELIDON_VERSION = "Helidon/" + Version.VERSION + " (java "
-            + PropertiesHelper.getSystemProperty("java.runtime.version") + ")";
+            + PropertiesHelper.getSystemProperty("java.runtime.version").run() + ")";
     static final Logger LOGGER = Logger.getLogger(HelidonConnector.class.getName());
 
     private final WebClient webClient;
@@ -139,8 +139,6 @@ class HelidonConnector implements Connector {
         final WebClientRequestBuilder webClientRequestBuilder = webClient.method(request.getMethod());
         webClientRequestBuilder.uri(request.getUri());
 
-        webClientRequestBuilder.headers(HelidonStructures.createHeaders(request.getRequestHeaders()));
-
         for (String propertyName : request.getConfiguration().getPropertyNames()) {
             Object property = request.getConfiguration().getProperty(propertyName);
             if (!propertyName.startsWith("jersey") && String.class.isInstance(property)) {
@@ -168,6 +166,7 @@ class HelidonConnector implements Connector {
                     entityType, request, webClientRequestBuilder, executorServiceKeeper.getExecutorService(request)
             );
         } else {
+            webClientRequestBuilder.headers(HelidonStructures.createHeaders(request.getRequestHeaders()));
             responseStage = webClientRequestBuilder.submit();
         }
 

--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonEntity.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/connector/src/main/java/module-info.java
+++ b/jersey/connector/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/connector/src/main/java/module-info.java
+++ b/jersey/connector/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,5 +31,6 @@ module io.helidon.jersey.connector {
     requires io.netty.codec.http;
 
     exports io.helidon.jersey.connector;
+    uses org.glassfish.jersey.client.spi.ConnectorProvider;
     provides org.glassfish.jersey.client.spi.ConnectorProvider with HelidonConnectorProvider;
 }

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
@@ -22,13 +22,14 @@ import io.helidon.microprofile.tests.junit5.AddBean;
 import io.helidon.microprofile.tests.junit5.AddExtension;
 import io.helidon.microprofile.tests.junit5.DisableDiscovery;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import javax.ws.rs.core.Response;
 import org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider;
 import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.BodyPartEntity;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.message.internal.ReaderWriter;
-import org.junit.jupiter.api.Assertions;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -43,11 +44,14 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @HelidonTest
 @DisableDiscovery
@@ -95,8 +99,9 @@ public class MultipartTest {
                     .register(MultiPartFeature.class)
                     .request()
                     .post(Entity.entity(multipart, multipart.getMediaType()))) {
-                Assertions.assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
-                Assertions.assertEquals(ENTITY, r.readEntity(String.class));
+
+                assertThat(r.getStatus(), is(Status.OK.getStatusCode()));
+                assertThat(r.readEntity(String.class), is(ENTITY));
             }
         }
     }

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
@@ -75,7 +75,6 @@ public class MultipartTest {
         @Path("upload")
         @Consumes(MediaType.MULTIPART_FORM_DATA)
         public String upload(@Context HttpHeaders headers, MultiPart multiPart) throws IOException {
-//            headers.getRequestHeaders().forEach((k,v) -> System.out.println(k + ":" + v));
             return ReaderWriter.readFromAsString(
                     ((BodyPartEntity) multiPart.getBodyParts().get(0).getEntity()).getInputStream(),
                     MediaType.TEXT_PLAIN_TYPE);
@@ -87,7 +86,6 @@ public class MultipartTest {
     void testMultipart(HelidonEntity.HelidonEntityType entityType, WebTarget webTarget) {
         // For each entity type make 10 consecutive requests
         for (int i = 0; i != 10; i++) {
-//                System.out.append(entityType.name()).println(i);
             MultiPart multipart = new MultiPart().bodyPart(new BodyPart().entity(ENTITY));
             multipart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
             try (Response r = ClientBuilder.newBuilder()

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.jersey.connector;
+
+import io.helidon.microprofile.server.JaxRsCdiExtension;
+import io.helidon.microprofile.server.ServerCdiExtension;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.DisableDiscovery;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider;
+import org.glassfish.jersey.media.multipart.BodyPart;
+import org.glassfish.jersey.media.multipart.BodyPartEntity;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.message.internal.ReaderWriter;
+import org.junit.jupiter.api.Assertions;
+
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+@HelidonTest
+@DisableDiscovery
+@AddExtension(ServerCdiExtension.class)
+@AddExtension(JaxRsCdiExtension.class)
+@AddExtension(CdiComponentProvider.class)
+
+@AddBean(MultipartTest.MultipartApplication.class)
+public class MultipartTest {
+    private static final String ENTITY = "hello";
+    public static class MultipartApplication extends Application {
+        @Override
+        public Set<Class<?>> getClasses() {
+            Set<Class<?>> set = new HashSet<>();
+            set.add(MultiPartFeature.class);
+            set.add(MultipartResource.class);
+            return set;
+        }
+    }
+
+    @Path("/")
+    public static class MultipartResource {
+        @POST
+        @Path("upload")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String upload(@Context HttpHeaders headers, MultiPart multiPart) throws IOException {
+//            headers.getRequestHeaders().forEach((k,v) -> System.out.println(k + ":" + v));
+            return ReaderWriter.readFromAsString(
+                    ((BodyPartEntity) multiPart.getBodyParts().get(0).getEntity()).getInputStream(),
+                    MediaType.TEXT_PLAIN_TYPE);
+        }
+    }
+
+    @Test
+    void testMultipart(WebTarget webTarget) {
+        // For each entity type
+        for (HelidonEntity.HelidonEntityType entityType : HelidonEntity.HelidonEntityType.values()) {
+            // make 10 consecutive requests
+            for (int i = 0; i != 10; i++) {
+//                System.out.append(entityType.name()).println(i);
+                MultiPart multipart = new MultiPart().bodyPart(new BodyPart().entity(ENTITY));
+                multipart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
+                try (Response r = ClientBuilder.newBuilder()
+                        .property(HelidonConnector.INTERNAL_ENTITY_TYPE, entityType.name())
+                        .build().target(webTarget.getUri())
+                        .path("upload")
+                        .register(MultiPartFeature.class)
+                        .request()
+                        .post(Entity.entity(multipart, multipart.getMediaType()))) {
+                    Assertions.assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
+                    Assertions.assertEquals(ENTITY, r.readEntity(String.class));
+                }
+            }
+        }
+    }
+}

--- a/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
+++ b/jersey/connector/src/test/java/io/helidon/jersey/connector/MultipartTest.java
@@ -30,7 +30,8 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.message.internal.ReaderWriter;
 import org.junit.jupiter.api.Assertions;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -57,6 +58,7 @@ import java.util.Set;
 @AddBean(MultipartTest.MultipartApplication.class)
 public class MultipartTest {
     private static final String ENTITY = "hello";
+
     public static class MultipartApplication extends Application {
         @Override
         public Set<Class<?>> getClasses() {
@@ -80,25 +82,23 @@ public class MultipartTest {
         }
     }
 
-    @Test
-    void testMultipart(WebTarget webTarget) {
-        // For each entity type
-        for (HelidonEntity.HelidonEntityType entityType : HelidonEntity.HelidonEntityType.values()) {
-            // make 10 consecutive requests
-            for (int i = 0; i != 10; i++) {
+    @ParameterizedTest
+    @EnumSource(value = HelidonEntity.HelidonEntityType.class)
+    void testMultipart(HelidonEntity.HelidonEntityType entityType, WebTarget webTarget) {
+        // For each entity type make 10 consecutive requests
+        for (int i = 0; i != 10; i++) {
 //                System.out.append(entityType.name()).println(i);
-                MultiPart multipart = new MultiPart().bodyPart(new BodyPart().entity(ENTITY));
-                multipart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
-                try (Response r = ClientBuilder.newBuilder()
-                        .property(HelidonConnector.INTERNAL_ENTITY_TYPE, entityType.name())
-                        .build().target(webTarget.getUri())
-                        .path("upload")
-                        .register(MultiPartFeature.class)
-                        .request()
-                        .post(Entity.entity(multipart, multipart.getMediaType()))) {
-                    Assertions.assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
-                    Assertions.assertEquals(ENTITY, r.readEntity(String.class));
-                }
+            MultiPart multipart = new MultiPart().bodyPart(new BodyPart().entity(ENTITY));
+            multipart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
+            try (Response r = ClientBuilder.newBuilder()
+                    .property(HelidonConnector.INTERNAL_ENTITY_TYPE, entityType.name())
+                    .build().target(webTarget.getUri())
+                    .path("upload")
+                    .register(MultiPartFeature.class)
+                    .request()
+                    .post(Entity.entity(multipart, multipart.getMediaType()))) {
+                Assertions.assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
+                Assertions.assertEquals(ENTITY, r.readEntity(String.class));
             }
         }
     }


### PR DESCRIPTION
Jersey multipart feature updates the headers just before the first write of entity takes place. This PR is to reflect this change in CONTENT-TYPE header before the `WebClientBuilder` submits the entity.

Fixes the `User-Agent` HTTP header value.