### PR TITLE
4.x: Use H2 in-memory in SE archetype

### DIFF
--- a/archetypes/helidon/src/main/archetype/se/custom/database-output.xml
+++ b/archetypes/helidon/src/main/archetype/se/custom/database-output.xml
@@ -34,7 +34,7 @@
                     </list>
                     <value key="db-health-check-stmt" if="${health}">SELECT 0</value>
                     <list key="db-connection">
-                        <value><![CDATA[    url: "jdbc:h2:~/test"
+                        <value><![CDATA[    url: "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE"
     username: sa
     password:]]></value>
                     </list>

--- a/archetypes/helidon/src/main/archetype/se/custom/database-output.xml
+++ b/archetypes/helidon/src/main/archetype/se/custom/database-output.xml
@@ -34,7 +34,7 @@
                     </list>
                     <value key="db-health-check-stmt" if="${health}">SELECT 0</value>
                     <list key="db-connection">
-                        <value><![CDATA[    url: "jdbc:h2:tcp://localhost:9092/~test"
+                        <value><![CDATA[    url: "jdbc:h2:~/test"
     username: sa
     password:]]></value>
                     </list>


### PR DESCRIPTION
### Description

Update the JDBC URL to be `jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE` instead of `jdbc:h2:tcp://localhost:9092/~test` to use H2 in-memory.

Fixes #7876

### Documentation

No doc impact
