### PR TITLE
Fix premature access to RegistryFactory

### DIFF
--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -804,7 +804,7 @@ public class JpaExtension implements Extension {
      * @exception IOException if an input or output error occurs, typically because a {@code META-INF/persistence.xml}
      * resource was found but could not be loaded for some reason
      *
-     * @exception JAXBException if there was a problem {@linkplain Unmarshaller#unmarshal(Reader) unmarshalling} a
+     * @exception JAXBException if there was a problem {@linkplain Unmarshaller#unmarshal(java.io.Reader) unmarshalling} a
      * {@code META-INF/persistence.xml} resource
      *
      * @exception NullPointerException if either {@code event} or {@code beanManager} is {@code null}
@@ -2045,7 +2045,7 @@ public class JpaExtension implements Extension {
 
     private void onStartup(@Observes
                            @Initialized(ApplicationScoped.class)
-                           @Priority(LIBRARY_BEFORE)
+                           @Priority(LIBRARY_BEFORE + 20)
                            Object event,
                            @ContainerManaged
                            Instance<EntityManagerFactory> emfs) {

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -2045,8 +2045,8 @@ public class JpaExtension implements Extension {
 
     private void onStartup(@Observes
                            @Initialized(ApplicationScoped.class)
-//                           @Priority(LIBRARY_BEFORE + 20)
-                           @Priority(LIBRARY_BEFORE)
+                           @Priority(LIBRARY_BEFORE + 20)
+//                           @Priority(LIBRARY_BEFORE)
                            Object event,
                            @ContainerManaged
                            Instance<EntityManagerFactory> emfs) {

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -2045,7 +2045,8 @@ public class JpaExtension implements Extension {
 
     private void onStartup(@Observes
                            @Initialized(ApplicationScoped.class)
-                           @Priority(LIBRARY_BEFORE + 20)
+//                           @Priority(LIBRARY_BEFORE + 20)
+                           @Priority(LIBRARY_BEFORE)
                            Object event,
                            @ContainerManaged
                            Instance<EntityManagerFactory> emfs) {

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -2045,8 +2045,7 @@ public class JpaExtension implements Extension {
 
     private void onStartup(@Observes
                            @Initialized(ApplicationScoped.class)
-                           @Priority(LIBRARY_BEFORE + 20)
-//                           @Priority(LIBRARY_BEFORE)
+                           @Priority(LIBRARY_BEFORE + 20) // Must be later than metrics CDI extension priority
                            Object event,
                            @ContainerManaged
                            Instance<EntityManagerFactory> emfs) {

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
@@ -29,7 +29,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MeterRegistry;
-import io.helidon.metrics.api.Metrics;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
@@ -89,10 +89,12 @@ class RegistryFactory {
     static RegistryFactory getInstance() {
         RegistryFactory result = REGISTRY_FACTORY.get();
         if (result == null) {
-            LOGGER.log(Level.WARNING, "Attempt to retrieve current " + RegistryFactory.class.getName()
-                    + " before it has been initialized; using default Helidon meter registry and continuing");
-            result = new RegistryFactory(Metrics.globalRegistry());
-            REGISTRY_FACTORY.set(result);
+            throw new IllegalStateException("Attempt to retrieve current " + RegistryFactory.class.getName()
+                                                    + " before it has been initialized");
+//            LOGGER.log(Level.WARNING, "Attempt to retrieve current " + RegistryFactory.class.getName()
+//                    + " before it has been initialized; using default Helidon meter registry and continuing");
+//            result = new RegistryFactory(Metrics.globalRegistry());
+//            REGISTRY_FACTORY.set(result);
         }
         return result;
     }

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.Metrics;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
@@ -88,12 +89,10 @@ class RegistryFactory {
     static RegistryFactory getInstance() {
         RegistryFactory result = REGISTRY_FACTORY.get();
         if (result == null) {
-            throw new IllegalStateException("Attempt to retrieve current " + RegistryFactory.class.getName()
-                                                    + " before it has been initialized");
-//            LOGGER.log(Level.WARNING, "Attempt to retrieve current " + RegistryFactory.class.getName()
-//                    + " before it has been initialized; using default Helidon meter registry and continuing");
-//            result = new RegistryFactory(Metrics.globalRegistry());
-//            REGISTRY_FACTORY.set(result);
+            LOGGER.log(Level.WARNING, "Attempt to retrieve current " + RegistryFactory.class.getName()
+                    + " before it has been initialized; using default Helidon meter registry and continuing");
+            result = new RegistryFactory(Metrics.globalRegistry());
+            REGISTRY_FACTORY.set(result);
         }
         return result;
     }


### PR DESCRIPTION
### Description
Resolves #8117 

The Helidon MP metrics `RegistryFactory` logged the warning because the JPA CDI extension was running some start-up complete code before the metrics CDI extension had a chance to prepare Helidon MP metrics.

The fix sets the priority on the JPA extension observer to be later than the corresponding priority on the metrics extension observer.

Not as part of the PR I temporarily changed the `RegistryFactory` code to thrown an exception instead of logging a warning, and the pipelines passed so it seems that no other CDI extensions need a similar adjustment.

