### PR TITLE
4.x: upgrade owasp depenency check to 8.4.3

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -154,7 +154,7 @@
    <notes><![CDATA[
    file name: netty-handler-4.1.94.Final.jar
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+   <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*@.*$</packageUrl>
    <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
 </suppress>
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>8.3.1</version.plugin.dependency-check>
+        <version.plugin.dependency-check>8.4.3</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

Upgrades owasp-dependency-check to 8.4.3 and fixes netty suppression

### Documentation

No impact