### PR TITLE
4.x jvm uptime units

### DIFF
--- a/docs/includes/guides/metrics.adoc
+++ b/docs/includes/guides/metrics.adoc
@@ -130,7 +130,7 @@ curl -H "Accept: application/json"  http://localhost:8080{metrics-endpoint}
     "classloader.loadedClasses.count": 3582,
     "thread.count": 18,
     "classloader.unloadedClasses.total": 0,
-    "jvm.uptime": 369478,
+    "jvm.uptime": 36.9478,
     "gc.time;name=G1 Young Generation": 0,
     "memory.committedHeap": 541065216,
     "thread.max.count": 19,

--- a/docs/mp/guides/metrics.adoc
+++ b/docs/mp/guides/metrics.adoc
@@ -44,9 +44,9 @@ classloader_loadedClasses_total{mp_scope="base",} 8146.0
 # HELP requests_count_total Each request (regardless of HTTP method) will increase this counter
 # TYPE requests_count_total counter
 requests_count_total{mp_scope="vendor",} 1.0
-# HELP jvm_uptime_seconds Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started.
+# HELP jvm_uptime_seconds Displays the start time of the Java virtual machine in seconds. This attribute displays the approximate time when the Java virtual machine started.
 # TYPE jvm_uptime_seconds gauge
-jvm_uptime_seconds{mp_scope="base",} 7377.0
+jvm_uptime_seconds{mp_scope="base",} 7.3770
 ----
 
 include::{rootdir}/includes/guides/metrics.adoc[tag=curl-metrics-json]
@@ -73,7 +73,7 @@ include::{rootdir}/includes/guides/metrics.adoc[tag=curl-metrics-json]
     "classloader.loadedClasses.count": 8224,
     "thread.count": 19,
     "classloader.unloadedClasses.total": 0,
-    "jvm.uptime": 368224
+    "jvm.uptime": 36.8224
   }
 }
 ----

--- a/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
+++ b/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
@@ -215,7 +215,7 @@ public class SystemMetersProvider implements MetersProvider {
                       typedFn(MemoryMXBean::getHeapMemoryUsage, MemoryUsage::getMax));
 
         RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
-        registerGauge(result, JVM_UPTIME, runtimeBean, RuntimeMXBean::getUptime);
+        registerGauge(result, JVM_UPTIME, runtimeBean, rtBean -> rtBean.getUptime() / 1000.0D);
 
         ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
         registerGauge(result, THREAD_COUNT, threadBean, ThreadMXBean::getThreadCount);

--- a/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
+++ b/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
@@ -78,7 +78,7 @@ public class SystemMetersProvider implements MetersProvider {
             .withName("jvm.uptime")
             .withDescription(
                     "Displays the start time of the Java virtual machine in "
-                            + "milliseconds. This "
+                            + "seconds. This "
                             + "attribute displays the approximate time when the Java "
                             + "virtual machine "
                             + "started.")
@@ -146,7 +146,7 @@ public class SystemMetersProvider implements MetersProvider {
     private static final Metadata GC_TIME = Metadata.builder()
             .withName("gc.time")
             .withDescription(
-                    "Displays the approximate accumulated collection elapsed time in milliseconds. "
+                    "Displays the approximate accumulated collection elapsed time in seconds. "
                             + "This attribute displays -1 if the collection elapsed time is undefined for this "
                             + "collector. The Java virtual machine implementation may use a high resolution "
                             + "timer to measure the elapsed time. This attribute may display the same value "


### PR DESCRIPTION
### Description
Resolves #8064 

1. Change calculation of `jvm.uptime` system meter to use seconds instead of milliseconds.
2. Change metadata for `jvm.uptime` and `gc.time` to refer to "seconds".
3. Change doc example output to reflect seconds in metadata and results.

### Documentation

PR includes doc updates.