### PR TITLE
4.x: archetype update se flavor description

### DIFF
--- a/archetypes/helidon/src/main/archetype/flavor.xml
+++ b/archetypes/helidon/src/main/archetype/flavor.xml
@@ -33,7 +33,7 @@
                   optional="true">
                 <option value="se"
                         name="Helidon SE"
-                        description="WebSever based on Virtual Threads">
+                        description="Programmatic, lean &amp; fast">
                     <exec src="se/se.xml"/>
                 </option>
                 <option value="mp"


### PR DESCRIPTION
### Description

In 4.0.0-RC1, the description of the SE flavor is:
> WebSever based on Virtual Threads

Note the typo `WebSever`, and the capitalization of `Virtual Threads`.

I’m suggesting the following instead:
> Programmatic, lean & fast

### Documentation

No doc impact.
