### PR TITLE
[4.x] Re-enables tests/functional/request-scope/TenantTest.java

### DIFF
--- a/tests/functional/request-scope/src/test/java/io/helidon/tests/functional/requestscope/TenantTest.java
+++ b/tests/functional/request-scope/src/test/java/io/helidon/tests/functional/requestscope/TenantTest.java
@@ -26,14 +26,12 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @HelidonTest
-@Disabled
 class TenantTest {
 
     private static final int CONCURRENT_REQS = 50;


### PR DESCRIPTION
Part of #5407.

Documentation impact: none.