### PR TITLE
[3.x] Backports database-related information present on 4.x to 3.x archetypes

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/custom/database.xml
+++ b/archetypes/helidon/src/main/archetype/mp/custom/database.xml
@@ -197,6 +197,8 @@ Instructions for H2 can be found here: https://www.h2database.com/html/cheatShee
                                     </list>
                                     <value key="jdbcDataSource">org.h2.jdbcx.JdbcDataSource</value>
                                     <value key="databaseUrl">jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</value>
+                                    <value key="dbUser">sa</value>
+                                    <value key="userPassword"></value>
                                     <list key="MainTest-methods">
                                         <value><![CDATA[
     @Test
@@ -307,6 +309,9 @@ docker run --rm --name mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -e MYSQL_D
                                         </map>
                                     </list>
                                     <value key="jdbcDataSource">com.mysql.cj.jdbc.MysqlDataSource</value>
+                                    <value key="databaseUrl">jdbc:mysql://127.0.0.1:3306/pokemon?useSSL=false</value>
+                                    <value key="dbUser">user</value>
+                                    <value key="userPassword">password</value>
                                 </model>
                             </output>
                         </option>
@@ -351,6 +356,9 @@ docker run --rm --name xe -p 1521:1521 -p 8888:8080 -e ORACLE_PWD=oracle wnamele
                                         </map>
                                     </list>
                                     <value key="jdbcDataSource">oracle.jdbc.pool.OracleDataSource</value>
+                                    <value key="databaseUrl">jdbc:oracle:thin:@localhost:1521:XE</value>
+                                    <value key="dbUser">sys as sysdba</value>
+                                    <value key="userPassword">oracle</value>
                                 </model>
                             </output>
                         </option>


### PR DESCRIPTION
The 4.x version of `archetypes/helidon/src/main/archetype/mp/custom/database.xml` contains default information for all databases. The 3.x does not. This PR backports this information, presuming that this is the correct thing to do.

Documentation impact: none