### PR TITLE
Partial fix for issue #7698 - TlsManager support for client-side

### DIFF
--- a/common/tls/pom.xml
+++ b/common/tls/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -124,6 +124,14 @@ public class ConfiguredTlsManager implements TlsManager {
         trustManager.ifPresent(reloadableTrustManager::reload);
     }
 
+    /**
+     * Initialize and set the {@link javax.net.ssl.SSLContext} on this manager instance.
+     *
+     * @param tlsConfig     the tls configuration
+     * @param secureRandom  the secure random
+     * @param keyManagers   the key managers
+     * @param trustManagers the trust managers
+     */
     protected void initSslContext(TlsConfig tlsConfig,
                                   SecureRandom secureRandom,
                                   KeyManager[] keyManagers,
@@ -197,6 +205,15 @@ public class ConfiguredTlsManager implements TlsManager {
         return RANDOM.get();
     }
 
+    /**
+     * Build the key manager factory.
+     *
+     * @param target        the tls configuration
+     * @param secureRandom  the secure random
+     * @param privateKey    the private key for the key store
+     * @param certificates the certificates for the keystore
+     * @return a key manager factory instance
+     */
     protected KeyManagerFactory buildKmf(TlsConfig target,
                                          SecureRandom secureRandom,
                                          PrivateKey privateKey,

--- a/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerCache.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerCache.java
@@ -28,8 +28,8 @@ class TlsManagerCache {
     private TlsManagerCache() {
     }
 
-    static TlsManager getOrCreate(Object configBean,
-                                  Function<Object, TlsManager> creator) {
+    static <T> TlsManager getOrCreate(T configBean,
+                                      Function<Object, TlsManager> creator) {
         Objects.requireNonNull(configBean);
         Objects.requireNonNull(creator);
         return CACHE.computeIfAbsent(configBean, creator);

--- a/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerCache.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerCache.java
@@ -28,11 +28,12 @@ class TlsManagerCache {
     private TlsManagerCache() {
     }
 
+    @SuppressWarnings("unchecked")
     static <T> TlsManager getOrCreate(T configBean,
-                                      Function<Object, TlsManager> creator) {
+                                      Function<T, TlsManager> creator) {
         Objects.requireNonNull(configBean);
         Objects.requireNonNull(creator);
-        return CACHE.computeIfAbsent(configBean, creator);
+        return CACHE.computeIfAbsent(configBean, (Function<Object, TlsManager>) creator);
     }
 
 }

--- a/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerCache.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerCache.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls.spi;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import io.helidon.common.tls.TlsManager;
+
+class TlsManagerCache {
+    private static final ConcurrentHashMap<Object, TlsManager> CACHE = new ConcurrentHashMap<>();
+
+    private TlsManagerCache() {
+    }
+
+    static TlsManager getOrCreate(Object configBean,
+                                  Function<Object, TlsManager> creator) {
+        Objects.requireNonNull(configBean);
+        Objects.requireNonNull(creator);
+        return CACHE.computeIfAbsent(configBean, creator);
+    }
+
+}

--- a/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerProvider.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerProvider.java
@@ -32,6 +32,7 @@ public interface TlsManagerProvider extends ConfiguredProvider<TlsManager> {
      *
      * @param configBean the config bean instance
      * @param creator    the creator to apply if not already in cache, which takes the config bean instance
+     * @param <T>        the type of the config bean
      * @return the tls manager instance from cache, defaulting to creation from the {@code creator} if not in cache
      */
     static <T> TlsManager getOrCreate(T configBean,

--- a/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerProvider.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerProvider.java
@@ -36,7 +36,7 @@ public interface TlsManagerProvider extends ConfiguredProvider<TlsManager> {
      * @return the tls manager instance from cache, defaulting to creation from the {@code creator} if not in cache
      */
     static <T> TlsManager getOrCreate(T configBean,
-                                      Function<Object, TlsManager> creator) {
+                                      Function<T, TlsManager> creator) {
         return TlsManagerCache.getOrCreate(configBean, creator);
     }
 

--- a/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerProvider.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerProvider.java
@@ -16,6 +16,10 @@
 
 package io.helidon.common.tls.spi;
 
+import java.util.Objects;
+import java.util.function.Function;
+
+import io.helidon.common.config.Config;
 import io.helidon.common.config.ConfiguredProvider;
 import io.helidon.common.tls.TlsManager;
 
@@ -23,5 +27,23 @@ import io.helidon.common.tls.TlsManager;
  * {@link java.util.ServiceLoader} service provider for {@link io.helidon.common.tls.TlsManager}.
  */
 public interface TlsManagerProvider extends ConfiguredProvider<TlsManager> {
+
+    /**
+     * Provides the ability to have a unique {@link TlsManager} per unique {@link Config} instance provided.
+     *
+     * @param config     the raw config instance
+     * @param configBean the config bean instance
+     * @param name       the config bean instance name
+     * @param creator    the creator to apply if not already in cache, which takes the config bean instance
+     * @return the tls manager instance from cache, defaulting to creation from the {@code creator} if not in cache
+     */
+    static TlsManager getOrCreate(Config config,
+                                  String name,
+                                  Object configBean,
+                                  Function<Object, TlsManager> creator) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(name);
+        return TlsManagerCache.getOrCreate(configBean, creator);
+    }
 
 }

--- a/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerProvider.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/spi/TlsManagerProvider.java
@@ -16,7 +16,6 @@
 
 package io.helidon.common.tls.spi;
 
-import java.util.Objects;
 import java.util.function.Function;
 
 import io.helidon.common.config.Config;
@@ -31,18 +30,12 @@ public interface TlsManagerProvider extends ConfiguredProvider<TlsManager> {
     /**
      * Provides the ability to have a unique {@link TlsManager} per unique {@link Config} instance provided.
      *
-     * @param config     the raw config instance
      * @param configBean the config bean instance
-     * @param name       the config bean instance name
      * @param creator    the creator to apply if not already in cache, which takes the config bean instance
      * @return the tls manager instance from cache, defaulting to creation from the {@code creator} if not in cache
      */
-    static TlsManager getOrCreate(Config config,
-                                  String name,
-                                  Object configBean,
-                                  Function<Object, TlsManager> creator) {
-        Objects.requireNonNull(config);
-        Objects.requireNonNull(name);
+    static <T> TlsManager getOrCreate(T configBean,
+                                      Function<Object, TlsManager> creator) {
         return TlsManagerCache.getOrCreate(configBean, creator);
     }
 

--- a/common/tls/src/test/java/io/helidon/common/tls/spi/TlsManagerProviderTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/spi/TlsManagerProviderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.tls.spi;
+
+import io.helidon.common.tls.ConfiguredTlsManager;
+import io.helidon.common.tls.TlsManager;
+import io.helidon.config.Config;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TlsManagerProviderTest {
+
+    @Test
+    void caching() {
+        TlsManager mock = Mockito.mock(TlsManager.class);
+        Config config = Config.create();
+        AtomicInteger count = new AtomicInteger();
+
+        // we are using "1" and "2" here abstractly to stand in for Config beans, which would hash properly
+        TlsManager manager1 = TlsManagerProvider.getOrCreate(config, "test", "1", (c) -> {
+            count.incrementAndGet();
+            return mock;
+        });
+        assertThat(manager1, sameInstance(mock));
+        assertThat(count.get(), is(1));
+
+        TlsManager manager2 = TlsManagerProvider.getOrCreate(config, "test", "1", (c) -> {
+            count.incrementAndGet();
+            return Mockito.mock(TlsManager.class);
+        });
+        assertThat(manager2, sameInstance(mock));
+        assertThat(count.get(), is(1));
+
+        TlsManager manager3 = TlsManagerProvider.getOrCreate(config, "test", "2", (c) -> {
+            count.incrementAndGet();
+            return Mockito.mock(TlsManager.class);
+        });
+        assertThat(manager3, notNullValue());
+        assertThat(manager3, not(sameInstance(mock)));
+        assertThat(count.get(), is(2));
+    }
+
+}

--- a/common/tls/src/test/java/io/helidon/common/tls/spi/TlsManagerProviderTest.java
+++ b/common/tls/src/test/java/io/helidon/common/tls/spi/TlsManagerProviderTest.java
@@ -16,15 +16,17 @@
 
 package io.helidon.common.tls.spi;
 
-import io.helidon.common.tls.ConfiguredTlsManager;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import io.helidon.common.tls.TlsManager;
-import io.helidon.config.Config;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class TlsManagerProviderTest {
@@ -32,25 +34,24 @@ class TlsManagerProviderTest {
     @Test
     void caching() {
         TlsManager mock = Mockito.mock(TlsManager.class);
-        Config config = Config.create();
         AtomicInteger count = new AtomicInteger();
 
         // we are using "1" and "2" here abstractly to stand in for Config beans, which would hash properly
-        TlsManager manager1 = TlsManagerProvider.getOrCreate(config, "test", "1", (c) -> {
+        TlsManager manager1 = TlsManagerProvider.getOrCreate("1", (c) -> {
             count.incrementAndGet();
             return mock;
         });
         assertThat(manager1, sameInstance(mock));
         assertThat(count.get(), is(1));
 
-        TlsManager manager2 = TlsManagerProvider.getOrCreate(config, "test", "1", (c) -> {
+        TlsManager manager2 = TlsManagerProvider.getOrCreate("1", (c) -> {
             count.incrementAndGet();
             return Mockito.mock(TlsManager.class);
         });
         assertThat(manager2, sameInstance(mock));
         assertThat(count.get(), is(1));
 
-        TlsManager manager3 = TlsManagerProvider.getOrCreate(config, "test", "2", (c) -> {
+        TlsManager manager3 = TlsManagerProvider.getOrCreate("2", (c) -> {
             count.incrementAndGet();
             return Mockito.mock(TlsManager.class);
         });

--- a/integrations/oci/tls-certificates/src/main/java/io/helidon/integrations/oci/tls/certificates/DefaultOciCertificatesTlsManagerProvider.java
+++ b/integrations/oci/tls-certificates/src/main/java/io/helidon/integrations/oci/tls/certificates/DefaultOciCertificatesTlsManagerProvider.java
@@ -43,7 +43,10 @@ public class DefaultOciCertificatesTlsManagerProvider implements TlsManagerProvi
     public TlsManager create(Config config,
                              String name) {
         OciCertificatesTlsManagerConfig cfg = OciCertificatesTlsManagerConfig.create(config);
-        return new DefaultOciCertificatesTlsManager(cfg, name, config);
+        return TlsManagerProvider.getOrCreate(config,
+                name,
+                cfg,
+                (c) -> new DefaultOciCertificatesTlsManager(cfg, name, config));
     }
 
 }

--- a/integrations/oci/tls-certificates/src/main/java/io/helidon/integrations/oci/tls/certificates/DefaultOciCertificatesTlsManagerProvider.java
+++ b/integrations/oci/tls-certificates/src/main/java/io/helidon/integrations/oci/tls/certificates/DefaultOciCertificatesTlsManagerProvider.java
@@ -43,9 +43,7 @@ public class DefaultOciCertificatesTlsManagerProvider implements TlsManagerProvi
     public TlsManager create(Config config,
                              String name) {
         OciCertificatesTlsManagerConfig cfg = OciCertificatesTlsManagerConfig.create(config);
-        return TlsManagerProvider.getOrCreate(config,
-                name,
-                cfg,
+        return TlsManagerProvider.getOrCreate(cfg,
                 (c) -> new DefaultOciCertificatesTlsManager(cfg, name, config));
     }
 


### PR DESCRIPTION
This provides an enhancement whereas on the same JVM, using the same config bean, you will get the same `TlsManager` instance. This is to prevent a proliferation of manager instances in client-side usages - which will officially be coming in a separator PR later.

Base issue is #7698 