### PR TITLE
Add meter type to JSON metrics metadata output

### DIFF
--- a/docs/includes/guides/metrics.adoc
+++ b/docs/includes/guides/metrics.adoc
@@ -392,23 +392,20 @@ You can get the metadata for any scope, such as `{metrics-endpoint}?scope=base`,
 .JSON response (truncated):
 ----
 {
-  "classloader.currentLoadedClass.count": {
-    "unit": "none",
-    "type": "counter",
-    "description": "Displays the number of classes that are currently loaded in the Java virtual machine."
-  },
-  "jvm.uptime": {
-    "unit": "milliseconds",
-    "type": "gauge",
-    "description": "Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started.",
-    "displayName": "JVM Uptime"
-  },
-  "memory.usedHeap": {
-    "unit": "bytes",
-    "type": "gauge",
-    "description": "Displays the amount of used heap memory in bytes.",
-    "displayName": "Used Heap Memory"
-  }
+   "classloader.loadedClasses.count": {
+      "type": "gauge",
+      "description": "Displays the number of classes that are currently loaded in the Java virtual machine."
+    },
+   "jvm.uptime": {
+      "type": "gauge",
+      "unit": "seconds",
+      "description": "Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started."
+    },
+   "memory.usedHeap": {
+      "type": "gauge",
+      "unit": "bytes",
+      "description": "Displays the amount of used heap memory in bytes."
+    }
 }
 ----
 

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Meter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Meter.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.metrics.api;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -89,6 +90,15 @@ public interface Meter extends Wrapper {
          * Other.
          */
         OTHER;
+
+        /**
+         * Type name suitable for metadata output.
+         *
+         * @return name of the type formatted for human output
+         */
+        public String typeName() {
+            return name().toLowerCase(Locale.ROOT);
+        }
 
     }
 

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/JsonFormatter.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/JsonFormatter.java
@@ -209,6 +209,7 @@ class JsonFormatter implements MeterRegistryFormatter {
 
                 JsonObjectBuilder builderForThisName = metadataOutputBuilderWithinParent
                         .computeIfAbsent(name, k -> JSON.createObjectBuilder());
+                addNonEmpty(builderForThisName, "type", meter.type().typeName());
                 meter.baseUnit().ifPresent(u -> addNonEmpty(builderForThisName, "unit", u));
                 meter.description().ifPresent(d -> addNonEmpty(builderForThisName, "description", d));
                 isAnyOutput.set(true);


### PR DESCRIPTION
### Description
Resolves #8055 

1. Update `JsonFormatter` to add the meter type to the JSON metadata output.
2. Add a public `typeName()` method to the `Meter.Type` enum to expose a human-readable, JSON-friendly type.

### Documentation
PR includes an update to the example JSON metadata output so it includes the type that now appears (again).