### PR TITLE
[4.x] Switches default JPA CDI portable extension to PersistenceExtension from JpaExtension

### DIFF
--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatform.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,19 @@
 package io.helidon.integrations.cdi.hibernate;
 
 import java.util.Objects;
+import java.util.Properties;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.persistence.spi.PersistenceUnitInfo;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.UserTransaction;
 import org.hibernate.engine.jndi.spi.JndiService;
 import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatform;
+
+import static org.hibernate.cfg.AvailableSettings.CONNECTION_HANDLING;
+import static org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION;
 
 /**
  * An {@link AbstractJtaPlatform} that is an {@link ApplicationScoped}
@@ -35,74 +41,112 @@ import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatfor
  */
 @ApplicationScoped
 public class CDISEJtaPlatform extends AbstractJtaPlatform {
-  private final TransactionManager transactionManager;
 
-  private final UserTransaction userTransaction;
+    private static final long serialVersionUID = 1L;
 
-  private static final long serialVersionUID = 1L;
+    private transient TransactionManager transactionManager;
 
-  /**
-   * Creates a new {@link CDISEJtaPlatform}.
-   *
-   * @param transactionManager the {@link TransactionManager} to use;
-   * must not be {@code null}
-   *
-   * @param userTransaction the {@link UserTransaction} to use; must
-   * not be {@code null}
-   *
-   * @exception NullPointerException if either {@code
-   * transactionManager} or {@code userTransaction} is {@code null}
-   */
-  @Inject
-  public CDISEJtaPlatform(final TransactionManager transactionManager,
-                          final UserTransaction userTransaction) {
-    super();
-    this.transactionManager = Objects.requireNonNull(transactionManager);
-    this.userTransaction = Objects.requireNonNull(userTransaction);
-  }
+    private transient UserTransaction userTransaction;
 
-  /**
-   * Throws an {@link UnsupportedOperationException} when invoked.
-   *
-   * @return (not applicable)
-   *
-   * @exception UnsupportedOperationException when invoked
-   */
-  @Override
-  protected JndiService jndiService() {
-    throw new UnsupportedOperationException();
-  }
+    /**
+     * Creates a new {@link CDISEJtaPlatform}.
+     *
+     * @deprecated <a href="https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0#unproxyable">Required by the
+     * CDI specification</a> and not intended for end-user use.
+     */
+    @Deprecated
+    CDISEJtaPlatform() {
+        super();
+        this.transactionManager = null;
+        this.userTransaction = null;
+    }
 
-  /**
-   * Returns the {@link UserTransaction} instance supplied at
-   * {@linkplain #CDISEJtaPlatform(TransactionManager,
-   * UserTransaction) construction time}.
-   *
-   * <p>This method never returns {@code null}.</p>
-   *
-   * @return a non-{@code null} {@link UserTransaction}
-   *
-   * @see #CDISEJtaPlatform(TransactionManager, UserTransaction)
-   */
-  @Override
-  protected UserTransaction locateUserTransaction() {
-    return this.userTransaction;
-  }
+    /**
+     * Creates a new {@link CDISEJtaPlatform}.
+     *
+     * @param transactionManager the {@link TransactionManager} to use;
+     * must not be {@code null}
+     *
+     * @param userTransaction the {@link UserTransaction} to use; must
+     * not be {@code null}
+     *
+     * @exception NullPointerException if either {@code
+     * transactionManager} or {@code userTransaction} is {@code null}
+     */
+    @Inject
+    public CDISEJtaPlatform(final TransactionManager transactionManager,
+                            final UserTransaction userTransaction) {
+        super();
+        this.transactionManager = Objects.requireNonNull(transactionManager);
+        this.userTransaction = Objects.requireNonNull(userTransaction);
+    }
 
-  /**
-   * Returns the {@link TransactionManager} instance supplied at
-   * {@linkplain #CDISEJtaPlatform(TransactionManager,
-   * UserTransaction) construction time}.
-   *
-   * <p>This method never returns {@code null}.</p>
-   *
-   * @return a non-{@code null} {@link TransactionManager}
-   *
-   * @see #CDISEJtaPlatform(TransactionManager, UserTransaction)
-   */
-  @Override
-  protected TransactionManager locateTransactionManager() {
-    return this.transactionManager;
-  }
+    @Override
+    protected boolean canCacheUserTransaction() {
+        return true;
+    }
+
+    /**
+     * Throws an {@link UnsupportedOperationException} when invoked.
+     *
+     * @return (not applicable)
+     *
+     * @exception UnsupportedOperationException when invoked
+     */
+    @Override
+    protected JndiService jndiService() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the {@link UserTransaction} instance supplied at
+     * {@linkplain #CDISEJtaPlatform(TransactionManager,
+     * UserTransaction) construction time}.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * @return a non-{@code null} {@link UserTransaction}
+     *
+     * @see #CDISEJtaPlatform(TransactionManager, UserTransaction)
+     */
+    @Override
+    protected UserTransaction locateUserTransaction() {
+        return this.userTransaction;
+    }
+
+    /**
+     * Returns the {@link TransactionManager} instance supplied at
+     * {@linkplain #CDISEJtaPlatform(TransactionManager,
+     * UserTransaction) construction time}.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * @return a non-{@code null} {@link TransactionManager}
+     *
+     * @see #CDISEJtaPlatform(TransactionManager, UserTransaction)
+     */
+    @Override
+    protected TransactionManager locateTransactionManager() {
+        return this.transactionManager;
+    }
+
+    /**
+     * Customizes the supplied {@link PersistenceUnitInfo}, when it is fired as a CDI event by, for example, the {@code
+     * io.helidon.integrations.cdi.jpa.PersistenceExtension} portable extension, by ensuring that certain important
+     * Hibernate properties are always set on the persistence unit.
+     *
+     * @param pui the {@link PersistenceUnitInfo} to customize; must not be {@code null}
+     *
+     * @exception NullPointerException if {@code pui} is {@code null}
+     *
+     * @see
+     * org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode#DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION
+     */
+    private static void customizePersistenceUnitInfo(@Observes PersistenceUnitInfo pui) {
+        Properties p = pui.getProperties();
+        if (p != null && p.getProperty(CONNECTION_HANDLING) == null && p.get(CONNECTION_HANDLING) == null) {
+            p.setProperty(CONNECTION_HANDLING, DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION.toString());
+        }
+    }
 
 }

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatform.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatform.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.integrations.cdi.hibernate;
 
