### PR TITLE
4.x: Change "Java for cloud" to "Helidon"

### DIFF
--- a/security/providers/common/src/main/java/module-info.java
+++ b/security/providers/common/src/main/java/module-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * Java for cloud security module providers.
+ * Helidon security module providers.
  */
 module io.helidon.security.providers.common {
 

--- a/security/security/src/main/java/module-info.java
+++ b/security/security/src/main/java/module-info.java
@@ -18,7 +18,7 @@ import io.helidon.common.features.api.Feature;
 import io.helidon.common.features.api.HelidonFlavor;
 
 /**
- * Java for cloud security module.
+ * Helidon security module.
  *
  * @see io.helidon.security.Security
  * @see io.helidon.security.SecurityContext


### PR DESCRIPTION
### Description

Change  "Java for cloud" to "Helidon" in javadocs

Fixes #8033

### Documentation

No impact