### PR TITLE
3.x netty 4.1.100.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -130,7 +130,7 @@
         <version.lib.mysql-connector-java>8.0.28</version.lib.mysql-connector-java>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
-        <version.lib.netty>4.1.94.Final</version.lib.netty>
+        <version.lib.netty>4.1.100.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.21.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
         <version.lib.junit4>4.13.1</version.lib.junit4>
         <version.lib.kafka-junit5>3.2.3</version.lib.kafka-junit5>
         <version.lib.mockito>2.23.4</version.lib.mockito>
-        <version.lib.netty.tcnative>2.0.61.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.2.10</version.lib.rxjava>
@@ -950,11 +949,6 @@
                 <groupId>com.xebialabs.restito</groupId>
                 <artifactId>restito</artifactId>
                 <version>${version.lib.restito}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>${version.lib.netty.tcnative}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
### Description

* Upgrade Netty to 4.1.100.Final
* Don't manage `netty-tcnative-boringssl-static` because it is already managed by Netty BOM

### Documentation

No impact