### PR TITLE
[4.x] Fixes a jar-only URL resolution bug

### DIFF
--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -1425,6 +1427,14 @@ public class JpaExtension implements Extension {
                         reader.close();
                     }
                 }
+                URL persistenceRootUrl;
+                URI persistenceXmlUri = url.toURI();
+                if ("jar".equalsIgnoreCase(persistenceXmlUri.getScheme())) {
+                  String ssp = persistenceXmlUri.getSchemeSpecificPart();
+                  persistenceRootUrl = new URI(ssp.substring(0, ssp.lastIndexOf('!'))).toURL();
+                } else {
+                  persistenceRootUrl = persistenceXmlUri.resolve("..").toURL();
+                }
                 Collection<? extends Persistence.PersistenceUnit> persistenceUnits = persistence.getPersistenceUnit();
                 if (persistenceUnits != null && !persistenceUnits.isEmpty()) {
                     persistenceUnitInfos = new ArrayList<>();
@@ -1434,7 +1444,7 @@ public class JpaExtension implements Extension {
                                 .add(PersistenceUnitInfoBean.fromPersistenceUnit(persistenceUnit,
                                                                                  classLoader,
                                                                                  tempClassLoaderSupplier,
-                                                                                 url.toURI().resolve("..").toURL(),
+                                                                                 persistenceRootUrl,
                                                                                  unlistedManagedClassesByPersistenceUnitNames,
                                                                                  dataSourceProviderSupplier));
                         }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
@@ -1012,8 +1012,7 @@ public final class PersistenceExtension implements Extension {
                                         ClassLoader classLoader,
                                         Enumeration<URL> persistenceXmlUrls,
                                         Iterable<? extends PersistenceProvider> providers,
-                                        boolean userSuppliedPuiBeans)
-    {
+                                        boolean userSuppliedPuiBeans) {
         if (!persistenceXmlUrls.hasMoreElements()) {
             return;
         }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
@@ -564,8 +564,7 @@ public final class PersistenceExtension implements Extension {
      *
      * @see #addContainerManagedJpaBeans(AfterBeanDiscovery)
      */
-    private void addSyntheticBeans(@Observes @Priority(LIBRARY_AFTER) AfterBeanDiscovery event, BeanManager bm)
-        throws URISyntaxException {
+    private void addSyntheticBeans(@Observes @Priority(LIBRARY_AFTER) AfterBeanDiscovery event, BeanManager bm) {
         if (!this.enabled) {
             return;
         }

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestPersistenceRootResolutionBehavior.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestPersistenceRootResolutionBehavior.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.cdi.jpa;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class TestPersistenceRootResolutionBehavior {
+
+    @Test
+    void testUriResolution() throws IOException, URISyntaxException {
+        Enumeration<URL> pxmls = Thread.currentThread().getContextClassLoader().getResources("META-INF/persistence.xml");
+        assertThat(pxmls.hasMoreElements(), is(true));
+        URL pxml = pxmls.nextElement();
+        assertThat(pxmls.hasMoreElements(), is(false));
+        URI pxmlUri = pxml.toURI();
+        assertThat(pxmlUri.isAbsolute(), is(true));
+        URI upOneLevel = pxmlUri.resolve("..");
+        assertThat(upOneLevel.isAbsolute(), is(true));
+        upOneLevel.toURL(); // make sure this doesn't blow up
+    }
+
+    @Test
+    void testJarStuff() throws IOException, URISyntaxException {
+        URI pxmlUri = URI.create("jar:file:///nonexistent/example.jar!/META-INF/persistence.xml");
+        assertThat(pxmlUri.isOpaque(), is(true));
+        assertThat(pxmlUri.isAbsolute(), is(true)); // implied by opacity
+        String ssp = pxmlUri.getSchemeSpecificPart();
+        assertThat(ssp, is("file:///nonexistent/example.jar!/META-INF/persistence.xml"));
+        URI sspUri = URI.create(ssp);
+        assertThat(sspUri.isAbsolute(), is(true));
+        assertThat(sspUri.isOpaque(), is(false));
+        URI up = URI.create("..");
+        assertThat(up.isAbsolute(), is(false));
+        assertThat(up.isOpaque(), is(false));
+        // Opacity means this should return, simply, and surprisingly to a quick glance, "..".
+        assertThat(pxmlUri.resolve(".."), is(up));
+        assertThat(URI.create("..").isOpaque(), is(false));
+    }
+
+}


### PR DESCRIPTION
This PR corrects a flaw where persistence roots were not being properly inferred from URLs pointing at `META-INF/persistence.xml` locations.

In prior versions, prior to the JDK's deprecation of `new URL(someOtherUrl, "..")` invocations, something in that recipe handled `jar` URLs transparently. When I changed this to work on `URI` objects as the deprecation warnings suggested, suddenly `jar` URLs were _not_ handled transparently.

This PR ensures that, for example, the inferring of a persistence root from a URI of `jar:file:///path/some.jar!/META-INF/persistence.xml` will correctly be `file:///path/some.jar`.

(In addition, the PR hoists this calculation out of a loop where it was incorrectly located for an embarrassingly long time.)

The PR also adds a unit test demonstrating some of the more amazing and interesting features of `jar` URIs.

Documentation impact: none