### PR TITLE
[4.x] Fixes user-reported typo in persistence guide

### DIFF
--- a/docs/mp/persistence.adoc
+++ b/docs/mp/persistence.adoc
@@ -928,7 +928,7 @@ managed]
 ----
 <dependency>
     <groupId>io.helidon.integrations.cdi</groupId>
-    <artifactId>helidon-integrations-cdi-eclipselink</artifactId>
+    <artifactId>helidon-integrations-cdi-hibernate</artifactId>
     <scope>runtime</scope> <!--1-->
 </dependency>
 ----


### PR DESCRIPTION
Fixes a typo in the persistence guide.

Documentation impact: I mean….