+import java.lang.System.Logger;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -27,6 +28,7 @@ import jakarta.transaction.UserTransaction;
 import org.hibernate.engine.jndi.spi.JndiService;
 import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatform;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static org.hibernate.cfg.AvailableSettings.CONNECTION_HANDLING;
 import static org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION;
 
@@ -41,6 +43,8 @@ import static org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode.DEL
  */
 @ApplicationScoped
 public class CDISEJtaPlatform extends AbstractJtaPlatform {
+
+    private static final Logger LOGGER = System.getLogger(CDISEJtaPlatform.class.getName());
 
     private static final long serialVersionUID = 1L;
 
@@ -145,6 +149,11 @@ public class CDISEJtaPlatform extends AbstractJtaPlatform {
     private static void customizePersistenceUnitInfo(@Observes PersistenceUnitInfo pui) {
         Properties p = pui.getProperties();
         if (p != null && p.getProperty(CONNECTION_HANDLING) == null && p.get(CONNECTION_HANDLING) == null) {
+            if (LOGGER.isLoggable(DEBUG)) {
+                LOGGER.log(DEBUG, "Setting " + CONNECTION_HANDLING + " property to "
+                           + DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION
+                           + " on persistence unit " + pui.getPersistenceUnitName());
+            }
             p.setProperty(CONNECTION_HANDLING, DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION.toString());
         }
     }

--- a/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
@@ -35,8 +35,10 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Aot(description = "Experimental support, tested on limited use cases")
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module io.helidon.integrations.cdi.hibernate {
-    requires jakarta.cdi;
-    requires jakarta.inject;
+
+    requires transitive jakarta.cdi;
+    requires transitive jakarta.inject;
+    requires jakarta.persistence;
     requires java.sql;
 
     requires static io.helidon.common.features.api;

--- a/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
@@ -39,12 +39,10 @@ module io.helidon.integrations.cdi.hibernate {
     requires transitive jakarta.cdi;
     requires transitive jakarta.inject;
     requires jakarta.persistence;
-    requires java.sql;
-
-    requires static io.helidon.common.features.api;
-
     requires transitive jakarta.transaction;
     requires transitive org.hibernate.orm.core;
+
+    requires static io.helidon.common.features.api;
 
     exports io.helidon.integrations.cdi.hibernate;
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/BeanManagerBackedDataSourceProvider.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/BeanManagerBackedDataSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,12 @@ import jakarta.inject.Inject;
  * @see PersistenceUnitInfoBean.DataSourceProvider
  *
  * @see JtaDataSourceProvider
+ *
+ * @deprecated This is an internal class used by the now-deprecated {@link JpaExtension} class. Its replacement is an
+ * internal class, {@link JtaAbsentDataSourceProvider}, used by the {@link PersistenceExtension} class.
  */
 @ApplicationScoped
+@Deprecated(since = "4.0")
 class BeanManagerBackedDataSourceProvider implements PersistenceUnitInfoBean.DataSourceProvider {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/CdiTransactionScoped.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/CdiTransactionScoped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,10 @@ import jakarta.inject.Qualifier;
  *
  * <p>This qualifier must not be combined with {@link Extended},
  * {@link JpaTransactionScoped} or {@link NonTransactional}.</p>
+ *
+ * @deprecated No replacement.
  */
+@Deprecated(since = "4.0")
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 @Target({}) // can only be programmatically added

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/CdiTransactionScopedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/CdiTransactionScopedEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,11 @@ import jakarta.persistence.EntityManager;
  * this class are not safe for concurrent use by multiple threads.</p>
  *
  * @see JpaExtension
+ *
+ * @deprecated This is an internal class used by the now-deprecated {@link JpaExtension} class. Its replacement is an
+ * internal detail of the {@link PersistenceExtension} class.
  */
+@Deprecated(since = "4.0")
 @Vetoed
 class CdiTransactionScopedEntityManager extends DelegatingEntityManager {
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ClearingQuery.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ClearingQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Objects;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 
+@Deprecated(since = "4.0")
 final class ClearingQuery extends DelegatingQuery {
 
     private final EntityManager entityManager;

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ClearingStoredProcedureQuery.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ClearingStoredProcedureQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Objects;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.StoredProcedureQuery;
 
+@Deprecated(since = "4.0")
 final class ClearingStoredProcedureQuery extends DelegatingStoredProcedureQuery {
 
     private final EntityManager entityManager;

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ClearingTypedQuery.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ClearingTypedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Objects;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
+@Deprecated(since = "4.0")
 final class ClearingTypedQuery<X> extends DelegatingTypedQuery<X> {
 
     private final EntityManager entityManager;

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/EntityManagerFactories.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/EntityManagerFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,10 @@ import jakarta.persistence.spi.PersistenceUnitTransactionType;
  *
  * @see PersistenceProvider#createContainerEntityManagerFactory(PersistenceUnitInfo,
  * Map)
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
+@Deprecated(since = "4.0")
 final class EntityManagerFactories {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/EntityManagers.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/EntityManagers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,10 @@ import jakarta.persistence.SynchronizationType;
  * requirements of the JPA specification.
  *
  * @see #createContainerManagedEntityManager(Instance, Set)
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
+@Deprecated(since = "4.0")
 final class EntityManagers {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ExtendedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/ExtendedEntityManager.java
@@ -30,7 +30,10 @@ import jakarta.persistence.EntityManager;
 /**
  * A {@link DelegatingEntityManager} created to support extended
  * persistence contexts.
+ *
+ * @deprecated This is an internal class used by the now-deprecated {@link JpaExtension} class.
  */
+@Deprecated(since = "4.0")
 class ExtendedEntityManager extends DelegatingEntityManager {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaCdiQualifiers.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaCdiQualifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,11 @@ import java.util.Set;
  * defined by this package.
  *
  * @see #JPA_CDI_QUALIFIERS
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension}, {@link EntityManagers}
+ * and {@link EntityManagerFactories} classes.
  */
+@Deprecated(since = "4.0")
 final class JpaCdiQualifiers {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.CodeSource;
@@ -114,7 +115,10 @@ import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
  * multiple threads.</p>
  *
  * @see PersistenceUnitInfoBean
+ *
+ * @deprecated Please use {@link PersistenceExtension} instead.
  */
+@Deprecated(since = "4.0")
 public class JpaExtension implements Extension {
 
 
@@ -158,7 +162,9 @@ public class JpaExtension implements Extension {
     /**
      * Whether or not this extension will do anything.
      *
-     * <p>This field's value is {@code true} by default.</p>
+     * <p>This field's value is {@code false} by default.</p>
+     *
+     * @see PersistenceExtension
      */
     private final boolean enabled;
 
@@ -309,7 +315,7 @@ public class JpaExtension implements Extension {
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.entering(cn, mn);
         }
-        this.enabled = Boolean.parseBoolean(System.getProperty(this.getClass().getName() + ".enabled", "true"));
+        this.enabled = Boolean.parseBoolean(System.getProperty(this.getClass().getName() + ".enabled", "false"));
         if (LOGGER.isLoggable(Level.FINE) && !this.enabled) {
             LOGGER.logp(Level.FINE, cn, mn, "jpaExtensionDisabled", this.getClass().getName());
         }
@@ -812,7 +818,7 @@ public class JpaExtension implements Extension {
                                     @Priority(LIBRARY_AFTER)
                                     AfterBeanDiscovery event,
                                     BeanManager beanManager)
-        throws IOException, JAXBException, ReflectiveOperationException, XMLStreamException {
+        throws IOException, JAXBException, ReflectiveOperationException, URISyntaxException, XMLStreamException {
         String cn = JpaExtension.class.getName();
         String mn = "afterBeanDiscovery";
         if (LOGGER.isLoggable(Level.FINER)) {
@@ -1357,7 +1363,7 @@ public class JpaExtension implements Extension {
                                         Enumeration<URL> urls,
                                         Collection<? extends PersistenceProvider> providers,
                                         boolean userSuppliedPersistenceUnitInfoBeans)
-        throws IOException, JAXBException, ReflectiveOperationException, XMLStreamException {
+        throws IOException, JAXBException, ReflectiveOperationException, URISyntaxException, XMLStreamException {
         String cn = JpaExtension.class.getName();
         String mn = "processPersistenceXmls";
         if (LOGGER.isLoggable(Level.FINER)) {
@@ -1428,7 +1434,7 @@ public class JpaExtension implements Extension {
                                 .add(PersistenceUnitInfoBean.fromPersistenceUnit(persistenceUnit,
                                                                                  classLoader,
                                                                                  tempClassLoaderSupplier,
-                                                                                 new URL(url, ".."), // i.e. META-INF/..
+                                                                                 url.toURI().resolve("..").toURL(),
                                                                                  unlistedManagedClassesByPersistenceUnitNames,
                                                                                  dataSourceProviderSupplier));
                         }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaTransactionScoped.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaTransactionScoped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,10 @@ import jakarta.inject.Qualifier;
  *
  * <p>This qualifier must not be combined with {@link Extended},
  * {@link CdiTransactionScoped} or {@link NonTransactional}.</p>
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
+@Deprecated(since = "4.0")
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 @Target({}) // can only be programmatically added

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaTransactionScopedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaTransactionScopedEntityManager.java
@@ -57,7 +57,10 @@ import jakarta.persistence.metamodel.Metamodel;
  *
  * <p>As with all {@link EntityManager} implementations, instances of
  * this class are not safe for concurrent use by multiple threads.</p>
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
+@Deprecated(since = "4.0")
 @Vetoed
 final class JpaTransactionScopedEntityManager extends DelegatingEntityManager {
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JtaDataSourceProvider.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JtaDataSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import jakarta.transaction.TransactionScoped;
 import jakarta.transaction.TransactionSynchronizationRegistry;
 
 @ApplicationScoped
+@Deprecated(since = "4.0")
 class JtaDataSourceProvider implements PersistenceUnitInfoBean.DataSourceProvider {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JtaTransactionSupport.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JtaTransactionSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,11 @@ import jakarta.transaction.TransactionScoped;
  * @see TransactionSupport
  *
  * @see NoTransactionSupport
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
 @ApplicationScoped
+@Deprecated(since = "4.0")
 class JtaTransactionSupport implements TransactionSupport {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/Messages.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.integrations.cdi.jpa;
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
 
+@Deprecated(since = "4.0")
 final class Messages {
 
   private static final ResourceBundle MESSAGES = ResourceBundle.getBundle(Messages.class.getName());

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/NoTransactionSupport.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/NoTransactionSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,11 @@ import jakarta.enterprise.context.spi.Context;
  * @see TransactionSupport
  *
  * @see JtaTransactionSupport
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
 @ApplicationScoped
+@Deprecated(since = "4.0")
 final class NoTransactionSupport implements TransactionSupport {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/NonTransactional.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/NonTransactional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,10 @@ import jakarta.inject.Qualifier;
  * <p>This qualifier must not be combined with {@link
  * CdiTransactionScoped}, {@link Extended} or {@code
  * JpaTransactionScoped}.</p>
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
+@Deprecated(since = "4.0")
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 @Target({}) // can only be programmatically added

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/NonTransactionalEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/NonTransactionalEntityManager.java
@@ -44,7 +44,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
  * #acquireDelegate()} method and only under appropriate
  * circumstances.</p>
  *
- * <p>This class is added as a synthetic bean by the {@link
+ * <p>This class is added as a synthetic bean by the (now-deprecated) {@link
  * JpaExtension} class.</p>
  *
  * <h2>Implementation Notes</h2>
@@ -60,7 +60,10 @@ import jakarta.persistence.criteria.CriteriaQuery;
  * this class are not safe for concurrent use by multiple threads.</p>
  *
  * @see JpaExtension
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
+@Deprecated(since = "4.0")
 @Vetoed
 class NonTransactionalEntityManager extends DelegatingEntityManager {
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
@@ -111,8 +111,8 @@ import static jakarta.persistence.SynchronizationType.UNSYNCHRONIZED;
 
 /**
  * An {@link Extension} that integrates <em>container-mode</em> <a
- * href="https://jakarta.ee/specifications/persistence/3.0/jakarta-persistence-spec-3.0.html">Jakarta Persistence
- * 3.0</a> into <a href="https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html">CDI SE 3.0</a>-based
+ * href="https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1.html">Jakarta Persistence
+ * 3.1</a> into <a href="https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html">CDI SE 4.0</a>-based
  * applications.
  */
 public final class PersistenceExtension implements Extension {
@@ -143,7 +143,7 @@ public final class PersistenceExtension implements Extension {
      * the "real" bean.</p>
      *
      * <p>This is necessary because the empty string ({@code ""}) as the value of the {@link Named#value()} element can
-     * have <a href="https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#default_name">special
+     * have <a href="https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html#default_name">special
      * semantics</a>, so cannot be used to designate an unnamed or otherwise default persistence unit.</p>
      *
      * <p>The value of this field is subject to change without prior notice at any point.  In general the mechanics
@@ -313,6 +313,7 @@ public final class PersistenceExtension implements Extension {
      *
      * @see JtaAdaptingDataSourceProvider
      */
+    @SuppressWarnings("deprecation")
     private void vetoDeprecatedJtaDataSourceProvider(@Observes ProcessBeanAttributes<JtaDataSourceProvider> event) {
         if (!this.enabled) {
             return;
@@ -326,6 +327,33 @@ public final class PersistenceExtension implements Extension {
                         + " replaces it", event.getBeanAttributes());
         }
         event.veto();
+    }
+
+    /**
+     * {@linkplain ProcessBeanAttributes#veto() Vetoes} any bean whose bean types includes the deprecated {@link
+     * BeanManagerBackedDataSourceProvider} class, since it is replaced by {@link JtaAbsentDataSourceProvider}.
+     *
+     * @param event the {@link ProcessBeanAttributes} event in question; must not be {@code null}
+     *
+     * @exception NullPointerException if {@code event} is {@code null}
+     *
+     * @see JtaAbsentDataSourceProvider
+     */
+    @SuppressWarnings("deprecation")
+    private void vetoDeprecatedBeanManagerBackedDataSourceProvider(@Observes
+                                                                   ProcessBeanAttributes<BeanManagerBackedDataSourceProvider> e) {
+        if (!this.enabled) {
+            return;
+        }
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.logp(Level.FINE, this.getClass().getName(), "vetoDeprecatedBeanManagerBackedDataSourceProvider",
+                        "Vetoing BeanAttributes {0} representing "
+                        + BeanManagerBackedDataSourceProvider.class
+                        + " because it is deprecated and "
+                        + JtaAbsentDataSourceProvider.class
+                        + " replaces it", e.getBeanAttributes());
+        }
+        e.veto();
     }
 
     private <T> void rewriteJpaAnnotations(@Observes

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceUnitInfoBean.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceUnitInfoBean.java
@@ -16,6 +16,7 @@
 package io.helidon.integrations.cdi.jpa;
 
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.AbstractList;
@@ -988,7 +989,11 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
         final List<URL> jarFileUrls = new ArrayList<>();
         for (final String jarFile : jarFiles) {
             if (jarFile != null) {
-                jarFileUrls.add(createJarFileURL(rootUrl, jarFile));
+                try {
+                    jarFileUrls.add(createJarFileURL(rootUrl, jarFile));
+                } catch (URISyntaxException e) {
+                    throw (MalformedURLException) new MalformedURLException(e.getMessage()).initCause(e);
+                }
             }
         }
 
@@ -1095,12 +1100,9 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
     }
 
     private static URL createJarFileURL(final URL persistenceUnitRootUrl, final String jarFileUrlString)
-        throws MalformedURLException {
-        Objects.requireNonNull(persistenceUnitRootUrl);
-        Objects.requireNonNull(jarFileUrlString);
+        throws MalformedURLException, URISyntaxException {
         // Revisit: probably won't work if persistenceUnitRootUrl is, say, a jar URL
-        final URL returnValue = new URL(persistenceUnitRootUrl, jarFileUrlString);
-        return returnValue;
+        return persistenceUnitRootUrl.toURI().resolve(jarFileUrlString).toURL();
     }
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceUnitInfoBean.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceUnitInfoBean.java
@@ -1016,7 +1016,7 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
         assert managedClasses != null;
         String name = persistenceUnit.getName();
         if (name == null || name.isEmpty()) {
-            name = JpaExtension.DEFAULT_PERSISTENCE_UNIT_NAME;
+            name = PersistenceExtension.DEFAULT_PERSISTENCE_UNIT_NAME;
         }
 
         final Boolean excludeUnlistedClasses = persistenceUnit.isExcludeUnlistedClasses();
@@ -1032,7 +1032,7 @@ public class PersistenceUnitInfoBean implements PersistenceUnitInfo {
                 }
             }
             // Also add "default" ones
-            myUnlistedClasses = unlistedClasses.get(JpaExtension.DEFAULT_PERSISTENCE_UNIT_NAME);
+            myUnlistedClasses = unlistedClasses.get(PersistenceExtension.DEFAULT_PERSISTENCE_UNIT_NAME);
             if (myUnlistedClasses != null && !myUnlistedClasses.isEmpty()) {
                 for (final Class<?> unlistedClass : myUnlistedClasses) {
                     if (unlistedClass != null) {

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/TransactionSupport.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/TransactionSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ import jakarta.enterprise.context.spi.Context;
  * @see NoTransactionSupport
  *
  * @see JtaTransactionSupport
+ *
+ * @deprecated This is an internal class used only by the now-deprecated {@link JpaExtension} class.
  */
+@Deprecated(since = "4.0")
 interface TransactionSupport {
 
 

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/package-info.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 /**
  * Provides classes and interfaces that integrate the
  * provider-independent parts of <a
- * href="https://jakarta.ee/specifications/persistence/3.0/"
+ * href="https://jakarta.ee/specifications/persistence/3.1/"
  * target="_parent">JPA</a> into CDI.
  *
- * @see io.helidon.integrations.cdi.jpa.JpaExtension
+ * @see io.helidon.integrations.cdi.jpa.PersistenceExtension
  *
  * @see io.helidon.integrations.cdi.jpa.PersistenceUnitInfoBean
  */

--- a/integrations/cdi/jpa-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/module-info.java
@@ -20,10 +20,10 @@ import io.helidon.common.features.api.HelidonFlavor;
 /**
  * Provides classes and interfaces that integrate the
  * provider-independent parts of <a
- * href="https://jakarta.ee/specifications/persistence/3.0/"
+ * href="https://jakarta.ee/specifications/persistence/3.1/"
  * target="_parent">JPA</a> into CDI.
  *
- * @see io.helidon.integrations.cdi.jpa.JpaExtension
+ * @see io.helidon.integrations.cdi.jpa.PersistenceExtension
  *
  * @see io.helidon.integrations.cdi.jpa.PersistenceUnitInfoBean
  */
@@ -32,7 +32,7 @@ import io.helidon.common.features.api.HelidonFlavor;
         in = HelidonFlavor.MP,
         path = "JPA"
 )
-@SuppressWarnings({ "requires-automatic"})
+@SuppressWarnings({ "deprecation", "requires-automatic"})
 module io.helidon.integrations.cdi.jpa {
   
     requires jakarta.xml.bind;

--- a/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/LocalXAResource.java
+++ b/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/LocalXAResource.java
@@ -725,34 +725,40 @@ final class LocalXAResource implements XAResource {
         // S5: Heuristically Completed
 
         Association(BranchState branchState, Xid xid, Connection connection) {
-            this(branchState, xid, false, connection);
-        }
-
-        Association(BranchState branchState, Xid xid, boolean suspended, Connection connection) {
-            this(branchState, xid, suspended, connection, true /* JDBC default; will be set from connection anyway */);
+            this(branchState, xid, false, connection, autoCommit(connection));
         }
 
         Association {
             Objects.requireNonNull(xid, "xid");
+            boolean autoCommit = false;
             switch (branchState) {
             case IDLE:
                 break;
             case ACTIVE:
             case HEURISTICALLY_COMPLETED:
-            case NON_EXISTENT_TRANSACTION:
             case PREPARED:
             case ROLLBACK_ONLY:
                 if (suspended) {
                     throw new IllegalArgumentException("suspended");
                 }
                 break;
+            case NON_EXISTENT_TRANSACTION:
+                if (suspended) {
+                    throw new IllegalArgumentException("suspended");
+                }
+                autoCommit = priorAutoCommit;
+                break;
             default:
                 throw new IllegalArgumentException("branchState: " + branchState);
             }
             try {
-                priorAutoCommit = connection.getAutoCommit();
-                if (priorAutoCommit) {
-                    connection.setAutoCommit(false);
+                if (connection.getAutoCommit() != autoCommit) {
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        LOGGER.logp(Level.FINE, Association.class.getName(), "<init>",
+                                    "Setting autoCommit to {0} on connection {1}",
+                                    new Object[] {autoCommit, connection});
+                    }
+                    connection.setAutoCommit(autoCommit);
                 }
             } catch (SQLException sqlException) {
                 throw new UncheckedSQLException(sqlException);
@@ -984,20 +990,24 @@ final class LocalXAResource implements XAResource {
         }
 
         private Association reset() throws SQLException {
-            Connection connection = this.connection();
-            connection.setAutoCommit(this.priorAutoCommit());
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.logp(Level.FINE, this.getClass().getName(), "reset",
-                            "Resetting; restored autoCommit to {0} on connection {1}",
-                            new Object[] {this.priorAutoCommit(), connection});
-                LOGGER.logp(Level.FINE, this.getClass().getName(), "reset",
-                            "Transitioning Association {0} to NON_EXISTENT_TRANSACTION", this);
+                            "Transitioning Association {0} from state {1} to state NON_EXISTENT_TRANSACTION",
+                            new Object[] {this, this.branchState()});
             }
             return new Association(BranchState.NON_EXISTENT_TRANSACTION,
                                    this.xid(),
                                    false,
                                    connection,
                                    this.priorAutoCommit());
+        }
+
+        private static boolean autoCommit(Connection c) {
+            try {
+                return c.getAutoCommit();
+            } catch (SQLException e) {
+                throw new UncheckedSQLException(e);
+            }
         }
 
         // Transaction Branch States (XA specification, table 6-4):

--- a/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/LocalXAResource.java
+++ b/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/LocalXAResource.java
@@ -644,7 +644,7 @@ final class LocalXAResource implements XAResource {
             throw new UncheckedSQLException(e);
         }
         if (LOGGER.isLoggable(Level.FINER)) {
-            LOGGER.exiting(Association.class.getName(), "preapre", a);
+            LOGGER.exiting(Association.class.getName(), "prepare", a);
         }
         return a;
     }


### PR DESCRIPTION
This PR "turns on" the "new" JPA machinery that has been lying somewhat dormant in Helidon since 3.x.  The "old" machinery remains, since the new machinery is a very different approach, and there may be production cases where the old machinery needs to be switched back on in case old behavior was being relied upon.

This PR also adds deprecation notices to various classes (most of which are internal anyway but it's good practice).

This PR also ensures that any usage of the `CDISEJtaPlatform` in combination with the ("new machinery") `PersistenceExtension` will cause the appropriate Hibernate-specific connection handling policy to be in effect, even if it isn't present in a `persistence.xml`.

This PR also fixes a setting-the-`autoCommit`-property-on-a-`Connection` bug that may be responsible for blocking #7448. We'll see.

Documentation impact: none.