### PR TITLE
4.x: Update examples to use Config.global(config)

### DIFF
--- a/examples/cors/src/main/java/io/helidon/examples/cors/GreetService.java
+++ b/examples/cors/src/main/java/io/helidon/examples/cors/GreetService.java
@@ -53,7 +53,8 @@ public class GreetService implements HttpService {
 
     private static final JsonBuilderFactory JSON_BF = Json.createBuilderFactory(Collections.emptyMap());
 
-    GreetService(Config config) {
+    GreetService() {
+        Config config = Config.global();
         this.greeting = config.get("app.greeting").asString().orElse("Ciao");
     }
 

--- a/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
+++ b/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
@@ -68,14 +68,14 @@ public final class Main {
      * @param routing routing builder
      */
     static void routing(HttpRouting.Builder routing) {
-        Config config = Config.global();
 
         // Note: Add the CORS routing *before* registering the GreetService routing.
-        routing.register("/greet", corsSupportForGreeting(config), new GreetService())
+        routing.register("/greet", corsSupportForGreeting(), new GreetService())
                 .addFeature(ObserveFeature.create());
     }
 
-    private static CorsSupport corsSupportForGreeting(Config config) {
+    private static CorsSupport corsSupportForGreeting() {
+        Config config = Config.global();
 
         // The default CorsSupport object (obtained using CorsSupport.create()) allows sharing for any HTTP method and with any
         // origin. Using CorsSupport.create(Config) with a missing config node yields a default CorsSupport, which might not be

--- a/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
+++ b/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
@@ -47,14 +47,15 @@ public final class Main {
         // load logging configuration
         LogConfig.configureRuntime();
 
-        // By default, this will pick up application.yaml from the classpath
+        // initialize global config from default configuration
         Config config = Config.create();
+        Config.global(config);
 
         // Get webserver config from the "server" section of application.yaml
         WebServerConfig.Builder builder = WebServer.builder();
         WebServer server = builder
                 .config(config.get("server"))
-                .routing(it -> routing(it, config))
+                .routing(Main::routing)
                 .build()
                 .start();
 
@@ -65,14 +66,12 @@ public final class Main {
      * Setup routing.
      *
      * @param routing routing builder
-     * @param config  configuration of this server
      */
-    static void routing(HttpRouting.Builder routing, Config config) {
-
-        GreetService greetService = new GreetService(config);
+    static void routing(HttpRouting.Builder routing) {
+        Config config = Config.global();
 
         // Note: Add the CORS routing *before* registering the GreetService routing.
-        routing.register("/greet", corsSupportForGreeting(config), greetService)
+        routing.register("/greet", corsSupportForGreeting(config), new GreetService())
                 .addFeature(ObserveFeature.create());
     }
 

--- a/examples/cors/src/test/java/io/helidon/examples/cors/MainTest.java
+++ b/examples/cors/src/test/java/io/helidon/examples/cors/MainTest.java
@@ -62,7 +62,7 @@ public class MainTest {
 
     @SetUpServer
     public static void setup(WebServerConfig.Builder server) {
-        server.routing(routing -> Main.routing(routing, Config.create()));
+        server.routing(routing -> Main.routing(routing));
     }
 
     @Order(1) // Make sure this runs before the greeting message changes so responses are deterministic.

--- a/examples/integrations/micrometer/se/src/main/java/io/helidon/examples/integrations/micrometer/se/GreetService.java
+++ b/examples/integrations/micrometer/se/src/main/java/io/helidon/examples/integrations/micrometer/se/GreetService.java
@@ -64,7 +64,8 @@ public class GreetService implements HttpService {
 
     private static final JsonBuilderFactory JSON_BF = Json.createBuilderFactory(Collections.emptyMap());
 
-    GreetService(Config config, Timer getTimer, Counter personalizedGetCounter) {
+    GreetService(Timer getTimer, Counter personalizedGetCounter) {
+        Config config = Config.global();
         this.greeting = config.get("app.greeting").asString().orElse("Ciao");
         this.getTimer = getTimer;
         this.personalizedGetCounter = personalizedGetCounter;

--- a/examples/integrations/micrometer/se/src/test/java/io/helidon/examples/integrations/micrometer/se/MainTest.java
+++ b/examples/integrations/micrometer/se/src/test/java/io/helidon/examples/integrations/micrometer/se/MainTest.java
@@ -62,7 +62,7 @@ public class MainTest {
 
     @SetUpServer
     public static void setup(Builder builder) {
-        builder.routing(r -> Main.setupRouting(r, Config.create()));
+        builder.routing(Main::setupRouting);
     }
 
     @Test

--- a/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
+++ b/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
@@ -64,7 +64,8 @@ public class GreetService implements HttpService {
     private final Timer timerForGets;
     private final Counter personalizedGreetingsCounter;
 
-    GreetService(Config config) {
+    GreetService() {
+        Config config = Config.global();
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
 
         MeterRegistry meterRegistry = Metrics.globalRegistry();

--- a/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/Main.java
+++ b/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/Main.java
@@ -60,8 +60,9 @@ public final class Main {
 
         // By default, this will pick up application.yaml from the classpath
         Config config = Config.create();
+        Config.global(config);
 
-        server.routing(r -> routing(r, config))
+        server.routing(Main::routing)
                 .config(config.get("server"));
 
     }
@@ -70,12 +71,12 @@ public final class Main {
      * Setup routing.
      *
      * @param routing routing builder
-     * @param config  configuration of this server
      */
-    static void routing(HttpRouting.Builder routing, Config config) {
+    static void routing(HttpRouting.Builder routing) {
+        Config config = Config.global();
         Tracer tracer = TracerBuilder.create(config.get("tracing")).build();
         routing.addFeature(ObserveFeature.create())
                 .addFeature(TracingFeature.create(tracer))
-                .register("/greet", new GreetService(config));
+                .register("/greet", new GreetService());
     }
 }

--- a/examples/metrics/exemplar/src/test/java/io/helidon/examples/metrics/exemplar/MainTest.java
+++ b/examples/metrics/exemplar/src/test/java/io/helidon/examples/metrics/exemplar/MainTest.java
@@ -56,7 +56,8 @@ public class MainTest {
 
     @SetUpServer
     public static void setup(WebServerConfig.Builder server) {
-        server.routing(it -> Main.routing(it, Config.create()));
+        Config.global(Config.create());
+        server.routing(Main::routing);
     }
 
     @Test

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/GreetService.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/GreetService.java
@@ -19,7 +19,7 @@ package io.helidon.examples.metrics.filtering.se;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.http.Status;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
@@ -63,7 +63,8 @@ public class GreetService implements HttpService {
     private final Timer timerForGets;
     private final Counter personalizedGreetingsCounter;
 
-    GreetService(Config config, MeterRegistry meterRegistry) {
+    GreetService(MeterRegistry meterRegistry) {
+        Config config = Config.global();
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
         timerForGets = meterRegistry.getOrCreate(Timer.builder(TIMER_FOR_GETS));
         personalizedGreetingsCounter = meterRegistry.getOrCreate(Counter.builder(COUNTER_FOR_PERSONALIZED_GREETINGS));

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
@@ -18,8 +18,7 @@ package io.helidon.examples.metrics.filtering.se;
 
 import java.util.regex.Pattern;
 
-import io.helidon.common.config.Config;
-import io.helidon.common.config.GlobalConfig;
+import io.helidon.config.Config;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MeterRegistry;
@@ -67,7 +66,8 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default, this will pick up application.yaml from the classpath
-        Config config = GlobalConfig.config();
+        Config config = Config.create();
+        Config.global(config);
 
         // Programmatically (not through config), tell the metrics feature to ignore the "gets" timer.
         // To do so, create the scope config, then add it to the metrics config that ultimately
@@ -100,7 +100,7 @@ public final class Main {
         MetricsObserver metrics = MetricsObserver.builder()
                 .metricsConfig(metricsConfigBuilder)
                 .build();
-        GreetService greetService = new GreetService(config, meterRegistry);
+        GreetService greetService = new GreetService(meterRegistry);
 
         routing.addFeature(ObserveFeature.just(metrics))
                 .register("/greet", greetService);

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
@@ -85,16 +85,17 @@ public final class Main {
                                  .putScope(Meter.Scope.APPLICATION, scopeConfig));
 
         server.config(config.get("server"))
-              .routing(r -> routing(r, config, metricsConfigBuilder));
+              .routing(r -> routing(r, metricsConfigBuilder));
     }
 
     /**
      * Set up routing.
      *
      * @param routing routing builder
-     * @param config  configuration of this server
      */
-    static void routing(HttpRouting.Builder routing, Config config, MetricsConfig.Builder metricsConfigBuilder) {
+    static void routing(HttpRouting.Builder routing, MetricsConfig.Builder metricsConfigBuilder) {
+        Config config = Config.global();
+
         MeterRegistry meterRegistry = MetricsFactory.getInstance(config).globalRegistry();
 
         MetricsObserver metrics = MetricsObserver.builder()

--- a/examples/metrics/filtering/se/src/test/java/io/helidon/examples/metrics/filtering/se/MainTest.java
+++ b/examples/metrics/filtering/se/src/test/java/io/helidon/examples/metrics/filtering/se/MainTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
 @ServerTest
-@Disabled
 public class MainTest {
 
     private static final JsonBuilderFactory JSON_BUILDER = Json.createBuilderFactory(Collections.emptyMap());
@@ -79,6 +78,7 @@ public class MainTest {
     }
 
     @Test
+    @Disabled // application metrics returns 404
     public void testMetrics() {
         try (Http1ClientResponse response = client.get("/greet").request()) {
             assertThat(response.as(String.class), containsString("Hello World!"));

--- a/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/GreetService.java
+++ b/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/GreetService.java
@@ -53,7 +53,8 @@ public class GreetService implements HttpService {
 
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
-    GreetService(Config config) {
+    GreetService() {
+        Config config = Config.global();
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
     }
 

--- a/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/Main.java
+++ b/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/Main.java
@@ -56,8 +56,9 @@ public final class Main {
 
         // By default, this will pick up application.yaml from the classpath
         Config config = Config.create();
+        Config.global(config);
 
-        server.routing(r -> routing(r, config))
+        server.routing(Main::routing)
                 .config(config.get("server"));
 
     }
@@ -68,12 +69,11 @@ public final class Main {
      * @param routing routing builder
      * @param config  configuration of this server
      */
-    static void routing(HttpRouting.Builder routing, Config config) {
-        SimpleGreetService simpleGreetService = new SimpleGreetService(config);
-        GreetService greetService = new GreetService(config);
+    static void routing(HttpRouting.Builder routing) {
+        Config config = Config.global();
         routing.addFeature(ObserveFeature.create())
                 .register(HttpStatusMetricService.create()) // no endpoint, just metrics updates
-                .register("/simple-greet", simpleGreetService)
-                .register("/greet", greetService);
+                .register("/simple-greet", new SimpleGreetService())
+                .register("/greet", new GreetService());
     }
 }

--- a/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/SimpleGreetService.java
+++ b/examples/metrics/http-status-count-se/src/main/java/io/helidon/examples/se/httpstatuscount/SimpleGreetService.java
@@ -49,7 +49,8 @@ public class SimpleGreetService implements HttpService {
 
     private final String greeting;
 
-    SimpleGreetService(Config config) {
+    SimpleGreetService() {
+        Config config = Config.global();
         greeting = config.get("app.greeting").asString().orElse("Ciao");
     }
 

--- a/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
+++ b/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusTest.java
@@ -43,7 +43,6 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ServerTest
-@Disabled
 public class StatusTest {
 
     private final Counter[] STATUS_COUNTERS = new Counter[6];
@@ -55,8 +54,9 @@ public class StatusTest {
 
     @SetUpServer
     public static void setup(WebServerConfig.Builder server) {
+        Config.global(Config.create());
         server.routing(r -> {
-            Main.routing(r, Config.create());
+            Main.routing(r);
             r.register("/status", new StatusService());
         });
     }
@@ -71,6 +71,7 @@ public class StatusTest {
     }
 
     @Test
+    @Disabled
     void checkStatusMetrics() throws InterruptedException {
         checkAfterStatus(Status.create(171));
         checkAfterStatus(Status.OK_200);

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
@@ -66,7 +66,8 @@ public class GreetService implements HttpService {
 
     private final Counter personalizedGreetingsCounter;
 
-    GreetService(Config config) {
+    GreetService() {
+        Config config = Config.global();
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
         MeterRegistry meterRegistry = Metrics.globalRegistry();
         timerForGets = meterRegistry.getOrCreate(Timer.builder(TIMER_FOR_GETS)

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/Main.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/Main.java
@@ -66,8 +66,9 @@ public final class Main {
 
         // By default, this will pick up application.yaml from the classpath
         Config config = Config.create();
+        Config.global(config);
 
-        server.routing(r -> routing(r, config))
+        server.routing(Main::routing)
                 .config(config.get("server"));
 
     }
@@ -76,9 +77,10 @@ public final class Main {
      * Setup routing.
      *
      * @param routing routing builder
-     * @param config  configuration of this server
      */
-    private static void routing(HttpRouting.Builder routing, Config config) {
+    private static void routing(HttpRouting.Builder routing) {
+        Config config = Config.global();
+
         /*
          * For purposes of illustration, the key performance indicator settings for the
          * MetricsSupport instance are set up according to a system property, so you can see,
@@ -89,10 +91,8 @@ public final class Main {
                 ? metricsSupportWithConfig(config.get("metrics"))
                 : metricsSupportWithoutConfig();
 
-        GreetService greetService = new GreetService(config);
-
         routing.addFeature(ObserveFeature.just(metricsSupport))
-                .register("/greet", greetService);
+                .register("/greet", new GreetService());
     }
 
     /**

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetService.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetService.java
@@ -52,7 +52,8 @@ public class GreetService implements HttpService {
 
     private static final JsonBuilderFactory JSON_BF = Json.createBuilderFactory(Map.of());
 
-    GreetService(Config config) {
+    GreetService() {
+        Config config = Config.global();
         this.greeting = config.get("app.greeting").asString().orElse("Ciao");
     }
 

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
@@ -59,22 +59,23 @@ public final class Main {
 
         // By default, this will pick up application.yaml from the classpath
         Config config = Config.create();
+        Config.global(config);
 
         server.config(config.get("server"))
-                .routing(r -> routing(r, config));
+                .routing(Main::routing);
     }
 
     /**
      * Set up routing.
      *
      * @param routing routing builder
-     * @param config  configuration of this server
      */
-    static void routing(HttpRouting.Builder routing, Config config) {
+    static void routing(HttpRouting.Builder routing) {
+        Config config = Config.global();
         routing.addFeature(ObserveFeature.create())
                 .addFeature(OpenApiFeature.builder()
                         .config(config.get(OpenApiFeature.Builder.CONFIG_KEY)))
-                .register("/greet", new GreetService(config));
+                .register("/greet", new GreetService());
     }
 
 }

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -19,7 +19,7 @@ package io.helidon.examples.quickstart.se;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.http.Status;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
@@ -52,6 +52,10 @@ public class GreetService implements HttpService {
      * The config value for the key {@code greeting}.
      */
     private final AtomicReference<String> greeting = new AtomicReference<>();
+
+    GreetService() {
+        this(Config.global().get("app"));
+    }
 
     GreetService(Config appConfig) {
         greeting.set(appConfig.get("greeting").asString().orElse("Ciao"));

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -43,8 +43,12 @@ public final class Main {
         // load logging configuration
         LogConfig.configureRuntime();
 
+        // initialize global config from default configuration
+        Config config = Config.create();
+        Config.global(config);
+
         WebServer server = WebServer.builder()
-                .config(Config.global().get("server"))
+                .config(config.get("server"))
                 .routing(Main::routing)
                 .build()
                 .start();
@@ -58,10 +62,8 @@ public final class Main {
     static void routing(HttpRouting.Builder routing) {
         Config config = Config.global();
 
-        OpenApiFeature openApi = OpenApiFeature.create(config.get("openapi"));
-        GreetService greetService = new GreetService(config.get("app"));
-        routing.addFeature(openApi)
-                .register("/greet", greetService)
+        routing.register("/greet", new GreetService())
+                .addFeature(OpenApiFeature.create(config.get("openapi")))
                 .addFeature(ObserveFeature.create(config.get("observe")));
     }
 }

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -86,6 +86,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.openapi</groupId>
+            <artifactId>helidon-openapi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -19,7 +19,7 @@ package io.helidon.examples.quickstart.se;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.http.Status;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
@@ -52,6 +52,10 @@ public class GreetService implements HttpService {
      * The config value for the key {@code greeting}.
      */
     private final AtomicReference<String> greeting = new AtomicReference<>();
+
+    GreetService() {
+        this(Config.global().get("app"));
+    }
 
     GreetService(Config appConfig) {
         greeting.set(appConfig.get("greeting").asString().orElse("Ciao"));

--- a/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -18,6 +18,7 @@ package io.helidon.examples.quickstart.se;
 
 import io.helidon.config.Config;
 import io.helidon.logging.common.LogConfig;
+import io.helidon.openapi.OpenApiFeature;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.observe.ObserveFeature;
@@ -42,8 +43,12 @@ public final class Main {
         // load logging configuration
         LogConfig.configureRuntime();
 
+        // initialize global config from default configuration
+        Config config = Config.create();
+        Config.global(config);
+
         WebServer server = WebServer.builder()
-                .config(Config.global().get("server"))
+                .config(config.get("server"))
                 .routing(Main::routing)
                 .build()
                 .start();
@@ -57,8 +62,8 @@ public final class Main {
     static void routing(HttpRouting.Builder routing) {
         Config config = Config.global();
 
-        GreetService greetService = new GreetService(config.get("app"));
-        routing.register("/greet", greetService)
+        routing.register("/greet", new GreetService())
+                .addFeature(OpenApiFeature.create(config.get("openapi")))
                 .addFeature(ObserveFeature.create(config.get("observe")));
     }
 }

--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/GreetService.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/GreetService.java
@@ -55,7 +55,8 @@ public class GreetService implements HttpService {
      */
     private final AtomicReference<String> greeting = new AtomicReference<>();
 
-    GreetService(Config config) {
+    GreetService() {
+        Config config = Config.global();
         greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
     }
 

--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
@@ -40,9 +40,10 @@ public final class ServerMain {
     public static void main(String[] args) {
         // By default, this will pick up application.yaml from the classpath
         Config config = Config.create();
+        Config.global(config);
 
         WebServerConfig.Builder builder = WebServer.builder();
-        setup(builder, config);
+        setup(builder);
         WebServer server = builder.build().start();
         server.context().register(server);
         System.out.println("WEB server is up! http://localhost:" + server.port() + "/greet");
@@ -52,20 +53,20 @@ public final class ServerMain {
      * Set up the server.
      *
      * @param server server builder
-     * @param config config
      */
-    static void setup(WebServerConfig.Builder server, Config config) {
+    static void setup(WebServerConfig.Builder server) {
+        Config config = Config.global();
         server.config(config.get("server"))
-              .routing(r -> routing(r, config));
+              .routing(ServerMain::routing);
     }
 
     /**
      * Setup routing.
      *
      * @param routing routing builder
-     * @param config  configuration of this server
      */
-    private static void routing(HttpRouting.Builder routing, Config config) {
+    private static void routing(HttpRouting.Builder routing) {
+        Config config = Config.global();
         routing.addFeature(ObserveFeature.create())
                .register("/greet", new GreetService(config));
     }

--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
@@ -66,8 +66,7 @@ public final class ServerMain {
      * @param routing routing builder
      */
     private static void routing(HttpRouting.Builder routing) {
-        Config config = Config.global();
         routing.addFeature(ObserveFeature.create())
-               .register("/greet", new GreetService(config));
+               .register("/greet", new GreetService());
     }
 }

--- a/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
+++ b/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
@@ -61,7 +61,8 @@ public class ClientMainTest {
 
     @SetUpServer
     public static void setup(WebServerConfig.Builder server) {
-        ServerMain.setup(server, Config.create());
+        Config.global(Config.create());
+        ServerMain.setup(server);
     }
 
     @AfterEach

--- a/examples/webserver/imperative/src/main/java/io/helidon/examples/webserver/imperative/ImperativeMain.java
+++ b/examples/webserver/imperative/src/main/java/io/helidon/examples/webserver/imperative/ImperativeMain.java
@@ -16,8 +16,7 @@
 
 package io.helidon.examples.webserver.imperative;
 
-import io.helidon.common.config.Config;
-import io.helidon.common.config.GlobalConfig;
+import io.helidon.config.Config;
 import io.helidon.http.Method;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
@@ -35,7 +34,8 @@ public final class ImperativeMain {
      * @param args ignored
      */
     public static void main(String[] args) {
-        Config config = GlobalConfig.config();
+        Config config = Config.create();
+        Config.global(config);
 
         WebServer server = WebServer.create(ws -> ws.config(config.get("server"))
                         .routing(ImperativeMain::routing))

--- a/examples/webserver/multiport/src/main/java/io/helidon/webserver/examples/multiport/Main.java
+++ b/examples/webserver/multiport/src/main/java/io/helidon/webserver/examples/multiport/Main.java
@@ -45,21 +45,24 @@ public final class Main {
 
         // By default, this will pick up application.yaml from the classpath
         Config config = Config.create();
+        Config.global(config);
 
-        WebServerConfig.Builder builder = WebServer.builder();
-        setup(builder, config);
-        WebServer server = builder.build().start();
+        WebServer server = WebServer.builder()
+                .config(config.get("server"))
+                .update(Main::setup)
+                .build()
+                .start();
+
         System.out.println("WEB server is up! http://localhost:" + server.port());
     }
 
     /**
      * Set up the server.
      */
-    static void setup(WebServerConfig.Builder server, Config config) {
+    static void setup(WebServerConfig.Builder server) {
         // Build server using three ports:
         // default public port, admin port, private port
-        server.config(config.get("server"))
-                .routing(Main::publicRouting)
+        server.routing(Main::publicRouting)
                 // Add a set of routes on the named socket "admin"
                 .putSocket("admin", socket -> socket.from(server.sockets().get("admin"))
                         .routing(Main::adminSocket))

--- a/examples/webserver/multiport/src/test/java/io/helidon/webserver/examples/multiport/MainTest.java
+++ b/examples/webserver/multiport/src/test/java/io/helidon/webserver/examples/multiport/MainTest.java
@@ -61,8 +61,9 @@ public class MainTest {
     @SetUpServer
     public static void setup(WebServerConfig.Builder server) {
         // Use test configuration so we can have ports allocated dynamically
-        Config config = Config.builder().addSource(ConfigSources.classpath("application-test.yaml")).build();
-        Main.setup(server, config);
+        Config config = Config.just(ConfigSources.classpath("application-test.yaml"));
+        server.config(config.get("server"))
+                .update(Main::setup);
     }
 
     static Stream<Params> initParams() {


### PR DESCRIPTION
### Description

* Remove use of `io.common.config` from examples
* Use pattern of explicitly initializing global config using `Config.global(config)`
* Use pattern of Http Services having a no-arg constructor  (use `Config.global()` instead)

This PR is not necessarily comprehensive. I did not inspect every example, just hit the common and obvious ones.

See Also: #7628

### Documentation

No impact
