### PR TITLE
4.x Fix nested config prefix for observer settings

### DIFF
--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCdiExtension.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCdiExtension.java
@@ -58,7 +58,7 @@ public class HealthCdiExtension extends HelidonRestCdiExtension {
      * Creates a new instance of the health CDI extension.
      */
     public HealthCdiExtension() {
-        super(LOGGER, "observe.providers.health", "health");
+        super(LOGGER, nestedConfigKey("health"), "health");
     }
 
     /**

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/NestedConfigTest.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/NestedConfigTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.health;
+
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest()
+@AddConfig(key = "server.features.observe.observers.health.details", value = "false")
+class NestedConfigTest {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void checkForNoDetailsWithConfigNested() {
+        Response response = webTarget.path("/health")
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .get();
+
+        assertThat("Response status", response.getStatus(), is(204));
+    }
+}

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -175,7 +175,7 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension {
      * Creates a new extension instance.
      */
     public MetricsCdiExtension() {
-        super(LOGGER, "observe.providers.metrics", "metrics");
+        super(LOGGER, nestedConfigKey("metrics"), "metrics");
     }
 
     /**

--- a/microprofile/service-common/src/main/java/io/helidon/microprofile/servicecommon/HelidonRestCdiExtension.java
+++ b/microprofile/service-common/src/main/java/io/helidon/microprofile/servicecommon/HelidonRestCdiExtension.java
@@ -255,6 +255,16 @@ public abstract class HelidonRestCdiExtension implements Extension {
     }
 
     /**
+     * Returns the config key for settings for the specified suffix nested within the server config tree.
+     *
+     * @param suffix the config key suffix (typically the name of the component: e.g., health)
+     * @return full nested config key for the specified suffix
+     */
+    protected static String nestedConfigKey(String suffix) {
+        return "server.features.observe.observers." + suffix;
+    }
+
+    /**
      * Configure with runtime config.
      *
      * @param config config to use


### PR DESCRIPTION
### Description
Resolves #8009 

The metrics and health CDI extension constructors passed the incorrect config key for nested (non-top-level) config settings.

The original code passed `observe.providers.metrics` and `observe.providers.health`. I suspect this was correct before the restructuring of features and observers, and their config now appears under `server.features.observe.observers.metrics` and `...health` instead and use `observers` instead of `providers` in the prefix. I further suspect these strings just fell through the cracks during the refactoring.

This PR adds a superclass method which computes the correct prefix (so the hard-coded part of the prefix is in _one_ place) and adjusts the constructors to invoke it.

Note that the superconstructor accepts a list of config prefixes, and the leaf constructors pass both the above correct prefixes and the old (3.x) top-level prefixes (`metrics` and `health`).

### Documentation
Bug fix - no doc impact.
