### PR TITLE
Change CorsConfig.enabled to optional and add logic to infer it

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsConfigBlueprint.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsConfigBlueprint.java
@@ -27,7 +27,7 @@ import io.helidon.webserver.spi.ServerFeatureProvider;
 /**
  * Configuration of CORS feature.
  */
-@Prototype.Blueprint
+@Prototype.Blueprint(decorator = CorsConfigSupport.BuilderDecorator.class)
 @Prototype.Configured(value = CorsFeature.CORS_ID, root = false)
 @Prototype.Provides(ServerFeatureProvider.class)
 interface CorsConfigBlueprint extends Prototype.Factory<CorsFeature> {
@@ -65,7 +65,7 @@ interface CorsConfigBlueprint extends Prototype.Factory<CorsFeature> {
      * @return whether the feature is enabled
      */
     @Option.Configured
-    @Option.DefaultBoolean(true)
+    @Option.Required
     boolean enabled();
 
     /**

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsConfigSupport.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsConfigSupport.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.cors;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.config.Config;
+
+class CorsConfigSupport {
+
+    static class BuilderDecorator implements Prototype.BuilderDecorator<CorsConfig.BuilderBase<?, ?>> {
+
+        @Override
+        public void decorate(CorsConfig.BuilderBase<?, ?> builder) {
+            // If enabled has been explicitly set (perhaps directly, perhaps by config) then use that value.
+            // Otherwise:
+            //    If there is explicit CORS config then set enabled to true.
+            //    Otherwise, set enabled to false.
+            if (builder.enabled().isPresent()) {
+                return;
+            }
+            Optional<Config> config = builder.config();
+            builder.enabled(config.isPresent() && config.get().exists());
+        }
+    }
+}


### PR DESCRIPTION
### Description
Resolves #7990 
Resolves #8024 

The PR changes `CorsConfig#enabled` to optional so we can tell if the value is ever explicitly set--either from code or config--on the `CorsSupport` builder. 

If so, we use the explicit setting.

If not, we set it as follows:
* If no `cors` config was used, set `enabled` to `false`.
* If `cors` config was used, set `enabled` to `true`.

This prevents the auto-discovered CORS logic from enabling permissive CORS settings by default.

Note that this changes the `CorsConfig#enabled()` method API. In 4.0.0 it returns `boolean`. With these changes it will return `Optional<Boolean>`.

### Documentation

Bug fix - no doc change