### PR TITLE
4:x UriQueryEmpty + NoSuchElementException

### DIFF
--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryEmpty.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryEmpty.java
@@ -39,22 +39,22 @@ final class UriQueryEmpty implements UriQuery {
 
     @Override
     public String getRaw(String name) throws NoSuchElementException {
-        throw new UnsupportedOperationException("Empty query");
+        throw new NoSuchElementException("Empty query");
     }
 
     @Override
     public List<String> getAllRaw(String name) {
-        throw new UnsupportedOperationException("Empty query");
+        throw new NoSuchElementException("Empty query");
     }
 
     @Override
     public List<String> all(String name) {
-        throw new UnsupportedOperationException("Empty query");
+        throw new NoSuchElementException("Empty query");
     }
 
     @Override
     public String get(String name) {
-        throw new UnsupportedOperationException("Empty query");
+        throw new NoSuchElementException("Empty query");
     }
 
     @Override


### PR DESCRIPTION
### Description

Update UriQueryEmpty to throw NoSuchElementException instead of UnsupportedOperationException as documented.

Fixes #7867

### Documentation

No doc impact.
