### PR TITLE
[4.x] Corrects a case typo in the custom MP archetype that results in an invalid property being installed on UCP

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/common/files/src/main/resources/META-INF/microprofile-config.properties.mustache
+++ b/archetypes/helidon/src/main/archetype/mp/common/files/src/main/resources/META-INF/microprofile-config.properties.mustache
@@ -17,7 +17,7 @@ javax.sql.DataSource.{{ds-name}}.dataSource.user={{dbUser}}
 javax.sql.DataSource.{{ds-name}}.dataSource.password={{userPassword}}
 {{/database-hikari}}
 {{#database-ucp}}
-oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.url={{databaseUrl}}
+oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.URL={{databaseUrl}}
 oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.connectionFactoryClassName={{jdbcDataSource}}
 oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.user={{dbUser}}
 oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.password={{userPassword}}


### PR DESCRIPTION
Documentation impact: none