### PR TITLE
Remove doc for tags on `content-read` and `content-write` spans; the tags are no longer added by the code in 4.x

### DIFF
--- a/docs/includes/tracing/common-spans.adoc
+++ b/docs/includes/tracing/common-spans.adoc
@@ -66,8 +66,6 @@ There are also tags that are set by Helidon components. These are not configurab
 |`HTTP Request`         |`http.status_code` |HTTP status code of the response
 |`HTTP Request`         |`http.url`         |The path of the request (for SE without protocol, host and port)
 |`HTTP Request`         |`error`            |If the request ends in error, this tag is set to `true`, usually accompanied by logs with details
-|`content-read`         |`requested.type`   |Type (class) of the requested entity (if entity is read)
-|`content-write`        |`response.type`    |Type (class) of the entity being sent (if entity is sent)
 |`security`             |`security.id`      |ID of the security context created for this request (if security is used)
 |`jersey-client-call`   |`http.method`      |HTTP method of the client request
 |`jersey-client-call`   |`http.status_code` |HTTP status code of client response


### PR DESCRIPTION
### Description
Resolves #8107 

In prior releases, Helidon added tracing tags to the `HTTP Request` `content-read` and `content-write` spans identifying the type written or read in the entity.

That behavior has intentionally been removed from the code in 4.x, so this PR updates the doc to remove references to those tags.

### Documentation
This is a doc PR.