### PR TITLE
4.x - named routing

### DIFF
--- a/examples/webserver/multiport/README.md
+++ b/examples/webserver/multiport/README.md
@@ -2,7 +2,7 @@
 
 It is common when deploying a microservice to run your service on
 multiple ports so that you can control the visibility of your
-service's endpoints. For example you might want to use three ports:
+service's endpoints. For example, you might want to use three ports:
 
 - 8080: public REST endpoints of application
 - 8081: private REST endpoints of application
@@ -16,7 +16,7 @@ as described above.
 
 The ports are configured in `application.yaml` by using named sockets.
 
-Seperate routing is defined for each named socket in `Main.java`
+Separate routing is defined for each named socket in `Main.java`
 
 ## Build and run
 
@@ -32,7 +32,7 @@ curl -X GET http://localhost:8080/hello
 
 curl -X GET http://localhost:8081/private/hello
 
-curl -X GET http://localhost:8082/health
+curl -X GET http://localhost:8082/observe/health
 
-curl -X GET http://localhost:8082/metrics
+curl -X GET http://localhost:8082/observe/metrics
 ```

--- a/examples/webserver/multiport/pom.xml
+++ b/examples/webserver/multiport/pom.xml
@@ -48,18 +48,20 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-health</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.health</groupId>
             <artifactId>helidon-health-checks</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
             <artifactId>helidon-webserver-observe-metrics</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics-system-meters</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>

--- a/examples/webserver/multiport/src/main/java/io/helidon/webserver/examples/multiport/Main.java
+++ b/examples/webserver/multiport/src/main/java/io/helidon/webserver/examples/multiport/Main.java
@@ -63,12 +63,8 @@ public final class Main {
         // Build server using three ports:
         // default public port, admin port, private port
         server.routing(Main::publicRouting)
-                // Add a set of routes on the named socket "admin"
-                .putSocket("admin", socket -> socket.from(server.sockets().get("admin"))
-                        .routing(Main::adminSocket))
-                // Add a set of routes on the named socket "private"
-                .putSocket("private", socket -> socket.from(server.sockets().get("admin"))
-                        .routing(Main::privateSocket));
+                .routing("admin", Main::adminSocket)
+                .routing("private", Main::privateSocket);
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigBlueprint.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,6 +33,7 @@ import io.helidon.inject.configdriven.api.ConfigBean;
  * See {@link WebServer#create(java.util.function.Consumer)}.
  */
 @Prototype.Blueprint(decorator = WebServerConfigBlueprint.ServerConfigDecorator.class)
+@Prototype.CustomMethods(WebServerConfigSupport.CustomMethods.class)
 @Configured(root = true, prefix = "server")
 @ConfigBean(wantDefault = true)
 interface WebServerConfigBlueprint extends ListenerConfigBlueprint, Prototype.Factory<WebServer> {
@@ -57,6 +59,17 @@ interface WebServerConfigBlueprint extends ListenerConfigBlueprint, Prototype.Fa
     Map<String, ListenerConfig> sockets();
 
     /**
+     * Routing for additional sockets.
+     * Note that socket named {@value WebServer#DEFAULT_SOCKET_NAME} cannot be used,
+     * configure the routing on the server directly.
+     *
+     * @return map of routing
+     */
+    @Option.Singular
+    @Option.Access("")
+    Map<String, List<Routing>> namedRoutings();
+
+    /**
      * Context for the WebServer, if none defined, a new one will be created with global context as the root.
      *
      * @return server context
@@ -69,6 +82,10 @@ interface WebServerConfigBlueprint extends ListenerConfigBlueprint, Prototype.Fa
             if (target.sockets().containsKey(WebServer.DEFAULT_SOCKET_NAME)) {
                 throw new ConfigException("Default socket must be configured directly on server config node, or through"
                                                   + " \"ServerConfig.Builder\", not as a separated socket.");
+            }
+            if (target.namedRoutings().containsKey(WebServer.DEFAULT_SOCKET_NAME)) {
+                throw new ConfigException("Default routing must be configured directly on server config node, or through"
+                                                  + " \"ServerConfig.Builder\", not as a named routing.");
             }
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.webserver.http.HttpRouting;
+
+class WebServerConfigSupport {
+
+    static class CustomMethods {
+
+        /**
+         * Add Http routing for an additional socket.
+         *
+         * @param builder  builder to update
+         * @param socket   name of the socket
+         * @param consumer HTTP Routing for the given socket name
+         */
+        @Prototype.BuilderMethod
+        static void routing(WebServerConfig.BuilderBase<?, ?> builder,
+                            String socket,
+                            Consumer<HttpRouting.Builder> consumer) {
+            HttpRouting.Builder routingBuilder = HttpRouting.builder();
+            consumer.accept(routingBuilder);
+            builder.addNamedRouting(socket, routingBuilder.build());
+        }
+
+        /**
+         * Add Http routing for an additional socket.
+         *
+         * @param builder builder to update
+         * @param socket  name of the socket
+         * @param routing HTTP Routing for the given socket name
+         */
+        @Prototype.BuilderMethod
+        static void routing(WebServerConfig.BuilderBase<?, ?> builder,
+                            String socket,
+                            HttpRouting routing) {
+            builder.addNamedRouting(socket, routing);
+        }
+    }
+}


### PR DESCRIPTION
### Description

- Add new `.routing` variants in `WebServerConfig.Builder`
- Update `LoomServer` to use the new named routings
- Update multiport example to use the new API
- Fix multiport example README.md and dependencies (`/observe` and dependencies)

Fixes #7702

---

### Documentation

One can now register routing for a named socket created via `.config(config.get("server"))`. 

Before:
```java
server.routing(Main::publicRouting)
        // Add a set of routes on the named socket "admin"
        .putSocket("admin", socket -> socket.from(server.sockets().get("admin"))
                .routing(Main::adminSocket))
        // Add a set of routes on the named socket "private"
        .putSocket("private", socket -> socket.from(server.sockets().get("private"))
                .routing(Main::privateSocket));
```

After:
```java
server.routing(Main::publicRouting)
        .routing("admin", Main::adminSocket)
        .routing("private", Main::privateSocket);
```