### PR TITLE
3.x: Upgrade slf4j to 2.0.9 and logback to 1.4.14

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -102,7 +102,7 @@
         <version.lib.junit>5.7.0</version.lib.junit>
         <version.lib.kafka>3.6.0</version.lib.kafka>
         <version.lib.log4j>2.21.1</version.lib.log4j>
-        <version.lib.logback>1.2.10</version.lib.logback>
+        <version.lib.logback>1.4.14</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.micrometer>1.6.6</version.lib.micrometer>
@@ -147,7 +147,7 @@
         <version.lib.parsson>1.0.5</version.lib.parsson>
         <version.lib.postgresql>42.4.3</version.lib.postgresql>
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
-        <version.lib.slf4j>1.7.32</version.lib.slf4j>
+        <version.lib.slf4j>2.0.9</version.lib.slf4j>
         <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>2.0</version.lib.snakeyaml>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>


### PR DESCRIPTION
### Description

3.x: Upgrades slf4j to 2.0.9 and logback to 1.4.14

### Documentation

No impact