### PR TITLE
Use correct config nodes for metrics settings; when using global meter registry set metrics config correctly

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
@@ -122,7 +122,8 @@ class MetricsFactoryManager {
      */
     static MetricsFactory getMetricsFactory() {
         return access(() -> {
-            metricsConfigNode = Objects.requireNonNullElseGet(metricsConfigNode, GlobalConfig::config);
+            metricsConfigNode = Objects.requireNonNullElseGet(metricsConfigNode,
+                                                              MetricsFactoryManager::externalMetricsConfig);
             metricsFactory = Objects.requireNonNullElseGet(metricsFactory,
                                                            () -> getMetricsFactory(metricsConfigNode));
             return metricsFactory;
@@ -147,6 +148,14 @@ class MetricsFactoryManager {
     static void closeAll() {
         METRICS_FACTORY_PROVIDER.get().close();
         metricsFactory = null;
+    }
+
+    private static Config externalMetricsConfig() {
+        Config serverFeaturesMetricsConfig = GlobalConfig.config().get("server.features.observe.observers.metrics");
+        if (!serverFeaturesMetricsConfig.exists()) {
+            serverFeaturesMetricsConfig = GlobalConfig.config().get("metrics");
+        }
+        return serverFeaturesMetricsConfig;
     }
 
     private static MetricsFactory completeGetInstance(MetricsConfig metricsConfig, Config metricsConfigNode) {

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -551,14 +551,10 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension {
         MetricsFactory metricsFactory = MetricsFactory.getInstance(config);
 
         Contexts.globalContext().register(metricsFactory);
-        MetricsConfig.Builder metricsConfigBuilder = MetricsConfig.builder()
-                .config(config);
-        MetricsConfig metricsConfig = metricsConfigBuilder.build();
+        MetricsConfig metricsConfig = metricsFactory.metricsConfig();
         MeterRegistry meterRegistry = metricsFactory.globalRegistry(metricsConfig);
-        RegistryFactory.getInstance(meterRegistry); // initialize before first use
-        return builder.metricsConfig(metricsConfigBuilder)
+        return builder.metricsConfig(metricsConfig)
                 .meterRegistry(meterRegistry)
-                .metricsConfig(MetricsConfig.builder(metricsConfig))
                 .build();
     }
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
@@ -76,8 +76,9 @@ class RegistryFactory {
     }
 
     static RegistryFactory getInstance(MeterRegistry meterRegistry) {
-        REGISTRY_FACTORY.set(create(meterRegistry));
-        return REGISTRY_FACTORY.get();
+        return REGISTRY_FACTORY.updateAndGet(rf -> rf != null && rf.meterRegistry == meterRegistry
+                ? rf
+                : create(meterRegistry));
     }
 
     /**

--- a/webserver/observe/metrics/pom.xml
+++ b/webserver/observe/metrics/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -64,8 +64,8 @@ class MetricsFeature {
     private KeyPerformanceIndicatorSupport.Metrics kpiMetrics;
 
     MetricsFeature(MetricsObserverConfig config) {
-        this.meterRegistry = config.meterRegistry().orElseGet(MetricsFactory.getInstance()::globalRegistry);
         this.metricsConfig = config.metricsConfig();
+        this.meterRegistry = config.meterRegistry().orElseGet(() -> MetricsFactory.getInstance().globalRegistry(metricsConfig));
     }
 
     /**

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserver.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsObserver.java
@@ -122,7 +122,7 @@ public class MetricsObserver implements Observer, RuntimeType.Api<MetricsObserve
 
     @Override
     public String type() {
-        return "log";
+        return "metrics";
     }
 
     @Override

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestMetricsConfigPropagation.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestMetricsConfigPropagation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.observe.metrics;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@ServerTest
+class TestMetricsConfigPropagation {
+
+    private final Http1Client client;
+
+    TestMetricsConfigPropagation(WebServer server, Http1Client client) {
+        this.client = client;
+    }
+
+    @Test
+    void checkExtendedKpiMetrics() {
+        try (Http1ClientResponse response = client.get("/observe/metrics")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .request()) {
+            assertThat("Metrics endpoint", response.status().code(), is(200));
+            JsonObject metricsResponse = response.as(JsonObject.class);
+            JsonObject vendorMeters = metricsResponse.getJsonObject("vendor");
+            assertThat("Vendor meters", vendorMeters, notNullValue());
+
+            // Make sure that the extended KPI metrics were turned on as directed by the configuration.
+            assertThat("Metrics KPI load",
+                       vendorMeters.getJsonNumber("requests.load").intValue(),
+                       greaterThan(0));
+
+            // Make sure that requests.count is absent because of the filtering in the config.
+            assertThat("Metrics KPI requests.count", vendorMeters.get("requests.count"), nullValue());
+        }
+    }
+}

--- a/webserver/observe/metrics/src/test/resources/application.yaml
+++ b/webserver/observe/metrics/src/test/resources/application.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+server:
+  features:
+    observe:
+      observers:
+        metrics:
+          scoping:
+            scopes:
+              - name: vendor
+                filter:
+                  include: requests.l.*
+          key-performance-indicators:
+            extended: true


### PR DESCRIPTION
### Description

Resolves #7911
Resolves #7980 

(I am using a single PR to resolve both bugs because fixing 7911 alone causes `microprofile/metrics` unit tests to fail; the fix to 7980 takes care of that.)

Changes

----


#### Fix: `MetricsFeature` incorrectly accessed global meter registry
The constructor uses the meter registry from the config if one has been set (that is correct). If none was set in the config, the code uses the global meter registry. That is also correct _except_ that the code should pass the metrics config when retrieving the global meter registry so that the global registry's behavior conforms to the config. 

As originally written, the code did not pass the metrics config so the global registry was set up using defaults, not the specified config.

----

#### Fix `MetricsObserver#type()` method
It incorrectly returned "log" instead of "metrics", causing the MP server to incorrectly add the metrics observer again via its observer provider instead of yielding to the one already added by the metrics MP CDI extension.

I expect this was an oversight after copying and pasting from `LogObserver`.

----

#### Optimize and fix: `MetricsCdiExtension` unnecessarily created a metrics config builder and initialized the MP `RegistryFactory`
The `configure()` method correctly initializes the `MetricsFactory using `MetricsFactory.getInstance(config)`. Doing so automatically sets the `metricsConfig` kept internally in the factory, so the code did not need to create its own config builder and build it to get the `metricsConfig` to use in retrieving the global meter registry. 

Also, the `RegistryFactory` is already initialized automatically by `RegistryFactoryManager` when the globe meter registry is set up, so there is no need to do so again in the `configure()` method.

----

#### Optimize: `RegistryFactory#getInstance(MeterRegistry)`
The static method now returns the existing registry factory instance if it exists and if the specified `MeterRegistry` is the same as the one that was used to initialized the existing one.

----

#### Clarification: `MetricsFactoryManager` did not itself refer to both `metrics` and `server.features.observe.observers.metrics` config nodes

Things worked because later code filled in the config using the top-level `metrics` config if the `server.features...` settings for metrics were absent. This change, while not really changing behavior, puts in one place in the code the logic to fetch from either config node.

-----

The PR also adds a test to make sure the configuration is processed correctly and the metrics behavior reflects the config.

### Documentation
These are bug fixes: no doc impact.
