### PR TITLE
Add openapi-ui submodule directory to the integrations module list

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -50,6 +50,7 @@
         <module>neo4j</module>
         <module>micrometer</module>
         <module>oci</module>
+        <module>openapi-ui</module>
         <module>vault</module>
         <module>microstream</module>
     </modules>


### PR DESCRIPTION
### Description

Resolves re-opened #7758 by adding a `<module>openapi-ui</module>` line to the `pom.xml`.

### Documentation
No impact.