### PR TITLE
Add proper handling of `content-read` and `content-write` logs within `HTTP Request` tracing span

### DIFF
--- a/docs/includes/tracing/common-spans.adoc
+++ b/docs/includes/tracing/common-spans.adoc
@@ -42,7 +42,7 @@ is used.
 
 Some of these spans `log` to the span. These log events can be (in most cases) configured:
 
-[cols="2,2,2,4", role="flex, sm10"]
+[cols="2,2,2,4,", role="flex, sm10"]
 |===
 |span name          |log name               |configurable   |enabled by default |description
 


### PR DESCRIPTION
### Description
Resolves #8103 

1. Before adding the `content-write` log to the `HTTP Request` span, the `TracingObserver` code did not check to see if `content-write` was enabled or not.
2. `TracingObserver` did not deal with `content-read` at all.
3. There was a formatting problem on the tracing doc page.

The first commit  addresses these, at least initially.

The doc (and previous releases?) added a `requested.type` tag to `content-read` and `response.type` to `content-write`. The current 4.x code does not do either. A subsequent commit for this PR might address that. TBD.

### Documentation
This is a bug fix. No doc changes (except for correcting the formatting problem) _unless_ we decide not to support the tags on the logs for `HTTP Request` in which case we'll need to remove the doc reference to those.