### PR TITLE
[3.x] Corrects a case typo in the custom MP archetype that results in an invalid property being installed on UCP

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/common/files/src/main/resources/META-INF/microprofile-config.properties.mustache
+++ b/archetypes/helidon/src/main/archetype/mp/common/files/src/main/resources/META-INF/microprofile-config.properties.mustache
@@ -17,7 +17,7 @@ javax.sql.DataSource.{{ds-name}}.dataSource.user=db_user
 javax.sql.DataSource.{{ds-name}}.dataSource.password=user_password
 {{/database-hikari}}
 {{#database-ucp}}
-oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.url={{databaseUrl}}
+oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.URL={{databaseUrl}}
 oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.connectionFactoryClassName={{jdbcDataSource}}
 oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.user=db_user
 oracle.ucp.jdbc.PoolDataSource.{{ds-name}}.password=user_password


### PR DESCRIPTION
Documentation impact: none.

Backport of #7924.