### PR TITLE
4.x: archetype - module-info opt-in

### DIFF
--- a/archetypes/helidon/src/main/archetype/common/common.xml
+++ b/archetypes/helidon/src/main/archetype/common/common.xml
@@ -49,7 +49,7 @@
             <includes>
                 <include>.helidon.mustache</include>
                 <include>README.md.mustache</include>
-                <include>src/main/java/**/*.java.mustache</include>
+                <include>src/main/java/**/Main.java.mustache</include>
             </includes>
         </templates>
         <model>

--- a/archetypes/helidon/src/main/archetype/common/packaging.xml
+++ b/archetypes/helidon/src/main/archetype/common/packaging.xml
@@ -92,6 +92,36 @@ kubectl delete -f app.yaml
                     </templates>
                 </output>
             </boolean>
+            <boolean id="jpms-se"
+                     name="Module support (JPMS)"
+                     description="Add a module-info"
+                     default="false"
+                     optional="true"
+                     if="${flavor} == 'se'">
+                <output>
+                    <templates engine="mustache" transformations="mustache,packaged">
+                        <directory>files</directory>
+                        <includes>
+                            <include>src/main/java/**/module-info.java.mustache</include>
+                        </includes>
+                    </templates>
+                </output>
+            </boolean>
+            <boolean id="jpms-mp"
+                     name="Module support (JPMS)"
+                     description="Add a module-info and a module main class"
+                     default="false"
+                     optional="true"
+                     if="${flavor} == 'mp'">
+                <output>
+                    <templates engine="mustache" transformations="mustache,packaged">
+                        <directory>files</directory>
+                        <includes>
+                            <include>src/main/java/**/module-info.java.mustache</include>
+                        </includes>
+                    </templates>
+                </output>
+            </boolean>
         </inputs>
     </step>
 </archetype-script>

--- a/archetypes/helidon/src/main/archetype/common/presets.xml
+++ b/archetypes/helidon/src/main/archetype/common/presets.xml
@@ -37,5 +37,7 @@
         <boolean path="docker.jlink-image">true</boolean>
         <boolean path="k8s">true</boolean>
         <boolean path="v8o">false</boolean>
+        <boolean path="jpms-se">false</boolean>
+        <boolean path="jpms-mp">false</boolean>
     </presets>
 </archetype-script>


### PR DESCRIPTION
### Description

fix #7735

By default, the `module-info.java` is not generated.

### Documentation

no impact
