### PR TITLE
Upgrade gradle guide and examples

### DIFF
--- a/docs/includes/guides/gradle-build.adoc
+++ b/docs/includes/guides/gradle-build.adoc
@@ -21,7 +21,7 @@ ifndef::rootdir[:rootdir: {docdir}/../..]
 == Introduction
 
 While most of Helidon's examples use Maven, you can also use Helidon
-with a Gradle project. We recommend Gradle 8.4+.
+with a Gradle project. Gradle 8.4+ is required to build Helidon 4 projects.
 
 == Gradle Example
 

--- a/docs/includes/guides/gradle-build.adoc
+++ b/docs/includes/guides/gradle-build.adoc
@@ -21,7 +21,7 @@ ifndef::rootdir[:rootdir: {docdir}/../..]
 == Introduction
 
 While most of Helidon's examples use Maven, you can also use Helidon
-with a Gradle project. We recommend Gradle 7+.
+with a Gradle project. We recommend Gradle 8.4+.
 
 == Gradle Example
 
@@ -43,13 +43,13 @@ without providing a version.
 ----
 dependencies {
     // import Helidon dependency management
-    implementation platform("io.helidon:helidon-dependencies:${project.helidonversion}")
+    implementation enforcedPlatform("io.helidon:helidon-dependencies:${project.helidonversion}")
 
     implementation 'io.helidon.microprofile.bundles:helidon-microprofile'
     implementation 'org.glassfish.jersey.media:jersey-media-json-binding'
 
-    runtimeOnly 'org.jboss:jandex'
-    runtimeOnly 'javax.activation:javax.activation-api'
+    runtimeOnly 'io.smallrye:jandex'
+    runtimeOnly 'jakarta.activation:jakarta.activation-api'
 
     testCompileOnly 'org.junit.jupiter:junit-jupiter-api:'
 }

--- a/examples/quickstarts/helidon-quickstart-mp/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/build.gradle
@@ -25,8 +25,8 @@ version = '1.0-SNAPSHOT'
 
 description = """helidon-quickstart-mp"""
 
-sourceCompatibility = 17
-targetCompatibility = 17
+sourceCompatibility = 21
+targetCompatibility = 21
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
@@ -48,11 +48,12 @@ dependencies {
     implementation 'io.helidon.microprofile.bundles:helidon-microprofile'
     implementation 'org.glassfish.jersey.media:jersey-media-json-binding'
 
-    runtimeOnly 'org.jboss:jandex'
+    runtimeOnly 'io.smallrye:jandex'
     runtimeOnly 'jakarta.activation:jakarta.activation-api'
 
     testImplementation 'io.helidon.microprofile.testing:helidon-microprofile-testing-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.hamcrest:hamcrest-all'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 

--- a/examples/quickstarts/helidon-quickstart-se/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/build.gradle
@@ -24,8 +24,8 @@ version = '1.0-SNAPSHOT'
 
 description = """helidon-quickstart-se"""
 
-sourceCompatibility = 20
-targetCompatibility = 20
+sourceCompatibility = 21
+targetCompatibility = 21
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
@@ -49,7 +49,8 @@ dependencies {
     implementation enforcedPlatform("io.helidon:helidon-dependencies:${project.helidonversion}")
     implementation 'io.helidon.webserver:helidon-webserver'
     implementation 'io.helidon.http.media:helidon-http-media-jsonp'
-    implementation 'io.helidon.webserver.observe:helidon-observe-health'
+    implementation 'io.helidon.webserver.observe:helidon-webserver-observe-health'
+    implementation 'io.helidon.webserver.observe:helidon-webserver-observe-metrics'
     implementation 'io.helidon.config:helidon-config-yaml'
     implementation 'io.helidon.health:helidon-health-checks'
 


### PR DESCRIPTION
### Description

fix https://github.com/helidon-io/helidon/issues/7892

Gradle Compatibility to enforce version 8.4+ : https://docs.gradle.org/current/userguide/compatibility.html

### Documentation

Documentation is updated in the PR
