### PR TITLE
Add Helidon Connector to sitegen.yaml

### DIFF
--- a/docs/sitegen.yaml
+++ b/docs/sitegen.yaml
@@ -173,6 +173,7 @@ backend:
                   - "application-configuration.adoc"
                   - "jaxrs-applications.adoc"
                   - "jaxrs-client.adoc"
+                  - "helidon-connector.adoc"
               - type: "PAGE"
                 title: "JWT"
                 source: "jwt.adoc"


### PR DESCRIPTION
### Description

### Documentation

New Helidon Connector doc needed an entry in sitegen.yaml for 4x ,

If feature: summarize feature and provide pointer to doc issue

If no doc impact: None
