### PR TITLE
4.x: Update workflows to Oracle JDK 21 LTS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
       - 'test-release-*'
 env:
   JAVA_VERSION: '21'
-  JAVA_DISTRO: 'oracle'
+  JAVA_DISTRO: 'oracle.com'
   MAVEN_HTTP_ARGS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3'
 
 concurrency:
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.SERVICE_ACCOUNT_TOKEN }}
           fetch-depth: '0'
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}

--- a/.github/workflows/snapshotrelease.yaml
+++ b/.github/workflows/snapshotrelease.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   JAVA_VERSION: '21'
-  JAVA_DISTRO: 'oracle'
+  JAVA_DISTRO: 'oracle.com'
   MAVEN_HTTP_ARGS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3'
 
 concurrency:
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ on: [pull_request, push]
 
 env:
   JAVA_RELEASE: '21'
-  JAVA_DISTRO: 'jdk.java.net'
+  JAVA_DISTRO: 'oracle.com'
   HELIDON_PIPELINES: 'true'
   MAVEN_HTTP_ARGS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3'
 
@@ -25,7 +25,7 @@ jobs:
        with:
          fetch-depth: 0
      - name: Set up JDK ${{ env.JAVA_VERSION }}
-       uses: oracle-actions/setup-java@v1.3.1
+       uses: oracle-actions/setup-java@v1.3.2
        with:
          website: ${{ env.JAVA_DISTRO }}
          release: ${{ env.JAVA_RELEASE }}
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}
@@ -116,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}
@@ -132,7 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}
@@ -148,7 +148,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: oracle-actions/setup-java@v1.3.1
+        uses: oracle-actions/setup-java@v1.3.2
         with:
           website: ${{ env.JAVA_DISTRO }}
           release: ${{ env.JAVA_RELEASE }}


### PR DESCRIPTION
### Description

Update `oracle-actions/setup-java` to the latest version and use the Oracle build of Java 21  instead of OpenJDK.

Also corrects the website parameter of `oracle-actions/setup-java`  in the snapshot and release workflows to use "oracle.com" and not "oracle" (obviously these workflows have not been used yet!).

### Documentation

No impact
