### PR TITLE
4.x: Fix build noise

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -56,19 +56,6 @@
                         </execution>
                     </executions>
                 </plugin>
-                 <plugin>
-                    <groupId>org.jvnet.jaxb2.maven2</groupId>
-                    <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>${version.plugin.jaxb}</version>
-                    <dependencies>
-                        <!-- Force upgrade version. Needed to support Java 16 -->
-                        <dependency>
-                            <groupId>org.glassfish.jaxb</groupId>
-                            <artifactId>jaxb-runtime</artifactId>
-                            <version>${version.lib.jaxb-runtime}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
                 <plugin>
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -89,7 +89,6 @@
         <version.lib.jaxb-impl>4.0.3</version.lib.jaxb-impl>
         <version.lib.jboss.classfilewriter>1.3.0.Final</version.lib.jboss.classfilewriter>
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
-        <!-- Force upgrade version used by maven-jaxb2-plugin. Needed to support Java 16 -->
         <version.lib.jaxb-runtime>4.0.3</version.lib.jaxb-runtime>
         <version.lib.jersey>3.1.3</version.lib.jersey>
         <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>

--- a/integrations/oci/sdk/processor/pom.xml
+++ b/integrations/oci/sdk/processor/pom.xml
@@ -43,6 +43,15 @@
             <artifactId>handlebars</artifactId>
         </dependency>
         <dependency>
+            <!-- required as handlebars use slf4j -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.testing</groupId>
             <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>

--- a/tests/integration/jpa/appl/pom.xml
+++ b/tests/integration/jpa/appl/pom.xml
@@ -106,6 +106,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -115,7 +120,6 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -154,32 +158,6 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>Generate persistence.xml Java objects</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <generatePackage>io.helidon.tests.integration.nativeimage.mp2.jaxb</generatePackage>
-                            <markGenerated>true</markGenerated>
-                            <schemas>
-                                <schema>
-                                    <dependencyResource>
-                                        <groupId>jakarta.persistence</groupId>
-                                        <artifactId>jakarta.persistence-api</artifactId>
-                                        <resource>javax/persistence/persistence_2_2.xsd</resource>
-                                    </dependencyResource>
-                                </schema>
-                            </schemas>
-                            <strict>false</strict>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.hibernate.orm.tooling</groupId>

--- a/tests/integration/native-image/mp-2/pom.xml
+++ b/tests/integration/native-image/mp-2/pom.xml
@@ -142,32 +142,6 @@
                 <artifactId>jandex-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>Generate persistence.xml Java objects</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <generatePackage>io.helidon.tests.integration.nativeimage.mp2.jaxb</generatePackage>
-                            <markGenerated>true</markGenerated>
-                            <schemas>
-                                <schema>
-                                    <dependencyResource>
-                                        <groupId>jakarta.persistence</groupId>
-                                        <artifactId>jakarta.persistence-api</artifactId>
-                                        <resource>javax/persistence/persistence_2_2.xsd</resource>
-                                    </dependencyResource>
-                                </schema>
-                            </schemas>
-                            <strict>false</strict>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.hibernate.orm.tooling</groupId>
                 <artifactId>hibernate-enhance-maven-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
Fix build noise:

- Remove all usages of `maven-jaxb2-plugin`
- add slf4j-api and slf4j-jdk14 dependencies to integrations/oci/sdk/processor/pom.xml (similar to #7706)

The removed execution of maven-jaxb2-plugin are currently failing with:
```
org.xml.sax.SAXParseException: java.net.MalformedURLException: unknown protocol: maven
```

Even though the executions are failing, everything is working as expected. It actually turns out that these executions are not needed (confirmed with @ljnelson ).
