### PR TITLE
2.x: Upgrade Netty to 4.1.100.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -125,7 +125,7 @@
         <version.lib.hibernate-validator>6.2.5.Final</version.lib.hibernate-validator>
         <version.lib.mysql-connector-java>8.0.28</version.lib.mysql-connector-java>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
-        <version.lib.netty>4.1.94.Final</version.lib.netty>
+        <version.lib.netty>4.1.100.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>2.60.1</version.lib.oci>
         <version.lib.oci-java-sdk-objectstorage>${version.lib.oci}</version.lib.oci-java-sdk-objectstorage>

--- a/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
@@ -40,6 +40,7 @@ Args=--allow-incomplete-classpath \
   --initialize-at-run-time=io.netty.handler.codec.marshalling.MarshallingDecoder \
   --initialize-at-run-time=io.netty.handler.codec.marshalling.MarshallingEncoder \
   --initialize-at-run-time=io.netty.handler.codec.protobuf.ProtobufDecoder \
+  --initialize-at-run-time=io.netty.handler.pcap.PcapWriteHandler$WildcardAddressHolder \
   --initialize-at-run-time=io.netty.handler.ssl.ConscryptAlpnSslEngine \
   --initialize-at-run-time=io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator \
   --initialize-at-run-time=io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine \


### PR DESCRIPTION

Description

    Upgrade Netty to 4.1.100.Final

Documentation

No impact
