### PR TITLE
4.x: 8059 Delayed fixed rate scheduling

### DIFF
--- a/docs/config/config_reference.adoc
+++ b/docs/config/config_reference.adoc
@@ -125,3 +125,7 @@ The following section lists all configurable types in Helidon.
 - xref:{rootdir}/config/io_helidon_tracing_providers_zipkin_ZipkinTracerBuilder.adoc[ZipkinTracerBuilder (tracing.providers.zipkin)]
 - xref:{rootdir}/config/io_opentracing_Tracer.adoc[io_opentracing_Tracer]
 - xref:{rootdir}/config/org_eclipse_microprofile_config_Config.adoc[org_eclipse_microprofile_config_Config]
+- xref:{rootdir}/config/io_helidon_scheduling_Cron.adoc[Cron (scheduling)]
+- xref:{rootdir}/config/io_helidon_scheduling_FixedRate.adoc[FixedRate (scheduling)]
+- xref:{rootdir}/config/io_helidon_scheduling_TaskConfig.adoc[TaskConfig (scheduling)]
+

--- a/docs/config/io_helidon_scheduling_Cron.adoc
+++ b/docs/config/io_helidon_scheduling_Cron.adoc
@@ -1,0 +1,69 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+ifndef::rootdir[:rootdir: {docdir}/..]
+:description: Configuration of io.helidon.scheduling.Cron
+:keywords: helidon, config, io.helidon.scheduling.Cron
+:basic-table-intro: The table below lists the configuration keys that configure io.helidon.scheduling.Cron
+include::{rootdir}/includes/attributes.adoc[]
+
+= Cron (scheduling) Configuration
+
+// tag::config[]
+
+
+Type: link:{javadoc-base-url}/io.helidon.scheduling/io/helidon/scheduling/Cron.html[io.helidon.scheduling.Cron]
+
+
+
+
+== Configuration options
+
+.Required configuration options
+[cols="3,3a,2,5a"]
+|===
+|key |type |default value |description
+
+|`expression` |string |{nbsp} |Cron expression for specifying period of execution.
+
+ <b>Examples:</b>
+
+- `0/2 * * * * ? *` - Every 2 seconds
+- `0 45 9 ? * *` - Every day at 9:45
+- `0 15 8 ? * MON-FRI` - Every workday at 8:15
+
+@return cron expression
+
+|===
+
+
+
+.Optional configuration options
+[cols="3,3a,2,5a"]
+
+|===
+|key |type |default value |description
+
+|`concurrent` |boolean |`true` |Allow concurrent execution if previous task didn't finish before next execution.
+ Default value is `true`.
+
+ @return true for allow concurrent execution.
+
+|===
+
+// end::config[]

--- a/docs/config/io_helidon_scheduling_FixedRate.adoc
+++ b/docs/config/io_helidon_scheduling_FixedRate.adoc
@@ -1,0 +1,76 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+ifndef::rootdir[:rootdir: {docdir}/..]
+:description: Configuration of io.helidon.scheduling.FixedRate
+:keywords: helidon, config, io.helidon.scheduling.FixedRate
+:basic-table-intro: The table below lists the configuration keys that configure io.helidon.scheduling.FixedRate
+include::{rootdir}/includes/attributes.adoc[]
+
+= FixedRate (scheduling) Configuration
+
+// tag::config[]
+
+
+Type: link:{javadoc-base-url}/io.helidon.scheduling/io/helidon/scheduling/FixedRate.html[io.helidon.scheduling.FixedRate]
+
+
+
+
+== Configuration options
+
+.Required configuration options
+[cols="3,3a,2,5a"]
+|===
+|key |type |default value |description
+
+|`delay` |long |{nbsp} |Fixed rate delay between each invocation. Time unit is by default java.util.concurrent.TimeUnit#SECONDS,
+ can be specified with io.helidon.scheduling.Scheduling.FixedRateBuilder#timeUnit(java.util.concurrent.TimeUnit).
+
+ @return delay between each invocation
+
+|===
+
+
+
+.Optional configuration options
+[cols="3,3a,2,5a"]
+
+|===
+|key |type |default value |description
+
+|`delay-type` |DelayType (SINCE_PREVIOUS_START, SINCE_PREVIOUS_END) |`@io.helidon.scheduling.FixedRate.DelayType@.SINCE_PREVIOUS_START` |Configure whether the delay between the invocations should be calculated from the time when previous task started or ended.
+ Delay type is by default FixedRate.DelayType#SINCE_PREVIOUS_START.
+
+ @return delay type
+|`initial-delay` |long |`0` |Initial delay of the first invocation. Time unit is by default java.util.concurrent.TimeUnit#SECONDS,
+ can be specified with
+ io.helidon.scheduling.Scheduling.FixedRateBuilder#timeUnit(java.util.concurrent.TimeUnit) timeUnit().
+
+ @return initial delay value
+|`time-unit` |TimeUnit (NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS) |`TimeUnit.SECONDS` |java.util.concurrent.TimeUnit TimeUnit used for interpretation of values provided with
+ io.helidon.scheduling.Scheduling.FixedRateBuilder#delay(long)
+ and io.helidon.scheduling.Scheduling.FixedRateBuilder#initialDelay(long).
+
+ @return time unit for interpreting values
+         in io.helidon.scheduling.Scheduling.FixedRateBuilder#delay(long)
+         and io.helidon.scheduling.Scheduling.FixedRateBuilder#initialDelay(long)
+
+|===
+
+// end::config[]

