### PR TITLE
4.x: Java 21 follow up

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
--Dnet.bytebuddy.experimental=true

--- a/examples/microprofile/hello-world-implicit/src/test/java/io/helidon/microprofile/example/helloworld/implicit/ImplicitHelloWorldTest.java
+++ b/examples/microprofile/hello-world-implicit/src/test/java/io/helidon/microprofile/example/helloworld/implicit/ImplicitHelloWorldTest.java
@@ -21,7 +21,6 @@ import io.helidon.microprofile.testing.junit5.HelidonTest;
 import jakarta.inject.Inject;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.WebTarget;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,8 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
  * Unit test for {@link HelloWorldResource}.
  */
 @HelidonTest
-@Disabled("3.0.0-JAKARTA") // OpenAPI: Caused by: java.lang.NoSuchMethodError:
-        // 'java.util.List io.smallrye.jandex.ClassInfo.unsortedFields()'
 class ImplicitHelloWorldTest {
     private final WebTarget target;
 

--- a/examples/todo-app/backend/pom.xml
+++ b/examples/todo-app/backend/pom.xml
@@ -39,10 +39,11 @@
         <mainClass>io.helidon.examples.todos.backend.Main</mainClass>
         <version.lib.cassandra>3.10.2</version.lib.cassandra>
         <version.cassandra.unit>4.3.1.0</version.cassandra.unit>
-        <version.datastax.driver.core>4.9.0</version.datastax.driver.core>
-        <version.datastax.driver.query.builder>4.9.0</version.datastax.driver.query.builder>
+        <version.datastax.driver>4.9.0</version.datastax.driver>
         <version.codahale.metrics.core>3.0.2</version.codahale.metrics.core>
-        <version.lib.snakeyaml.override>1.32</version.lib.snakeyaml.override>
+        <version.snakeyaml.override>1.32</version.snakeyaml.override>
+        <version.testcontainers>1.19.1</version.testcontainers>
+        <version.testcontainers.cassandra>1.19.1</version.testcontainers.cassandra>
     </properties>
 
     <dependencyManagement>
@@ -61,7 +62,14 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>${version.lib.snakeyaml.override}</version>
+                <version>${version.snakeyaml.override}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${version.testcontainers}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -110,27 +118,32 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.cassandraunit</groupId>
-            <artifactId>cassandra-unit</artifactId>
-            <version>${version.cassandra.unit}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.datastax.oss</groupId>
             <artifactId>java-driver-core</artifactId>
-            <version>${version.datastax.driver.core}</version>
+            <version>${version.datastax.driver}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.datastax.oss</groupId>
             <artifactId>java-driver-query-builder</artifactId>
-            <version>${version.datastax.driver.query.builder}</version>
+            <version>${version.datastax.driver}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${version.codahale.metrics.core}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cassandra</artifactId>
+            <version>${version.testcontainers.cassandra}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/todo-app/backend/src/test/java/io/helidon/examples/todos/backend/BackendTests.java
+++ b/examples/todo-app/backend/src/test/java/io/helidon/examples/todos/backend/BackendTests.java
@@ -16,7 +16,6 @@
 
 package io.helidon.examples.todos.backend;
 
-import java.io.IOException;
 import java.util.Base64;
 import java.util.Properties;
 
@@ -35,29 +34,30 @@ import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Testcontainers
 @HelidonTest
 @Configuration(useExisting = true)
-// Embedded cassandra does not start on Java 17+
-@Disabled("3.0.0-JAKARTA")
 class BackendTests {
-
-    private final static String CASSANDRA_HOST = "127.0.0.1";
+    @Container
+    static final CassandraContainer<?> CASSANDRA_CONTAINER = new CassandraContainer<>("cassandra:3.11.2")
+            .withReuse(true);
 
     @Inject
     private WebTarget webTarget;
 
     @BeforeAll
-    static void init() throws IOException {
+    static void init() {
         Properties cassandraProperties = initCassandra();
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
@@ -73,23 +73,23 @@ class BackendTests {
 
     @AfterAll
     static void stopServer() {
-        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
     }
 
-    private static Properties initCassandra() throws IOException {
-        EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE,
-                                                             20000L);
+    private static Properties initCassandra() {
+        String host = CASSANDRA_CONTAINER.getHost();
+        Integer port = CASSANDRA_CONTAINER.getMappedPort(CassandraContainer.CQL_PORT);
+
         Properties prop = new Properties();
-        prop.put("cassandra.port", String.valueOf(EmbeddedCassandraServerHelper.getNativeTransportPort()));
-        prop.put("cassandra.servers.host.host", CASSANDRA_HOST);
+        prop.put("cassandra.port", String.valueOf(port));
+        prop.put("cassandra.servers.host.host", host);
 
         Cluster cluster = Cluster.builder()
                 .withoutMetrics()
-                .addContactPoint(CASSANDRA_HOST)
-                .withPort(EmbeddedCassandraServerHelper.getNativeTransportPort())
+                .addContactPoint(host)
+                .withPort(port)
                 .build();
 
-        Session session = cluster.connect();
+        Session session = cluster.newSession();
         session.execute("CREATE KEYSPACE backend WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1};");
         session.execute(
                 "CREATE TABLE backend.backend (id ascii, user ascii, message ascii, completed Boolean, created timestamp, "

--- a/examples/todo-app/backend/src/test/java/io/helidon/examples/todos/backend/BackendTests.java
+++ b/examples/todo-app/backend/src/test/java/io/helidon/examples/todos/backend/BackendTests.java
@@ -38,6 +38,8 @@ import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.testcontainers.containers.CassandraContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -48,6 +50,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Testcontainers
 @HelidonTest
 @Configuration(useExisting = true)
+@EnabledOnOs(OS.LINUX) // due to usage of docker with testcontainers, only Linux is enabled by default
 class BackendTests {
     @Container
     static final CassandraContainer<?> CASSANDRA_CONTAINER = new CassandraContainer<>("cassandra:3.11.2")

--- a/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
+++ b/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
@@ -22,7 +22,6 @@ import jakarta.inject.Inject;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -31,7 +30,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
 
 @HelidonTest
-@Disabled("3.0.0-JAKARTA")
 class MainTest {
 
     @Inject

--- a/tests/integration/zipkin-mp-2.2/src/test/java/io/helidon/tests/integration/zipkin/mp22/ZipkinMp22Test.java
+++ b/tests/integration/zipkin-mp-2.2/src/test/java/io/helidon/tests/integration/zipkin/mp22/ZipkinMp22Test.java
@@ -25,7 +25,6 @@ import io.opentracing.util.GlobalTracer;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -59,7 +58,6 @@ class ZipkinMp22Test {
     }
 
     @Test
-    @Disabled("3.0.0-JAKARTA") // java.lang.IllegalStateException: No RestClientBuilderResolver implementation found!
     void invokeEndpoint() {
         MpResource client = RestClientBuilder.newBuilder()
                 .baseUri(URI.create("http://localhost:" + port))


### PR DESCRIPTION
### Description
Resolves #7221 
- byte buddy workaround
- backend test for cassandra now uses test containers (could not start in-process Cassandra in later Java releases)
- re-enabled tests disabled for Jakarta upgrade

### Documentation
No impact