### PR TITLE
Change gc.time system meter to a gauge; temporarily exclude related TCK test

### DIFF
--- a/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
+++ b/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
@@ -240,7 +240,7 @@ public class SystemMetersProvider implements MetersProvider {
                           GarbageCollectorMXBean::getCollectionCount,
                           Tag.create("name", poolName));
             // Express the GC time in seconds.
-            registerFunctionalCounter(result,
+            registerGauge(result,
                           GC_TIME,
                           gcBean,
                           bean -> (long) (bean.getCollectionTime() / 1000.0D),

--- a/microprofile/tests/tck/tck-metrics/excludeTests.txt
+++ b/microprofile/tests/tck/tck-metrics/excludeTests.txt
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Temporary - see pom.xml for details
+# Ideally we would exclude only testGcTimeMetrics but cannot get the per-method exclusion to work.
+org.eclipse.microprofile.metrics.test.optional.MPMetricBaseMetricsTest

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -132,6 +132,9 @@
                         <context.root/> <!-- Suppress the TCK's default of /optionalTCK -->
                         <metrics.rest-request.enabled>true</metrics.rest-request.enabled> <!-- off by default -->
                     </systemPropertyVariables>
+                    <!-- TODO temporary exclusion until MP metrics tck is updated
+                     https://github.com/eclipse/microprofile-metrics/pull/788 -->
+                    <excludesFile>excludeTests.txt</excludesFile>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION



### Description
Resolves #7578 

MP Metrics will be fixing a TCK bug which will cause us to change the `gc.time` system meter from a counter to a gauge. This PR makes that change sooner rather than later and temporarily excludes the buggy TCK test which expect it to be a counter.

### Documentation
Bug fix, and there are no existing documentation references to the `gc.time` system meter that identify it as a counter or a gauge or refer to the Prometheus format.