### PR TITLE
Support for longer WebSocket frames

### DIFF
--- a/webserver/tests/websocket/src/test/resources/application.yaml
+++ b/webserver/tests/websocket/src/test/resources/application.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  protocols:
+    websocket:
+      max-frame-length: 10000

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConfigBlueprint.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConfigBlueprint.java
@@ -56,4 +56,13 @@ interface WsConfigBlueprint extends ProtocolConfig {
     @ConfiguredOption(WsUpgradeProvider.CONFIG_NAME)
     @Override
     String name();
+
+    /**
+     * Max WebSocket frame size supported by the server on a read operation.
+     * Default is 1 MB.
+     *
+     * @return max frame size to read
+     */
+    @ConfiguredOption(WsConnection.MAX_FRAME_LENGTH)
+    int maxFrameLength();
 }

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
@@ -45,11 +45,14 @@ import io.helidon.websocket.WsSession;
 public class WsConnection implements ServerConnection, WsSession {
     private static final System.Logger LOGGER = System.getLogger(WsConnection.class.getName());
 
+    static final String MAX_FRAME_LENGTH = "1048576";
+
     private final ConnectionContext ctx;
     private final HttpPrologue prologue;
     private final Headers upgradeHeaders;
     private final String wsKey;
     private final WsListener listener;
+    private final WsConfig wsConfig;
 
     private final BufferData sendBuffer = BufferData.growing(1024);
     private final DataReader dataReader;
@@ -75,6 +78,13 @@ public class WsConnection implements ServerConnection, WsSession {
         this.listener = wsRoute.listener();
         this.dataReader = ctx.dataReader();
         this.lastRequestTimestamp = DateTime.timestamp();
+        this.wsConfig = (WsConfig) ctx.listenerContext()
+                                      .config()
+                                      .protocols()
+                                      .stream()
+                                      .filter(p -> p instanceof WsConfig)
+                                      .findFirst()
+                                      .orElse(null);
     }
 
     /**
@@ -243,8 +253,9 @@ public class WsConnection implements ServerConnection, WsSession {
 
     private ClientWsFrame readFrame() {
         try {
-            // TODO check may payload size, danger of oom
-            return ClientWsFrame.read(ctx, dataReader, Integer.MAX_VALUE);
+            int maxFrameLength = wsConfig != null ? wsConfig.maxFrameLength()
+                                                  : Integer.parseInt(MAX_FRAME_LENGTH);
+            return ClientWsFrame.read(ctx, dataReader, maxFrameLength);
         } catch (DataReader.InsufficientDataAvailableException e) {
             throw new CloseConnectionException("Socket closed by the other side", e);
         } catch (WsCloseException e) {
@@ -276,9 +287,18 @@ public class WsConnection implements ServerConnection, WsSession {
         opCodeFull |= usedCode.code();
         sendBuffer.write(opCodeFull);
 
-        if (frame.payloadLength() < 126) {
-            sendBuffer.write((int) frame.payloadLength());
-            // TODO finish other options (payload longer than 126 bytes)
+        long length = frame.payloadLength();
+        if (length < 126) {
+            sendBuffer.write((int) length);
+        } else if (length < 1 << 16) {
+            sendBuffer.write(126);
+            sendBuffer.write((int) (length >>> 8));
+            sendBuffer.write((int) (length & 0xFF));
+        } else {
+            sendBuffer.write(127);
+            for (int i = 56; i >= 0; i -= 8){
+                sendBuffer.write((int) (length >>> i) & 0xFF);
+            }
         }
         sendBuffer.write(frame.payloadData());
         ctx.dataWriter().writeNow(sendBuffer);

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
@@ -84,7 +84,7 @@ public class WsConnection implements ServerConnection, WsSession {
                                       .stream()
                                       .filter(p -> p instanceof WsConfig)
                                       .findFirst()
-                                      .orElse(null);
+                                      .orElseThrow(() -> new InternalError("Unable to find WebSocket config"));
     }
 
     /**
@@ -253,9 +253,7 @@ public class WsConnection implements ServerConnection, WsSession {
 
     private ClientWsFrame readFrame() {
         try {
-            int maxFrameLength = wsConfig != null ? wsConfig.maxFrameLength()
-                                                  : Integer.parseInt(MAX_FRAME_LENGTH);
-            return ClientWsFrame.read(ctx, dataReader, maxFrameLength);
+            return ClientWsFrame.read(ctx, dataReader, wsConfig.maxFrameLength());
         } catch (DataReader.InsufficientDataAvailableException e) {
             throw new CloseConnectionException("Socket closed by the other side", e);
         } catch (WsCloseException e) {

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgradeProvider.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgradeProvider.java
@@ -25,7 +25,7 @@ import io.helidon.webserver.http1.spi.Http1Upgrader;
  */
 public class WsUpgradeProvider implements Http1UpgradeProvider<WsConfig> {
     /**
-     * HTTP/2 server connection provider configuration node name.
+     * WebSocket server connection provider configuration node name.
      */
     protected static final String CONFIG_NAME = "websocket";
 

--- a/websocket/src/main/java/io/helidon/websocket/AbstractWsFrame.java
+++ b/websocket/src/main/java/io/helidon/websocket/AbstractWsFrame.java
@@ -109,7 +109,7 @@ abstract sealed class AbstractWsFrame implements WsFrame permits ServerWsFrame, 
             throw new WsCloseException("Payload too large", WsCloseCodes.TOO_BIG);
         }
 
-        return new FrameHeader(opCode, fin, masked, length);
+        return new FrameHeader(opCode, fin, masked, (int) frameLength);
     }
 
     protected static BufferData readPayload(DataReader reader, FrameHeader header) {


### PR DESCRIPTION
### Description

1. Support for writing WS frames of more than 125 bytes, i.e. with lengths that fit in two bytes and eight bytes.
2. Configuration of max-frame-length to limit the size of a frame read by the server. The JDK WS client splits a long payload into 16K frames.
3. Some new tests for (1) and (2).

Related to issue #7986.

### Documentation

JavaDoc has been updated.
