### PR TITLE
4.x: Upgrade log4j to 2.21.1 . Use log4j-bom

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -92,7 +92,7 @@
         <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>
         <version.lib.kafka>3.6.0</version.lib.kafka>
-        <version.lib.log4j>2.18.0</version.lib.log4j>
+        <version.lib.log4j>2.21.1</version.lib.log4j>
         <version.lib.logback>1.4.0</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
@@ -745,16 +745,6 @@
                 <version>${version.lib.slf4j}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${version.lib.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-jpl</artifactId>
-                <version>${version.lib.log4j}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-core</artifactId>
                 <version>${version.lib.smallrye-openapi}</version>
@@ -1111,16 +1101,6 @@
                 <version>${version.lib.slf4j}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${version.lib.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-jul</artifactId>
-                <version>${version.lib.log4j}</version>
-            </dependency>
-            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${version.lib.logback}</version>
@@ -1410,6 +1390,13 @@
                 <groupId>com.oracle.oci.sdk</groupId>
                 <artifactId>oci-java-sdk-bom</artifactId>
                 <version>${version.lib.oci}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${version.lib.log4j}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
### Description

Upgrade log4j to 2.21.1 . Use log4j-bom

### Documentation

No impact