### PR TITLE
[4.x] Upgrades Hibernate to version 6.3.1.Final

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -56,20 +56,6 @@
                         </execution>
                     </executions>
                 </plugin>
-                <plugin>
-                    <groupId>org.hibernate.orm.tooling</groupId>
-                    <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                    <version>${version.plugin.hibernate.enhance}</version>
-                    <dependencies>
-                        <dependency>
-                            <!-- Force upgrade byte-buddy for Java 21.     -->
-                            <!-- Remove after upgrading to Hibernate 6.2.7 -->
-                            <groupId>net.bytebuddy</groupId>
-                            <artifactId>byte-buddy</artifactId>
-                            <version>${version.lib.byte-buddy}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -33,9 +33,6 @@
 
     <properties>
         <version.plugin.jandex>3.1.2</version.plugin.jandex>
-        <version.plugin.jaxb>0.14.0</version.plugin.jaxb>
-        <version.plugin.eclipselink>2.7.5.1</version.plugin.eclipselink>
-        <version.plugin.hibernate.enhance>6.3.1.Final</version.plugin.hibernate.enhance>
         <mainClass>io.helidon.Main</mainClass>
     </properties>
 

--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -35,7 +35,7 @@
         <version.plugin.jandex>3.1.2</version.plugin.jandex>
         <version.plugin.jaxb>0.14.0</version.plugin.jaxb>
         <version.plugin.eclipselink>2.7.5.1</version.plugin.eclipselink>
-        <version.plugin.hibernate.enhance>6.1.7.Final</version.plugin.hibernate.enhance>
+        <version.plugin.hibernate.enhance>6.3.1.Final</version.plugin.hibernate.enhance>
         <mainClass>io.helidon.Main</mainClass>
     </properties>
 

--- a/archetypes/helidon/src/main/archetype/mp/custom/database.xml
+++ b/archetypes/helidon/src/main/archetype/mp/custom/database.xml
@@ -187,6 +187,8 @@ Instructions for H2 can be found here: https://www.h2database.com/html/cheatShee
                                     </list>
                                     <list key="main-persistence-properties">
                                         <map if="${..jpa-impl} == 'hibernate'">
+                                            <value key="name">hibernate.column_ordering_strategy</value>
+                                            <value key="value">legacy</value>
                                             <value key="name">hibernate.dialect</value>
                                             <value key="value">org.hibernate.dialect.H2Dialect</value>
                                         </map>
@@ -293,6 +295,8 @@ docker run --rm --name mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -e MYSQL_D
                                     </list>
                                     <list key="main-persistence-properties">
                                         <map if="${..jpa-impl} == 'hibernate'">
+                                            <value key="name">hibernate.column_ordering_strategy</value>
+                                            <value key="value">legacy</value>
                                             <value key="name">hibernate.dialect</value>
                                             <value key="value">org.hibernate.dialect.MySQLDialect</value>
                                         </map>
@@ -335,6 +339,8 @@ docker run --rm --name xe -p 1521:1521 -p 8888:8080 -e ORACLE_PWD=oracle wnamele
                                     </list>
                                     <list key="main-persistence-properties">
                                         <map if="${..jpa-impl} == 'hibernate'">
+                                            <value key="name">hibernate.column_ordering_strategy</value>
+                                            <value key="value">legacy</value>
                                             <value key="name">hibernate.dialect</value>
                                             <value key="value">org.hibernate.dialect.OracleDialect</value>
                                         </map>

--- a/archetypes/helidon/src/main/archetype/mp/database/files/src/main/resources/hibernate.properties.mustache
+++ b/archetypes/helidon/src/main/archetype/mp/database/files/src/main/resources/hibernate.properties.mustache
@@ -1,3 +1,4 @@
 # Byte code for JPA must be generated at compile time.
 # This is a limitation of native image
-hibernate.bytecode.provider=none
+# No longer supported with Hibernate 6.3.x
+# hibernate.bytecode.provider=none

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -63,7 +63,7 @@
         <version.lib.h2>2.2.220</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.handlebars>4.3.1</version.lib.handlebars>
-        <version.lib.hibernate>6.1.7.Final</version.lib.hibernate>
+        <version.lib.hibernate>6.3.1.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>7.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -40,8 +40,6 @@
         <version.lib.animal-sniffer>1.18</version.lib.animal-sniffer>
         <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
-        <!-- Force upgrade byte-buddy for Java 21. Remove after upgrading hibernate to 6.2.7 -->
-        <version.lib.byte-buddy>1.14.6</version.lib.byte-buddy>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>

--- a/examples/integrations/cdi/pokemons/src/main/resources/META-INF/persistence.xml
+++ b/examples/integrations/cdi/pokemons/src/main/resources/META-INF/persistence.xml
@@ -28,6 +28,7 @@
         <properties>
             <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
             <property name="jakarta.persistence.sql-load-script-source" value="META-INF/init_script.sql"/>
+            <property name="hibernate.column_ordering_strategy" value="legacy"/>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
         </properties>
     </persistence-unit>

--- a/pom.xml
+++ b/pom.xml
@@ -635,15 +635,6 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate-enhance}</version>
-                    <dependencies>
-                        <dependency>
-                            <!-- Force upgrade byte-buddy for Java 21.     -->
-                            <!-- Remove after upgrading to Hibernate 6.2.7 -->
-                            <groupId>net.bytebuddy</groupId>
-                            <artifactId>byte-buddy</artifactId>
-                            <version>${version.lib.byte-buddy}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/tests/integration/jpa/appl/src/main/resources/hibernate.properties
+++ b/tests/integration/jpa/appl/src/main/resources/hibernate.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,5 @@
 
 # Byte code for JPA must be generated at compile time.
 # This is a limitation of native image
-hibernate.bytecode.provider=none
+# No longer supported with Hibernate 6.3.x
+# hibernate.bytecode.provider=none

--- a/tests/integration/jpa/simple/src/test/resources/hibernate.properties
+++ b/tests/integration/jpa/simple/src/test/resources/hibernate.properties
@@ -16,4 +16,5 @@
 
 # Byte code for JPA must be generated at compile time.
 # This is a limitation of native image
-hibernate.bytecode.provider=none
+# No longer supported with Hibernate 6.3.x
+# hibernate.bytecode.provider=none


### PR DESCRIPTION
This PR upgrades Hibernate to verison 6.3.1.Final and adjusts certain `hibernate.properties` files found in integration tests to comply with Hibernate's ongoing series of settings removals.

Documentation impact: Hibernate 6.3.x has (somewhat oddly) removed support for the `none` bytecode provider, so any instances that end users have of `hibernate.properties` must remove any lines that resemble the following:
> hibernate.bytecode.provider=none

This may have an impact on native image.

More specifics: the `none` bytecode provider still exists, but throws an exception when its "reflection optimizer" is accessed. There used to be a guard in the Hibernate source code that would not attempt to access the reflection optimizer if the `none` bytecode provider was selected, but [that guard was removed](https://github.com/hibernate/hibernate-orm/pull/7197/files#diff-2907b1254eed5e31600371471560e28b875699a5e6266345062ba6f21aead4f9L290-L292), so any use of the `none` bytecode provider will result in an exception.