### PR TITLE
4.x: Updates for MP upgrade guide

### DIFF
--- a/docs/about/doc_overview.adoc
+++ b/docs/about/doc_overview.adoc
@@ -73,9 +73,9 @@ xref:{rootdir}/se/guides/quickstart.adoc[Using the SE Quick Start Guide]
 --
 Use the upgrade guides to help you upgrade your existing Helidon applications to the latest version of Helidon.
 
-xref:{rootdir}/mp/guides/upgrade_4x.adoc[Upgrade From Helidon MP 4.x]
+xref:{rootdir}/mp/guides/upgrade_4x.adoc[Upgrade From Helidon MP 3.x]
 
-xref:{rootdir}/se/guides/upgrade_4x.adoc[Upgrade From Helidon SE 4.x]
+xref:{rootdir}/se/guides/upgrade_4x.adoc[Upgrade From Helidon SE 3.x]
 
 --
 

--- a/docs/mp/guides/upgrade_4x.adoc
+++ b/docs/mp/guides/upgrade_4x.adoc
@@ -23,50 +23,18 @@
 
 include::{rootdir}/includes/mp.adoc[]
 
-
 In Helidon 4.x we have made some changes to APIs and runtime behavior. This guide
 will help you upgrade a Helidon MP 3.x application to 4.x.
-
 
 == Java 21 Runtime
 
 Java 17 is no longer supported in Helidon 4. Java 21 or newer is required. Please follow the instructions in xref:{rootdir}/about/prerequisites.adoc[Prerequisites] for proper installation.
 
-Helidon 4 no longer uses Netty. Helidon MP is now running on Helidon WebServer which is based on Virtual threads technology, available in Java 21.
-
+Helidon 4 no longer uses Netty. Helidon MP is now running on Helidon WebServer which is based on virtual threads technology, available in Java 21.
 
 == MicroProfile 6.0 support
 
-MicroProfile 6.0  enables MicroProfile APIs to be used together with Jakarta EE 10 Core Profile.
-
-MicroProfile 6.0  is an umbrella for the following specifications and their corresponding versions:
-
-* Open Telemetry {version-lib-microprofile-telemetry}
-* MicroProfile Config {version-lib-microprofile-config}
-* MicroProfile Fault Tolerance {version-lib-microprofile-fault-tolerance-api}
-* MicroProfile Health {version-lib-microprofile-health}
-* MicroProfile JWT Authentication {version-lib-microprofile-jwt}
-* MicroProfile Metrics {version-lib-microprofile-metrics-api}
-* MicroProfile OpenAPI {version-lib-microprofile-openapi-api}
-* MicroProfile Rest Client {version-lib-microprofile-rest-client}
-
-Includes:
-
-* Jakarta EE Core Profile {version-lib-jakarta-core}
-
-Helidon 4.x supports the following Jakarta EE specifications:
-
-* CDI (Jakarta Contexts and Dependency Injection) {version-lib-jakarta-cdi}
-* JAX-RS (Jakarta RESTful Web Services) {version-lib-jakarta-jaxrs-api}
-* JSON-B (Jakarta JSON Binding) {version-lib-jakarta-jsonb-api}
-* JSON-P (Jakarta JSON Processing) {version-lib-jakarta-jsonp-api}
-* Jakarta Annotations {version-lib-jakarta-annotations-api}
-* Jakarta Persistence API {version-lib-jakarta-persistence-api}
-* Jakarta Transactions API {version-lib-jakarta-transaction-api}
-* Jakarta WebSocket API {version-lib-jakarta-websockets-api}
-* Jakarta Bean Validation {version-lib-jakarta-bean-validation}
-
-Corresponding changes to Helidon code were made to support the corresponding specifications' versions.
+MicroProfile 6.0 enables MicroProfile APIs to be used together with Jakarta EE 10 Core Profile.
 
 === MicroProfile specifications
 
@@ -100,6 +68,10 @@ Incompatible changes described in link:https://download.eclipse.org/microprofile
 +
 Incompatible changes described in link:https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html#_incompatible_changes[MicroProfile Rest Client {version-lib-microprofile-rest-client} Specification]
 
