### PR TITLE
4.x: Disable failing `testNonTransactionalEntityManager` JPA test.

### DIFF
--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAnnotationRewriting.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAnnotationRewriting.java
@@ -39,6 +39,7 @@ import jakarta.transaction.TransactionManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -154,6 +155,7 @@ class TestAnnotationRewriting {
     }
 
     @Test
+    @Disabled // TODO See https://github.com/helidon-io/helidon/issues/8122
     void testNonTransactionalEntityManager() {
         this.cdiContainer.getBeanManager()
             .getEvent()


### PR DESCRIPTION
### Description

Disable test `io.helidon.integrations.cdi.jpa.TestAnnotationRewriting.testNonTransactionalEntityManager` because it has started to fail regularly in the validation pipeline.

See issue #8122 

### Documentation

No impact