### PR TITLE
4.x: Verify Starter with 4.x archetypes

### DIFF
--- a/archetypes/helidon/src/main/archetype/common/common.xml
+++ b/archetypes/helidon/src/main/archetype/common/common.xml
@@ -49,7 +49,7 @@
             <includes>
                 <include>.helidon.mustache</include>
                 <include>README.md.mustache</include>
-                <include>src/main/java/**/*.java.mustache</include>
+                <include>src/main/java/**/Main.java.mustache</include>
             </includes>
         </templates>
         <model>

--- a/archetypes/helidon/src/main/archetype/common/media.xml
+++ b/archetypes/helidon/src/main/archetype/common/media.xml
@@ -22,7 +22,8 @@
 
     <step name="Media Support" optional="true">
         <variables>
-            <text path="media.default-json-lib">jsonb</text>
+            <text path="media.default-json-lib" if="${flavor} == 'mp'">jsonb</text>
+            <text path="media.default-json-lib" if="${flavor} == 'se'">jsonp</text>
         </variables>
         <inputs>
             <!-- TODO https://github.com/oracle/helidon-build-tools/issues/699 -->

--- a/archetypes/helidon/src/main/archetype/common/packaging.xml
+++ b/archetypes/helidon/src/main/archetype/common/packaging.xml
@@ -92,6 +92,36 @@ kubectl delete -f app.yaml
                     </templates>
                 </output>
             </boolean>
+            <boolean id="jpms-se"
+                     name="Module support (JPMS)"
+                     description="Add a module-info"
+                     default="false"
+                     optional="true"
+                     if="${flavor} == 'se'">
+                <output>
+                    <templates engine="mustache" transformations="mustache,packaged">
+                        <directory>files</directory>
+                        <includes>
+                            <include>src/main/java/**/module-info.java.mustache</include>
+                        </includes>
+                    </templates>
+                </output>
+            </boolean>
+            <boolean id="jpms-mp"
+                     name="Module support (JPMS)"
+                     description="Add a module-info and a module main class"
+                     default="false"
+                     optional="true"
+                     if="${flavor} == 'mp'">
+                <output>
+                    <templates engine="mustache" transformations="mustache,packaged">
+                        <directory>files</directory>
+                        <includes>
+                            <include>src/main/java/**/module-info.java.mustache</include>
+                        </includes>
+                    </templates>
+                </output>
+            </boolean>
         </inputs>
     </step>
 </archetype-script>

--- a/archetypes/helidon/src/main/archetype/common/packaging.xml
+++ b/archetypes/helidon/src/main/archetype/common/packaging.xml
@@ -92,27 +92,11 @@ kubectl delete -f app.yaml
                     </templates>
                 </output>
             </boolean>
-            <boolean id="jpms-se"
+            <boolean id="jpms"
                      name="Module support (JPMS)"
-                     description="Add a module-info"
+                     description="Add a module-info to your project"
                      default="false"
-                     optional="true"
-                     if="${flavor} == 'se'">
-                <output>
-                    <templates engine="mustache" transformations="mustache,packaged">
-                        <directory>files</directory>
-                        <includes>
-                            <include>src/main/java/**/module-info.java.mustache</include>
-                        </includes>
-                    </templates>
-                </output>
-            </boolean>
-            <boolean id="jpms-mp"
-                     name="Module support (JPMS)"
-                     description="Add a module-info and a module main class"
-                     default="false"
-                     optional="true"
-                     if="${flavor} == 'mp'">
+                     optional="true">
                 <output>
                     <templates engine="mustache" transformations="mustache,packaged">
                         <directory>files</directory>

--- a/archetypes/helidon/src/main/archetype/common/presets.xml
+++ b/archetypes/helidon/src/main/archetype/common/presets.xml
@@ -37,5 +37,7 @@
         <boolean path="docker.jlink-image">true</boolean>
         <boolean path="k8s">true</boolean>
         <boolean path="v8o">false</boolean>
+        <boolean path="jpms-se">false</boolean>
+        <boolean path="jpms-mp">false</boolean>
     </presets>
 </archetype-script>

--- a/archetypes/helidon/src/main/archetype/common/presets.xml
+++ b/archetypes/helidon/src/main/archetype/common/presets.xml
@@ -37,7 +37,6 @@
         <boolean path="docker.jlink-image">true</boolean>
         <boolean path="k8s">true</boolean>
         <boolean path="v8o">false</boolean>
-        <boolean path="jpms-se">false</boolean>
-        <boolean path="jpms-mp">false</boolean>
+        <boolean path="jpms">false</boolean>
     </presets>
 </archetype-script>

