### PR TITLE
[4.x] Provides an example using the oci-secrets-mp-config-source project

### DIFF
--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -236,13 +236,15 @@ These steps should only need to be performed once.
 1. In the resulting project, edit this example's `src/main/resources/mp-meta-config-yaml` file to include the OCIDs of
    the compartment and vault you created above.
 
-    1. Replace the occurrence of `compartment-ocid: '${compartment-ocid}'` with the contents of the line you added in
-       `/tmp/helidon-examples-ocids.txt` above that begins with `compartment-ocid: `. Ensure the YAML indentation is
-       correct (`compartment-ocid:` should appear at zero-based character position 4, under the `c` in `sources`).
+    1. Following the directions in the file, insert the value of your compartment's OCID between the colon (`:`) and the
+       comment character (`#`) in the line starting with `compartment-ocid`.  Consult `/tmp/helidon-examples-ocids.txt`
+       as necessary. Ensure the YAML indentation is correct (`compartment-ocid:` should appear at zero-based character
+       position 4, under the `c` in `sources`).
 
-    2. Replace the occurrence of `vault-ocid: '${vault-ocid}'` with the contents of the line you added in
-       `/tmp/helidon-examples-ocids.txt` above that begins with `vault-ocid: `. Ensure the YAML indentation is correct
-       (`vault-ocid:` should appear at zero-based character position 4, under the `c` in `sources`).
+    2. Following the directions in the file, insert the value of your compartment's OCID between the colon (`:`) and the
+       comment character (`#`) in the line starting with `compartment-ocid`.  Consult `/tmp/helidon-examples-ocids.txt`
+       as necessary. Ensure the YAML indentation is correct (`vault-ocid:` should appear at zero-based character
+       position 4, under the `c` in `sources`).
 
     3. Note the `accept-pattern: ` line. Its single-quoted value is `^helidon-examples-secret$`, which is a regular
        expression identifying the names of configuration properties whose values should be fetched from the
@@ -287,8 +289,40 @@ gathered. It is no longer needed.
 
 ## Build The Example
 
+In the root directory of your computer's copy of this project, open a shell and type:
+
+```sh
 `mvn clean verify`
+```
 
 ## Run The Example
 
