### PR TITLE
Fix SLF4J binding for annotation processors

### DIFF
--- a/inject/tools/pom.xml
+++ b/inject/tools/pom.xml
@@ -68,6 +68,10 @@
         <dependency>
             <!-- required as handlebars use slf4j -->
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Description

Add `slf4j-api` as a dependency to inject/tools to ensure that the version of both `slf4j-api` and `slf4j-jdk14` are aligned.

Fixes #7129

### Documentation

No impact.
