### PR TITLE
[3.x] Fixes user-reported typo in persistence guide

### DIFF
--- a/docs/mp/persistence.adoc
+++ b/docs/mp/persistence.adoc
@@ -971,7 +971,7 @@ managed]
 ----
 <dependency>
     <groupId>io.helidon.integrations.cdi</groupId>
-    <artifactId>helidon-integrations-cdi-eclipselink</artifactId>
+    <artifactId>helidon-integrations-cdi-hibernate</artifactId>
     <scope>runtime</scope> <!--1-->
 </dependency>
 ----


### PR DESCRIPTION
Backports #7750 to `helidon-3.x`.