-`java -jar target/TODO.jar`
+The jar file produced by this example contains a main class that accepts a single command-line argument, treats it as
+the name of a configuration property that the Helidon Microprofile Config implementation will look up, and prints its
+value if it is found.
+
+You can run the example with, for example, the name of a System property that will always be resolved:
+
+```sh
+java -jar target/helidon-examples-integrations-oci-secrets-mp-config-source.jar java.home
+```
+
+(You may see log information printed to the terminal that reflects the initialization of the OCI configuration source,
+but `java.home` will be resolved from Helidon's system properties configuration source.)
+
+You can run the same example with logging if you want to experiment with levels. Edit your local copy of
+`logging.properties` appropriately, and then run:
+
+```sh
+java -Djava.util.logging.config.file=logging.properties -jar target/helidon-examples-integrations-oci-secrets-mp-config-source.jar java.home
+```
+
+Finally you can run the example with logging that looks up the decoded value of the secret you created above, if you set
+everything up according to the directions above:
+
+```sh
+java -Djava.util.logging.config.file=logging.properties -jar target/helidon-examples-integrations-oci-secrets-mp-config-source.jar helidon-examples-secret
+```
+
+You should see the value of your secret (for example, `secret value`, as created in the instructions above) printed to
+the terminal.

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -27,63 +27,62 @@ These steps should only need to be performed once.
    go along. This example will presume this document is located in `/tmp/helidon-examples-ocids.txt`.
 1. Set up authentication information on your computer to allow this example to authenticate to your Oracle Cloud
    account.
-  1. Create a [`${HOME}/.oci/config`] file with the [required entries for authenticating to your Oracle Cloud
-   account](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#SDK_and_CLI_Configuration_File). Note
-   the [Required Keys and
-   OCIDs](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#Required_Keys_and_OCIDs)
-   documentation.
-  2. (There are many ways to authenticate to your Oracle Cloud account that are supported by Helidon. This is just one
-     of them that is particularly easy to set up.)
-  3. At a minimum, in this file you'll need to have `fingerprint`, `key_file`, `region`, `tenancy` and `user`
-     [entries](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#ariaid-title3).
+    1. Create a [`${HOME}/.oci/config`] file with the [required entries for authenticating to your Oracle Cloud
+       account](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#SDK_and_CLI_Configuration_File). Note
+       the [Required Keys and
+       OCIDs](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#Required_Keys_and_OCIDs)
+       documentation.
+    2. (There are many ways to authenticate to your Oracle Cloud account that are supported by Helidon. This is just one
+       of them that is particularly easy to set up.)
+    3. At a minimum, in this file you'll need to have `fingerprint`, `key_file`, `region`, `tenancy` and `user`
+       [entries](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#ariaid-title3).
 2. [Log in to Oracle Cloud](https://cloud.oracle.com/).
 3. Create a compartment to host OCI resources related to this example and gather its OCID.
-  1. Go to https://cloud.oracle.com/identity/compartments
-  2. Press the *Create Compartment* button.
-  3. Supply a name for the compartment in the Name text field. This example uses "helidon-examples", but it can be any
-     name you like that uses alphanumeric characters and the hyphen (`-`) character.
-  4. Supply a description for the compartment in the Description text field. This example uses "A compartment for
-     Helidon Examples" but it can be any text you like.
-  5. Select a parent compartment for your new compartment from the Parent Compartment drop-down list. It will probably
-     be your account's root compartment, and may already be selected for you.
-  6. Press the *Create Compartment* button.
-  7. Click on your new compartment's hyperlink that now appears in the Compartments table.
-  8. In the Compartment Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the Oracle Cloud
-     Identifier (OCID) of your new compartment to your computer's clipboard.
-  9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `compartment-ocid: ` and paste the just-copied OCID.
+    1. Go to https://cloud.oracle.com/identity/compartments
+    2. Press the *Create Compartment* button.
+    3. Supply a name for the compartment in the Name text field. This example uses "helidon-examples", but it can be any
+       name you like that uses alphanumeric characters and the hyphen (`-`) character.
+    4. Supply a description for the compartment in the Description text field. This example uses "A compartment for
+       Helidon Examples" but it can be any text you like.
+    5. Select a parent compartment for your new compartment from the Parent Compartment drop-down list. It will probably
+       be your account's root compartment, and may already be selected for you.
+    6. Press the *Create Compartment* button.
+    7. Click on your new compartment's hyperlink that now appears in the Compartments table.
+    8. In the Compartment Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the Oracle Cloud
+       Identifier (OCID) of your new compartment to your computer's clipboard.
+    9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `compartment-ocid: ` and paste the just-copied OCID.
 3. Create a vault to host secret information related to this example and gather its OCID
-  1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
-     from the resulting menu.
-  2. Click on *Vault* in the page that results, under the *Key Management & Secret Management* section.
-  3. On the left of the page, under the List scope section, select your new compartment from the drop down list.
-  3. Press the *Create Vault* button.
-  4. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
-     name you like that uses alphanumeric characters and the hyphen (`-`) character.
-  5. Press the *Create Vault* button toward the bottom of the page.
-  6. After several seconds, your new vault should appear in the table with a *State* of *Creating*.
-  7. Click on your new vault's hyperlink.
-  8. In the Vault Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the OCID of your new
-     vault to your computer's clipboard.
-  9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `vault-ocid: ` and paste the just-copied OCID.
+    1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
+       from the resulting menu.
+    2. Click on *Vault* in the page that results, under the *Key Management & Secret Management* section.
+    3. On the left of the page, under the List scope section, select your new compartment from the drop down list.
+    3. Press the *Create Vault* button.
+    4. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
+       name you like that uses alphanumeric characters and the hyphen (`-`) character.
+    5. Press the *Create Vault* button toward the bottom of the page.
+    6. After several seconds, your new vault should appear in the table with a *State* of *Creating*.
+    7. Click on your new vault's hyperlink.
+    8. In the Vault Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the OCID of your new
+       vault to your computer's clipboard.
+    9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `vault-ocid: ` and paste the just-copied OCID.
 4. Create a master encryption key in your newly-created vault to encrypt secret information hosted in the vault.
-  1. Press the *Create Key* button.
-  2. Supply a name for the new master encryption key in the Name text field. This example uses "Helidon Examples Master
-     Encryption Key" but it can be any text you like.
-  3. Press the *Create Key* button toward the bottom of the page.
-  4. After several seconds, your new master encryption key will appear in the table with a *State* of *Creating*.
+    1. Press the *Create Key* button.
+    2. Supply a name for the new master encryption key in the Name text field. This example uses "Helidon Examples Master
+       Encryption Key" but it can be any text you like.
+    3. Press the *Create Key* button toward the bottom of the page.
+    4. After several seconds, your new master encryption key will appear in the table with a *State* of *Creating*.
 5. Create a secret that will be used by this example.
-  1. On the left side of the page, in the *Resources* section, click on *Secrets*.
-  2. Press the *Create Secret* button.
-  3. Supply a name for the secret in the Name text field. This example uses "helidon-examples-secret", but it can be any
-     name you like that uses alphanumeric characters and the hyphen (`-`) character.
-  4. Supply a description for the secret in the Description text field. This example uses "A secret for Helidon
-     Examples" but it can be any text you like.
-  5. Choose the Helidon Examples Master Encryption Key in the Encryption Key drop down (the master encryption key you
-     just created).
-  6. Supply a plain text value for the secret in the Secret Contents text area. This example uses "secret value", but it
-     can be any text you like.
-  7. Press the *Create Secret* button toward the bottom of the page.
-
+    1. On the left side of the page, in the *Resources* section, click on *Secrets*.
+    2. Press the *Create Secret* button.
+    3. Supply a name for the secret in the Name text field. This example uses "helidon-examples-secret", but it can be any
+       name you like that uses alphanumeric characters and the hyphen (`-`) character.
+    4. Supply a description for the secret in the Description text field. This example uses "A secret for Helidon
+       Examples" but it can be any text you like.
+    5. Choose the Helidon Examples Master Encryption Key in the Encryption Key drop down (the master encryption key you
+       just created).
+    6. Supply a plain text value for the secret in the Secret Contents text area. This example uses "secret value", but it
+       can be any text you like.
+    7. Press the *Create Secret* button toward the bottom of the page.
 ### Edit The Example's Meta-Configuration to Reference OCI Resources
 
 This example relies on a Helidon configuration feature known as _meta-configuration_, configuration about
@@ -95,16 +94,16 @@ created above makes the example work.
 These steps should only need to be performed once.
 
 1. Edit this example's `src/main/resources/mp-meta-config-yaml` file to include the OCIDs of the compartment and vault you created above.
-  1. Replace the occurrence of `compartment-ocid: ${compartment-ocid}` with the contents of the line you added in
-     `/tmp/helidon-examples-ocids.txt` above that begins with `compartment-ocid: `. Ensure the YAML indentation is correct
-     (`compartment-ocid` should appear at zero-based character position 4, under the `c` in `sources`).
-  2. Replace the occurrence of `vault-ocid: ${vault-ocid}` with the contents of the line you added in
-     `/tmp/helidon-examples-ocids.txt` above that begins with `vault-ocid: `. Ensure the YAML indentation is correct
-     (`vault-ocid` should appear at zero-based character position 4, under the `c` in `sources`).
-  3. Note the `accept-pattern: ` line. Its quoted value is `^helidon-examples-secret$`, which is a regular expression
-     identifying the names of configuration properties whose values should be fetched from the identically-named secret
-     you just created. If you used a name for your new secret other than `helidon-examples-secret` above, replace
-     `helidon-examples-secret` with the name of the newly-created secret.
+    1. Replace the occurrence of `compartment-ocid: ${compartment-ocid}` with the contents of the line you added in
+       `/tmp/helidon-examples-ocids.txt` above that begins with `compartment-ocid: `. Ensure the YAML indentation is correct
+       (`compartment-ocid` should appear at zero-based character position 4, under the `c` in `sources`).
+    2. Replace the occurrence of `vault-ocid: ${vault-ocid}` with the contents of the line you added in
+       `/tmp/helidon-examples-ocids.txt` above that begins with `vault-ocid: `. Ensure the YAML indentation is correct
+       (`vault-ocid` should appear at zero-based character position 4, under the `c` in `sources`).
+    3. Note the `accept-pattern: ` line. Its quoted value is `^helidon-examples-secret$`, which is a regular expression
+       identifying the names of configuration properties whose values should be fetched from the identically-named secret
+       you just created. If you used a name for your new secret other than `helidon-examples-secret` above, replace
+       `helidon-examples-secret` with the name of the newly-created secret.
 
 The resulting file should look similar to this:
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -224,13 +224,17 @@ Your OCI resources should be ready to go.
 
 This example relies on a Helidon configuration feature known as _meta-configuration_, configuration about
 configuration. Since this example is Microprofile-based, it specifically relies on Helidon's Microprofile Config
-meta-configuration, which is represented by the `mp-meta-config.yaml` classpath resource. You can find this file in this
-example under the `src/main/resources` directory. Editing this file properly to reference the OCI resources you just
-created above makes the example work.
+meta-configuration, which is represented by the `mp-meta-config.yaml` classpath resource. You can find [this file in
+this example under the `src/main/resources`](src/main/resources/mp-meta-config.yaml) directory. Editing this file
+properly in a checked-out copy of this project on your computer to reference the OCI resources you just created above
+makes the example work.
 
 These steps should only need to be performed once.
 
-1. Edit this example's `src/main/resources/mp-meta-config-yaml` file to include the OCIDs of the compartment and vault you created above.
+0. Check out this project to your computer.
+
+1. In the resulting project, edit this example's `src/main/resources/mp-meta-config-yaml` file to include the OCIDs of
+   the compartment and vault you created above.
 
     1. Replace the occurrence of `compartment-ocid: '${compartment-ocid}'` with the contents of the line you added in
        `/tmp/helidon-examples-ocids.txt` above that begins with `compartment-ocid: `. Ensure the YAML indentation is

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -33,7 +33,7 @@ These steps should only need to be performed once.
     1. (There are many ways to authenticate to your Oracle Cloud account that are supported by Helidon. This is just one
        of them that is particularly easy to set up, which is why it is used in this example.)
 
-2. [Log in to Oracle Cloud](https://cloud.oracle.com/).
+2. [Log in to Oracle Cloud](https://cloud.oracle.com/) (open this link in a new brower tab or window).
 
 3. Create a user for this example if needed.
 
@@ -44,7 +44,7 @@ These steps should only need to be performed once.
 
     3. Press the **Create User** button.
 
-    4. Supply a name for the user in the Name text field. This exmaple uses "helidon-examples-user", but it can be any
+    4. Supply a name for the user in the Name text field. This example uses "helidon-examples-user", but it can be any
        name you like that conforms to OCI's valid character restrictions.
 
     5. Supply a description for the user in the Description text field. This example uses "A user for Helidon examples",
@@ -63,7 +63,7 @@ These steps should only need to be performed once.
     4. Press the **Download Public Key** button and take note of where the file is saved.
 
     5. Press the **Add** button
-    
+
     6. Take note of the contents of the Configuration File Preview text area. This will become part of the contents of
        your `${HOME}/.oci/config` file.
 
@@ -80,11 +80,34 @@ These steps should only need to be performed once.
     11. In your now non-empty `${HOME}/.oci/config` file, replace the occurrence of `<path to your private keyfile>
        #TODO` with `~/.oci/oci_api_key.pem`.
 
+5. Create a group for your new user.
+
+    1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
+       from the resulting menu.
+
+    2. Click on Groups under the **Identity** section.
+
+    3. Press the **Create Group** button.
+
+    4. Supply a name for the group in the Name text field. This example uses "helidon-examples-group", but it can be any
+       name you like that conforms to OCI's valid character restrictions.
+
+    5. Supply a description for the user in the Description text field. This example uses "A group for Helidon
+       examples", but it can be any text you like.
+
+    6. Press the **Create** button.
+
+    7. Press the **Add User to Group** button.
+
+    8. Select your new user from the Users drop-down list.
+
+    9. Press the **Add** button.
+
 5. Create a compartment to host OCI resources related to this example and gather its OCID.
 
     1. Go to https://cloud.oracle.com/identity/compartments
 
-    2. Press the *Create Compartment* button.
+    2. Press the **Create Compartment** button.
 
     3. Supply a name for the compartment in the Name text field. This example uses "helidon-examples", but it can be any
        name you like that uses alphanumeric characters and the hyphen (`-`) character.
@@ -95,7 +118,7 @@ These steps should only need to be performed once.
     5. Select a parent compartment for your new compartment from the Parent Compartment drop-down list. It will probably
        be your account's root compartment, and may already be selected for you.
 
-    6. Press the *Create Compartment* button.
+    6. Press the **Create Compartment** button.
 
     7. Click on your new compartment's hyperlink that now appears in the Compartments table.
 
@@ -111,14 +134,14 @@ These steps should only need to be performed once.
 
     2. Click on *Vault* in the page that results, under the *Key Management & Secret Management* section.
 
-    3. On the left of the page, under the List scope section, select your new compartment from the drop down list.
+    3. On the left of the page, under the List scope section, select your new compartment from the drop-down list.
 
-    4. Press the *Create Vault* button.
+    4. Press the **Create Vault** button.
 
     5. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
        name you like that uses alphanumeric characters and the hyphen (`-`) character.
 
-    6. Press the *Create Vault* button toward the bottom of the page.
+    6. Press the **Create Vault** button toward the bottom of the page.
 
     7. After several seconds, your new vault should appear in the table with a *State* of *Creating*.
 
@@ -131,12 +154,12 @@ These steps should only need to be performed once.
 
 7. Create a master encryption key in your newly-created vault to encrypt secret information hosted in the vault.
 
-    1. Press the *Create Key* button.
+    1. Press the **Create Key** button.
 
     2. Supply a name for the new master encryption key in the Name text field. This example uses "Helidon Examples Master
        Encryption Key" but it can be any text you like.
 
-    3. Press the *Create Key* button toward the bottom of the page.
+    3. Press the **Create Key** button toward the bottom of the page.
 
     4. After several seconds, your new master encryption key will appear in the table with a *State* of *Creating*.
 
@@ -144,7 +167,7 @@ These steps should only need to be performed once.
 
     1. On the left side of the page, in the *Resources* section, click on *Secrets*.
 
-    2. Press the *Create Secret* button.
+    2. Press the **Create Secret** button.
 
     3. Supply a name for the secret in the Name text field. This example uses "helidon-examples-secret", but it can be any
        name you like that uses alphanumeric characters and the hyphen (`-`) character.
@@ -152,13 +175,46 @@ These steps should only need to be performed once.
     4. Supply a description for the secret in the Description text field. This example uses "A secret for Helidon
        Examples" but it can be any text you like.
 
-    5. Choose the Helidon Examples Master Encryption Key in the Encryption Key drop down (the master encryption key you
-       just created).
+    5. Choose the Helidon Examples Master Encryption Key in the Encryption Key drop-down list (the master encryption key
+       you just created).
 
     6. Supply a plain text value for the secret in the Secret Contents text area. This example uses "secret value", but it
        can be any text you like.
 
-    7. Press the *Create Secret* button toward the bottom of the page.
+    7. Press the **Create Secret** button toward the bottom of the page.
+
+9. Create a policy to allow your new user in your new group to read your new secret in your new vault.
+
+    1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
+       from the resulting menu.
+
+    2. Click on Policies under the **Identity** section.
+
+    3. Press the **Create Policy** button.
+
+    4. Supply a name for this new policy in the Name text field. This example uses
+       "helidon-examples-group-manipulate-secrets", but it can be any name you like that conforms to OCI's valid
+       character requirements.
+
+    5. Supply a description for this new policy in the Description text field. This example uses "Permits
+       helidon-examples-group members to manipulate secrets in the helidon-examples compartment" but it can be any text
+       you like.
+
+    6. Select your new compartment from the Compartment drop-down list.
+
+    7. In the **Policy Builder** area, select "Key and Secret Management" from the Policy use cases drop-down list.
+
+    8. In the **Policy Builder** area, select "Let users read, update and rotate all secrets" from the Common policy
+       template drop-down list.
+
+    9. In the **Policy Builder** area, select your new group from the Groups drop-down list.
+
+    10. In the **Policy Builder** area, select your new compartment from the Location drop-down list.
+
+    11. Observe that the **Policy Statements** area now contains a statement like "Allow group
+        **helidon-examples-group** to use secret-family in **compartment helidon-examples**".
+
+    12. Press the **Create** button toward the bottom of the page.
 
 ### Edit The Example's Meta-Configuration to Reference OCI Resources
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -14,14 +14,12 @@ This example shows how to configure and use a Microprofile Config configuration 
 Config meta-configuration feature, that can transparently fetch text values from an OCI vault resource. It exercises the
 classes present in the `integrations/oci/oci-secrets-mp-config-source` project elsewhere in this source code repository.
 
-## Setup Steps
+## One-Time Setup Steps
 
-Because this example makes use of Oracle Cloud, you will need to set up some Oracle Cloud resources before you begin,
-along with a way to authenticate to your Oracle Cloud account.
+Because this example makes use of Oracle Cloud, you will need to set up some Oracle Cloud resources before you
+begin. You should have to perform these steps only once.
 
 ### Create OCI Resources and Gather OCI Information
-
-These steps should only need to be performed once.
 
 0. Open a text document on your computer where you can save some important information related to OCI resources as you
    go along. This example will presume this document is located in `/tmp/helidon-examples-ocids.txt`.
@@ -37,12 +35,9 @@ These steps should only need to be performed once.
 
 3. Create a user for this example if needed.
 
-    1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
-       from the resulting menu.
+    1. Go to https://cloud.oracle.com/identity/users (open this link in a new browser tab or window).
 
-    2. Click on Users under the **Identity** section.
-
-    3. Press the **Create User** button.
+    2. Press the **Create User** button.
 
     4. Supply a name for the user in the Name text field. This example uses "helidon-examples-user", but it can be any
        name you like that conforms to OCI's valid character requirements.
@@ -82,26 +77,23 @@ These steps should only need to be performed once.
 
 4. Create a group for your new user.
 
-    1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
-       from the resulting menu.
+    1. Go to https://cloud.oracle.com/identity/groups/ (open this link in a new browser tab or window).
 
-    2. Click on Groups under the **Identity** section.
+    2. Press the **Create Group** button.
 
-    3. Press the **Create Group** button.
-
-    4. Supply a name for the group in the Name text field. This example uses "helidon-examples-group", but it can be any
+    3. Supply a name for the group in the Name text field. This example uses "helidon-examples-group", but it can be any
        name you like that conforms to OCI's valid character requirements.
 
-    5. Supply a description for the user in the Description text field. This example uses "A group for Helidon
+    4. Supply a description for the user in the Description text field. This example uses "A group for Helidon
        examples", but it can be any text you like.
 
-    6. Press the **Create** button.
+    5. Press the **Create** button.
 
-    7. Press the **Add User to Group** button.
+    6. Press the **Add User to Group** button.
 
-    8. Select your new user from the Users drop-down list.
+    7. Select your new user from the Users drop-down list.
 
-    9. Press the **Add** button.
+    8. Press the **Add** button.
 
 5. Create a compartment to host OCI resources related to this example and gather its OCID.
 
@@ -129,28 +121,25 @@ These steps should only need to be performed once.
 
 6. Create a vault to host secret information related to this example and gather its OCID.
 
-    1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
-       from the resulting menu.
+    1. Go to https://cloud.oracle.com/security/kms/ (open this link in a new browser tab or window).
 
-    2. Click on *Vault* in the page that results, under the *Key Management & Secret Management* section.
+    2. On the left of the page, under the List scope section, select your new compartment from the drop-down list.
 
-    3. On the left of the page, under the List scope section, select your new compartment from the drop-down list.
+    3. Press the **Create Vault** button.
 
-    4. Press the **Create Vault** button.
-
-    5. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
+    4. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
        name you like that conforms to OCI's valid character requirements.
 
-    6. Press the **Create Vault** button toward the bottom of the page.
+    5. Press the **Create Vault** button toward the bottom of the page.
 
-    7. After several seconds, your new vault should appear in the table with a **State** of **Creating**.
+    6. After several seconds, your new vault should appear in the table with a **State** of **Creating**.
 
-    8. Click on your new vault's hyperlink.
+    7. Click on your new vault's hyperlink.
 
-    9. In the Vault Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the OCID of your new
+    8. In the Vault Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the OCID of your new
        vault to your computer's clipboard.
 
-    10. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `vault-ocid: ` and paste the just-copied OCID.
+    9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `vault-ocid: ` and paste the just-copied OCID.
 
 7. Create a master encryption key in your newly-created vault to encrypt secret information hosted in the vault.
 
@@ -165,7 +154,7 @@ These steps should only need to be performed once.
 
 8. Create a secret that will be used by this example.
 
-    1. On the left side of the page, in the *Resources* section, click on *Secrets*.
+    1. On the left side of the page, in the Resources section, click on Secrets.
 
     2. Press the **Create Secret** button.
 
@@ -185,36 +174,33 @@ These steps should only need to be performed once.
 
 9. Create a policy to allow your new user in your new group to read your new secret in your new vault.
 
-    1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
-       from the resulting menu.
+    1. Go to https://cloud.oracle.com/identity/policies/ (open this link in a new browser tab or window).
 
-    2. Click on Policies under the **Identity** section.
+    2. Press the **Create Policy** button.
 
-    3. Press the **Create Policy** button.
-
-    4. Supply a name for this new policy in the Name text field. This example uses
+    3. Supply a name for this new policy in the Name text field. This example uses
        "helidon-examples-group-manipulate-secrets", but it can be any name you like that conforms to OCI's valid
        character requirements.
 
-    5. Supply a description for this new policy in the Description text field. This example uses "Permits
+    4. Supply a description for this new policy in the Description text field. This example uses "Permits
        helidon-examples-group members to manipulate secrets in the helidon-examples compartment" but it can be any text
        you like.
 
-    6. Select your new compartment from the Compartment drop-down list.
+    5. Select your new compartment from the Compartment drop-down list.
 
-    7. In the **Policy Builder** area, select "Key and Secret Management" from the Policy use cases drop-down list.
+    6. In the **Policy Builder** area, select "Key and Secret Management" from the Policy use cases drop-down list.
 
-    8. In the **Policy Builder** area, select "Let users read, update and rotate all secrets" from the Common policy
+    7. In the **Policy Builder** area, select "Let users read, update and rotate all secrets" from the Common policy
        template drop-down list.
 
-    9. In the **Policy Builder** area, select your new group from the Groups drop-down list.
+    8. In the **Policy Builder** area, select your new group from the Groups drop-down list.
 
-    10. In the **Policy Builder** area, select your new compartment from the Location drop-down list.
+    9. In the **Policy Builder** area, select your new compartment from the Location drop-down list.
 
-    11. Observe that the **Policy Statements** area now contains a statement like "Allow group
+    10. Observe that the **Policy Statements** area now contains a statement like "Allow group
         **helidon-examples-group** to use secret-family in **compartment helidon-examples**".
 
-    12. Press the **Create** button toward the bottom of the page.
+    11. Press the **Create** button toward the bottom of the page.
 
 To recap, you have, in dependency order:
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -218,7 +218,7 @@ To recap, you have, in dependency order:
 
 * Created a policy that lets your group's users manipulate secrets found in your compartment ("helidon-examples-group-manipulate-secrets")
 
-You should be ready to go.
+Your OCI resources should be ready to go.
 
 ### Edit The Example's Meta-Configuration to Reference OCI Resources
 
@@ -231,18 +231,21 @@ created above makes the example work.
 These steps should only need to be performed once.
 
 1. Edit this example's `src/main/resources/mp-meta-config-yaml` file to include the OCIDs of the compartment and vault you created above.
-    1. Replace the occurrence of `compartment-ocid: ${compartment-ocid}` with the contents of the line you added in
-       `/tmp/helidon-examples-ocids.txt` above that begins with `compartment-ocid: `. Ensure the YAML indentation is correct
-       (`compartment-ocid` should appear at zero-based character position 4, under the `c` in `sources`).
-    2. Replace the occurrence of `vault-ocid: ${vault-ocid}` with the contents of the line you added in
-       `/tmp/helidon-examples-ocids.txt` above that begins with `vault-ocid: `. Ensure the YAML indentation is correct
-       (`vault-ocid` should appear at zero-based character position 4, under the `c` in `sources`).
-    3. Note the `accept-pattern: ` line. Its quoted value is `^helidon-examples-secret$`, which is a regular expression
-       identifying the names of configuration properties whose values should be fetched from the identically-named secret
-       you just created. If you used a name for your new secret other than `helidon-examples-secret` above, replace
-       `helidon-examples-secret` with the name of the newly-created secret.
 
-The resulting file should look similar to this:
+    1. Replace the occurrence of `compartment-ocid: '${compartment-ocid}'` with the contents of the line you added in
+       `/tmp/helidon-examples-ocids.txt` above that begins with `compartment-ocid: `. Ensure the YAML indentation is
+       correct (`compartment-ocid:` should appear at zero-based character position 4, under the `c` in `sources`).
+
+    2. Replace the occurrence of `vault-ocid: '${vault-ocid}'` with the contents of the line you added in
+       `/tmp/helidon-examples-ocids.txt` above that begins with `vault-ocid: `. Ensure the YAML indentation is correct
+       (`vault-ocid:` should appear at zero-based character position 4, under the `c` in `sources`).
+
+    3. Note the `accept-pattern: ` line. Its single-quoted value is `^helidon-examples-secret$`, which is a regular
+       expression identifying the names of configuration properties whose values should be fetched from the
+       identically-named secret you just created. If you used a name for your new secret other than
+       `helidon-examples-secret` above, replace `helidon-examples-secret` with the name of the newly-created secret.
+
+The resulting file should look similar to this (with trailing explanatory comments):
 
 ```
 add-default-sources: false
@@ -272,6 +275,11 @@ The file instructs the Helidon MicroProfile Config implementation:
     by the (OCID) value of the `compartment-ocid` setting.
   * It will use a `NodeConfigSource`-based configuration source rather than a `LazyConfigSource`-based configuration
     source. See Helidon's documentation about configuration sources for more information.
+
+### Remove `/tmp/helidon-examples-ocids.txt`
+
+You can now remove the `/tmp/helidon-examples-ocids.txt` file you created above to temporarily hold the OCIDs you
+gathered. It is no longer needed.
 
 ## Build The Example
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -25,64 +25,143 @@ These steps should only need to be performed once.
 
 0. Open a text document on your computer where you can save some important information related to OCI resources as you
    go along. This example will presume this document is located in `/tmp/helidon-examples-ocids.txt`.
-1. Set up authentication information on your computer to allow this example to authenticate to your Oracle Cloud
-   account.
-    1. Create a [`${HOME}/.oci/config`] file with the [required entries for authenticating to your Oracle Cloud
-       account](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#SDK_and_CLI_Configuration_File). Note
-       the [Required Keys and
-       OCIDs](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#Required_Keys_and_OCIDs)
-       documentation.
-    2. (There are many ways to authenticate to your Oracle Cloud account that are supported by Helidon. This is just one
-       of them that is particularly easy to set up.)
-    3. At a minimum, in this file you'll need to have `fingerprint`, `key_file`, `region`, `tenancy` and `user`
-       [entries](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#ariaid-title3).
-2. [Log in to Oracle Cloud](https://cloud.oracle.com/).
-3. Create a compartment to host OCI resources related to this example and gather its OCID.
-    1. Go to https://cloud.oracle.com/identity/compartments
-    2. Press the *Create Compartment* button.
-    3. Supply a name for the compartment in the Name text field. This example uses "helidon-examples", but it can be any
-       name you like that uses alphanumeric characters and the hyphen (`-`) character.
-    4. Supply a description for the compartment in the Description text field. This example uses "A compartment for
-       Helidon Examples" but it can be any text you like.
-    5. Select a parent compartment for your new compartment from the Parent Compartment drop-down list. It will probably
-       be your account's root compartment, and may already be selected for you.
-    6. Press the *Create Compartment* button.
-    7. Click on your new compartment's hyperlink that now appears in the Compartments table.
-    8. In the Compartment Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the Oracle Cloud
-       Identifier (OCID) of your new compartment to your computer's clipboard.
-    9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `compartment-ocid: ` and paste the just-copied OCID.
-3. Create a vault to host secret information related to this example and gather its OCID
+
+1. Create a new, empty '${HOME}/.oci/config' file whose contents you will fill in shortly. This example presumes that
+   you do not already have one. If you do have one, you may need to edit it carefully rather than following these
+   instructions.
+
+    1. (There are many ways to authenticate to your Oracle Cloud account that are supported by Helidon. This is just one
+       of them that is particularly easy to set up, which is why it is used in this example.)
+
+2. [Log in to Oracle Cloud](https://cloud.oracle.com/)
+
+3. Create a user for this example if needed.
+
     1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
        from the resulting menu.
-    2. Click on *Vault* in the page that results, under the *Key Management & Secret Management* section.
-    3. On the left of the page, under the List scope section, select your new compartment from the drop down list.
-    3. Press the *Create Vault* button.
-    4. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
+
+    2. Click on Users under the **Identity** section.
+
+    3. Press the **Create User** button.
+
+    4. Supply a name for the user in the Name text field. This exmaple uses "helidon-examples-user", but it can be any
+       name you like that conforms to OCI's valid character restrictions.
+
+    5. Supply a description for the user in the Description text field. This example uses "A user for Helidon examples",
+       but it can be any text you like.
+
+    5. Press the **Create** button.
+
+4. Fill in the contents of your `${HOME}/.oci/config` file.
+
+    1. Click on **API Keys** in the Resources section.
+
+    2. Press the **Add API Key** button.
+
+    3. Press the **Download Private Key** button and take note of where the file is saved.
+
+    4. Press the **Download Public Key** button and take note of where the file is saved.
+
+    5. Press the **Add** button
+    
+    6. Take note of the contents of the Configuration File Preview text area. This will become part of the contents of
+       your `${HOME}/.oci/config` file.
+
+    7. Click the "Copy" hyperlink to copy the contents of the Configuration File Preview text area to your computer's
+       clipboard.
+
+    8. Paste the copied contents into the currently empty `${HOME}/.oci/config` file you just created.
+
+    9. Locate the private key file that you downloaded. Rename it to `${HOME}/.oci/oci_api_key.pem` and adjust its
+       permissions so that it is read-only and only you can read it.
+
+    10. Locate the public key file that you downloaded. Rename it to `${HOME}/.oci/oci_api_key_public.pem`.
+
+    11. In your now non-empty `${HOME}/.oci/config` file, replace the occurrence of `<path to your private keyfile>
+       #TODO` with `~/.oci/oci_api_key.pem`.
+
+5. [Log in to Oracle Cloud](https://cloud.oracle.com/).
+
+6. Create a compartment to host OCI resources related to this example and gather its OCID.
+
+    1. Go to https://cloud.oracle.com/identity/compartments
+
+    2. Press the *Create Compartment* button.
+
+    3. Supply a name for the compartment in the Name text field. This example uses "helidon-examples", but it can be any
        name you like that uses alphanumeric characters and the hyphen (`-`) character.
-    5. Press the *Create Vault* button toward the bottom of the page.
-    6. After several seconds, your new vault should appear in the table with a *State* of *Creating*.
-    7. Click on your new vault's hyperlink.
-    8. In the Vault Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the OCID of your new
+
+    4. Supply a description for the compartment in the Description text field. This example uses "A compartment for
+       Helidon Examples" but it can be any text you like.
+
+    5. Select a parent compartment for your new compartment from the Parent Compartment drop-down list. It will probably
+       be your account's root compartment, and may already be selected for you.
+
+    6. Press the *Create Compartment* button.
+
+    7. Click on your new compartment's hyperlink that now appears in the Compartments table.
+
+    8. In the Compartment Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the Oracle Cloud
+       Identifier (OCID) of your new compartment to your computer's clipboard.
+
+    9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `compartment-ocid: ` and paste the just-copied OCID.
+
+7. Create a vault to host secret information related to this example and gather its OCID
+
+    1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
+       from the resulting menu.
+
+    2. Click on *Vault* in the page that results, under the *Key Management & Secret Management* section.
+
+    3. On the left of the page, under the List scope section, select your new compartment from the drop down list.
+
+    4. Press the *Create Vault* button.
+
+    5. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
+       name you like that uses alphanumeric characters and the hyphen (`-`) character.
+
+    6. Press the *Create Vault* button toward the bottom of the page.
+
+    7. After several seconds, your new vault should appear in the table with a *State* of *Creating*.
+
+    8. Click on your new vault's hyperlink.
+
+    9. In the Vault Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the OCID of your new
        vault to your computer's clipboard.
-    9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `vault-ocid: ` and paste the just-copied OCID.
-4. Create a master encryption key in your newly-created vault to encrypt secret information hosted in the vault.
+
+    10. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `vault-ocid: ` and paste the just-copied OCID.
+
+8. Create a master encryption key in your newly-created vault to encrypt secret information hosted in the vault.
+
     1. Press the *Create Key* button.
+
     2. Supply a name for the new master encryption key in the Name text field. This example uses "Helidon Examples Master
        Encryption Key" but it can be any text you like.
+
     3. Press the *Create Key* button toward the bottom of the page.
+
     4. After several seconds, your new master encryption key will appear in the table with a *State* of *Creating*.
-5. Create a secret that will be used by this example.
+
+9. Create a secret that will be used by this example.
+
     1. On the left side of the page, in the *Resources* section, click on *Secrets*.
+
     2. Press the *Create Secret* button.
+
     3. Supply a name for the secret in the Name text field. This example uses "helidon-examples-secret", but it can be any
        name you like that uses alphanumeric characters and the hyphen (`-`) character.
+
     4. Supply a description for the secret in the Description text field. This example uses "A secret for Helidon
        Examples" but it can be any text you like.
+
     5. Choose the Helidon Examples Master Encryption Key in the Encryption Key drop down (the master encryption key you
        just created).
+
     6. Supply a plain text value for the secret in the Secret Contents text area. This example uses "secret value", but it
        can be any text you like.
+
     7. Press the *Create Secret* button toward the bottom of the page.
+
 ### Edit The Example's Meta-Configuration to Reference OCI Resources
 
 This example relies on a Helidon configuration feature known as _meta-configuration_, configuration about

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -1,0 +1,144 @@
+# OCI Secrets MP Config Source Example
+
+This example project demonstrates the use of the `integrations/oci/oci-secrets-mp-config-source` library.
+
+## Prerequisites
+
+* Java 21+
+* Maven 3.8+
+* An [Oracle Cloud Infrastructure (OCI) account](https://www.oracle.com/cloud/).
+
+## Overview
+
+This example shows how to configure and use a Microprofile Config configuration source, via Helidon's Microprofile
+Config meta-configuration feature, that can transparently fetch text values from an OCI vault resource. It exercises the
+classes present in the `integrations/oci/oci-secrets-mp-config-source` project elsewhere in this source code repository.
+
+## Setup Steps
+
+Because this example makes use of Oracle Cloud, you will need to set up some Oracle Cloud resources before you begin,
+along with a way to authenticate to your Oracle Cloud account.
+
+### Create OCI Resources and Gather OCI Information
+
+These steps should only need to be performed once.
+
+0. Open a text document on your computer where you can save some important information related to OCI resources as you
+   go along. This example will presume this document is located in `/tmp/helidon-examples-ocids.txt`.
+1. Set up authentication information on your computer to allow this example to authenticate to your Oracle Cloud
+   account.
+  1. Create a [`${HOME}/.oci/config`] file with the [required entries for authenticating to your Oracle Cloud
+   account](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#SDK_and_CLI_Configuration_File). Note
+   the [Required Keys and
+   OCIDs](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#Required_Keys_and_OCIDs)
+   documentation.
+  2. (There are many ways to authenticate to your Oracle Cloud account that are supported by Helidon. This is just one
+     of them that is particularly easy to set up.)
+  3. At a minimum, in this file you'll need to have `fingerprint`, `key_file`, `region`, `tenancy` and `user`
+     [entries](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm#ariaid-title3).
+2. [Log in to Oracle Cloud](https://cloud.oracle.com/).
+3. Create a compartment to host OCI resources related to this example and gather its OCID.
+  1. Go to https://cloud.oracle.com/identity/compartments
+  2. Press the *Create Compartment* button.
+  3. Supply a name for the compartment in the Name text field. This example uses "helidon-examples", but it can be any
+     name you like that uses alphanumeric characters and the hyphen (`-`) character.
+  4. Supply a description for the compartment in the Description text field. This example uses "A compartment for
+     Helidon Examples" but it can be any text you like.
+  5. Select a parent compartment for your new compartment from the Parent Compartment drop-down list. It will probably
+     be your account's root compartment, and may already be selected for you.
+  6. Press the *Create Compartment* button.
+  7. Click on your new compartment's hyperlink that now appears in the Compartments table.
+  8. In the Compartment Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the Oracle Cloud
+     Identifier (OCID) of your new compartment to your computer's clipboard.
+  9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `compartment-ocid: ` and paste the just-copied OCID.
+3. Create a vault to host secret information related to this example and gather its OCID
+  1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
+     from the resulting menu.
+  2. Click on *Vault* in the page that results, under the *Key Management & Secret Management* section.
+  3. On the left of the page, under the List scope section, select your new compartment from the drop down list.
+  3. Press the *Create Vault* button.
+  4. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
+     name you like that uses alphanumeric characters and the hyphen (`-`) character.
+  5. Press the *Create Vault* button toward the bottom of the page.
+  6. After several seconds, your new vault should appear in the table with a *State* of *Creating*.
+  7. Click on your new vault's hyperlink.
+  8. In the Vault Information tab, note the *OCID* item. Click on the "Copy" hyperlink to copy the OCID of your new
+     vault to your computer's clipboard.
+  9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `vault-ocid: ` and paste the just-copied OCID.
+4. Create a master encryption key in your newly-created vault to encrypt secret information hosted in the vault.
+  1. Press the *Create Key* button.
+  2. Supply a name for the new master encryption key in the Name text field. This example uses "Helidon Examples Master
+     Encryption Key" but it can be any text you like.
+  3. Press the *Create Key* button toward the bottom of the page.
+  4. After several seconds, your new master encryption key will appear in the table with a *State* of *Creating*.
+5. Create a secret that will be used by this example.
+  1. On the left side of the page, in the *Resources* section, click on *Secrets*.
+  2. Press the *Create Secret* button.
+  3. Supply a name for the secret in the Name text field. This example uses "helidon-examples-secret", but it can be any
+     name you like that uses alphanumeric characters and the hyphen (`-`) character.
+  4. Supply a description for the secret in the Description text field. This example uses "A secret for Helidon
+     Examples" but it can be any text you like.
+  5. Choose the Helidon Examples Master Encryption Key in the Encryption Key drop down (the master encryption key you
+     just created).
+  6. Supply a plain text value for the secret in the Secret Contents text area. This example uses "secret value", but it
+     can be any text you like.
+  7. Press the *Create Secret* button toward the bottom of the page.
+
+### Edit The Example's Meta-Configuration to Reference OCI Resources
+
+This example relies on a Helidon configuration feature known as _meta-configuration_, configuration about
+configuration. Since this example is Microprofile-based, it specifically relies on Helidon's Microprofile Config
+meta-configuration, which is represented by the `mp-meta-config.yaml` classpath resource. You can find this file in this
+example under the `src/main/resources` directory. Editing this file properly to reference the OCI resources you just
+created above makes the example work.
+
+These steps should only need to be performed once.
+
+1. Edit this example's `src/main/resources/mp-meta-config-yaml` file to include the OCIDs of the compartment and vault you created above.
+  1. Replace the occurrence of `compartment-ocid: ${compartment-ocid}` with the contents of the line you added in
+     `/tmp/helidon-examples-ocids.txt` above that begins with `compartment-ocid: `. Ensure the YAML indentation is correct
+     (`compartment-ocid` should appear at zero-based character position 4, under the `c` in `sources`).
+  2. Replace the occurrence of `vault-ocid: ${vault-ocid}` with the contents of the line you added in
+     `/tmp/helidon-examples-ocids.txt` above that begins with `vault-ocid: `. Ensure the YAML indentation is correct
+     (`vault-ocid` should appear at zero-based character position 4, under the `c` in `sources`).
+  3. Note the `accept-pattern: ` line. Its quoted value is `^helidon-examples-secret$`, which is a regular expression
+     identifying the names of configuration properties whose values should be fetched from the identically-named secret
+     you just created. If you used a name for your new secret other than `helidon-examples-secret` above, replace
+     `helidon-examples-secret` with the name of the newly-created secret.
+
+The resulting file should look similar to this:
+
+```
+add-default-sources: false
+add-discovered-converters: false
+add-discovered-sources: false
+
+sources:
+  - type: 'environment-variables'
+  - type: 'system-properties'
+  - type: 'oci-secrets'
+    accept-pattern: '^helidon-examples-secret$'
+    compartment-ocid: ocid1.compartment.oc1... # the OCID of the compartment you created above
+    lazy: false
+    vault-ocid: ocid1.vault.oc1... # the OCID of the vault you created above
+```
+
+The file instructs the Helidon MicroProfile Config implementation:
+* not to add any default or discovered configuration sources via the normal discovery mechanisms (this file will instead specify
+  exactly what configuration sources will apply for this example application)
+* not to add any discovered converters (this application does not require them)
+* to add a configuration source of type `oci-secrets` with characteristics
+  * It will attempt to fetch a value for any configuration property name that matches the `accept-pattern`'s regular
+    expression value, and none other.
+  * It will look in the vault identified by the (OCID) value of the `vault-ocid` setting, in the compartment identified
+    by the (OCID) value of the `compartment-ocid` setting.
+  * It will use a `NodeConfigSource`-based configuration source rather than a `LazyConfigSource`-based configuration
+    source. See Helidon's documentation about configuration sources for more information.
+
+## Build The Example
+
+`mvn clean verify`
+
+## Run The Example
+
+`java -jar target/TODO.jar`

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -35,7 +35,7 @@ begin. You should have to perform these steps only once.
 
 3. Create a user for this example if needed.
 
-    1. Go to https://cloud.oracle.com/identity/users (open this link in a new browser tab or window).
+    1. Go to https://cloud.oracle.com/identity/users/ (open this link in a new browser tab or window).
 
     2. Press the **Create User** button.
 
@@ -97,7 +97,7 @@ begin. You should have to perform these steps only once.
 
 5. Create a compartment to host OCI resources related to this example and gather its OCID.
 
-    1. Go to https://cloud.oracle.com/identity/compartments
+    1. Go to https://cloud.oracle.com/identity/compartments/ (open this link in a new browser tab or window).
 
     2. Press the **Create Compartment** button.
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -210,13 +210,16 @@ To recap, you have, in dependency order:
 
 * Created a group ("helidon-examples-group")
 
+* Added the user to the group
+
 * Created a compartment ("helidon-examples")
 
 * Created a vault in the compartment ("helidon-examples-vault")
 
 * Created a secret in the vault ("helidon-examples-secret")
 
-* Created a policy that lets your group's users manipulate secrets found in your compartment ("helidon-examples-group-manipulate-secrets")
+* Created a policy that lets your group's users manipulate secrets found in your compartment
+  ("helidon-examples-group-manipulate-secrets")
 
 Your OCI resources should be ready to go.
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -26,14 +26,14 @@ These steps should only need to be performed once.
 0. Open a text document on your computer where you can save some important information related to OCI resources as you
    go along. This example will presume this document is located in `/tmp/helidon-examples-ocids.txt`.
 
-1. Create a new, empty '${HOME}/.oci/config' file whose contents you will fill in shortly. This example presumes that
+1. Create a new, empty `${HOME}/.oci/config` file whose contents you will fill in shortly. This example presumes that
    you do not already have one. If you do have one, you may need to edit it carefully rather than following these
    instructions.
 
     1. (There are many ways to authenticate to your Oracle Cloud account that are supported by Helidon. This is just one
        of them that is particularly easy to set up, which is why it is used in this example.)
 
-2. [Log in to Oracle Cloud](https://cloud.oracle.com/)
+2. [Log in to Oracle Cloud](https://cloud.oracle.com/).
 
 3. Create a user for this example if needed.
 
@@ -52,7 +52,7 @@ These steps should only need to be performed once.
 
     5. Press the **Create** button.
 
-4. Fill in the contents of your `${HOME}/.oci/config` file.
+4. Fill in the contents of your `${HOME}/.oci/config` file with your new user's information.
 
     1. Click on **API Keys** in the Resources section.
 
@@ -67,10 +67,10 @@ These steps should only need to be performed once.
     6. Take note of the contents of the Configuration File Preview text area. This will become part of the contents of
        your `${HOME}/.oci/config` file.
 
-    7. Click the "Copy" hyperlink to copy the contents of the Configuration File Preview text area to your computer's
-       clipboard.
+        7. Click the "Copy" hyperlink to copy the contents of the Configuration File Preview text area to your computer's
+           clipboard.
 
-    8. Paste the copied contents into the currently empty `${HOME}/.oci/config` file you just created.
+        8. Paste the copied contents into the currently empty `${HOME}/.oci/config` file you just created.
 
     9. Locate the private key file that you downloaded. Rename it to `${HOME}/.oci/oci_api_key.pem` and adjust its
        permissions so that it is read-only and only you can read it.
@@ -80,9 +80,7 @@ These steps should only need to be performed once.
     11. In your now non-empty `${HOME}/.oci/config` file, replace the occurrence of `<path to your private keyfile>
        #TODO` with `~/.oci/oci_api_key.pem`.
 
-5. [Log in to Oracle Cloud](https://cloud.oracle.com/).
-
-6. Create a compartment to host OCI resources related to this example and gather its OCID.
+5. Create a compartment to host OCI resources related to this example and gather its OCID.
 
     1. Go to https://cloud.oracle.com/identity/compartments
 
@@ -106,7 +104,7 @@ These steps should only need to be performed once.
 
     9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `compartment-ocid: ` and paste the just-copied OCID.
 
-7. Create a vault to host secret information related to this example and gather its OCID
+6. Create a vault to host secret information related to this example and gather its OCID
 
     1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
        from the resulting menu.
@@ -131,7 +129,7 @@ These steps should only need to be performed once.
 
     10. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `vault-ocid: ` and paste the just-copied OCID.
 
-8. Create a master encryption key in your newly-created vault to encrypt secret information hosted in the vault.
+7. Create a master encryption key in your newly-created vault to encrypt secret information hosted in the vault.
 
     1. Press the *Create Key* button.
 
@@ -142,7 +140,7 @@ These steps should only need to be performed once.
 
     4. After several seconds, your new master encryption key will appear in the table with a *State* of *Creating*.
 
-9. Create a secret that will be used by this example.
+8. Create a secret that will be used by this example.
 
     1. On the left side of the page, in the *Resources* section, click on *Secrets*.
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -116,7 +116,7 @@ sources:
   - type: 'environment-variables'
   - type: 'system-properties'
   - type: 'oci-secrets'
-    accept-pattern: '^helidon-examples-secret$'
+    accept-pattern: '^helidon-examples-secret$' # note the name of the secret you created above
     compartment-ocid: ocid1.compartment.oc1... # the OCID of the compartment you created above
     lazy: false
     vault-ocid: ocid1.vault.oc1... # the OCID of the vault you created above
@@ -126,7 +126,9 @@ The file instructs the Helidon MicroProfile Config implementation:
 * not to add any default or discovered configuration sources via the normal discovery mechanisms (this file will instead specify
   exactly what configuration sources will apply for this example application)
 * not to add any discovered converters (this application does not require them)
-* to add a configuration source of type `oci-secrets` with characteristics
+* to add the `environment-variables` configuration source first
+* to add the `system-properties` configuration source second
+* to add a configuration source of type `oci-secrets` third, with characteristics:
   * It will attempt to fetch a value for any configuration property name that matches the `accept-pattern`'s regular
     expression value, and none other.
   * It will look in the vault identified by the (OCID) value of the `vault-ocid` setting, in the compartment identified

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -210,16 +210,17 @@ To recap, you have, in dependency order:
 
 * Created a group ("helidon-examples-group")
 
-* Added the user to the group
+* Added the user named "helidon-examples" to the group named "helidon-examples-group"
 
 * Created a compartment ("helidon-examples")
 
 * Created a vault in the compartment ("helidon-examples-vault")
 
-* Created a secret in the vault ("helidon-examples-secret")
+* Created a secret in the vault ("helidon-examples-secret"), with a value of "secret value"
 
 * Created a policy that lets your group's users manipulate secrets found in your compartment
-  ("helidon-examples-group-manipulate-secrets")
+  ("helidon-examples-group-manipulate-secrets"), with an effective value of "Allow group **helidon-examples-group** to
+  use secret-family in **compartment helidon-examples**"
 
 Your OCI resources should be ready to go.
 
@@ -257,9 +258,9 @@ These steps should only need to be performed once.
 The resulting file should look similar to this (with trailing explanatory comments):
 
 ```
-add-default-sources: false
-add-discovered-converters: false
-add-discovered-sources: false
+add-default-sources: false       # don't load anything not specified below
+add-discovered-converters: false # don't load anything not specified below
+add-discovered-sources: false    # don't load anything not specified below
 
 sources:
   - type: 'environment-variables'

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -52,23 +52,23 @@ These steps should only need to be performed once.
 
     5. Press the **Create** button.
 
-4. Fill in the contents of your `${HOME}/.oci/config` file with your new user's information.
+    4. Fill in the contents of your `${HOME}/.oci/config` file with your new user's information.
 
-    1. Click on **API Keys** in the Resources section.
+        1. Click on **API Keys** in the Resources section.
 
-    2. Press the **Add API Key** button.
+        2. Press the **Add API Key** button.
 
-    3. Press the **Download Private Key** button and take note of where the file is saved.
+        3. Press the **Download Private Key** button and take note of where the file is saved.
 
-    4. Press the **Download Public Key** button and take note of where the file is saved.
+        4. Press the **Download Public Key** button and take note of where the file is saved.
 
-    5. Press the **Add** button
+        5. Press the **Add** button
 
-    6. Take note of the contents of the Configuration File Preview text area. This will become part of the contents of
-       your `${HOME}/.oci/config` file.
+        6. Take note of the contents of the Configuration File Preview text area. This will become part of the contents
+           of your `${HOME}/.oci/config` file.
 
-        7. Click the "Copy" hyperlink to copy the contents of the Configuration File Preview text area to your computer's
-           clipboard.
+        7. Click the "Copy" hyperlink to copy the contents of the Configuration File Preview text area to your
+           computer's clipboard.
 
         8. Paste the copied contents into the currently empty `${HOME}/.oci/config` file you just created.
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -80,7 +80,7 @@ These steps should only need to be performed once.
     11. In your now non-empty `${HOME}/.oci/config` file, replace the occurrence of `<path to your private keyfile>
        #TODO` with `~/.oci/oci_api_key.pem`.
 
-5. Create a group for your new user.
+4. Create a group for your new user.
 
     1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
        from the resulting menu.
@@ -215,6 +215,24 @@ These steps should only need to be performed once.
         **helidon-examples-group** to use secret-family in **compartment helidon-examples**".
 
     12. Press the **Create** button toward the bottom of the page.
+
+To recap, you have, in dependency order:
+
+* Created a user ("helidon-examples")
+
+* Created a `${HOME}/.oci/config` file with that user's authentication information
+
+* Created a group ("helidon-examples-group")
+
+* Created a compartment ("helidon-examples")
+
+* Created a vault in the compartment ("helidon-examples-vault")
+
+* Created a secret in the vault ("helidon-examples-secret")
+
+* Created a policy that lets your group's users manipulate secrets found in your compartment ("helidon-examples-group-manipulate-secrets")
+
+You should be ready to go.
 
 ### Edit The Example's Meta-Configuration to Reference OCI Resources
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -45,7 +45,7 @@ These steps should only need to be performed once.
     3. Press the **Create User** button.
 
     4. Supply a name for the user in the Name text field. This example uses "helidon-examples-user", but it can be any
-       name you like that conforms to OCI's valid character restrictions.
+       name you like that conforms to OCI's valid character requirements.
 
     5. Supply a description for the user in the Description text field. This example uses "A user for Helidon examples",
        but it can be any text you like.
@@ -62,7 +62,7 @@ These steps should only need to be performed once.
 
         4. Press the **Download Public Key** button and take note of where the file is saved.
 
-        5. Press the **Add** button
+        5. Press the **Add** button.
 
         6. Take note of the contents of the Configuration File Preview text area. This will become part of the contents
            of your `${HOME}/.oci/config` file.
@@ -90,7 +90,7 @@ These steps should only need to be performed once.
     3. Press the **Create Group** button.
 
     4. Supply a name for the group in the Name text field. This example uses "helidon-examples-group", but it can be any
-       name you like that conforms to OCI's valid character restrictions.
+       name you like that conforms to OCI's valid character requirements.
 
     5. Supply a description for the user in the Description text field. This example uses "A group for Helidon
        examples", but it can be any text you like.
@@ -110,7 +110,7 @@ These steps should only need to be performed once.
     2. Press the **Create Compartment** button.
 
     3. Supply a name for the compartment in the Name text field. This example uses "helidon-examples", but it can be any
-       name you like that uses alphanumeric characters and the hyphen (`-`) character.
+       name you like that conforms to OCI's valid character requirements.
 
     4. Supply a description for the compartment in the Description text field. This example uses "A compartment for
        Helidon Examples" but it can be any text you like.
@@ -127,7 +127,7 @@ These steps should only need to be performed once.
 
     9. In `/tmp/helidon-examples-ocids.txt`, on a new line, type `compartment-ocid: ` and paste the just-copied OCID.
 
-6. Create a vault to host secret information related to this example and gather its OCID
+6. Create a vault to host secret information related to this example and gather its OCID.
 
     1. Click on the three-dash "hamburger" menu in the upper left of the navigation bar. Click on *Identity and Security*
        from the resulting menu.
@@ -139,11 +139,11 @@ These steps should only need to be performed once.
     4. Press the **Create Vault** button.
 
     5. Supply a name for the vault in the Name text field. This example uses "helidon-examples-vault", but it can be any
-       name you like that uses alphanumeric characters and the hyphen (`-`) character.
+       name you like that conforms to OCI's valid character requirements.
 
     6. Press the **Create Vault** button toward the bottom of the page.
 
-    7. After several seconds, your new vault should appear in the table with a *State* of *Creating*.
+    7. After several seconds, your new vault should appear in the table with a **State** of **Creating**.
 
     8. Click on your new vault's hyperlink.
 
@@ -170,7 +170,7 @@ These steps should only need to be performed once.
     2. Press the **Create Secret** button.
 
     3. Supply a name for the secret in the Name text field. This example uses "helidon-examples-secret", but it can be any
-       name you like that uses alphanumeric characters and the hyphen (`-`) character.
+       name you like that conform's to OCI's valid character requirements.
 
     4. Supply a description for the secret in the Description text field. This example uses "A secret for Helidon
        Examples" but it can be any text you like.

--- a/examples/integrations/oci/oci-secrets-mp-config-source/README.md
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/README.md
@@ -292,7 +292,7 @@ gathered. It is no longer needed.
 In the root directory of your computer's copy of this project, open a shell and type:
 
 ```sh
-`mvn clean verify`
+mvn clean verify
 ```
 
 ## Run The Example
@@ -311,7 +311,7 @@ java -jar target/helidon-examples-integrations-oci-secrets-mp-config-source.jar 
 but `java.home` will be resolved from Helidon's system properties configuration source.)
 
 You can run the same example with logging if you want to experiment with levels. Edit your local copy of
-`logging.properties` appropriately, and then run:
+`logging.properties` in the root directory of this project appropriately, and then run:
 
 ```sh
 java -Djava.util.logging.config.file=logging.properties -jar target/helidon-examples-integrations-oci-secrets-mp-config-source.jar java.home

--- a/examples/integrations/oci/oci-secrets-mp-config-source/logging.properties
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/logging.properties
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+#com.oracle.bmc.level=FINE
+#io.helidon.integrations.level=FINE
+#io.helidon.level=FINE

--- a/examples/integrations/oci/oci-secrets-mp-config-source/pom.xml
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../../../../applications/mp/pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.helidon.examples.integrations.oci</groupId>
+    <artifactId>helidon-examples-integrations-oci-secrets-mp-config-source</artifactId>
+    <name>Helidon Examples Integration OCI Secrets MP Config Source</name>
+    <description>An example showing the usage of the oci-secrets-mp-config-source library.</description>
+
+    <dependencies>
+
+        <!-- Compile-scoped dependencies. -->
+
+        <dependency>
+            <groupId>io.helidon.integrations.oci</groupId>
+            <artifactId>helidon-integrations-oci-secrets-mp-config-source</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+
+        <!-- Runtime-scoped dependencies. -->
+
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>io.helidon.examples.integrations.oci.secrets.mp.configsource.SecretLister</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
@@ -40,7 +40,7 @@ public final class SecretLister {
      */
     public static void main(String[] args) {
         if (args.length == 0) {
-            System.out.println("(No configuration property name supplied as a command-line argument.");
+            System.out.println("(No configuration property name supplied as a command-line argument.)");
         } else {
             System.out.println(ConfigProvider.getConfig().getOptionalValue(args[0], String.class).orElse("No such configuration property: " + args[0]));
         }

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.integrations.oci.secrets.mp.configsource;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * A main class that
+ */
+public final class SecretLister {
+
+    /**
+     * Asks the Helidon MicroProfile Config implementation to retrieve a configuration property whose name is supplied
+     * by the first command-line argument and prints its value, if it is found, or {@code No such configuration
+     * property: <name>} if it is not.
+     *
+     * @param args the command-line arguments; must not be {@code null}
+     *
+     * @exception NullPointerException if {@code args} is {@code null}
+     */
+    public static void main(String[] args) {
+        System.out.println(ConfigProvider.getConfig().getOptionalValue(args[0], String.class).orElse("No such configuration property: " + args[0]));
+    }
+
+}

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
@@ -18,9 +18,16 @@ package io.helidon.examples.integrations.oci.secrets.mp.configsource;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
- * A main class that
+ * A main class that retrieves configuration property values using various Helidon Microprofile Config implementation
+ * classes.
+ *
+ * @see io.helidon.integrations.oci.secrets.mp.configsource.OciSecretsMpMetaConfigProvider
  */
 public final class SecretLister {
+
+    private SecretLister() {
+        super();
+    }
 
     /**
      * Asks the Helidon MicroProfile Config implementation to retrieve a configuration property whose name is supplied

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
@@ -42,7 +42,9 @@ public final class SecretLister {
         if (args.length == 0) {
             System.out.println("(No configuration property name supplied as a command-line argument.)");
         } else {
-            System.out.println(ConfigProvider.getConfig().getOptionalValue(args[0], String.class).orElse("No such configuration property: " + args[0]));
+            System.out.println(ConfigProvider.getConfig()
+                               .getOptionalValue(args[0], String.class)
+                               .orElse("No such configuration property: " + args[0]));
         }
     }
 

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/SecretLister.java
@@ -39,7 +39,11 @@ public final class SecretLister {
      * @exception NullPointerException if {@code args} is {@code null}
      */
     public static void main(String[] args) {
-        System.out.println(ConfigProvider.getConfig().getOptionalValue(args[0], String.class).orElse("No such configuration property: " + args[0]));
+        if (args.length == 0) {
+            System.out.println("(No configuration property name supplied as a command-line argument.");
+        } else {
+            System.out.println(ConfigProvider.getConfig().getOptionalValue(args[0], String.class).orElse("No such configuration property: " + args[0]));
+        }
     }
 
 }

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/package-info.java
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/java/io/helidon/examples/integrations/oci/secrets/mp/configsource/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes and interfaces used in demonstrating the use of the {@link
+ * io.helidon.integrations.oci.secrets.mp.configsource.OciSecretsMpMetaConfigProvider}.
+ *
+ * @see io.helidon.integrations.oci.secrets.mp.configsource.OciSecretsMpMetaConfigProvider
+ */
+package io.helidon.examples.integrations.oci.secrets.mp.configsource;

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/resources/mp-meta-config.yaml
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/resources/mp-meta-config.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 add-default-sources: false
 add-discovered-converters: false
 add-discovered-sources: false

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/resources/mp-meta-config.yaml
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/resources/mp-meta-config.yaml
@@ -1,0 +1,12 @@
+add-default-sources: false
+add-discovered-converters: false
+add-discovered-sources: false
+
+sources:
+  - type: 'environment-variables'
+  - type: 'system-properties'
+  - type: 'oci-secrets'
+    accept-pattern: '^helidon-examples-secret$'
+    compartment-ocid: '${compartment-ocid}'
+    lazy: false
+    vault-ocid: '${vault-ocid}'

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/resources/mp-meta-config.yaml
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/resources/mp-meta-config.yaml
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-add-default-sources: false
-add-discovered-converters: false
-add-discovered-sources: false
+add-default-sources: false       # don't load anything not specified below
+add-discovered-converters: false # don't load anything not specified below
+add-discovered-sources: false    # don't load anything not specified below
 
 sources:
   - type: 'environment-variables'

--- a/examples/integrations/oci/oci-secrets-mp-config-source/src/main/resources/mp-meta-config.yaml
+++ b/examples/integrations/oci/oci-secrets-mp-config-source/src/main/resources/mp-meta-config.yaml
@@ -6,7 +6,7 @@ sources:
   - type: 'environment-variables'
   - type: 'system-properties'
   - type: 'oci-secrets'
-    accept-pattern: '^helidon-examples-secret$'
-    compartment-ocid: '${compartment-ocid}'
+    accept-pattern: '^helidon-examples-secret$' # Replace helidon-examples-secret with the name of your secret. See ../../../README.md.
+    compartment-ocid: # Insert your compartment's OCID between the colon (:) and the comment character (#).
     lazy: false
-    vault-ocid: '${vault-ocid}'
+    vault-ocid: # Insert your vault's OCID between the colon (:) and the comment character (#).

--- a/examples/integrations/oci/pom.xml
+++ b/examples/integrations/oci/pom.xml
@@ -38,6 +38,7 @@
         <module>metrics</module>
         <module>objectstorage</module>
         <module>objectstorage-cdi</module>
+        <module>oci-secrets-mp-config-source</module>
         <module>vault</module>
         <module>vault-cdi</module>
     </modules>


### PR DESCRIPTION
This PR adds an example showing the usage of the `oci-secrets-mp-config-source` project.

Documentation impact: none