### PR TITLE
Keep EOF at end of OpenMetrics output

### DIFF
--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
@@ -131,10 +131,10 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
                 return Optional.empty();
             }
 
-            String prometheusOutput = filter(prometheusMeterRegistry.get()
-                                                     .scrape(MicrometerPrometheusFormatter.MEDIA_TYPE_TO_FORMAT.get(
-                                                                     resultMediaType),
-                                                             meterNamesOfInterest));
+            String prometheusOutput = prometheusMeterRegistry.get()
+                    .scrape(MicrometerPrometheusFormatter.MEDIA_TYPE_TO_FORMAT.get(
+                                    resultMediaType),
+                            meterNamesOfInterest);
 
             return prometheusOutput.isBlank() ? Optional.empty() : Optional.of(prometheusOutput);
         }
@@ -216,16 +216,6 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
                             .forEach(suffix -> result.add(normalizedMeterName + units + suffix)));
         }
         return result;
-    }
-
-    /**
-     * Filter the Prometheus-format report.
-     *
-     * @param output Prometheus-format report
-     * @return output filtered
-     */
-    private static String filter(String output) {
-        return output.replaceFirst("# EOF\r?\n?", "");
     }
 
     private static Optional<PrometheusMeterRegistry> prometheusMeterRegistry(MeterRegistry meterRegistry) {


### PR DESCRIPTION
### Description
Resolves #7981

Now that Helidon's metrics is based on Micrometer, we use Micrometer's Prometheus meter registry for formatting the output. The Prometheus meter registry handles both Prometheus exposition format (which does not include a trailing EOF line) and OpenMetrics (which does).

That said, our formatting needs to do some processing on the output from that registry before returning it and that processing was incorrectly removing the `# EOF` string from the end of OpenMetrics output.

The changes here remove that trimming and also enhance unit tests of the formatter to:
1. Select OpenMetrics as the output (since that's the format, not the Prometheus exposition format, that has the `# EOF` trailer.
2. Make sure the formatted output ends with that trailer.
3. Slightly revise the expected results. Prometheus format allows for (and the Micrometer Prometheus meter registry includes) a trailing `,` after tags; the OpenMetrics output does not have that trailing `,` and since the tests now specify OpenMetrics format they need to _not_ expect the trailing `,` after tags.

As a test specific to the use case in the issue, I ran the SE Quickstart app and started a Prometheus server locally using the `prometheus.yml` configuration file below. The Prometheus server now accepts and processes the response from the metrics endpoint. (Most of the config is boilerplate; the interesting part is the last `job` in the `scrape_config` section.)

```yaml
# my global config
global:
  scrape_interval:     5s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
  # scrape_timeout is set to the global default (10s).

# Alertmanager configuration
alerting:
  alertmanagers:
  - static_configs:
    - targets:
      # - alertmanager:9093

# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
rule_files:
  # - "first_rules.yml"
  # - "second_rules.yml"

# A scrape configuration containing exactly one endpoint to scrape:
# Here it's Prometheus itself.
scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: 'prometheus'

    # metrics_path defaults to '/metrics'
    # scheme defaults to 'http'.

    static_configs:
    - targets: ['localhost:9090']

  - job_name: 'helidon'
    metrics_path: /observe/metrics
    static_configs:
    - targets: ['localhost:8080']
```

### Documentation
No doc impact - this is a bug fix.
