### PR TITLE
Updates header type hierarchy to make HeaderValueCached not writeable

### DIFF
--- a/http/http/src/main/java/io/helidon/http/HeaderValueArray.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueArray.java
@@ -19,7 +19,7 @@ package io.helidon.http;
 import java.util.ArrayList;
 import java.util.List;
 
-class HeaderValueArray extends HeaderValueBase {
+class HeaderValueArray extends HeaderWritableValueBase {
     private final String[] originalValues;
     private List<String> values;
 

--- a/http/http/src/main/java/io/helidon/http/HeaderValueBase.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueBase.java
@@ -25,7 +25,7 @@ import io.helidon.common.mapper.MapperException;
 import io.helidon.common.mapper.MapperManager;
 import io.helidon.common.mapper.Value;
 
-abstract class HeaderValueBase implements HeaderWriteable {
+abstract class HeaderValueBase implements Header {
     private static final String[] QUALIFIER = new String[] {"http", "header"};
     private final HeaderName name;
     private final String actualName;
@@ -40,9 +40,6 @@ abstract class HeaderValueBase implements HeaderWriteable {
         this.sensitive = sensitive;
         this.firstValue = value;
     }
-
-    @Override
-    public abstract HeaderWriteable addValue(String value);
 
     @Override
     public String name() {

--- a/http/http/src/main/java/io/helidon/http/HeaderValueCached.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueCached.java
@@ -55,11 +55,6 @@ class HeaderValueCached extends HeaderValueBase {
     }
 
     @Override
-    public HeaderWriteable addValue(String value) {
-        throw new UnsupportedOperationException("Cannot change values of a cached header " + name());
-    }
-
-    @Override
     public List<String> allValues() {
         return List.of(value);
     }

--- a/http/http/src/main/java/io/helidon/http/HeaderValueCopy.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueCopy.java
@@ -19,7 +19,7 @@ package io.helidon.http;
 import java.util.ArrayList;
 import java.util.List;
 
-class HeaderValueCopy extends HeaderValueBase {
+class HeaderValueCopy extends HeaderWritableValueBase {
     private final Header original;
     private List<String> values;
 

--- a/http/http/src/main/java/io/helidon/http/HeaderValueLazy.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueLazy.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import io.helidon.common.buffers.LazyString;
 
-class HeaderValueLazy extends HeaderValueBase {
+class HeaderValueLazy extends HeaderWritableValueBase {
     private final LazyString value;
     private List<String> values;
 

--- a/http/http/src/main/java/io/helidon/http/HeaderValueList.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueList.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-class HeaderValueList extends HeaderValueBase {
+class HeaderValueList extends HeaderWritableValueBase {
     private List<String> values;
 
     HeaderValueList(HeaderName name, boolean changing, boolean sensitive, Collection<String> values) {

--- a/http/http/src/main/java/io/helidon/http/HeaderValueSingle.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValueSingle.java
@@ -19,7 +19,7 @@ package io.helidon.http;
 import java.util.ArrayList;
 import java.util.List;
 
-class HeaderValueSingle extends HeaderValueBase {
+class HeaderValueSingle extends HeaderWritableValueBase {
     private final String value;
     private List<String> values;
 

--- a/http/http/src/main/java/io/helidon/http/HeaderWritableValueBase.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderWritableValueBase.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http;
+
+abstract class HeaderWritableValueBase extends HeaderValueBase implements HeaderWriteable {
+
+    HeaderWritableValueBase(HeaderName name, boolean changing, boolean sensitive, String value) {
+        super(name, changing, sensitive, value);
+    }
+}


### PR DESCRIPTION
### Description

Updates header type hierarchy to make HeaderValueCached not writeable. Separates base header classes into writeable and non-writeable. Prevents unnecessary copying of cached headers. Issue #7999.

### Documentation

None
