### PR TITLE
Fix link from upgrade guide to testing guide

### DIFF
--- a/docs/se/guides/upgrade_4x.adoc
+++ b/docs/se/guides/upgrade_4x.adoc
@@ -261,13 +261,13 @@ There is a new testing framework for Helidon SE.
 [source, xml]
 ----
 <dependency>
-    <groupId>io.helidon.microprofile.testing</groupId>
-    <artifactId>helidon-microprofile-testing-junit5</artifactId>
+    <groupId>io.helidon.testing.junit5</groupId>
+    <artifactId>helidon-testing-junit5-webserver</artifactId>
     <scope>test</scope>
 </dependency>
 ----
 
-Find more information, see xref:../introduction.adoc[Helidon SE testing]
+Find more information, see xref:../testing.adoc[Helidon SE testing]
 
 ==== Observability
 


### PR DESCRIPTION
Also it seems that dependency from MP was referenced instead of SE version (this guide is about upgrading SE version)