--- a/docs/config/io_helidon_scheduling_TaskConfig.adoc
+++ b/docs/config/io_helidon_scheduling_TaskConfig.adoc
@@ -1,0 +1,39 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+ifndef::rootdir[:rootdir: {docdir}/..]
+:description: Configuration of io.helidon.scheduling.TaskConfig
+:keywords: helidon, config, io.helidon.scheduling.TaskConfig
+:basic-table-intro: The table below lists the configuration keys that configure io.helidon.scheduling.TaskConfig
+include::{rootdir}/includes/attributes.adoc[]
+
+= TaskConfig (scheduling) Configuration
+
+// tag::config[]
+
+
+Type: link:{javadoc-base-url}/io.helidon.scheduling/io/helidon/scheduling/TaskConfig.html[io.helidon.scheduling.TaskConfig]
+
+
+
+
+== Configuration options
+
+
+
+// end::config[]

--- a/docs/se/scheduling.adoc
+++ b/docs/se/scheduling.adoc
@@ -32,6 +32,8 @@ include::{rootdir}/includes/se.adoc[]
 - <<Maven Coordinates, Maven Coordinates>>
 - <<Usage, Usage>>
 - <<Configuration, Configuration>>
+- <<Cron, Cron>>
+- <<Fixed rate, Fixed Rate>>
 - <<Examples, Examples>>
 - <<Reference, Reference>>
 
@@ -56,9 +58,9 @@ For scheduling periodic tasks, it is possible to choose a fixed rate or a Cron e
 === Fixed rate
 
 [source,java]
-.Scheduling with fixed rate use `Scheduling.fixedRateBuilder()` builder.
+.Scheduling with fixed rate use `Scheduling.fixedRate()` builder.
 ----
-Scheduling.fixedRateBuilder()
+Scheduling.fixedRate()
         .delay(10)
         .initialDelay(5)
         .timeUnit(TimeUnit.MINUTES)
@@ -72,39 +74,31 @@ FixedRateInvocation provided as task parameter.
 [source,java]
 .Invocation metadata
 ----
-Scheduling.fixedRateBuilder()
+Scheduling.fixedRate()
         .delay(10)
         .task(inv -> System.out.println("Method invoked " + inv.description()))
         .build();
 ----
 
-=== Cron expression
+include::{rootdir}/config/io_helidon_scheduling_FixedRate.adoc[tag=config,leveloffset=+2]
+
+=== Cron
 
 For more complicated interval definition, Cron expression can be leveraged with
-`Scheduling.cronBuilder()` builder.
+`Scheduling.cron()` builder.
 
 [source,java]
 .Scheduling with Cron expression
 ----
-Scheduling.cronBuilder()
+Scheduling.cron()
     .expression("0 15 8 ? * *")
     .task(inv -> System.out.println("Executer every day at 8:15"))
     .build();
 ----
 
-== Configuration
+include::{rootdir}/config/io_helidon_scheduling_Cron.adoc[tag=config,leveloffset=+2]
 
