### PR TITLE
2.x: Fix #7783: max-payload-size is parsed as an Integer

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SocketConfiguration.java
@@ -587,7 +587,7 @@ public interface SocketConfiguration {
             config.get("backlog").asInt().ifPresent(this::backlog);
             config.get("max-header-size").asInt().ifPresent(this::maxHeaderSize);
             config.get("max-initial-line-length").asInt().ifPresent(this::maxInitialLineLength);
-            config.get("max-payload-size").asInt().ifPresent(this::maxPayloadSize);
+            config.get("max-payload-size").asLong().ifPresent(this::maxPayloadSize);
 
             DeprecatedConfig.get(config, "timeout-millis", "timeout")
                     .asInt()

--- a/webserver/webserver/src/test/java/io/helidon/webserver/MaxPayloadSizeTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/MaxPayloadSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/test/java/io/helidon/webserver/MaxPayloadSizeTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/MaxPayloadSizeTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webserver;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
@@ -25,6 +26,8 @@ import java.util.logging.Logger;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 import io.helidon.webclient.WebClient;
 import io.helidon.webclient.WebClientRequestBuilder;
 import io.helidon.webclient.WebClientResponse;
@@ -186,6 +189,18 @@ public class MaxPayloadSizeTest {
                 .submit(PAYLOAD.substring(0, (int) MAX_PAYLOAD_SIZE))
                 .await(5, TimeUnit.SECONDS);
         assertThat(response.status().code(), is(Http.Status.OK_200.code()));
+    }
+
+    /**
+     * Verify fix for 7783
+     */
+    @Test
+    public void testMaxLongMaxPayloadSizeFromConfig() {
+        final long MAX_PAYLOAD_SIZE = Long.MAX_VALUE;
+        Config justConfig = Config.just(ConfigSources.create(Map.of("max-payload-size", Long.toString(MAX_PAYLOAD_SIZE))).build());
+        WebServer webServer = WebServer.builder().config(justConfig).build();
+        assertThat(webServer.configuration().namedSocket(WebServer.DEFAULT_SOCKET_NAME).get().maxPayloadSize(),
+                is(Long.MAX_VALUE));
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes #7783: max-payload-size is parsed as an Integer

## Documentation

No impact
