### PR TITLE
4.x: Fix broken link and explicitly state MP uses Helidon WebServer

### DIFF
--- a/docs/about/doc_overview.adoc
+++ b/docs/about/doc_overview.adoc
@@ -90,7 +90,8 @@ Use these hands-on development tutorials to learn how to generate a small "Hello
 
 xref:{rootdir}/mp/guides/mp-tutorial.adoc[Helidon MP Tutorial]
 
-xref:{rootdir}/mp/guides/mp-tutorial.adoc[Helidon SE Tutorial]
+// We do not have an SE application tutorial. So for now point at quickstart.
+xref:{rootdir}/se/guides/quickstart.adoc[Helidon SE Quickstart]
 
 --
 

--- a/docs/about/introduction.adoc
+++ b/docs/about/introduction.adoc
@@ -41,6 +41,8 @@ Helidon is cloud-native ready. It provides fast start-up time and has low memory
 
 Helidon fully supports GraalVM native image allowing you to build a native executable from your Java application.
 
+Helidon applications are stand-alone Java applications running in their own JVM and powered by the Helidon WebServer.
+
 == Helidon Flavors
 
 Helidon comes in two flavors: *Helidon SE* and *Helidon MP*. Think about these flavors as frameworks providing similar functionality but offering different developer experiences.
@@ -89,6 +91,10 @@ public class HelloWorld {
     }
 }
 ----
+
+Even though Helidon MP supports Jakarta EE APIs it does not require
+an application server. Helidon MP applications are stand-alone Java applications running
+in their own JVM powered by Helidon WebServer.
 
 === What flavor shall I use?
 

--- a/docs/mp/introduction.adoc
+++ b/docs/mp/introduction.adoc
@@ -27,6 +27,11 @@ include::{rootdir}/includes/mp.adoc[]
 
 Helidon MP is an Eclipse MicroProfile {version-lib-microprofile-api} runtime that allows the Jakarta EE community to run microservices in a portable way. It is designed for ease of use and provides Spring Boot like development experience with heavy usage of dependency injection and annotations.
 
+Even though Helidon MP supports Jakarta EE APIs it does not require
+an application server. Helidon MP applications are stand-alone Java applications running
+in their own JVM powered by Helidon WebServer. So you get all the benefits of a low
+overhead server built on Java virtual threads.
+
 == Supported Jakarta EE Specifications
 
 |===


### PR DESCRIPTION
### Description

Fix #7885 : we now explicitly state that Helidon MP applications run in a stand-alone JVM and are powered by Helidon WebServer

Fix #8022: Since we currently do not have an SE tutorial I've changed link to point at the quickstart.

### Documentation

Doc fixes