--- a/archetypes/helidon/src/main/archetype/flavor.xml
+++ b/archetypes/helidon/src/main/archetype/flavor.xml
@@ -31,15 +31,15 @@
                   default="se"
                   global="true"
                   optional="true">
-                <option value="mp"
-                        name="Helidon MP"
-                        description="Declarative, MicroProfile compliant">
-                    <exec src="mp/mp.xml"/>
-                </option>
                 <option value="se"
                         name="Helidon SE"
                         description="WebSever based on Virtual Threads">
                     <exec src="se/se.xml"/>
+                </option>
+                <option value="mp"
+                        name="Helidon MP"
+                        description="Declarative, MicroProfile compliant">
+                    <exec src="mp/mp.xml"/>
                 </option>
             </enum>
         </inputs>

--- a/archetypes/helidon/src/main/archetype/mp/oci/oci-mp.xml
+++ b/archetypes/helidon/src/main/archetype/mp/oci/oci-mp.xml
@@ -45,6 +45,7 @@ This will mount `~/.oci` as a volume in the running docker container.
         <boolean path="docker.jlink-image">false</boolean>
         <boolean path="k8s">true</boolean>
         <boolean path="v8o">false</boolean>
+        <boolean path="jpms">false</boolean>
     </presets>
     <call method="pre-processed-models"/>
     <exec src="/common/common.xml"/>

--- a/archetypes/helidon/src/main/archetype/se/custom/custom-se.xml
+++ b/archetypes/helidon/src/main/archetype/se/custom/custom-se.xml
@@ -26,9 +26,9 @@
     <source src="/se/custom/database.xml"/>
     <source src="/common/extra.xml"/>
     <source src="/se/custom/extra.xml"/>
-    <exec src="/common/packaging.xml"/>
     <source src="/common/observability.xml"/>
     <source src="/se/custom/observability.xml"/>
+    <exec src="/common/packaging.xml"/>
 
     <output>
         <file source="files/src/main/resources/WEB/index.html" target="src/main/resources/WEB/index.html" if="${media} contains 'multipart'"/>

--- a/archetypes/helidon/src/main/archetype/se/quickstart/quickstart-se.xml
+++ b/archetypes/helidon/src/main/archetype/se/quickstart/quickstart-se.xml
@@ -19,25 +19,9 @@
 <archetype-script xmlns="https://helidon.io/archetype/2.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://helidon.io/archetype/2.0 https://helidon.io/xsd/archetype-2.0.xsd">
+    <exec src="/common/presets.xml"/>
     <presets>
-        <list path="media">
-            <value>json</value>
-        </list>
         <boolean path="db">false</boolean>
-        <enum path="media.json-lib">jsonp</enum>
-        <boolean path="metrics">true</boolean>
-        <enum path="metrics.provider">microprofile</enum>
-        <boolean path="metrics.builtin">true</boolean>
-        <boolean path="health">true</boolean>
-        <boolean path="health.builtin">true</boolean>
-        <boolean path="tracing">false</boolean>
-        <list path="extra"/>
-        <boolean path="security">false</boolean>
-        <boolean path="docker">true</boolean>
-        <boolean path="docker.native-image">true</boolean>
-        <boolean path="docker.jlink-image">true</boolean>
-        <boolean path="k8s">false</boolean>
-        <boolean path="v8o">false</boolean>
     </presets>
     <exec src="/se/custom/custom-se.xml"/>
     <source src="/common/sources.xml"/>

--- a/archetypes/helidon/src/main/archetype/se/se.xml
+++ b/archetypes/helidon/src/main/archetype/se/se.xml
@@ -32,15 +32,15 @@
                         description="Sample Helidon Nima project that includes multiple REST operations">
                     <exec src="quickstart/quickstart-se.xml"/>
                 </option>
-                <option value="custom"
-                        name="Custom"
-                        description="Custom Helidon SE project">
-                    <exec src="custom/custom-se.xml"/>
-                </option>
                 <option value="database"
                         name="Database"
                         description="Helidon SE application that uses a database with JPA">
                     <exec src="database/database-se.xml"/>
+                </option>
+                <option value="custom"
+                        name="Custom"
+                        description="Custom Helidon SE project">
+                    <exec src="custom/custom-se.xml"/>
                 </option>
             </enum>
         </inputs>


### PR DESCRIPTION
### Description

This PR is built on top of https://github.com/helidon-io/helidon/pull/7769. It has to be merged after #7769. 

fix #7734

This PR make sure the 4.x archetype workflow is the same than 3.x in `Starter`. 

### Documentation

no impact
