### PR TITLE
Update HttpRules API to not have varargs with generics

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/RoutingPath.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/RoutingPath.java
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Path of a {@link io.helidon.webserver.http.HttpService} to register with routing.
  * If a service is not annotated with this annotation, it would be registered without a path using
- * {@link io.helidon.webserver.http.HttpRules#register(java.util.function.Supplier[])}.
+ * {@link io.helidon.webserver.http.HttpRules#register(io.helidon.webserver.http.HttpService[])}.
  *
  * Configuration can be overridden using configuration:
  * <ul>

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityFeature.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityFeature.java
@@ -125,7 +125,7 @@ public final class SecurityFeature implements HttpSecurity, HttpFeature, Weighte
 
     /**
      * Create a consumer of routing config to be
-     * {@link io.helidon.webserver.http.HttpRouting.Builder#register(java.util.function.Supplier[])}  registered} with
+     * {@link io.helidon.webserver.http.HttpRouting.Builder#addFeature(java.util.function.Supplier)   registered} with
      * web server routing to process security requests.
      * This method is to be used together with other routing methods to protect web resources programmatically.
      * Example:
@@ -143,7 +143,7 @@ public final class SecurityFeature implements HttpSecurity, HttpFeature, Weighte
 
     /**
      * Create a consumer of routing config to be
-     * {@link io.helidon.webserver.http.HttpRouting.Builder#register(java.util.function.Supplier[])}  registered} with
+     * {@link io.helidon.webserver.http.HttpRouting.Builder#addFeature(java.util.function.Supplier)  registered} with
      * web server routing to process security requests.
      * This method configures security and web server integration from a config instance
      *
@@ -157,7 +157,7 @@ public final class SecurityFeature implements HttpSecurity, HttpFeature, Weighte
 
     /**
      * Create a consumer of routing config to be
-     * {@link io.helidon.webserver.http.HttpRouting.Builder#register(java.util.function.Supplier[])}  registered} with
+     * {@link io.helidon.webserver.http.HttpRouting.Builder#addFeature(java.util.function.Supplier)  registered} with
      * web server routing to process security requests.
      * This method expects initialized security and creates web server integration from a config instance
      *

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentService.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentService.java
@@ -33,7 +33,7 @@ import io.helidon.webserver.http.HttpService;
  * Serves 'static content' (files) from filesystem or using a classloader to the
  * {@link io.helidon.webserver.WebServer WebServer}
  * {@link io.helidon.webserver.http.HttpRouting}. It is possible to
- * {@link io.helidon.webserver.http.HttpRouting.Builder#register(java.util.function.Supplier[]) register} it on the routing.
+ * {@link io.helidon.webserver.http.HttpRouting.Builder#register(HttpService[]) register} it on the routing.
  * <pre>{@code
  * // Serve content of attached '/static/pictures' on '/pics'
  * Routing.builder()

--- a/webserver/tracing/src/main/java/io/helidon/webserver/tracing/TracingFeature.java
+++ b/webserver/tracing/src/main/java/io/helidon/webserver/tracing/TracingFeature.java
@@ -78,8 +78,7 @@ public class TracingFeature implements HttpFeature, Weighted {
      *
      * @param tracer tracer to use for tracing spans created by this feature
      * @return tracing configuration to register with
-     *         {@link
-     *         io.helidon.webserver.http.HttpRouting.Builder#register(java.util.function.Supplier[])}
+     *         {@link io.helidon.webserver.http.HttpRouting.Builder#addFeature(java.util.function.Supplier)}
      */
     public static TracingFeature create(Tracer tracer) {
         return create(tracer, TracingConfig.ENABLED);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
@@ -143,10 +143,105 @@ public final class HttpRouting implements Routing, Prototype.Api {
      */
     public interface Builder extends HttpRules, io.helidon.common.Builder<Builder, HttpRouting> {
         @Override
-        Builder register(Supplier<? extends HttpService>... service);
+        Builder register(HttpService... service);
 
         @Override
-        Builder register(String path, Supplier<? extends HttpService>... service);
+        default Builder register(Supplier<? extends HttpService> service) {
+            HttpRules.super.register(service);
+            return this;
+        }
+
+        @Override
+        default Builder register(Supplier<? extends HttpService> service1, Supplier<? extends HttpService> service2) {
+            HttpRules.super.register(service1, service2);
+            return this;
+        }
+
+        @Override
+        default Builder register(Supplier<? extends HttpService> service1,
+                                 Supplier<? extends HttpService> service2,
+                                 Supplier<? extends HttpService> service3) {
+            HttpRules.super.register(service1, service2, service3);
+            return this;
+        }
+
+        @Override
+        default Builder register(Supplier<? extends HttpService> service1,
+                                 Supplier<? extends HttpService> service2,
+                                 Supplier<? extends HttpService> service3,
+                                 Supplier<? extends HttpService> service4) {
+            HttpRules.super.register(service1, service2, service3, service4);
+            return this;
+        }
+
+        @Override
+        default Builder register(Supplier<? extends HttpService> service1,
+                                 Supplier<? extends HttpService> service2,
+                                 Supplier<? extends HttpService> service3,
+                                 Supplier<? extends HttpService> service4,
+                                 Supplier<? extends HttpService> service5) {
+            HttpRules.super.register(service1, service2, service3, service4, service5);
+            return this;
+        }
+
+        @Override
+        default Builder register(List<Supplier<? extends HttpService>> services) {
+            HttpRules.super.register(services);
+            return this;
+        }
+
+        @Override
+        Builder register(String path, HttpService... service);
+
+        @Override
+        default Builder register(String pathPattern, Supplier<? extends HttpService> service) {
+            HttpRules.super.register(pathPattern, service);
+            return this;
+        }
+
+        @Override
+        default Builder register(String pathPattern,
+                                 Supplier<? extends HttpService> service1,
+                                 Supplier<? extends HttpService> service2) {
+            HttpRules.super.register(pathPattern, service1, service2);
+            return this;
+        }
+
+        @Override
+        default Builder register(String pathPattern,
+                                 Supplier<? extends HttpService> service1,
+                                 Supplier<? extends HttpService> service2,
+                                 Supplier<? extends HttpService> service3) {
+            HttpRules.super.register(pathPattern, service1, service2, service3);
+            return this;
+        }
+
+        @Override
+        default Builder register(String pathPattern,
+                                 Supplier<? extends HttpService> service1,
+                                 Supplier<? extends HttpService> service2,
+                                 Supplier<? extends HttpService> service3,
+                                 Supplier<? extends HttpService> service4) {
+            HttpRules.super.register(pathPattern, service1, service2, service3, service4);
+            return this;
+        }
+
+        @Override
+        default Builder register(String pathPattern,
+                                 Supplier<? extends HttpService> service1,
+                                 Supplier<? extends HttpService> service2,
+                                 Supplier<? extends HttpService> service3,
+                                 Supplier<? extends HttpService> service4,
+                                 Supplier<? extends HttpService> service5) {
+            HttpRules.super.register(pathPattern, service1, service2, service3, service4, service5);
+            return this;
+        }
+
+        @Override
+        default Builder register(String pathPattern, List<Supplier<? extends HttpService>> services) {
+            HttpRules.super.register(pathPattern, services);
+            return this;
+        }
 
         @Override
         Builder route(HttpRoute route);
@@ -438,13 +533,13 @@ public final class HttpRouting implements Routing, Prototype.Api {
         }
 
         @Override
-        public Builder register(Supplier<? extends HttpService>... service) {
+        public Builder register(HttpService... service) {
             mainRouting.service(service);
             return this;
         }
 
         @Override
-        public Builder register(String path, Supplier<? extends HttpService>... service) {
+        public Builder register(String path, HttpService... service) {
             mainRouting.service(path, service);
             return this;
         }
@@ -620,13 +715,13 @@ public final class HttpRouting implements Routing, Prototype.Api {
         }
 
         @Override
-        public Builder register(Supplier<? extends HttpService>... service) {
+        public Builder register(HttpService... service) {
             rootRules.register(service);
             return this;
         }
 
         @Override
-        public Builder register(String pathPattern, Supplier<? extends HttpService>... service) {
+        public Builder register(String pathPattern, HttpService... service) {
             rootRules.register(pathPattern, service);
             return this;
         }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingFeature.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingFeature.java
@@ -18,7 +18,6 @@ package io.helidon.webserver.http;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 
 import io.helidon.common.Weighted;
 
@@ -42,14 +41,14 @@ class HttpRoutingFeature implements HttpFeature, Weighted {
     }
 
     <T extends Throwable> void error(Class<T> exceptionClass, ErrorHandler<? super T> handler) {
-        this.registrations.add(new ErrorReg<T>(exceptionClass, handler));
+        this.registrations.add(new ErrorReg<>(exceptionClass, handler));
     }
 
-    void service(Supplier<? extends HttpService>... services) {
+    void service(HttpService... services) {
         this.registrations.add(new ServiceReg(services));
     }
 
-    void service(String path, Supplier<? extends HttpService>... services) {
+    void service(String path, HttpService... services) {
         this.registrations.add(new ServicePathReg(path, services));
     }
 
@@ -78,14 +77,14 @@ class HttpRoutingFeature implements HttpFeature, Weighted {
         }
     }
 
-    private record ServiceReg(Supplier<? extends HttpService>[] services) implements Registration {
+    private record ServiceReg(HttpService[] services) implements Registration {
         @Override
         public void register(HttpRouting.Builder routing) {
             routing.register(services);
         }
     }
 
-    private record ServicePathReg(String path, Supplier<? extends HttpService>[] services) implements Registration {
+    private record ServicePathReg(String path, HttpService[] services) implements Registration {
         @Override
         public void register(HttpRouting.Builder routing) {
             routing.register(path, services);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRules.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRules.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -36,7 +37,87 @@ public interface HttpRules {
      * @param service service to register
      * @return updated rules
      */
-    HttpRules register(Supplier<? extends HttpService>... service);
+    HttpRules register(HttpService... service);
+
+    /**
+     * Register a service on the current path.
+     *
+     * @param service service to register
+     * @return updated rules
+     */
+    default HttpRules register(Supplier<? extends HttpService> service) {
+        return register(service.get());
+    }
+
+    /**
+     * Register two services on the current path.
+     *
+     * @param service1 first service to register
+     * @param service2 second service to register
+     * @return updated rules
+     */
+    default HttpRules register(Supplier<? extends HttpService> service1,
+                               Supplier<? extends HttpService> service2) {
+        return register(service1.get(), service2.get());
+    }
+
+    /**
+     * Register three services on the current path.
+     *
+     * @param service1 first service to register
+     * @param service2 second service to register
+     * @param service3 third service to register
+     * @return updated rules
+     */
+    default HttpRules register(Supplier<? extends HttpService> service1,
+                               Supplier<? extends HttpService> service2,
+                               Supplier<? extends HttpService> service3) {
+        return register(service1.get(), service2.get(), service3.get());
+    }
+
+    /**
+     * Register four services on the current path.
+     *
+     * @param service1 first service to register
+     * @param service2 second service to register
+     * @param service3 third service to register
+     * @param service4 fourth service to register
+     * @return updated rules
+     */
+    default HttpRules register(Supplier<? extends HttpService> service1,
+                               Supplier<? extends HttpService> service2,
+                               Supplier<? extends HttpService> service3,
+                               Supplier<? extends HttpService> service4) {
+        return register(service1.get(), service2.get(), service3.get(), service4.get());
+    }
+
+    /**
+     * Register five services on the current path.
+     *
+     * @param service1 first service to register
+     * @param service2 second service to register
+     * @param service3 third service to register
+     * @param service4 fourth service to register
+     * @param service5 fifth service to register
+     * @return updated rules
+     */
+    default HttpRules register(Supplier<? extends HttpService> service1,
+                               Supplier<? extends HttpService> service2,
+                               Supplier<? extends HttpService> service3,
+                               Supplier<? extends HttpService> service4,
+                               Supplier<? extends HttpService> service5) {
+        return register(service1.get(), service2.get(), service3.get(), service4.get(), service5.get());
+    }
+
+    /**
+     * Register services on the current path.
+     *
+     * @param services services to register
+     * @return updated rules
+     */
+    default HttpRules register(List<Supplier<? extends HttpService>> services) {
+        return register(services.stream().map(Supplier::get).toArray(HttpService[]::new));
+    }
 
     /**
      * Register a service on sub-path of the current path.
@@ -45,7 +126,97 @@ public interface HttpRules {
      * @param service     service to register
      * @return updated rules
      */
-    HttpRules register(String pathPattern, Supplier<? extends HttpService>... service);
+    HttpRules register(String pathPattern, HttpService... service);
+
+    /**
+     * Register a service on sub-path of the current path.
+     *
+     * @param pathPattern URI path pattern
+     * @param service     service to register
+     * @return updated rules
+     */
+    default HttpRules register(String pathPattern, Supplier<? extends HttpService> service) {
+        return register(pathPattern, service.get());
+    }
+
+    /**
+     * Register two services on sub-path of the current path.
+     *
+     * @param pathPattern URI path pattern
+     * @param service1    first service to register
+     * @param service2    second service to register
+     * @return updated rules
+     */
+    default HttpRules register(String pathPattern,
+                               Supplier<? extends HttpService> service1,
+                               Supplier<? extends HttpService> service2) {
+        return register(pathPattern, service1.get(), service2.get());
+    }
+
+    /**
+     * Register three services on sub-path of the current path.
+     *
+     * @param pathPattern URI path pattern
+     * @param service1    first service to register
+     * @param service2    second service to register
+     * @param service3    third service to register
+     * @return updated rules
+     */
+    default HttpRules register(String pathPattern,
+                               Supplier<? extends HttpService> service1,
+                               Supplier<? extends HttpService> service2,
+                               Supplier<? extends HttpService> service3) {
+        return register(pathPattern, service1.get(), service2.get(), service3.get());
+    }
+
+    /**
+     * Register four services on sub-path of the current path.
+     *
+     * @param pathPattern URI path pattern
+     * @param service1    first service to register
+     * @param service2    second service to register
+     * @param service3    third service to register
+     * @param service4    fourth service to register
+     * @return updated rules
+     */
+    default HttpRules register(String pathPattern,
+                               Supplier<? extends HttpService> service1,
+                               Supplier<? extends HttpService> service2,
+                               Supplier<? extends HttpService> service3,
+                               Supplier<? extends HttpService> service4) {
+        return register(pathPattern, service1.get(), service2.get(), service3.get(), service4.get());
+    }
+
+    /**
+     * Register five services on sub-path of the current path.
+     *
+     * @param pathPattern URI path pattern
+     * @param service1    first service to register
+     * @param service2    second service to register
+     * @param service3    third service to register
+     * @param service4    fourth service to register
+     * @param service5    fifth service to register
+     * @return updated rules
+     */
+    default HttpRules register(String pathPattern,
+                               Supplier<? extends HttpService> service1,
+                               Supplier<? extends HttpService> service2,
+                               Supplier<? extends HttpService> service3,
+                               Supplier<? extends HttpService> service4,
+                               Supplier<? extends HttpService> service5) {
+        return register(pathPattern, service1.get(), service2.get(), service3.get(), service4.get(), service5.get());
+    }
+
+    /**
+     * Register services on sub-path of the current path.
+     *
+     * @param pathPattern URI path pattern
+     * @param services    services to register
+     * @return updated rules
+     */
+    default HttpRules register(String pathPattern, List<Supplier<? extends HttpService>> services) {
+        return register(pathPattern, services.stream().map(Supplier::get).toArray(HttpService[]::new));
+    }
 
     /**
      * Add a route. This allows also protocol version specific routing.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpService.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpService.java
@@ -16,22 +16,16 @@
 
 package io.helidon.webserver.http;
 
-import java.util.function.Supplier;
-
 import io.helidon.webserver.ServerLifecycle;
 
 /**
  * Encapsulates a set of {@link HttpRouting routing} rules and related logic.
  * <p>
  * Instance can be assigned to the {@link HttpRouting routing} using
- * {@link HttpRouting.Builder#register(java.util.function.Supplier[])} methods.
+ * {@link HttpRouting.Builder#register(java.util.function.Supplier)} methods.
  */
 @FunctionalInterface
-public interface HttpService extends Supplier<HttpService>, ServerLifecycle {
-    @Override
-    default HttpService get() {
-        return this;
-    }
+public interface HttpService extends ServerLifecycle {
 
     /**
      * Updates the routing to add handlers of this service.
@@ -40,4 +34,3 @@ public interface HttpService extends Supplier<HttpService>, ServerLifecycle {
      */
     void routing(HttpRules rules);
 }
-

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceRules.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceRules.java
@@ -19,7 +19,6 @@ package io.helidon.webserver.http;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import io.helidon.http.Method;
 import io.helidon.http.PathMatcher;
@@ -46,26 +45,22 @@ class ServiceRules implements HttpRules {
     }
 
     @Override
-    public HttpRules register(Supplier<? extends HttpService>... services) {
-        for (Supplier<? extends HttpService> service : services) {
-            HttpService theService = service.get();
-            ServiceRules subRules = new ServiceRules(theService, PathMatchers.any(), ALWAYS_PREDICATE);
-            theService.routing(subRules);
+    public HttpRules register(HttpService... services) {
+        for (HttpService service : services) {
+            ServiceRules subRules = new ServiceRules(service, PathMatchers.any(), ALWAYS_PREDICATE);
+            service.routing(subRules);
             routes.add(subRules.build());
         }
-
         return this;
     }
 
     @Override
-    public HttpRules register(String pathPattern, Supplier<? extends HttpService>... services) {
-        for (Supplier<? extends HttpService> service : services) {
-            HttpService theService = service.get();
-            ServiceRules subRules = new ServiceRules(theService, PathMatchers.create(pathPattern), ALWAYS_PREDICATE);
-            theService.routing(subRules);
+    public HttpRules register(String pathPattern, HttpService... services) {
+        for (HttpService service : services) {
+            ServiceRules subRules = new ServiceRules(service, PathMatchers.create(pathPattern), ALWAYS_PREDICATE);
+            service.routing(subRules);
             routes.add(subRules.build());
         }
-
         return this;
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpRoutingTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpRoutingTest.java
@@ -118,12 +118,12 @@ class HttpRoutingTest {
         }
 
         @Override
-        public HttpRouting.Builder register(Supplier<? extends HttpService>... service) {
+        public HttpRouting.Builder register(HttpService... service) {
             return null;
         }
 
         @Override
-        public HttpRouting.Builder register(String path, Supplier<? extends HttpService>... service) {
+        public HttpRouting.Builder register(String path, HttpService... service) {
             return null;
         }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpRulesTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpRulesTest.java
@@ -17,7 +17,6 @@
 package io.helidon.webserver.http;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import io.helidon.http.Method;
@@ -119,12 +118,12 @@ class HttpRulesTest {
         }
 
         @Override
-        public HttpRules register(Supplier<? extends HttpService>... service) {
+        public HttpRules register(HttpService... service) {
             return null;
         }
 
         @Override
-        public HttpRules register(String pathPattern, Supplier<? extends HttpService>... service) {
+        public HttpRules register(String pathPattern, HttpService... service) {
             return null;
         }
 


### PR DESCRIPTION
### Description

- Update `HttpService` interface to not be a `Supplier<HttpService>` to remove ambiguity

- Replace `register(Supplier<? extends HttpService>... service)` with `register(HttpService... service)`
- Overload it with 5 variants to accept up to 5 suppliers of services (`@SafeVarags` is not usable on interfaces)
- Add `register(List<HttpService> services)` for more than 5 services

- Replace `register(String pathPattern, Supplier<? extends HttpService>... service)` with `register(String pathPattern, HttpService... service)`
- Overload it with 5 variants to accept up to 5 suppliers of services (`@SafeVarags` is not usable on interfaces)
- Add `register(String pathPattern, List<HttpService> services)` for more than 5 services

Fixes #7656

### Documentation

The changes are mostly compile compatible.
It's incompatible if an application was using an array of suppliers explicitly or if it was using more than 5 suppliers.

I.e.

```java
// the method with var-arg of supplier has been removed
rules.register((Supplier<HttpService>[]) svcs);
rules.register("/foo", (Supplier<HttpService>[]) svcs);

// the method with var-arg of supplier has been removed
// it is replaced with overloaded methods with up to 5 arguments
// using more than 5 won't compile
rules.register(Svc1::new, Svc2::new, Svc3::new, Svc4::new, Svc5::new, Svc6::new);
rules.register("/foo", Svc1::new, Svc2::new, Svc3::new, Svc4::new, Svc5::new, Svc6::new);
```