-Configuration properties are added to `application.yaml` file:
-
-.Configuration properties
-[width="90%",cols="3,10",frame="topbot",options="header"]
-|====
-| Property              | Description
-| cron                  | String containing Cron setup
-| concurrent            | Boolean, equivalent `concurrentExecution` property of `@Scheduled`. Default `true`.
-|====
-
-=== Cron expression
+=== Cron expression syntax
 
 Cron expressions should be configured as follows.
 
@@ -113,15 +107,34 @@ include::{rootdir}/includes/cron.adoc[lines=19..]
 Metadata like human-readable interval description or configured values are available through
 CronInvocation provided as task parameter.
 
+== Configuration
+Scheduling is configurable with xref:../se/config/introduction.adoc[Helidon Config].
+
+[source,java]
+.Example of configuring
+----
+Scheduling.fixedRate()
+    .config(Config.create(() -> ConfigSources.create(
+    """
+    delay: 4
+    delay-type: SINCE_PREVIOUS_END
+    initial-delay: 1
+    time-unit: SECONDS
+    """, MediaTypes.APPLICATION_X_YAML)))
+    .task(inv -> System.out.println("Every 4 minutes, first invocation 1 minutes after start"))
+    .build();
+----
+
+
 == Examples
 
 === Fixed rate
 For simple fixed rate invocation use .
 
 [source,java]
-.Example of scheduling with fixed rate use `Scheduling.fixedRateBuilder()` builder.
+.Example of scheduling with fixed rate use `Scheduling.fixedRate()` builder.
 ----
-Scheduling.fixedRateBuilder()
+Scheduling.fixedRate()
         .delay(10)
         .initialDelay(5)
         .timeUnit(TimeUnit.MINUTES)
@@ -136,7 +149,7 @@ Metadata like human-readable interval description or configured values are avail
 [source,java]
 .Example with invocation metadata
 ----
-Scheduling.fixedRateBuilder()
+Scheduling.fixedRate()
         .delay(10)
         .task(inv -> System.out.println("Method invoked " + inv.description()))
         .build();

