### PR TITLE
4.x: Upgrades ojdbc8 to 21.4.0.0 and fixes JAXP parser conflict

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -128,7 +128,7 @@
         <version.lib.netty>4.1.94.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.8.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.21.0</version.lib.oci>
-        <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
+        <version.lib.ojdbc8>21.4.0.0</version.lib.ojdbc8>
         <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
         <version.lib.okio>3.4.0</version.lib.okio>
         <!-- Force upgrade okhttp3 for CVE-2023-0833 -->

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -48,7 +48,19 @@
                     <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ucp</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- Contains JAXP impl, so we exclude it to not interfere -->
+                    <groupId>com.oracle.database.xml</groupId>
+                    <artifactId>xmlparserv2</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!-- Include version without JAXP impl -->
+            <groupId>com.oracle.database.xml</groupId>
+            <artifactId>xmlparserv2_sans_jaxp_services</artifactId>
+            <version>${version.lib.ojdbc8}</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Description

Upgrades ojdbc8 to 21.4.0.0 (needed to fix issue)

Fixes #7736  

### Documentation

No impact
