### PR TITLE
4.x: Upgrade ASM version used by  plugins to 9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.arquillian>1.7.0.Final</version.lib.arquillian>
-        <version.lib.asm>9.4</version.lib.asm>
+        <version.lib.asm>9.5</version.lib.asm>
         <version.lib.checkstyle>9.1</version.lib.checkstyle>
         <version.lib.commons-io>2.11.0</version.lib.commons-io>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
@@ -697,12 +697,12 @@
                         <dependency>
                             <groupId>org.ow2.asm</groupId>
                             <artifactId>asm</artifactId>
-                            <version>6.0</version>
+                            <version>${version.lib.asm}</version>
                         </dependency>
                         <dependency>
                             <groupId>org.ow2.asm</groupId>
                             <artifactId>asm-commons</artifactId>
-                            <version>6.0</version>
+                            <version>${version.lib.asm}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION

### Description

Upgrades the version of ASM we use for compiler, javadoc, surefire and shade plugins to 9.5

### Documentation

No impact