### PR TITLE
4.x json metadata fix

### DIFF
--- a/docs/includes/guides/metrics.adoc
+++ b/docs/includes/guides/metrics.adoc
@@ -377,12 +377,12 @@ endif::se-flavor[]
 Each {metric} has associated metadata that includes:
 
 1. name: The name of the {metric}.
-2. units: The unit of the {metric} such as time (seconds, millisecond), size (bytes, megabytes), etc.
+2. units: The unit of the {metric} such as time (seconds, milliseconds), size (bytes, megabytes), etc.
 3. a description of the {metric}.
 
-You can get the metadata for any scope, such as `/metrics/base`, as shown below:
+You can get the metadata for any scope, such as `{metrics-endpoint}?scope=base`, as shown below:
 
-[source,bash]
+[source,bash, subs="attributes+"]
 .Get the metrics metadata using HTTP OPTIONS method:
 ----
  curl -X OPTIONS -H "Accept: application/json"  'http://localhost:8080{metrics-endpoint}?scope=base'

--- a/docs/mp/guides/metrics.adoc
+++ b/docs/mp/guides/metrics.adoc
@@ -104,6 +104,7 @@ Note that the applications you generate using the full Helidon archetype _do_ en
 generated config file.
 You can see the results in the sample output shown in earlier example runs.
 
+include::{rootdir}/includes/guides/metrics.adoc[tag=metrics-metadata]
 
 === Application-Specific Metrics Data
 

--- a/docs/se/guides/metrics.adoc
+++ b/docs/se/guides/metrics.adoc
@@ -169,6 +169,8 @@ Your Helidon SE application can also control the KPI settings programmatically.
 
 // end of Controlling Metrics section
 
+include::{rootdir}/includes/guides/metrics.adoc[tag=metrics-metadata]
+
 === Application-Specific Metrics Data
 
 This section demonstrates how to use application-specific {metrics} and integrate them with Helidon, starting from a Helidon SE QuickStart application.

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -112,6 +112,20 @@ class MetricsFeature {
         return formatter.format();
     }
 
+    Optional<?> outputMetadata(MediaType mediaType,
+                       Iterable<String> scopeSelection,
+                       Iterable<String> nameSelection) {
+        MeterRegistryFormatter formatter = chooseFormatter(meterRegistry,
+                                                           mediaType,
+                                                           SystemTagsManager.instance().scopeTagName(),
+                                                           scopeSelection,
+                                                           nameSelection);
+
+        return formatter.formatMetadata();
+    }
+
+
+
     private static MediaType bestAccepted(ServerRequest req) {
         return req.headers()
                 .bestAccepted(MediaTypes.TEXT_PLAIN,
@@ -261,9 +275,9 @@ class MetricsFeature {
             res.send();
         }
 
-        getOrOptionsMatching(mediaType, res, () -> output(mediaType,
-                                                          scopeSelection,
-                                                          nameSelection));
+        getOrOptionsMatching(mediaType, res, () -> outputMetadata(mediaType,
+                                                                  scopeSelection,
+                                                                  nameSelection));
     }
 
     private void setUpDisabledEndpoints(HttpRules rules) {


### PR DESCRIPTION
### Description
Resolves #7857 

The rewritten JSON formatter contains code to emit the meter metadata in JSON format, but the handler that processes `OPTIONS` requests (vs. `GET`s) invoked the code to emit the data--not the metadata.

This PR adds a private method to gather the metadata and then invokes it from the `OPTIONS` handler.

### Documentation
Minor doc changes included in this PR.
