### PR TITLE
Replace usage of Priority with Weight in helidon-config

### DIFF
--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -39,10 +39,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-config</artifactId>
         </dependency>

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -158,10 +158,10 @@ import io.helidon.config.spi.OverrideSource;
  * which return {@link ConfigValue} representing Java primitive data values ({@code boolean, double, int}, etc.)
  * <p>
  * The {@link ConfigValue} can be used to access the value or use optional style methods.
- *
+ * <p>
  * The config value provides access to the value in multiple ways.
  * See {@link ConfigValue} for reference.
- *
+ * <p>
  * Basic usages:
  * <pre>{@code
  * // throws a MissingValueException in case the config node does not exist
@@ -232,13 +232,13 @@ import io.helidon.config.spi.OverrideSource;
  * throws {@link ConfigMappingException}, unless you use the config beans support,
  * that can handle classes that fulfill some requirements (see documentation), such as a public constructor,
  * static "create(Config)" method etc.
- *
+ * <p>
  * <h3><a id="multipleSources">Handling Multiple Configuration
  * Sources</a></h3>
  * A {@code Config} instance, including the default {@code Config} returned by
  * {@link Config#create}, might be associated with multiple {@link ConfigSource}s. The
- * config system merges these together so that values from config sources with higher priority have
- * precedence over values from config sources with lower priority.
+ * config system merges these together so that values from config sources with higher {@link io.helidon.common.Weight weight}
+ * have priority over values from config sources with lower weight.
  */
 public interface Config extends io.helidon.common.config.Config {
     /**
@@ -700,7 +700,7 @@ public interface Config extends io.helidon.common.config.Config {
      *
      * @param predicate predicate evaluated on each visited {@code Config} node
      *                  to continue or stop visiting the node
-     * @return stream of deepening depth-first subnodes
+     * @return stream of deepening depth-first sub nodes
      */
     Stream<Config> traverse(Predicate<Config> predicate);
 
@@ -912,7 +912,7 @@ public interface Config extends io.helidon.common.config.Config {
     /**
      * Register a {@link Consumer} that is invoked each time a change occurs on whole Config or on a particular Config node.
      * <p>
-     * A user can subscribe on root Config node and than will be notified on any change of Configuration.
+     * A user can subscribe on root Config node and then will be notified on any change of Configuration.
      * You can also subscribe on any sub-node, i.e. you will receive notification events just about sub-configuration.
      * No matter how much the sub-configuration has changed you will receive just one notification event that is associated
      * with a node you are subscribed on.
@@ -1198,7 +1198,7 @@ public interface Config extends io.helidon.common.config.Config {
          * the value is found in a configuration source, the value immediately is returned without consulting any of the remaining
          * configuration sources in the prioritized collection.
          * <p>
-         * Target source is composed from following sources, in order:
+         * Target source is composed of following sources, in order:
          * <ol>
          * <li>{@link ConfigSources#environmentVariables() environment variables config source}<br>
          * Can disabled by {@link #disableEnvironmentVariablesSource()}</li>
@@ -1244,7 +1244,7 @@ public interface Config extends io.helidon.common.config.Config {
         /**
          * Sets a {@link ConfigSource} instance to be used as a source of configuration to be wrapped into {@link Config} API.
          * <p>
-         * Target source is composed from {@code configSource} and following sources (unless they are disabled) in order:
+         * Target source is composed of {@code configSource} and following sources (unless they are disabled) in order:
          * <ol>
          * <li>{@link ConfigSources#environmentVariables() environment variables config source}<br>
          * Can disabled by {@link #disableEnvironmentVariablesSource()}</li>
@@ -1269,7 +1269,7 @@ public interface Config extends io.helidon.common.config.Config {
          * Sets an ordered pair of {@link ConfigSource} instances to be used as single source of configuration
          * to be wrapped into {@link Config} API.
          * <p>
-         * Target source is composed from {@code configSource} and following sources (unless they are disabled) in order:
+         * Target source is of from {@code configSource} and following sources (unless they are disabled) in order:
          * <ol>
          * <li>{@link ConfigSources#environmentVariables() environment variables config source}<br>
          * Can disabled by {@link #disableEnvironmentVariablesSource()}</li>
@@ -1296,7 +1296,7 @@ public interface Config extends io.helidon.common.config.Config {
          * Sets an ordered trio of {@link ConfigSource} instances to be used as single source of configuration
          * to be wrapped into {@link Config} API.
          * <p>
-         * Target source is composed from config sources parameters and following sources (unless they are disabled) in order:
+         * Target source is composed of config sources parameters and following sources (unless they are disabled) in order:
          * <ol>
          * <li>{@link ConfigSources#environmentVariables() environment variables config source}<br>
          * Can disabled by {@link #disableEnvironmentVariablesSource()}</li>
@@ -1322,11 +1322,12 @@ public interface Config extends io.helidon.common.config.Config {
         }
 
         /**
-         * Sets source of a override source.
+         * Sets the source of an override source.
          * <p>
          * The feature allows user to override existing values with other ones, specified by wildcards. Default values might be
          * defined with key token references (i.e. {@code $env.$pod.logging.level: INFO}) that might be overridden by a config
-         * source with a higher priority to identify the current environment (i.e. {@code env: test} and {@code pod: qwerty}. The
+         * source with a higher {@link io.helidon.common.Weight weight} to identify the current environment
+         * (i.e. {@code env: test} and {@code pod: qwerty}). The
          * overrides are able to redefine values using wildcards (or without them). For example {@code test.*.logging.level =
          * FINE} overrides {@code logging.level} for all pods in test environment.
          * <p>
@@ -1338,7 +1339,7 @@ public interface Config extends io.helidon.common.config.Config {
         Builder overrides(Supplier<? extends OverrideSource> overridingSource);
 
         /**
-         * Disables an usage of resolving key tokens.
+         * Disables any usage of resolving key tokens.
          * <p>
          * A key can contain tokens starting with {@code $} (i.e. $host.$port), that are resolved by default and tokens are
          * replaced with a value of the key with the token as a key.
@@ -1358,12 +1359,12 @@ public interface Config extends io.helidon.common.config.Config {
         Builder failOnMissingKeyReference(boolean shouldFail);
 
         /**
-         * Disables an usage of resolving value tokens.
+         * Disables any usage of resolving value tokens.
          * <p>
          * A value can contain tokens enclosed in {@code ${}} (i.e. ${name}), that are resolved by default and tokens are replaced
          * with a value of the key with the token as a key.
          * <p>
-         * By default a value resolving filter is added to configuration. When this method is called, the filter will
+         * By default, a value resolving filter is added to configuration. When this method is called, the filter will
          *  not be added and value resolving will be disabled
          * @return an updated builder instance
          */
@@ -1417,7 +1418,7 @@ public interface Config extends io.helidon.common.config.Config {
 
         /**
          * Register a mapping function for specified {@link GenericType}.
-         * This is useful for mappers that support specificly typed generics, such as {@code Map<String, Integer>}
+         * This is useful for mappers that support specifically typed generics, such as {@code Map<String, Integer>}
          * or {@code Set<Foo<Bar>>}.
          * To support mappers that can map any type (e.g. all cases of {@code Map<String, V>}),
          * use {@link #addMapper(ConfigMapperProvider)} as it gives you full control over which types are supported, through
@@ -1473,7 +1474,7 @@ public interface Config extends io.helidon.common.config.Config {
          * loaded as a {@link java.util.ServiceLoader service}.
          * <p>
          * Order of configuration mapper providers loaded as a service
-         * is defined by {@link jakarta.annotation.Priority} annotation.
+         * is defined by {@link io.helidon.common.Weight} annotation.
          * <p>
          * Automatic registration of mappers as a service is enabled by default.
          *
@@ -1484,7 +1485,7 @@ public interface Config extends io.helidon.common.config.Config {
 
         /**
          * Registers a {@link ConfigParser} instance that can be used by config system to parse
-         * parse {@link io.helidon.config.spi.ConfigParser.Content} of {@link io.helidon.config.spi.ParsableSource}.
+         * {@link io.helidon.config.spi.ConfigParser.Content} of {@link io.helidon.config.spi.ParsableSource}.
          * Parsers {@link io.helidon.config.spi.ConfigParser#supportedMediaTypes()} is queried
          * in same order as was registered by this method.
          * Programmatically registered parsers have priority over other options.
@@ -1501,7 +1502,7 @@ public interface Config extends io.helidon.common.config.Config {
         /**
          * Disables automatic registration of parsers loaded as a {@link java.util.ServiceLoader service}.
          * <p>
-         * Order of configuration parsers loaded as a service is defined by {@link jakarta.annotation.Priority} annotation.
+         * Order of configuration parsers loaded as a service is defined by {@link io.helidon.common.Weight} annotation.
          * <p>
          * Automatic registration of parsers as a service is enabled by default.
          *
@@ -1514,7 +1515,7 @@ public interface Config extends io.helidon.common.config.Config {
          * Registers a {@link ConfigFilter} instance that will be used by {@link Config} to
          * filter elementary value before it is returned to a user.
          * <p>
-         * Filters are applied in same order as was registered by the this method, {@link
+         * Filters are applied in same order as was registered by this method, {@link
          * #addFilter(Function)} or {@link #addFilter(Supplier)} method.
          * <p>
          * {@link ConfigFilter} is actually a {@link java.util.function.BiFunction}&lt;{@link String},{@link String},{@link
@@ -1544,7 +1545,7 @@ public interface Config extends io.helidon.common.config.Config {
          * Filters are applied in same order as was registered by the {@link #addFilter(ConfigFilter)}, this method,
          * or {@link #addFilter(Supplier)} method.
          * <p>
-         * Registered provider's {@link Function#apply(Object)} method is called every time the new Config is created. Eg. when
+         * Registered provider's {@link Function#apply(Object)} method is called every time the new Config is created. E.g. when
          * this builder's {@link #build} method creates the {@link Config} or when the new
          * {@link Config#onChange(java.util.function.Consumer)} is fired with new Config instance with its own filter instance
          * is created.
@@ -1564,7 +1565,7 @@ public interface Config extends io.helidon.common.config.Config {
          * Filters are applied in same order as was registered by the {@link #addFilter(ConfigFilter)}, {@link
          * #addFilter(Function)}, or this method.
          * <p>
-         * Registered provider's {@link Function#apply(Object)} method is called every time the new Config is created. Eg. when
+         * Registered provider's {@link Function#apply(Object)} method is called every time the new Config is created. E.g. when
          * this builder's {@link #build} method creates the {@link Config} or when the new
          * {@link Config#onChange(java.util.function.Consumer)} change event
          * is fired with new Config instance with its own filter instance is created.
@@ -1580,7 +1581,7 @@ public interface Config extends io.helidon.common.config.Config {
         /**
          * Disables automatic registration of filters loaded as a {@link java.util.ServiceLoader service}.
          * <p>
-         * Order of configuration filters loaded as a service is defined by {@link jakarta.annotation.Priority} annotation.
+         * Order of configuration filters loaded as a service is defined by {@link io.helidon.common.Weight} annotation.
          * <p>
          * Automatic registration of filters as a service is enabled by default.
          *
@@ -1608,7 +1609,7 @@ public interface Config extends io.helidon.common.config.Config {
          * new Config instance.
          * Executor is also used to process reloading of config from appropriate {@link ConfigSource source}.
          * <p>
-         * By default dedicated thread pool that creates new threads as needed, but
+         * By default, dedicated thread pool that creates new threads as needed, but
          * will reuse previously constructed threads when they are available is used.
          *
          * @param changesExecutor the executor to use for async delivery of {@link Config#onChange(java.util.function.Consumer)}

--- a/config/config/src/main/java/io/helidon/config/spi/ConfigFilter.java
+++ b/config/config/src/main/java/io/helidon/config/spi/ConfigFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,20 +31,20 @@ import io.helidon.config.Config;
  * given {@code Builder} by invoking
  * {@link Config.Builder#disableFilterServices()}.
  * <p>
- * A filter can specify a {@link jakarta.annotation.Priority}. If no priority is
- * explicitly assigned, the value of {@value PRIORITY} is assumed.
+ * A filter can specify a {@link io.helidon.common.Weight}. If no weight is
+ * explicitly assigned, the value of {@value io.helidon.common.Weighted#DEFAULT_WEIGHT} is assumed.
  * <h2>Initializing Filters</h2>
  * Any filter that uses the {@code Config} instance during its initialization
  * should do so in its {@link #init(Config)} method,
  * <em>not</em>
  * in its constructor. The {@code Config.Builder.build()} method invokes each
- * filter's `init` method according to the filters' priority order and just
+ * filter's `init` method according to the filters' weight and just
  * before returning the new {@code Config} instance to the application.
  * <p>
  * If a filter's {@code init} method uses {@code Config#get} to retrieve config
  * information, then -- as always -- the config system will invoke the
  * {@code apply} method on every filter which the application added to the
- * builder. But the {@code init} methods of filters with lower priority than the
+ * builder. But the {@code init} methods of filters with lower weight than the
  * current filter <em>will not</em> have executed. Developers should keep this
  * in mind while writing filter {@code init} methods.
  *
@@ -53,11 +53,6 @@ import io.helidon.config.Config;
  */
 @FunctionalInterface
 public interface ConfigFilter {
-
-    /**
-     * Default priority of the filter if registered by {@link io.helidon.config.Config.Builder} automatically.
-     */
-    int PRIORITY = 100;
 
     /**
      * Filters an elementary config value before it is made available to the

--- a/config/config/src/main/java/io/helidon/config/spi/ConfigMapperProvider.java
+++ b/config/config/src/main/java/io/helidon/config/spi/ConfigMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import io.helidon.config.Config;
  * {@link Config.Builder#disableMapperServices()}.
  * <p>
  * Each {@code ConfigMapperProvider} can specify a
- * {@link jakarta.annotation.Priority}. The default priority is {@value PRIORITY}.
+ * {@link io.helidon.common.Weight}. The default weight is {@value io.helidon.common.Weighted#DEFAULT_WEIGHT}.
  *
  * @see Config.Builder#addStringMapper(Class, Function)
  * @see Config.Builder#addMapper(ConfigMapperProvider)
@@ -44,15 +44,11 @@ import io.helidon.config.Config;
  */
 @FunctionalInterface
 public interface ConfigMapperProvider {
-    /**
-     * Default priority of the mapper provider if registered by {@link Config.Builder} automatically.
-     */
-    int PRIORITY = 100;
 
     /**
      * Returns a map of mapper functions associated with appropriate target type ({@code Class<?>}.
      * <p>
-     * Mappers will by automatically registered by {@link Config.Builder} during
+     * Mappers will be automatically registered by {@link Config.Builder} during
      * bootstrapping of {@link Config} unless
      * {@link Config.Builder#disableMapperServices() disableld}.
      *
@@ -64,7 +60,7 @@ public interface ConfigMapperProvider {
     /**
      * Returns a map of mapper functions associated with appropriate target type ({@code GenericType<?>}.
      * <p>
-     * Mappers will by automatically registered by {@link Config.Builder} during
+     * Mappers will be automatically registered by {@link Config.Builder} during
      * bootstrapping of {@link Config} unless
      * {@link Config.Builder#disableMapperServices() disableld}.
      *
@@ -90,7 +86,7 @@ public interface ConfigMapperProvider {
     /**
      * Mapper for a specific generic type.
      * If your mapper only supports simple classes, get it using {@link GenericType#rawType()}.
-     * Otherwise you have access to the (possibly) generics type of the expected result using
+     * Otherwise, you have access to the (possibly) generics type of the expected result using
      * {@link GenericType#type()}.
      * <p>
      * The mapping function has two parameters:

--- a/config/config/src/main/java/io/helidon/config/spi/ConfigParser.java
+++ b/config/config/src/main/java/io/helidon/config/spi/ConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import io.helidon.config.spi.ConfigNode.ObjectNode;
  * given {@code Builder} by invoking
  * {@link io.helidon.config.Config.Builder#disableParserServices()}.
  * <p>
- * A parser can specify a {@link io.helidon.common.Weight}. If no priority is
+ * A parser can specify a {@link io.helidon.common.Weight}. If no weight is
  * explicitly assigned, the value of {@value io.helidon.common.Weighted#DEFAULT_WEIGHT} is assumed.
  * <p>
  * Parser is used by the config system and a config source provides data as an input stream.

--- a/config/config/src/main/java/module-info.java
+++ b/config/config/src/main/java/module-info.java
@@ -37,8 +37,6 @@ module io.helidon.config {
     requires transitive io.helidon.common.config;
     requires transitive io.helidon.common.media.type;
     requires transitive io.helidon.common;
-    requires transitive jakarta.annotation;
-
 
     exports io.helidon.config;
     exports io.helidon.config.spi;

--- a/config/config/src/test/java/io/helidon/config/AutoLoadedConfigHighPriority.java
+++ b/config/config/src/test/java/io/helidon/config/AutoLoadedConfigHighPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package io.helidon.config;
 
-import jakarta.annotation.Priority;
+import io.helidon.common.Weight;
 
 /**
  * Higher-priority of two auto-loaded filters identical except for their priorities
  * and their expected filtered values.
  */
-@Priority(AutoLoadedConfigPriority.HIGH_PRIORITY_VALUE)
+@Weight(AutoLoadedConfigPriority.HIGH_PRIORITY_VALUE)
 public class AutoLoadedConfigHighPriority extends AutoLoadedConfigPriority {
 
     public static final String EXPECTED_FILTERED_VALUE = "higherPriorityValue";

--- a/config/config/src/test/java/io/helidon/config/AutoLoadedConfigLowPriority.java
+++ b/config/config/src/test/java/io/helidon/config/AutoLoadedConfigLowPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package io.helidon.config;
 
-import jakarta.annotation.Priority;
+import io.helidon.common.Weight;
 
 /**
  * Lower-priority of two auto-loaded filters identical except for their priorities
  * and their expected filtered values.
  */
-@Priority(AutoLoadedConfigPriority.LOW_PRIORITY_VALUE)
+@Weight(AutoLoadedConfigPriority.LOW_PRIORITY_VALUE)
 public class AutoLoadedConfigLowPriority extends AutoLoadedConfigPriority {
 
     private static final String EXPECTED_FILTERED_VALUE = "lowerPriorityValue";

--- a/config/config/src/test/java/io/helidon/config/AutoLoadedConfigPriority.java
+++ b/config/config/src/test/java/io/helidon/config/AutoLoadedConfigPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,11 @@ public abstract class AutoLoadedConfigPriority implements ConfigFilter {
     public static final String KEY_SUBJECT_TO_AUTO_FILTERING = "key1.subjectToPrioritizedAutoloadedFilter";
 
     public static final int HIGH_PRIORITY_VALUE = 10;
-    public static final int LOW_PRIORITY_VALUE = HIGH_PRIORITY_VALUE + 1;
+    public static final int LOW_PRIORITY_VALUE = HIGH_PRIORITY_VALUE - 1;
 
     @Override
     public String apply(Config.Key key, String stringValue) {
-        // the original implementation was wrong (priorities were inversed and this test was wrong)
+        // the original implementation was wrong (priorities were reversed and this test was wrong)
         // the new approach makes sure the filter with higher priority modifies the value, and
         // any filter down the filter chain sees the modified value, and ignores it
         if (key.toString().equals(KEY_SUBJECT_TO_AUTO_FILTERING)

--- a/config/hocon/pom.xml
+++ b/config/hocon/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>config</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/config/tests/module-mappers-1-base/pom.xml
+++ b/config/tests/module-mappers-1-base/pom.xml
@@ -38,9 +38,5 @@
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/config/tests/module-mappers-2-override/pom.xml
+++ b/config/tests/module-mappers-2-override/pom.xml
@@ -39,9 +39,5 @@
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/config/tests/module-parsers-1-override/pom.xml
+++ b/config/tests/module-parsers-1-override/pom.xml
@@ -39,9 +39,5 @@
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/config/tests/test-bundle/pom.xml
+++ b/config/tests/test-bundle/pom.xml
@@ -39,10 +39,6 @@
             <artifactId>helidon-bundles-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
         </dependency>

--- a/config/tests/test-default_config-2-hocon-json/pom.xml
+++ b/config/tests/test-default_config-2-hocon-json/pom.xml
@@ -56,10 +56,5 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/config/tests/test-default_config-3-hocon/pom.xml
+++ b/config/tests/test-default_config-3-hocon/pom.xml
@@ -58,11 +58,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/config/tests/test-default_config-4-yaml/pom.xml
+++ b/config/tests/test-default_config-4-yaml/pom.xml
@@ -66,10 +66,5 @@
             <artifactId>config</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/config/tests/test-default_config-5-env_vars/pom.xml
+++ b/config/tests/test-default_config-5-env_vars/pom.xml
@@ -61,11 +61,6 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/config/tests/test-default_config-7-meta-hocon-json/pom.xml
+++ b/config/tests/test-default_config-7-meta-hocon-json/pom.xml
@@ -62,10 +62,5 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/config/tests/test-default_config-8-meta-hocon/pom.xml
+++ b/config/tests/test-default_config-8-meta-hocon/pom.xml
@@ -57,10 +57,5 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/config/tests/test-default_config-9-meta-yaml/pom.xml
+++ b/config/tests/test-default_config-9-meta-yaml/pom.xml
@@ -66,10 +66,5 @@
             <artifactId>config</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/config/yaml-mp/pom.xml
+++ b/config/yaml-mp/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
         </dependency>

--- a/config/yaml/pom.xml
+++ b/config/yaml/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/docs/includes/attributes.adoc
+++ b/docs/includes/attributes.adoc
@@ -188,8 +188,9 @@ endif::[]
 
 // Helidon component javadoc base URLs
 :http-javadoc-base-url: {javadoc-base-url}/io.helidon.http
+:common-javadoc-base-url: {javadoc-base-url}/io.helidon.common
 :config-javadoc-base-url: {javadoc-base-url}/io.helidon.config
-:configurable-javadoc-base-url: {javadoc-base-url}/apidocs/io.helidon.common.configurable
+:configurable-javadoc-base-url: {javadoc-base-url}/io.helidon.common.configurable
 :faulttolerance-javadoc-base-url: {javadoc-base-url}/io.helidon.faulttolerance
 :grpc-server-javadoc-base-url: {javadoc-base-url}/io.helidon.grpc.server
 :health-javadoc-base-url: {javadoc-base-url}/io.helidon.health.checks

--- a/docs/se/config/extensions.adoc
+++ b/docs/se/config/extensions.adoc
@@ -141,15 +141,17 @@ sources:
       my-config: "configuration"
 ----
 
-The config system would iterate through all `ConfigSourceProvider` implementations found through Java `ServiceLoader` based on their priority.
-First provider that returns `true` when `supports("my-type")` is called would be used, and an instance of a `ConfigSource` created using `create("my-type", config)`, where `config` is located on the node of `properties` from config profile.
+The config system would iterate through all `ConfigSourceProvider` implementations found through Java `ServiceLoader` based on
+ their link:{common-javadoc-base-url}/io/helidon/common/Weight.html[weight].
+First provider that returns `true` when `supports("my-type")` is called would be used, and an instance of a `ConfigSource`
+ created using `create("my-type", config)`, where `config` is located on the node of `properties` from config profile.
 
 === About Priority [[priority-info]]
 
 The config system invokes extensions of a given type in priority order.
 Developers can express the relative importance of an extension by annotating the service implementation class with
-`@jakarta.annotation.Priority`.
-The default value is 100. A _lower_ priority value represents _greater_ importance.
+link:{common-javadoc-base-url}/io/helidon/common/Weight.html[`@Weight`].
+The default value is 100. The higher the weight, the more important the extension is.
 
 == ConfigSource SPI [[Config-SPI-ConfigSource]]
 
@@ -207,7 +209,7 @@ The config system also uses the Java service loader mechanism to load automatica
 `META-INF/services/io.helidon.config.spi.ConfigParser` resource on the runtime classpath.
 Prevent autoloading of parsers for a given builder by invoking `Config.Builder#disableParserServices()`.
 
-`ConfigParser` accepts `@Priority`.
+`ConfigParser` accepts link:{common-javadoc-base-url}/io/helidon/common/Weight.html[`@Weight`].
 See <<priority-info, About Priority>>.
 
 [source,listing]
@@ -275,7 +277,7 @@ method.
 
 |link:{config-javadoc-base-url}/io/helidon/config/spi/ConfigFilter.html[`ConfigFilter`]
 
-Accepts `@Priority`. See <<priority-info, About Priority>>.
+Accepts link:{common-javadoc-base-url}/io/helidon/common/Weight.html[`@Weight`]. See <<priority-info, About Priority>>.
 |`String apply(Config.Key key, String stringValue);`
 |Accepts a key and the corresponding `String` value and
 returns the `String` which the config system should use for that key.
@@ -290,8 +292,7 @@ function which, when passed a `Config` instance, returns a `ConfigFilter`.
 access the `Config` instance passed to the provider function._*
 
 Instead, implement the `ConfigFilter.init(Config)` method on the filter. The config
-system invokes the filters' `init` methods according to the filters' `@Priority`
-order.
+system invokes the filters' `init` methods according to the filters <<priority-info, priority>>.
 
 Recall that whenever any code invokes `Config.get`, the `Config` instance
 invokes the `apply` method of _all_ registered filters. By the time the application
@@ -346,12 +347,12 @@ runtime classpath. The application can prevent autoloading of mappers for a
 given builder by invoking `Config.Builder#disableMapperServices()`. Note
 that the built-in mappers described in `ConfigMappers` still operate.
 
-Mapper providers accept `@Priority`. See <<priority-info, About Priority>>.
+Mapper providers accept `@Weight`. See <<priority-info, About Priority>>.
 
 image::config/spi-ConfigMapperProvider.png[title="ConfigMapperProvider SPI",align="center"]
 
-A mapper provider can specify a `@jakarta.annotation.Priority`.
-If no priority is explicitly assigned, the value of `100` is assumed.
+A mapper provider can specify link:{common-javadoc-base-url}/io/helidon/common/Weight.html[`@Weight`].
+If no weight is explicitly assigned, the value of `100` is assumed.
 
 [source,java]
 .Reference custom mapper provider implementation in `META-INF/services/io.helidon.config.spi.ConfigMapperProvider`

--- a/inject/tests/runtime/pom.xml
+++ b/inject/tests/runtime/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>helidon-inject-runtime</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
             <scope>test</scope>

--- a/inject/tests/runtime/src/test/java/io/helidon/inject/runtime/testsubjects/HelloInjection$$Application.java
+++ b/inject/tests/runtime/src/test/java/io/helidon/inject/runtime/testsubjects/HelloInjection$$Application.java
@@ -18,17 +18,17 @@ package io.helidon.inject.runtime.testsubjects;
 
 import java.util.Optional;
 
+import io.helidon.common.Generated;
 import io.helidon.inject.api.Application;
 import io.helidon.inject.api.ServiceInjectionPlanBinder;
 
-import jakarta.annotation.Generated;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
 /**
  * For testing.
  */
-@Generated(value = "example", comments = "API Version: n")
+@Generated(value = "example", comments = "API Version: n", trigger = "io.helidon.inject.tools.ApplicationCreatorDefault")
 @Singleton
 @Named(HelloInjection$$Application.NAME)
 public class HelloInjection$$Application implements Application {

--- a/inject/tests/runtime/src/test/java/io/helidon/inject/runtime/testsubjects/HelloInjection$$Module.java
+++ b/inject/tests/runtime/src/test/java/io/helidon/inject/runtime/testsubjects/HelloInjection$$Module.java
@@ -18,14 +18,14 @@ package io.helidon.inject.runtime.testsubjects;
 
 import java.util.Optional;
 
+import io.helidon.common.Generated;
 import io.helidon.inject.api.ModuleComponent;
 import io.helidon.inject.api.ServiceBinder;
 
-import jakarta.annotation.Generated;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
-@Generated(value = "example", comments = "API Version: n")
+@Generated(value = "example", comments = "API Version: n", trigger = "io.helidon.inject.tools.ActivatorCreatorDefault")
 @Singleton
 @Named(HelloInjection$$Module.NAME)
 public final class HelloInjection$$Module implements ModuleComponent {

--- a/inject/tests/runtime/src/test/java/io/helidon/inject/runtime/testsubjects/HelloInjectionImpl$$injectionActivator.java
+++ b/inject/tests/runtime/src/test/java/io/helidon/inject/runtime/testsubjects/HelloInjectionImpl$$injectionActivator.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.Generated;
 import io.helidon.common.Weight;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.TypeName;
@@ -33,7 +34,6 @@ import io.helidon.inject.api.ServiceInfo;
 import io.helidon.inject.runtime.AbstractServiceProvider;
 import io.helidon.inject.runtime.Dependencies;
 
-import jakarta.annotation.Generated;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 
@@ -42,7 +42,7 @@ import static io.helidon.inject.api.ServiceInfoBasics.DEFAULT_INJECT_WEIGHT;
 /**
  * Serves as an exemplar of what will is normally code generated.
  */
-@Generated(value = "example", comments = "API Version: N")
+@Generated(value = "example", comments = "API Version: N", trigger = "io.helidon.inject.runtime.testsubjects.HelloInjectionImpl")
 @Singleton
 @Weight(DEFAULT_INJECT_WEIGHT)
 @SuppressWarnings({"unchecked", "checkstyle:TypeName"})

--- a/inject/tests/runtime/src/test/java/io/helidon/inject/runtime/testsubjects/InjectionWorldImpl$$injectionActivator.java
+++ b/inject/tests/runtime/src/test/java/io/helidon/inject/runtime/testsubjects/InjectionWorldImpl$$injectionActivator.java
@@ -18,18 +18,18 @@ package io.helidon.inject.runtime.testsubjects;
 
 import java.util.Map;
 
+import io.helidon.common.Generated;
 import io.helidon.common.Weight;
 import io.helidon.inject.api.DependenciesInfo;
 import io.helidon.inject.api.ServiceInfo;
 import io.helidon.inject.runtime.AbstractServiceProvider;
 import io.helidon.inject.runtime.Dependencies;
 
-import jakarta.annotation.Generated;
 import jakarta.inject.Singleton;
 
 import static io.helidon.inject.api.ServiceInfoBasics.DEFAULT_INJECT_WEIGHT;
 
-@Generated(value = "example", comments = "API Version: n")
+@Generated(value = "example", comments = "API Version: n", trigger = "io.helidon.inject.runtime.testsubjects.InjectionWorldImpl")
 @Singleton
 @Weight(DEFAULT_INJECT_WEIGHT)
 public class InjectionWorldImpl$$injectionActivator extends AbstractServiceProvider<InjectionWorldImpl> {

--- a/integrations/micrometer/micrometer/pom.xml
+++ b/integrations/micrometer/micrometer/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>simpleclient</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/security/abac/role/src/main/java/module-info.java
+++ b/security/abac/role/src/main/java/module-info.java
@@ -28,6 +28,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 module io.helidon.security.abac.role {
 
     requires io.helidon.security.providers.abac;
+    requires jakarta.annotation;
 
     requires static io.helidon.common.features.api;
 

--- a/security/providers/abac/pom.xml
+++ b/security/providers/abac/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>helidon-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/security/providers/abac/src/main/java/module-info.java
+++ b/security/providers/abac/src/main/java/module-info.java
@@ -27,6 +27,8 @@ import io.helidon.common.features.api.HelidonFlavor;
 )
 module io.helidon.security.providers.abac {
 
+    requires jakarta.annotation;
+
     requires static io.helidon.common.features.api;
     requires static io.helidon.config.metadata;
 

--- a/security/providers/jwt/pom.xml
+++ b/security/providers/jwt/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>helidon-security-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/security/providers/jwt/src/main/java/module-info.java
+++ b/security/providers/jwt/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module io.helidon.security.providers.jwt {
     requires io.helidon.security.util;
 
     requires static io.helidon.common.features.api;
+    requires static jakarta.annotation;
 
     requires transitive io.helidon.config;
     requires transitive io.helidon.security.jwt;

--- a/webserver/security/src/main/java/module-info.java
+++ b/webserver/security/src/main/java/module-info.java
@@ -22,7 +22,6 @@ module io.helidon.webserver.security {
     requires io.helidon.common.context;
     requires io.helidon.security.integration.common;
     requires io.helidon.webserver;
-    requires jakarta.annotation;
     requires java.logging;
 
     requires transitive io.helidon.common.config;

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -103,6 +103,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>

--- a/webserver/webserver/src/main/java/module-info.java
+++ b/webserver/webserver/src/main/java/module-info.java
@@ -33,7 +33,6 @@ module io.helidon.webserver {
     requires io.helidon.common.uri;
     requires io.helidon.inject.api;  // needed to compile injection generated classes
     requires io.helidon.logging.common;
-    requires jakarta.annotation;
     requires java.logging; // only used to keep logging active until shutdown hook finishes
     requires java.management;
 
@@ -41,6 +40,7 @@ module io.helidon.webserver {
     requires static io.helidon.inject.configdriven.runtime;
     requires static io.helidon.inject.runtime;
     requires static jakarta.inject;
+    requires static jakarta.annotation;
     requires static java.compiler;
 
     requires transitive io.helidon.common.buffers;


### PR DESCRIPTION
### Description

Replace usage of jakarta.annotation.Priority with io.helidon.common.Weight in `helidon-config`.

- Add explicit dependency for `jakarta.annotation-api` in modules that were relying on `helidon-config`
- Updated `helidon-webserver` to use `requires static jakarta.annotation`
- Updated both `helidon-security-providers-abac` and `helidon-security-abac-role` to add `require jakarta.annotation`
- Updated `helidon-security` to remove `requires jakarta.annotation`
- Updated `helidon-security-providers-jwt` to add an optional dependency on jakarta-annotation (`requires static` and `<optional>true</option>` because it contains javadoc links to `jakarta.annotation.security` annotations
- Replaced usage of `jakarta.annotation.Generated` with `io.helidon.common.Generated`
- Minor javadoc updates in `helidon-config`
- Fix `:configurable-javadoc-base-url:` doc attribute (see #4909)

Fixes #7744

### Documentation

doc impact: none
