### PR TITLE
1.x: upgrade owasp depenency check to 8.4.3

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -275,7 +275,7 @@
    <notes><![CDATA[
    file name: netty-handler-4.1.94.Final.jar
    ]]></notes>
-   <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+   <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*@.*$</packageUrl>
    <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
 </suppress>
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.plugin.spotbugs>3.1.12</version.plugin.spotbugs>
         <version.plugin.surefire.provider.junit>1.0.3</version.plugin.surefire.provider.junit>
         <version.plugin.surefire>2.19.1</version.plugin.surefire>
-        <version.plugin.dependency-check>8.4.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>8.4.3</version.plugin.dependency-check>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>


### PR DESCRIPTION
### Description

Upgrade owasp depenency check to 8.4.3 and fix netty suppression

### Documentation

No impact