### PR TITLE
1.x upgrade netty to 4.1.100.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -87,7 +87,7 @@
         <version.lib.mockito>2.23.4</version.lib.mockito>
         <version.lib.mysql-connector-java>8.0.29</version.lib.mysql-connector-java>
         <version.lib.narayana>5.9.3.Final</version.lib.narayana>
-        <version.lib.netty>4.1.94.Final</version.lib.netty>
+        <version.lib.netty>4.1.100.Final</version.lib.netty>
         <version.lib.oci-java-sdk-objectstorage>2.66.0</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>19.3.0.0</version.lib.ojdbc8>
         <version.lib.opentracing>0.32.0</version.lib.opentracing>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -279,4 +279,18 @@
    <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
 </suppress>
 
+<!--
+    This is a FP. We have upgrade jgit to a fixed version, but it is still getting flagged.
+    Probably due to the funky version string used by jgit. See
+    https://github.com/jeremylong/DependencyCheck/issues/5943
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: org.eclipse.jgit-6.7.0.202309050840-r.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jgit/org\.eclipse\.jgit@.*$</packageUrl>
+   <cve>CVE-2023-4759</cve>
+</suppress>
+
+
 </suppressions>


### PR DESCRIPTION
### Description

Upgrades netty to 4.1.100.Final

Also suppresses a false positive for jgit 

### Documentation

No impact