--- a/microprofile/scheduling/src/main/java/io/helidon/microprofile/scheduling/FixedRate.java
+++ b/microprofile/scheduling/src/main/java/io/helidon/microprofile/scheduling/FixedRate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
+import io.helidon.scheduling.FixedRate.DelayType;
+
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Scheduled to be invoked periodically at fixed rate.
+ * Scheduled to be invoked periodically at fixed rate. Fixed rate tasks are never invoked concurrently.
  * Value is interpreted as seconds by default, can be overridden by {@link #timeUnit()}.
  */
 @Retention(RUNTIME)
@@ -51,4 +53,11 @@ public @interface FixedRate {
      * @return time unit for evaluating supplied values
      */
     TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * Whether the delay should be calculated from the start or end of the previous task.
+     *
+     * @return delay type
+     */
+    DelayType delayType() default DelayType.SINCE_PREVIOUS_START;
 }

--- a/scheduling/pom.xml
+++ b/scheduling/pom.xml
@@ -16,8 +16,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon</groupId>
@@ -84,8 +84,40 @@
                             <artifactId>helidon-common-features-processor</artifactId>
                             <version>${helidon.version}</version>
                         </path>
+                        <path>
+                            <groupId>io.helidon.config</groupId>
+                            <artifactId>helidon-config-metadata-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.common.processor</groupId>
+                            <artifactId>helidon-common-processor-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.config</groupId>
+                        <artifactId>helidon-config-metadata-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.common.processor</groupId>
+                        <artifactId>helidon-common-processor-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/scheduling/src/main/java/io/helidon/scheduling/Cron.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/Cron.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.scheduling;
+
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+
+/**
+ * Scheduling periodically executed task with specified cron expression.
+ *
+ * <pre>{@code
+ * Scheduling.cron()
+ *      .expression("0 45 9 ? * *")
+ *      .task(inv -> System.out.println("Executed every day at 9:45"))
+ *      .build()
+ * }</pre>
+ */
+@RuntimeType.PrototypedBy(CronConfig.class)
+public interface Cron extends RuntimeType.Api<CronConfig>, Task {
+
+    /**
+     * Create a new fluent API builder to build a cron task.
+     *
+     * @return a builder instance
+     */
+    static CronConfig.Builder builder() {
+        return CronConfig.builder();
+    }
+
+    /**
+     * Create a cron task from configuration.
+     *
+     * @param configConsumer config consumer
+     * @return a new cron task configured from config
+     */
+    static Cron create(Consumer<CronConfig.Builder> configConsumer) {
+        return builder().update(configConsumer).build();
+    }
+
+    /**
+     * Create a cron task from programmatic configuration.
+     *
+     * @param config configuration
+     * @return a new cron task
+     */
+    static Cron create(CronConfig config) {
+        return new CronTask(config);
+    }
+}

--- a/scheduling/src/main/java/io/helidon/scheduling/CronConfigBlueprint.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/CronConfigBlueprint.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.scheduling;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.Configured
+interface CronConfigBlueprint extends TaskConfigBlueprint, Prototype.Factory<Cron> {
+
+    /**
+     * Cron expression for specifying period of execution.
+     * <p>
+     * <b>Examples:</b>
+     * <ul>
+     * <li>{@code 0/2 * * * * ? *} - Every 2 seconds</li>
+     * <li>{@code 0 45 9 ? * *} - Every day at 9:45</li>
+     * <li>{@code 0 15 8 ? * MON-FRI} - Every workday at 8:15</li>
+     * </ul>
+     *
+     * @return cron expression
+     */
+    @Option.Configured
+    @Option.Required
+    String expression();
+
+    /**
+     * Allow concurrent execution if previous task didn't finish before next execution.
+     * Default value is {@code true}.
+     *
+     * @return true for allow concurrent execution.
+     */
+    @Option.Configured("concurrent")
+    @Option.DefaultBoolean(true)
+    boolean concurrentExecution();
+
+    /**
+     * Task to be scheduled for execution.
+     *
+     * @return scheduled for execution
+     */
+    ScheduledConsumer<CronInvocation> task();
+}

--- a/scheduling/src/main/java/io/helidon/scheduling/FixedRate.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/FixedRate.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.scheduling;
+
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+
+/**
+ * Scheduling periodically executed task with specified fixed rate.
+ *
+ * <pre>{@code
+ * Scheduling.fixedRate()
+ *      .delay(2)
+ *      .task(inv -> System.out.println("Executed every 2 seconds"))
+ *      .build();
+ * }</pre>
+ */
+@RuntimeType.PrototypedBy(FixedRateConfig.class)
+public interface FixedRate extends RuntimeType.Api<FixedRateConfig>, Task {
+
+    /**
+     * Create a new fluent API builder to build a fixed rate task.
+     *
+     * @return a builder instance
+     */
+    static FixedRateConfig.Builder builder() {
+        return FixedRateConfig.builder();
+    }
+
+    /**
+     * Create a fixed rate task from configuration.
+     *
+     * @param configConsumer config consumer
+     * @return a new fixed rate task configured from config
+     */
+    static FixedRate create(Consumer<FixedRateConfig.Builder> configConsumer) {
+        return builder().update(configConsumer).build();
+    }
+
+    /**
+     * Create a fixed rate task from programmatic configuration.
+     *
+     * @param config configuration
+     * @return a new fixed rate task
+     */
+    static FixedRate create(FixedRateConfig config) {
+        return new FixedRateTask(config);
+    }
+
+    /**
+     * Whether the delay should be calculated from the start or end of the previous task.
+     */
+    enum DelayType {
+        /**
+         * Next invocation delay is measured from the previous invocation task start.
+         */
+        SINCE_PREVIOUS_START,
+        /**
+         * Next invocation delay is measured from the previous invocation task end.
+         */
+        SINCE_PREVIOUS_END
+    }
+}

--- a/scheduling/src/main/java/io/helidon/scheduling/FixedRateConfigBlueprint.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/FixedRateConfigBlueprint.java
@@ -21,14 +21,14 @@ import java.util.concurrent.TimeUnit;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
-@Prototype.Blueprint(decorator = TaskConfigBlueprint.TaskConfigDecorator.class)
+@Prototype.Blueprint(decorator = TaskConfigDecorator.class)
 @Prototype.Configured
 interface FixedRateConfigBlueprint extends TaskConfigBlueprint, Prototype.Factory<FixedRate> {
 
     /**
      * Initial delay of the first invocation. Time unit is by default {@link java.util.concurrent.TimeUnit#SECONDS},
      * can be specified with
-     * {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#timeUnit(java.util.concurrent.TimeUnit) timeUnit()}.
+     * {@link io.helidon.scheduling.FixedRateConfig.Builder#timeUnit(java.util.concurrent.TimeUnit) timeUnit()}.
      *
      * @return initial delay value
      */
@@ -38,7 +38,7 @@ interface FixedRateConfigBlueprint extends TaskConfigBlueprint, Prototype.Factor
 
     /**
      * Fixed rate delay between each invocation. Time unit is by default {@link java.util.concurrent.TimeUnit#SECONDS},
-     * can be specified with {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#timeUnit(java.util.concurrent.TimeUnit)}.
+     * can be specified with {@link io.helidon.scheduling.FixedRateConfig.Builder#timeUnit(java.util.concurrent.TimeUnit)}.
      *
      * @return delay between each invocation
      */
@@ -53,7 +53,7 @@ interface FixedRateConfigBlueprint extends TaskConfigBlueprint, Prototype.Factor
      * @return delay type
      */
     @Option.Configured
-    @Option.DefaultCode("@io.helidon.scheduling.FixedRate.DelayType@.SINCE_PREVIOUS_START")
+    @Option.Default("SINCE_PREVIOUS_START")
     FixedRate.DelayType delayType();
 
     /**
@@ -65,12 +65,12 @@ interface FixedRateConfigBlueprint extends TaskConfigBlueprint, Prototype.Factor
 
     /**
      * {@link java.util.concurrent.TimeUnit TimeUnit} used for interpretation of values provided with
-     * {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#delay(long)}
-     * and {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#initialDelay(long)}.
+     * {@link io.helidon.scheduling.FixedRateConfig.Builder#delay(long)}
+     * and {@link io.helidon.scheduling.FixedRateConfig.Builder#initialDelay(long)}.
      *
      * @return time unit for interpreting values
-     *         in {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#delay(long)}
-     *         and {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#initialDelay(long)}
+     *         in {@link io.helidon.scheduling.FixedRateConfig.Builder#delay(long)}
+     *         and {@link io.helidon.scheduling.FixedRateConfig.Builder#initialDelay(long)}
      */
     @Option.Configured
     @Option.Default("TimeUnit.SECONDS")

--- a/scheduling/src/main/java/io/helidon/scheduling/FixedRateConfigBlueprint.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/FixedRateConfigBlueprint.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.scheduling;
+
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint(decorator = TaskConfigBlueprint.TaskConfigDecorator.class)
+@Prototype.Configured
+interface FixedRateConfigBlueprint extends TaskConfigBlueprint, Prototype.Factory<FixedRate> {
+
+    /**
+     * Initial delay of the first invocation. Time unit is by default {@link java.util.concurrent.TimeUnit#SECONDS},
+     * can be specified with
+     * {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#timeUnit(java.util.concurrent.TimeUnit) timeUnit()}.
+     *
+     * @return initial delay value
+     */
+    @Option.Configured
+    @Option.DefaultLong(0)
+    long initialDelay();
+
+    /**
+     * Fixed rate delay between each invocation. Time unit is by default {@link java.util.concurrent.TimeUnit#SECONDS},
+     * can be specified with {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#timeUnit(java.util.concurrent.TimeUnit)}.
+     *
+     * @return delay between each invocation
+     */
+    @Option.Configured
+    @Option.Required
+    long delay();
+
+    /**
+     * Configure whether the delay between the invocations should be calculated from the time when previous task started or ended.
+     * Delay type is by default {@link FixedRate.DelayType#SINCE_PREVIOUS_START}.
+     *
+     * @return delay type
+     */
+    @Option.Configured
+    @Option.DefaultCode("@io.helidon.scheduling.FixedRate.DelayType@.SINCE_PREVIOUS_START")
+    FixedRate.DelayType delayType();
+
+    /**
+     * Task to be scheduled for execution.
+     *
+     * @return scheduled for execution
+     */
+    ScheduledConsumer<FixedRateInvocation> task();
+
+    /**
+     * {@link java.util.concurrent.TimeUnit TimeUnit} used for interpretation of values provided with
+     * {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#delay(long)}
+     * and {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#initialDelay(long)}.
+     *
+     * @return time unit for interpreting values
+     *         in {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#delay(long)}
+     *         and {@link io.helidon.scheduling.Scheduling.FixedRateBuilder#initialDelay(long)}
+     */
+    @Option.Configured
+    @Option.Default("TimeUnit.SECONDS")
+    TimeUnit timeUnit();
+
+}

--- a/scheduling/src/main/java/io/helidon/scheduling/Scheduling.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/Scheduling.java
@@ -48,9 +48,9 @@ public class Scheduling {
      * Build a task executed periodically at a fixed rate.
      *
      * @return this builder
-     * @deprecated
+     * @deprecated use {@link #fixedRate()} instead
      */
-    @Deprecated(since = "4.0.2")
+    @Deprecated(since = "4.0.2", forRemoval = true)
     public static FixedRateBuilder fixedRateBuilder() {
         return new FixedRateBuilder();
     }
@@ -68,8 +68,9 @@ public class Scheduling {
      * Build a task executed periodically according to provided cron expression.
      *
      * @return this builder
+     * @deprecated use {@link #cron()} instead
      */
-    @Deprecated(since = "4.0.2")
+    @Deprecated(since = "4.0.2", forRemoval = true)
     public static CronBuilder cronBuilder() {
         return new CronBuilder();
     }
@@ -85,8 +86,10 @@ public class Scheduling {
 
     /**
      * Builder for task executed periodically at a fixed rate.
+     *
+     * @deprecated use {@link io.helidon.scheduling.FixedRateConfig.Builder} instead
      */
-    @Deprecated(since = "4.0.2")
+    @Deprecated(since = "4.0.2", forRemoval = true)
     public static final class FixedRateBuilder implements io.helidon.common.Builder<FixedRateBuilder, Task> {
 
         private ScheduledExecutorService executorService;
@@ -186,8 +189,10 @@ public class Scheduling {
 
     /**
      * Builder for task executed periodically according to provided cron expression.
+     *
+     * @deprecated use {@link io.helidon.scheduling.CronConfig.Builder} instead
      */
-    @Deprecated(since = "4.0.2")
+    @Deprecated(since = "4.0.2", forRemoval = true)
     public static final class CronBuilder implements io.helidon.common.Builder<CronBuilder, Task> {
 
         static final String DEFAULT_THREAD_NAME_PREFIX = "scheduled-";

--- a/scheduling/src/main/java/io/helidon/scheduling/Scheduling.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/Scheduling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,20 @@ public class Scheduling {
      * Build a task executed periodically at a fixed rate.
      *
      * @return this builder
+     * @deprecated
      */
+    @Deprecated(since = "4.0.2")
     public static FixedRateBuilder fixedRateBuilder() {
         return new FixedRateBuilder();
+    }
+
+    /**
+     * Build a task executed periodically at a fixed rate.
+     *
+     * @return this builder
+     */
+    public static FixedRateConfig.Builder fixedRate() {
+        return FixedRate.builder();
     }
 
     /**
@@ -58,13 +69,24 @@ public class Scheduling {
      *
      * @return this builder
      */
+    @Deprecated(since = "4.0.2")
     public static CronBuilder cronBuilder() {
         return new CronBuilder();
     }
 
     /**
+     * Build a task executed periodically according to provided cron expression.
+     *
+     * @return this builder
+     */
+    public static CronConfig.Builder cron() {
+        return Cron.builder();
+    }
+
+    /**
      * Builder for task executed periodically at a fixed rate.
      */
+    @Deprecated(since = "4.0.2")
     public static final class FixedRateBuilder implements io.helidon.common.Builder<FixedRateBuilder, Task> {
 
         private ScheduledExecutorService executorService;
@@ -151,14 +173,21 @@ public class Scheduling {
                         .build()
                         .get();
             }
-            return new FixedRateTask(executorService, initialDelay, delay, timeUnit,
-                    invocation -> task.run((FixedRateInvocation) invocation));
+            return FixedRate.builder()
+                    .executor(executorService)
+                    .initialDelay(initialDelay)
+                    .delay(delay)
+                    .delayType(FixedRate.DelayType.SINCE_PREVIOUS_START)
+                    .timeUnit(timeUnit)
+                    .task(task)
+                    .build();
         }
     }
 
     /**
      * Builder for task executed periodically according to provided cron expression.
      */
+    @Deprecated(since = "4.0.2")
     public static final class CronBuilder implements io.helidon.common.Builder<CronBuilder, Task> {
 
         static final String DEFAULT_THREAD_NAME_PREFIX = "scheduled-";
@@ -240,10 +269,13 @@ public class Scheduling {
                         .get();
             }
 
-            CronTask task = new CronTask(executorService, cronExpression, concurrentExecution,
-                    invocation -> this.task.run((CronInvocation) invocation));
+            return Cron.builder()
+                    .executor(executorService)
+                    .expression(cronExpression)
+                    .concurrentExecution(concurrentExecution)
+                    .task(task)
+                    .build();
 
-            return task;
         }
     }
 }

--- a/scheduling/src/main/java/io/helidon/scheduling/TaskConfigBlueprint.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/TaskConfigBlueprint.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.scheduling;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.configurable.ScheduledThreadPoolSupplier;
+
+@Prototype.Blueprint(decorator = TaskConfigBlueprint.TaskConfigDecorator.class)
+@Prototype.Configured
+interface TaskConfigBlueprint {
+
+    /**
+     * Custom {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} used for executing scheduled task.
+     *
+     * @return custom ScheduledExecutorService
+     */
+    ScheduledExecutorService executor();
+
+    class TaskConfigDecorator implements Prototype.BuilderDecorator<TaskConfig.BuilderBase<?, ?>> {
+
+        @Override
+        public void decorate(TaskConfig.BuilderBase<?, ?> target) {
+            if (target.executor().isEmpty()) {
+                target.executor(ScheduledThreadPoolSupplier.builder()
+                                        .threadNamePrefix("scheduled-")
+                                        .build()
+                                        .get());
+            }
+        }
+    }
+}

--- a/scheduling/src/main/java/io/helidon/scheduling/TaskConfigDecorator.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/TaskConfigDecorator.java
@@ -16,19 +16,18 @@
 
 package io.helidon.scheduling;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.configurable.ScheduledThreadPoolSupplier;
 
-@Prototype.Blueprint(decorator = TaskConfigDecorator.class)
-@Prototype.Configured
-interface TaskConfigBlueprint {
+class TaskConfigDecorator implements Prototype.BuilderDecorator<TaskConfig.BuilderBase<?, ?>> {
 
-    /**
-     * Custom {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} used for executing scheduled task.
-     *
-     * @return custom ScheduledExecutorService
-     */
-    ScheduledExecutorService executor();
-
+    @Override
+    public void decorate(TaskConfig.BuilderBase<?, ?> target) {
+        if (target.executor().isEmpty()) {
+            target.executor(ScheduledThreadPoolSupplier.builder()
+                                    .threadNamePrefix("scheduled-")
+                                    .build()
+                                    .get());
+        }
+    }
 }

--- a/scheduling/src/main/java/module-info.java
+++ b/scheduling/src/main/java/module-info.java
@@ -21,15 +21,16 @@ import io.helidon.common.features.api.HelidonFlavor;
  * Scheduling module for Helidon reactive implementation.
  */
 @Feature(value = "Scheduling",
-        description = "Scheduling of periodical tasks",
-        in = HelidonFlavor.SE,
-        path = "Scheduling"
+         description = "Scheduling of periodical tasks",
+         in = HelidonFlavor.SE,
+         path = "Scheduling"
 )
 module io.helidon.scheduling {
 
     requires com.cronutils;
     requires io.helidon.common.config;
     requires io.helidon.common.configurable;
+    requires io.helidon.builder.api;
 
     requires static io.helidon.common.features.api;
 


### PR DESCRIPTION
Fixes #8059

Adds `delay-type` config property to fixed rate, so user can choose to set delay from previous execution end or start. 

```java
Scheduling.fixedRate()
                    .executor(executorService)
                    .delayType(FixedRate.DelayType.SINCE_PREVIOUS_END)
```