### PR TITLE
Update gRPC version to 1.60.0

### DIFF
--- a/config/etcd/pom.xml
+++ b/config/etcd/pom.xml
@@ -57,8 +57,12 @@
         </dependency>
         <!-- etcd v3 -->
         <dependency>
-            <groupId>io.helidon.grpc</groupId>
-            <artifactId>io.grpc</artifactId>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/config/etcd/src/main/java/module-info.java
+++ b/config/etcd/src/main/java/module-info.java
@@ -24,9 +24,9 @@ module io.helidon.config.etcd {
     requires java.logging;
     requires transitive io.helidon.config;
     requires etcd4j;
-    requires grpc.protobuf;
-    requires grpc.stub;
-    requires grpc.api;
+    requires io.grpc.protobuf;
+    requires io.grpc.stub;
+    requires io.grpc;
     requires com.google.protobuf;
     requires com.google.common;
     requires io.helidon.common;

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -61,7 +61,7 @@
         <version.lib.graphql-java>18.6</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>18.3</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
-        <version.lib.grpc>1.57.1</version.lib.grpc>
+        <version.lib.grpc>1.60.0</version.lib.grpc>
         <version.lib.guava>32.0.1-jre</version.lib.guava>
         <version.lib.h2>2.1.212</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelDescriptor.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelDescriptor.java
@@ -102,7 +102,7 @@ public class GrpcChannelDescriptor {
 
     /**
      * Get the {@link NameResolver.Factory} to use.
-     * <p/>
+     * <p>
      * This method is deprecated due to the deprecation of the
      * {@link io.grpc.ManagedChannelBuilder#nameResolverFactory(io.grpc.NameResolver.Factory)}
      * method in the gRPC Java API.
@@ -228,7 +228,7 @@ public class GrpcChannelDescriptor {
         /**
          * Set the {@link io.grpc.NameResolver.Factory} to use.
          * @param factory the {@link io.grpc.NameResolver.Factory} to use
-         * <p/>
+         * <p>
          * This method is deprecated due to the deprecation of the
          * {@link io.grpc.ManagedChannelBuilder#nameResolverFactory(io.grpc.NameResolver.Factory)}
          * method in the gRPC Java API.

--- a/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelDescriptor.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelDescriptor.java
@@ -102,9 +102,14 @@ public class GrpcChannelDescriptor {
 
     /**
      * Get the {@link NameResolver.Factory} to use.
+     * <p/>
+     * This method is deprecated due to the deprecation of the
+     * {@link io.grpc.ManagedChannelBuilder#nameResolverFactory(io.grpc.NameResolver.Factory)}
+     * method in the gRPC Java API.
      *
      * @return the optional {@link NameResolver.Factory} to use
      */
+    @Deprecated
     public Optional<NameResolver.Factory> nameResolverFactory() {
         return Optional.ofNullable(nameResolver);
     }
@@ -223,11 +228,16 @@ public class GrpcChannelDescriptor {
         /**
          * Set the {@link io.grpc.NameResolver.Factory} to use.
          * @param factory the {@link io.grpc.NameResolver.Factory} to use
+         * <p/>
+         * This method is deprecated due to the deprecation of the
+         * {@link io.grpc.ManagedChannelBuilder#nameResolverFactory(io.grpc.NameResolver.Factory)}
+         * method in the gRPC Java API.
          *
          * @return this instance for fluent API
          *
          * @see io.grpc.ManagedChannelBuilder#nameResolverFactory(io.grpc.NameResolver.Factory)
          */
+        @Deprecated
         public Builder nameResolverFactory(NameResolver.Factory factory) {
             this.nameResolver = factory;
             return this;

--- a/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelDescriptor.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelsProvider.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelsProvider.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/GrpcChannelsProvider.java
@@ -155,6 +155,7 @@ public class GrpcChannelsProvider {
         return channelConfigs;
     }
 
+    @SuppressWarnings("deprecation")
     private ManagedChannel createChannel(GrpcChannelDescriptor descriptor) {
         ManagedChannelBuilder<?> builder = descriptor.tlsDescriptor()
                 .map(tlsDescriptor -> createNettyChannelBuilder(descriptor, tlsDescriptor))

--- a/grpc/client/src/main/java/module-info.java
+++ b/grpc/client/src/main/java/module-info.java
@@ -20,6 +20,9 @@
 module io.helidon.grpc.client {
     exports io.helidon.grpc.client;
 
+    requires io.grpc.netty;
+    requires io.netty.handler;
+
     requires transitive io.helidon.grpc.core;
 
     requires io.helidon.tracing;

--- a/grpc/client/src/main/java/module-info.java
+++ b/grpc/client/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderIT.java
+++ b/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ import io.helidon.grpc.server.GrpcServer;
 import io.helidon.grpc.server.GrpcServerConfiguration;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
 import io.grpc.StatusRuntimeException;
 
 import io.netty.handler.codec.DecoderException;
@@ -209,12 +211,11 @@ public class GrpcChannelsProviderIT {
 
     @Test
     public void shouldUseTarget() throws Exception {
-        FakeNameResolverFactory factory = new FakeNameResolverFactory(portNoSsl);
+        NameResolverRegistry.getDefaultRegistry().register(new FakeNameResolverProvider("foo", portNoSsl));
         String channelKey = "ChannelKey";
         GrpcChannelDescriptor.Builder builder = GrpcChannelDescriptor
                 .builder()
-                .target("foo://bar.com")
-                .nameResolverFactory(factory);
+                .target("foo://bar.com");
 
         GrpcChannelsProvider provider = GrpcChannelsProvider.builder()
                 .channel(channelKey, builder.build())
@@ -304,6 +305,39 @@ public class GrpcChannelsProviderIT {
         }
     }
 
+    private static class FakeNameResolverProvider extends NameResolverProvider {
+        private final String scheme;
+        private final int port;
+        private URI targetUri;
+        private NameResolver.Args args;
+
+        public FakeNameResolverProvider(String scheme, int port) {
+            this.scheme = scheme;
+            this.port = port;
+        }
+
+        @Override
+        protected boolean isAvailable() {
+            return true;
+        }
+
+        @Override
+        protected int priority() {
+            return 0;
+        }
+
+        @Override
+        public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+            this.targetUri = targetUri;
+            this.args = args;
+            return new FakeNameResolver(port);
+        }
+
+        @Override
+        public String getDefaultScheme() {
+            return scheme;
+        }
+    }
 
     private static class FakeNameResolver extends NameResolver {
         private final int port;

--- a/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderTest.java
+++ b/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderTest.java
+++ b/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("deprecation")
 public class GrpcChannelsProviderTest {
 
     private static final String CLIENT_CERT = "ssl/clientCert.pem";

--- a/grpc/core/pom.xml
+++ b/grpc/core/pom.xml
@@ -44,33 +44,27 @@
             <groupId>io.helidon.tracing</groupId>
             <artifactId>helidon-tracing</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.helidon.grpc</groupId>
-            <artifactId>io.grpc</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-inprocess</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-services</artifactId>
             <exclusions>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-stub</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-core</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>com.google.j2objc</groupId>
                     <artifactId>j2objc-annotations</artifactId>
@@ -80,29 +74,11 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <exclusions>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-api</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>com.google.j2objc</groupId>
                     <artifactId>j2objc-annotations</artifactId>

--- a/grpc/core/src/main/java/module-info.java
+++ b/grpc/core/src/main/java/module-info.java
@@ -31,11 +31,11 @@ module io.helidon.grpc.core {
     requires io.helidon.common.context;
     requires io.helidon.common.http;
 
-    requires grpc.netty;
-    requires transitive grpc.protobuf;
-    requires grpc.protobuf.lite;
-    requires transitive grpc.stub;
-    requires transitive grpc.api;
+    requires io.grpc.netty;
+    requires transitive io.grpc.protobuf;
+    requires io.grpc.protobuf.lite;
+    requires transitive io.grpc.stub;
+    requires transitive io.grpc;
     requires io.netty.handler;
     requires io.netty.transport;
     requires transitive com.google.protobuf;

--- a/grpc/io.grpc/pom.xml
+++ b/grpc/io.grpc/pom.xml
@@ -33,6 +33,7 @@
     <description>Bundle of grpc dependencies provided for backwards compatibility</description>
 
     <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
         <spotbugs.skip>true</spotbugs.skip>
     </properties>
 

--- a/grpc/io.grpc/pom.xml
+++ b/grpc/io.grpc/pom.xml
@@ -32,6 +32,10 @@
     <name>Helidon grpc-java Bundle</name>
     <description>Bundle of grpc dependencies provided for backwards compatibility</description>
 
+    <properties>
+        <spotbugs.skip>true</spotbugs.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/grpc/io.grpc/src/main/java/module-info.java
+++ b/grpc/io.grpc/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The deprecated repackaged gRPC Module.
+ */
+module io.helidon.grpc.deprecated {
+}

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
@@ -16,6 +16,8 @@
 
 package io.helidon.grpc.server;
 
+import java.time.Duration;
+
 import io.helidon.common.context.Context;
 import io.helidon.grpc.core.GrpcTlsDescriptor;
 import io.helidon.tracing.Tracer;
@@ -42,7 +44,10 @@ public class GrpcServerBasicConfig
 
     private final Context context;
 
-    private final int maxRstFramesPerSecond;
+    private final int maxRapidResets;
+
+    private final Duration rapidResetCheckPeriod;
+
     /**
      * Construct {@link GrpcServerBasicConfig} instance.
      *
@@ -58,7 +63,8 @@ public class GrpcServerBasicConfig
         this.tracingConfig = builder.tracingConfig();
         this.workers = builder.workers();
         this.tlsConfig = builder.tlsConfig();
-        this.maxRstFramesPerSecond = builder.maxRstFramesPerSecond();
+        this.maxRapidResets = builder.maxRapidResets();
+        this.rapidResetCheckPeriod = builder.rapidResetCheckPeriod();
     }
 
     /**
@@ -136,7 +142,12 @@ public class GrpcServerBasicConfig
     }
 
     @Override
-    public int maxRstFramesPerSecond() {
-        return maxRstFramesPerSecond;
+    public Duration rapidResetCheckPeriod() {
+        return rapidResetCheckPeriod;
+    }
+
+    @Override
+    public int maxRapidResets() {
+        return maxRapidResets;
     }
 }

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
@@ -42,6 +42,7 @@ public class GrpcServerBasicConfig
 
     private final Context context;
 
+    private final int maxRstFramesPerSecond;
     /**
      * Construct {@link GrpcServerBasicConfig} instance.
      *
@@ -57,6 +58,7 @@ public class GrpcServerBasicConfig
         this.tracingConfig = builder.tracingConfig();
         this.workers = builder.workers();
         this.tlsConfig = builder.tlsConfig();
+        this.maxRstFramesPerSecond = builder.maxRstFramesPerSecond();
     }
 
     /**
@@ -131,5 +133,10 @@ public class GrpcServerBasicConfig
     @Override
     public GrpcTlsDescriptor tlsConfig() {
         return tlsConfig;
+    }
+
+    @Override
+    public int maxRstFramesPerSecond() {
+        return maxRstFramesPerSecond;
     }
 }

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
@@ -184,9 +184,9 @@ public interface GrpcServerConfiguration {
 
         private Context context;
 
-        private int maxRapidResets;
+        private int maxRapidResets = 200;
 
-        private Duration rapidResetCheckPeriod;
+        private Duration rapidResetCheckPeriod = Duration.ofSeconds(30);
 
         private Builder() {
         }

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -178,17 +179,15 @@ public class GrpcServerImpl implements GrpcServer {
 
             HandlerRegistry handlerRegistry = this.handlerRegistry;
 
-            int maxRstFramesPerSecond = config.maxRstFramesPerSecond();
-            if (maxRstFramesPerSecond <= 0) {
-                maxRstFramesPerSecond = Integer.MAX_VALUE;
-            }
+            int maxRapidResets = config.maxRapidResets();
+            Duration rapidResetCheckPeriod = config.rapidResetCheckPeriod();
 
             server = configureNetty(builder)
                     .directExecutor()
                     .addService(healthService)
                     .addService(ProtoReflectionService.newInstance())
                     .fallbackHandlerRegistry(handlerRegistry)
-                    .maxRstFramesPerWindow(maxRstFramesPerSecond, 1)
+                    .maxRstFramesPerWindow(maxRapidResets, (int) rapidResetCheckPeriod.toSeconds())
                     .build()
                     .start();
 

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
@@ -178,11 +178,17 @@ public class GrpcServerImpl implements GrpcServer {
 
             HandlerRegistry handlerRegistry = this.handlerRegistry;
 
+            int maxRstFramesPerSecond = config.maxRstFramesPerSecond();
+            if (maxRstFramesPerSecond <= 0) {
+                maxRstFramesPerSecond = Integer.MAX_VALUE;
+            }
+
             server = configureNetty(builder)
                     .directExecutor()
                     .addService(healthService)
                     .addService(ProtoReflectionService.newInstance())
                     .fallbackHandlerRegistry(handlerRegistry)
+                    .maxRstFramesPerWindow(maxRstFramesPerSecond, 1)
                     .build()
                     .start();
 

--- a/grpc/server/src/main/java/module-info.java
+++ b/grpc/server/src/main/java/module-info.java
@@ -28,8 +28,15 @@ module io.helidon.grpc.server {
     requires transitive io.helidon.health;
     requires io.helidon.tracing;
 
-    requires transitive grpc.services;
-    requires transitive grpc.core;
+    requires transitive io.grpc;
+    requires transitive io.grpc.inprocess;
+    requires transitive io.grpc.internal;
+    requires transitive io.grpc.services;
+    requires io.grpc.netty;
+    requires io.grpc.util;
+    requires io.netty.transport;
+    requires io.netty.handler;
+    requires io.netty.common;
     requires transitive microprofile.health.api;
 
     requires jakarta.annotation;

--- a/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServerConfigurationTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServerConfigurationTest.java
@@ -226,33 +226,33 @@ public class GrpcServerConfigurationTest {
         GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
                 .build();
 
-        assertThat(configuration.maxRstFramesPerSecond(), is(Integer.MAX_VALUE));
+        assertThat(configuration.maxRapidResets(), is(200));
     }
 
     @Test
     public void shouldSetMaxRstFrames() {
         GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
-                .maxRstFramesPerSecond(19)
+                .maxRapidResets(19)
                 .build();
 
-        assertThat(configuration.maxRstFramesPerSecond(), is(19));
+        assertThat(configuration.maxRapidResets(), is(19));
     }
 
     @Test
     public void shouldSetMaxRstFramesToZero() {
         GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
-                .maxRstFramesPerSecond(0)
+                .maxRapidResets(0)
                 .build();
 
-        assertThat(configuration.maxRstFramesPerSecond(), is(Integer.MAX_VALUE));
+        assertThat(configuration.maxRapidResets(), is(200));
     }
 
     @Test
     public void shouldSetMaxRstFramesToLessThanZero() {
         GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
-                .maxRstFramesPerSecond(-19)
+                .maxRapidResets(-19)
                 .build();
 
-        assertThat(configuration.maxRstFramesPerSecond(), is(Integer.MAX_VALUE));
+        assertThat(configuration.maxRapidResets(), is(200));
     }
 }

--- a/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServerConfigurationTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServerConfigurationTest.java
@@ -220,4 +220,39 @@ public class GrpcServerConfigurationTest {
         assertThat(serverConfig.useNativeTransport(), is(true));
         assertThat(serverConfig.workers(), is(51));
     }
+
+    @Test
+    public void shouldHaveDefaultMaxRstFrames() {
+        GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
+                .build();
+
+        assertThat(configuration.maxRstFramesPerSecond(), is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldSetMaxRstFrames() {
+        GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
+                .maxRstFramesPerSecond(19)
+                .build();
+
+        assertThat(configuration.maxRstFramesPerSecond(), is(19));
+    }
+
+    @Test
+    public void shouldSetMaxRstFramesToZero() {
+        GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
+                .maxRstFramesPerSecond(0)
+                .build();
+
+        assertThat(configuration.maxRstFramesPerSecond(), is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldSetMaxRstFramesToLessThanZero() {
+        GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
+                .maxRstFramesPerSecond(-19)
+                .build();
+
+        assertThat(configuration.maxRstFramesPerSecond(), is(Integer.MAX_VALUE));
+    }
 }

--- a/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServerConfigurationTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServerConfigurationTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.grpc.server;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import io.helidon.config.Config;
@@ -222,7 +223,7 @@ public class GrpcServerConfigurationTest {
     }
 
     @Test
-    public void shouldHaveDefaultMaxRstFrames() {
+    public void shouldHaveDefaultMaxRapidResets() {
         GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
                 .build();
 
@@ -230,7 +231,7 @@ public class GrpcServerConfigurationTest {
     }
 
     @Test
-    public void shouldSetMaxRstFrames() {
+    public void shouldSetMaxRapidResets() {
         GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
                 .maxRapidResets(19)
                 .build();
@@ -239,20 +240,19 @@ public class GrpcServerConfigurationTest {
     }
 
     @Test
-    public void shouldSetMaxRstFramesToZero() {
+    public void shouldHaveDefaultRapidResetCheckPeriod() {
         GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
-                .maxRapidResets(0)
                 .build();
 
-        assertThat(configuration.maxRapidResets(), is(200));
+        assertThat(configuration.rapidResetCheckPeriod(), is(Duration.ofSeconds(30)));
     }
 
     @Test
-    public void shouldSetMaxRstFramesToLessThanZero() {
+    public void shouldSetRapidResetCheckPeriod() {
         GrpcServerConfiguration configuration = GrpcServerConfiguration.builder()
-                .maxRapidResets(-19)
+                .rapidResetCheckPeriod(Duration.ofSeconds(19))
                 .build();
 
-        assertThat(configuration.maxRapidResets(), is(200));
+        assertThat(configuration.rapidResetCheckPeriod(), is(Duration.ofSeconds(19)));
     }
 }

--- a/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServerConfigurationTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServerConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/grpc/client/src/main/java/module-info.java
+++ b/microprofile/grpc/client/src/main/java/module-info.java
@@ -23,7 +23,8 @@ module io.helidon.microprofile.grpc.client {
     requires jakarta.cdi;
     requires jakarta.inject;
 
-    requires transitive grpc.core;
+    requires transitive io.grpc.inprocess;
+    requires transitive io.grpc.internal;
     requires transitive io.helidon.microprofile.grpc.core;
 
     exports io.helidon.microprofile.grpc.client;

--- a/microprofile/grpc/server/src/main/java/module-info.java
+++ b/microprofile/grpc/server/src/main/java/module-info.java
@@ -27,7 +27,7 @@ module io.helidon.microprofile.grpc.server {
     requires io.helidon.microprofile.server;
     requires io.helidon.config.mp;
 
-    requires grpc.protobuf.lite;
+    requires io.grpc.protobuf.lite;
     requires com.google.protobuf;
 
     requires java.logging;


### PR DESCRIPTION
### Update gRPC version to 1.60.0

### Documentation

This PR is to fix issue #8106

The gRPC Java libraries now have automatic module names in the jar files. These names differ slightly from those previously used by Helidon as they are all prefixed with `io.grpc` instead of just `grpc`. An issue resulting from this is that the gRPC API module has a module name of `io.grpc` which is the same as the repackaged gRPC module in Helidon. The Helidon repackaged io.grpc module no longer has any code, it is just a pom file with some dependencies. Its `io.grpc` module name is generated from the artifactId. We cannot change the artifactId but we can add a module-info to the jar to set its module name to be something other than `io.grpc`.

Usages of the repackaged `io.grpc` module have been removed from the rest of Helidon, other modules in Helidon now depend directly on whatever gRPC libraries they require. The  repackaged `io.grpc` module has been left in place so as not to break any customer's that depend on it. Having said that, customer code that uses gRPC libraries is almost certainly going to break anyway due to the change of module names, which is beyond our control.