### PR TITLE
4.x: Remove exclusion of jandex dependency now that hibernate has been upgraded

### DIFF
--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -71,13 +71,6 @@
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <scope>compile</scope>
-            <!-- Use the io.smallrye jandex artifact (which the rest of Helidon uses) instead of the org.jboss one. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss</groupId>
-                    <artifactId>jandex</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <!-- As we exclude javax from hibernate, we need to add jakarta -->


### PR DESCRIPTION

### Description

Removes dependency exclusion of `org.jboss:jandex` because it is no longer needed after hibernate upgrade (#7742).

Completes fix for #7448

### Documentation

No impact