### PR TITLE
3.x: Upgrade kafka-clients and okhttp

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -132,6 +132,8 @@
         <version.lib.oci>3.21.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
+        <!-- Manage okio version for dependency convergence -->
+        <version.lib.okio>3.6.0</version.lib.okio>
         <!-- Force upgrade okhttp3 transitive dependency -->
         <version.lib.okhttp3>4.12.0</version.lib.okhttp3>
         <version.lib.opentelemetry>1.22.0</version.lib.opentelemetry>
@@ -1326,6 +1328,14 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
                 <version>${version.lib.google-protobuf}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <!-- For dependency convergence. Used by okhttp -->
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-bom</artifactId>
+                <version>${version.lib.okio}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -99,10 +99,7 @@
         <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
         <version.lib.jsonp-impl>2.0.1</version.lib.jsonp-impl>
         <version.lib.junit>5.7.0</version.lib.junit>
-        <version.lib.kafka>3.4.0</version.lib.kafka>
-        <!-- Force upgrade of snappy. This should be removed once kafka-clients is upgraded -->
-        <!-- See https://issues.apache.org/jira/browse/KAFKA-15498 -->
-        <version.lib.snappy>1.1.10.5</version.lib.snappy>
+        <version.lib.kafka>3.6.0</version.lib.kafka>
         <version.lib.log4j>2.17.1</version.lib.log4j>
         <version.lib.logback>1.2.10</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
@@ -135,9 +132,8 @@
         <version.lib.oci>3.21.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
-        <version.lib.okhttp3>3.14.9</version.lib.okhttp3>
-        <!-- Force upgrade to more current version -->
-        <version.lib.okio>3.4.0</version.lib.okio>
+        <!-- Force upgrade okhttp3 transitive dependency -->
+        <version.lib.okhttp3>4.12.0</version.lib.okhttp3>
         <version.lib.opentelemetry>1.22.0</version.lib.opentelemetry>
         <version.lib.opentelemetry.semconv>1.22.0-alpha</version.lib.opentelemetry.semconv>
         <version.lib.opentelemetry.opentracing.shim>1.22.0-alpha</version.lib.opentelemetry.opentracing.shim>
@@ -918,13 +914,6 @@
                 <artifactId>kafka-clients</artifactId>
                 <version>${version.lib.kafka}</version>
             </dependency>
-            <!-- Force upgrade of snappy. This should be removed once kafka-clients is upgraded -->
-            <!-- to 3.4.2 or newer. See https://issues.apache.org/jira/browse/KAFKA-15096 -->
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${version.lib.snappy}</version>
-            </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-json-binding</artifactId>
@@ -1233,23 +1222,10 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!-- 4.x versions cause problems with native-image This is used by jaeger-client -->
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
                 <version>${version.lib.okhttp3}</version>
-            </dependency>
-            <dependency>
-                <!-- required for dependency convergence
-                used from both
-                com.squareup.okhttp3:mockwebserver:3.13.1
-                com.squareup.moshi:moshi:1.8.0
-                both referenced by
-                io.zipkin.zipkin2:zipkin-junit:2.12.5
-                -->
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
-                <version>${version.lib.okio}</version>
             </dependency>
             <!-- END OF Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
 

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -80,6 +80,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${version.lib.okhttp3}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -44,6 +44,18 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <exclusions>
+                <!-- For dependency convergence. This excludes the transitive dep
+                     on kotlin from okhttp. We defer to the transitive dep from okio -->
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-jdk8</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.tracing</groupId>

--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -41,6 +41,11 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
         </dependency>
+        <!-- For dependency convergence of kotlin-stdlib -->
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-jaeger</artifactId>


### PR DESCRIPTION
### Description

* Upgrades kafka-clients to 3.6.0. With this we can remove our force upgrade of snappy
* Upgrades oktthp3 to 4.12.0. With this we can remove force upgrade of okio

### Documentation

No impact