+* *MicroProfile Telemetry Tracing {version-lib-microprofile-telemetry}*:
++
+Incompatible changes described in link:https://download.eclipse.org/microprofile/microprofile-telemetry-1.0/tracing/microprofile-telemetry-tracing-spec-1.0.html#_incompatible_changes[MicroProfile Telemetry Tracing {version-lib-microprofile-telemetry} Specification]
+
 === Supported Jakarta EE specifications
 
 * *CDI (Jakarta Contexts and Dependency Injection) {version-lib-jakarta-cdi}*:
@@ -108,12 +80,15 @@ Changes described in link:https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-
 
 * *JAX-RS (Jakarta RESTful Web Services) {version-lib-jakarta-jaxrs-api}*:
 +
-Changes described in link:https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html#_incompatible_changes[JAX-RS (Jakarta RESTful Web Services) {version-lib-jakarta-jaxrs-api}Specification]
+Changes described in link:https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html#_incompatible_changes[JAX-RS (Jakarta RESTful Web Services) {version-lib-jakarta-jaxrs-api} Specification]
 
 * *JSON-B (Jakarta JSON Binding) {version-lib-jakarta-jsonb-api}*:
 +
 Changes described in link:https://jakarta.ee/specifications/jsonb/2.0/jakarta-jsonb-spec-2.0.html#change-log[JSON-B (Jakarta JSON Binding) {version-lib-jakarta-jsonb-api} Specification]
 
+* *JSON-P (Jakarta JSON Processing) {version-lib-jakarta-jsonp-api}*:
++
+Changes described in link:https://jakarta.ee/specifications/jsonp/2.1/apidocs/[JSON-P (Jakarta JSON Parsing) {version-lib-jakarta-jsonp-api} Specification]
 
 * *Jakarta Annotations {version-lib-jakarta-annotations-api}*:
 +
@@ -139,9 +114,9 @@ NOTE: Please, read each specification carefully for incompatible changes!
 
 === Significant changes
 
-==== Smallrye
+==== Jandex
 
-Smallrye group id was `org.jboss.jandex` and now is `io.smallrye`.
+Jandex group id was `org.jboss.jandex` and now is `io.smallrye`.
 
 ==== Metrics and observability
 
@@ -185,6 +160,22 @@ Now is:
 </dependency>
 ----
 
+And the Java package has changed from `io.helidon.microprofile.tests.junit5` to `io.helidon.microprofile.testing.junit5`
+
+=== Logging
+
+The Helidon console handler has changed from `io.helidon.common.HelidonConsoleHandler` to `io.helidon.logging.jul.HelidonConsoleHandler`.
+
+If you use this handler in your `logging.properties` you will need to update it and add the following dependency:
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.helidon.logging</groupId>
+    <artifactId>helidon-logging-jul</artifactId>
+    <scope>runtime</scope>
+</dependency>
+----
 
 == Conclusion
 

--- a/docs/mp/guides/upgrade_4x.adoc
+++ b/docs/mp/guides/upgrade_4x.adoc
@@ -118,24 +118,6 @@ NOTE: Please, read each specification carefully for incompatible changes!
 
 Jandex group id was `org.jboss.jandex` and now is `io.smallrye`.
 
-==== Metrics and observability
-
-The correct work of observability in quickstarts now requires dependencies:
-
-[source, xml]
-----
-<dependency>
-    <groupId>io.helidon.webserver.observe</groupId>
-    <artifactId>helidon-webserver-observe-metrics</artifactId>
-    <scope>runtime</scope>
-</dependency>
-<dependency>
-    <groupId>io.helidon.metrics</groupId>
-    <artifactId>helidon-metrics-system-meters</artifactId>
-    <scope>runtime</scope>
-</dependency>
-----
-
 ==== Testing
 
 Testing is now in a new package. It was:


### PR DESCRIPTION
### Description

Updates to MP upgrade guide.
- Upgrade is from 3.x (not 4.x)
- Remove double listing of specifications. Make sure the second group (with spec links) includes everything that was in first group (that have been deleted)
- Remove section on metrics dependencies because those aren't needed for MP (they are brought in by the helidon microprofile metrics support)
- "Smallrye" -> "Jandex"
- Mention Java package name change for testing
- Add section on log handler change

### Documentation

Included in this PR