### PR TITLE
Significant changes and corrections to the SE health doc

### DIFF
--- a/docs/se/guides/health.adoc
+++ b/docs/se/guides/health.adoc
@@ -184,14 +184,14 @@ The following trivial but illustrative example adds a custom start-up check that
 ----
 AtomicLong serverStartTime = new AtomicLong();  // <1>
 
-ObserveFeature observe = ObserveFeature.builder()
+ObserveFeature o = ObserveFeature.builder()
         .config(config.get("server.features.observe")) // <2>
         .addObserver(HealthObserver.builder() // <3>
                              .details(true) // <4>
                              .addCheck(() -> HealthCheckResponse.builder() // <5>
-                                               .status(System.currentTimeMillis() - serverStartTime.get() >= 8000)
-                                               .detail("time", System.currentTimeMillis())
-                                               .build(),
+                                         .status(System.currentTimeMillis() - serverStartTime.get() >= 8000)
+                                         .detail("time", System.currentTimeMillis())
+                                         .build(),
                                        HealthCheckType.STARTUP,
                                        "warmedUp")
                              .build()) // <6>
@@ -329,7 +329,7 @@ Once it creates a custom health observer, your code has full responsibility for 
 The next example customizes the URL path for the health endpoint, first explicitly in the code and then via configuration.
 
 ==== Customizing the endpoint path in the code
-Customize the URL path for heath checks by invoking the `endpoint` method on the `HealthObserver.Builder`.
+Customize the URL path for health checks by invoking the `endpoint` method on the `HealthObserver.Builder`.
 
 [source,java]
 .Set a custom endpoint path
@@ -356,7 +356,7 @@ Earlier you added health config to the `application.yaml` config file to turn on
 The output _remains_ detailed because your code--which has full responsibility for determining the custom health observer's behavior--does not apply configuration to the custom observer's builder.
 
 ==== Adding configuration to a custom observer
-In addition to preparing the health observer builder with hard-coded settings, your code can also apply configuration for health so your user could set any health behavior there as well.
+In addition to preparing the health observer builder with hard-coded settings, your code can also apply configuration for health. This allows someone who deploys your application to control the behavior of the health subsystem using configuration without requiring source code changes to your application.
 
 The generated `Main` class in the application already creates a `Config` object for the top-level config node. Using the following code to create the observe feature also applies any health-related configuration settings to the custom health observer. Notice the added line just before the `HealthObserver.Build` `build()` invocation near the end of the example code.
 
@@ -369,9 +369,9 @@ ObserveFeature observe = ObserveFeature.builder()
                              .endpoint("/myhealth")
                              .details(true)
                              .addCheck(() -> HealthCheckResponse.builder()
-                                               .status(System.currentTimeMillis() - serverStartTime.get() >= 8000)
-                                               .detail("time", System.currentTimeMillis())
-                                               .build(),
+                                         .status(System.currentTimeMillis() - serverStartTime.get() >= 8000)
+                                         .detail("time", System.currentTimeMillis())
+                                         .build(),
                                        HealthCheckType.STARTUP,
                                        "warmedUp")
                              .config(config.get("server.features.observe.observers.health")) // <1>
@@ -381,7 +381,7 @@ ObserveFeature observe = ObserveFeature.builder()
 ----
 <1> Find and apply any health-related settings from configuration at the `server.features.observe.observers.health` config key.
 
-Your code decides what config key to use for retrieving the configuration. Recall earlier, before adding custom health checks, you added a config section for health--to set `details` to `true`--at `server.features.observe.observers.health`. Helidon used that configuration to set up the health observer _it_ created automatically. To be consistent for your users, it's a good idea for your application code, as it preares a custom `HealthObserver`, to look in the same place Helidon does for health config.
+Your code decides what config key to use for retrieving the configuration. Recall earlier, before adding custom health checks, you added a config section for health--to set `details` to `true`--at `server.features.observe.observers.health`. Helidon used that configuration to set up the health observer _it_ created automatically. To be consistent for anyone preparing the configuration file, it's a good idea for your application code--as it prepares a custom `HealthObserver`--to look in the same place Helidon does for health config.
 
 Order is important. Here, the code first sets `details` to `true` explicitly and later applies configuration. If your end user sets `details` in the `server.features.observe.observers.health` config to `false`, that setting overrides the hard-coded `true` setting in the code _because of where in the code you apply the configuration_. Try changing the `details` value to `false` in the config file and then stop, rebuild, and rerun the application. Access the health endpoint and notice that the output is no longer detailed.
 

--- a/docs/se/guides/health.adoc
+++ b/docs/se/guides/health.adoc
@@ -57,12 +57,17 @@ Helidon has a set of built-in health checks:
 * available disk space
 * available heap memory
 
-The following example will demonstrate how to use the built-in health checks.  These examples are all executed
+The following example shows how to use the built-in health checks.  These examples are all executed
 from the root directory of your project (helidon-quickstart-se).
 
+Notice that the `pom.xml` file in the generated project already contains dependencies for Helidon's health component and for the built-in health checks.
 [source,xml]
-.Notice that the built-in health check dependency is already in the project's pom.xml file:
+.Generated dependencies related to health
 ----
+<dependency>
+    <groupId>io.helidon.webserver.observe</groupId>
+    <artifactId>helidon-webserver-observe-health</artifactId>
+</dependency>
 <dependency>
     <groupId>io.helidon.health</groupId>
     <artifactId>helidon-health-checks</artifactId>
@@ -71,72 +76,74 @@ from the root directory of your project (helidon-quickstart-se).
 
 Handling health checks is part of Helidon's observability support.
 By default, when you add the dependency for the built-in health checks, Helidon automatically registers the built-in checks.
-But the generated project explicitly suppresses the build-in health checks, thereby highlighting the custom health checks it adds.
-
-[source,java]
-.Excerpt from `Main.main`:
-----
-ObserveFeature observe = ObserveFeature.builder()
-     .config(config.get("server.features.observe")) // <1>
-     .addObserver(HealthObserver.builder() // <2>
-         .details(true) // <3>
-         .useSystemServices(false) // <4>
-         .addCheck(() -> HealthCheckResponse.builder() // <5>
-                  .status(HealthCheckResponse.Status.UP)
-                  .detail("time", System.currentTimeMillis())
-                  .build(), HealthCheckType.READINESS)
-         .addCheck(() -> HealthCheckResponse.builder() // <6>
-                  .status(isStarted())
-                  .detail("time", System.currentTimeMillis())
-                  .build(), HealthCheckType.STARTUP)
-         .build()) // <7>
-     .build();
-
-----
-<1> Finds and applies configuration for observability.
-<2> Begins preparing the `HealthObserver` according to this app's specific needs.
-<3> Turns on detailed output in HTTP responses to the health endpoint.
-<4> Suppresses automatic registration of built-in health checks.
-<5> Adds a custom readiness health check which always reports `UP`'.
-<6> Adds a custom start-up health check.
-<7> Builds the `HealthObserver` for addition to the `ObserveFeature`.
-
-To see the built-in health checks, temporarily change `useSystemServices` to `true`:
-[source,java]
-.Temporarily enable all built-in health checks
-----
-         .useSystemServices(true)
-----
 
 [source,bash]
-.Build the application then run it:
+.Build and run the project
 ----
-mvn package
+mvn clean package
 java -jar target/helidon-quickstart-se.jar
 ----
 
+In another window, access the application's health endpoint.
 [source,bash]
-.Verify the health endpoint in a new terminal window:
+.Access the health endpoint
 ----
-curl http://localhost:8080/observe/health
+curl -v http://localhost:8080/observe/health
 ----
 
+The verbose `curl` output reports the HTTP status:
+[listing]
+----
+< HTTP/1.1 204 No Content
+----
+
+The successful status means all health checks reported `UP`.
+
+To see the details about each health check, add the following `features` configuration fragment in the `server` section of the `application.yaml`. Make sure the `features` key is at the same level as `port` and `host` that are already in the file.
+[source,yaml]
+.Configuration fragment to include details in the health output (nested under `server`)
+----
+server:
+  port: 8080
+  host: 0.0.0.0
+  features: # <1>
+    observe:
+      observers:
+        health:
+          details: true
+----
+<1> Added `features` config section.
+
+Press ^C to stop the running server, rebuild it, and rerun it.
+[source,bash]
+.Stop, rebuild, and rerun the server
+----
+^C
+mvn clean package
+java -jar target/helidon-quickstart-se.jar
+----
+In the other window access the health endpoint again.
+[source,bash]
+.Access the health endpoint
+----
+curl -v http://localhost:8080/observe/health
+----
+This time the `curl` output shows not only the HTTP status--as 200 instead of 204 because the response now contains data--but also the detailed output for all health checks.
 [source,json]
-.Built-in health checks in the JSON response:
+.Health check details
 ----
 {
-  "status": "DOWN",
-  "checks": [
-    ...
+  "status": "UP",              # <1>
+  "checks": [                  # <2>
     {
       "name": "diskSpace",
       "status": "UP",
       "data": {
         "total": "465.63 GB",
-        "percentFree": "15.77%",
+        "percentFree": "14.10%",
         "totalBytes": 499963174912,
-        "free": "73.42 GB",
-        "freeBytes": 78837497856
+        "free": "65.67 GB",
+        "freeBytes": 70513274880
       }
     },
     {
@@ -144,12 +151,12 @@ curl http://localhost:8080/observe/health
       "status": "UP",
       "data": {
         "total": "516.00 MB",
-        "percentFree": "99.81%",
+        "percentFree": "99.82%",
         "max": "8.00 GB",
         "totalBytes": 541065216,
         "maxBytes": 8589934592,
-        "free": "500.80 MB",
-        "freeBytes": 525126760
+        "free": "500.87 MB",
+        "freeBytes": 525201320
       }
     },
     {
@@ -158,96 +165,129 @@ curl http://localhost:8080/observe/health
     }
   ]
 }
-
 ----
-
-
+<1> Overall application health status
+<2> List of individual health checks.
 
 === Adding Custom Health Checks
 
-As illustrated above, the generated `Main` class in the QuickStart project adds two custom health checks.
-Your own checks typically assess the conditions in and around your application and report whether the service should be considered started, live, and/or ready.
+You can add your own custom health checks. These typically assess the conditions in and around your application and report whether the service should be considered started, live, and/or ready.
 
-As a trivial but illustrative example, the custom start-up health check in the generated `Main` class reports that the app is _not_ started until eight seconds after the server has started. After that, the start-up check reports that the app _is_ started.
+The following trivial but illustrative example adds a custom start-up check that reports `DOWN` until the server has been running for eight seconds and reports `UP` thereafter. Note the two main steps in the example code:
 
-To see this start-up check in action, stop your running server (press ^C), then rerun it.
+1. Create an explicit instance of `ObserveFeature` which contains a custom `HealthObserver` with the custom check.
+2. Add that `ObserveFeature` instance to the `WebServer.Builder` as a feature.
+
+
+[source,java]
+.Updated `Main.main`, augmenting the creation of `WebServer` instance with a custom health check
+----
+AtomicLong serverStartTime = new AtomicLong();  // <1>
+
+ObserveFeature observe = ObserveFeature.builder()
+        .config(config.get("server.features.observe")) // <2>
+        .addObserver(HealthObserver.builder() // <3>
+                             .details(true) // <4>
+                             .addCheck(() -> HealthCheckResponse.builder() // <5>
+                                               .status(System.currentTimeMillis() - serverStartTime.get() >= 8000)
+                                               .detail("time", System.currentTimeMillis())
+                                               .build(),
+                                       HealthCheckType.STARTUP,
+                                       "warmedUp")
+                             .build()) // <6>
+        .build();
+
+    WebServer server = WebServer.builder()
+            .config(config.get("server"))
+            .addFeature(observe)            // <7>
+            .routing(Main::routing)
+            .build()
+            .start();
+
+    serverStartTime.set(System.currentTimeMillis()); // <8>
+
+----
+<1> Declare a variable for holding the server start-up time. (This is set later in the code.)
+<2> Find and apply configuration for observability observers _other_ than health (because we are about to create our own custom `HealthObserver`).
+<3> Begin preparing the custom `HealthObserver` according to this app's specific needs.
+<4> Turn on detailed output in HTTP responses to the health endpoint.
+<5> Add a custom start-up health check:
+   * Compute the status for the response according to whether the server has been up for at least eight seconds.
+   * Add a detail to the response reporting the time at which the health check was queried.
+   * Set the health check type as `STARTUP`.
+   * Set the health check name to `"warmedUp"`.
+<6> Build the `HealthObserver` for addition to the `ObserveFeature`.
+<7> Add the `ObserveFeature` instance as a feature to the webserver.
+<8> Record when the server has actually started.
+
+Note that the health check type and name are fixed, whereas the health check recomputes the value of the response every time Helidon queries it.
+
+NOTE: For the next step, be ready to access the health endpoint very quickly after you restart the server!
 
 [source,bash]
-.Stop the application:
+.Stop, rebuild, and rerun the application
 ----
 ^C
-----
-and note the output from the server
-[listing]
-----
-Shutdown requested by JVM shutting down
-[0x4fdb2ff3] @default socket closed.
-Shutdown finished
-----
-then restart the server
-[source,bash]
-----
+mvn package
 java -jar target/helidon-quickstart-se.jar
 ----
 
-In another terminal window, within eight seconds access the health endpoint [source,bash]
-.Verify the health endpoint in a new terminal window:
+[source,bash]
+.Access the health endpoint **quickly**
 ----
-curl http://localhost:8080/observe/health
+curl -v http://localhost:8080/observe/health
 ----
-and notice the output.
+
+If you access the health endpoint before the server has been up for eight seconds, `curl` reports the response status as `503 Service Unavailable` and displays output similar to the following:
+
 [source,json]
+.Health response shortly after server restart (partial)
 ----
 {
-  "status": "DOWN",                              // <1>
+  "status": "DOWN",
   "checks": [
     {
-      "name": "Main$$Lambda/0x00000001310a8dc8", // <2>
-      "status": "UP",
-      "data": {
-        "time": 1697584867358
-      }
-    },
-    {
-      "name": "Main$$Lambda/0x00000001310a9a78", // <3>
+      "name": "warmedUp",
       "status": "DOWN",
       "data": {
-        "time": 1697584867358
+        "time": 1702068978353
       }
     },
 ...
-}
+
 ----
-<1> Overall health (`DOWN` because at least one check reports `DOWN`).
-<2> The custom readiness check (hard-coded as `UP`).
-<3> The custom start-up check (`DOWN` because the server has not been up for at least eight seconds yet).
+The built-in health checks (not shown in the example output) all report `UP` but the new custom start-up health check reports `DOWN` because the server has been up only a short time.
 
-Now wait eight seconds and access the endpoint again.
-
+Access the health endpoint again, after the server has been up at least eight seconds.
+[source,bash]
+.Access the health endpoint again **after 8 seconds**
+----
+curl -v http://localhost:8080/observe/health
+----
+This time, `curl` reports `200 OK` for the response status and displays different output for the custom health check.
 [source,json]
+.Health response after the server has been running a while (partial)
 ----
 {
-  "status": "UP",                                // <1>
+  "status": "UP",
   "checks": [
     {
-      "name": "Main$$Lambda/0x00000001310a8dc8",
+      "name": "warmedUp",
       "status": "UP",
       "data": {
-        "time": 1697584869478
+        "time": 1702069379717
       }
     },
-    {
-      "name": "Main$$Lambda/0x00000001310a9a78", // <2>
-      "status": "UP",
-      "data": {
-        "time": 1697584869478
-      }
-    },
-...
-}
 ----
-<1> Overall status (now `UP` because all checks report `UP`).
-<2> The custom start-up check (now `UP` because the server has been up at least eight seconds).
+
+The example code includes the built-in health checks in Helidon's overall health assessment of the application. To exclude them invoke the `HealthObserver.Builder` `useSystemServices` method (for example, just after invoking `details` on the builder).
+[source,java]
+.Disable all built-in health checks
+----
+         .useSystemServices(false)
+----
+Alternatively, you could instead remove the dependency on the `helidon-health-checks` component from the `pom.xml` file.
+
 
 === Accessing Specific Health Check Types
 You can choose which category of health check to retrieve when you access the health endpoint by adding the health check type as an additional part of the resource path:
@@ -271,28 +311,37 @@ curl http://localhost:8080/observe/started
   "status": "UP",
   "checks": [
     {
-      "name": "Main$$Lambda/0x00000001360a9a78",
+      "name": "warmedUp",
       "status": "UP",
       "data": {
-        "time": 1697585727515
+        "time": 1702069835172
       }
     }
   ]
 }
 ----
 
-=== Custom Health Check URL Path
+=== Applying Configuration to a Custom Health Observer: Customizing the URL path
+Earlier examples showed how to add custom health checks by building a custom `HealthObserver` in which the code set up the behavior of the health subsystem explicitly. Recall that the example code invoked the `HealthObserver.Builder` `details` method to turn on detailed output.
 
-You can use a custom URL path for heath checks by setting the `endpoint` for the `HealthObserver`.
+Once it creates a custom health observer, your code has full responsibility for determining the observer's behavior; Helidon does not automatically apply configuration to a custom observer. But your code can easily do so.
+
+The next example customizes the URL path for the health endpoint, first explicitly in the code and then via configuration.
+
+==== Customizing the endpoint path in the code
+Customize the URL path for heath checks by invoking the `endpoint` method on the `HealthObserver.Builder`.
 
 [source,java]
-.Set a custom endpoint path:
+.Set a custom endpoint path
 ----
 ObserveFeature observe = ObserveFeature.builder()
      .config(config.get("server.features.observe"))
      .addObserver(HealthObserver.builder()
-     .endpoint("/myhealth") // <1>
-     .details(true)
+         .endpoint("/myhealth") // <1>
+         .details(true)
+         ...
+         .build()
+     ...
 ...
 ----
 <1> Changes the health endpoint path to `/myhealth`.
@@ -303,6 +352,40 @@ ObserveFeature observe = ObserveFeature.builder()
 curl http://localhost:8080/myhealth
 ----
 
+Earlier you added health config to the `application.yaml` config file to turn on detailed output. If you want to run an experiment, change that `details` setting in the config file to `false` and stop, rebuild, and rerun the application. Now access the health endpoint (at `/myhealth`, remember).
+The output _remains_ detailed because your code--which has full responsibility for determining the custom health observer's behavior--does not apply configuration to the custom observer's builder.
+
+==== Adding configuration to a custom observer
+In addition to preparing the health observer builder with hard-coded settings, your code can also apply configuration for health so your user could set any health behavior there as well.
+
+The generated `Main` class in the application already creates a `Config` object for the top-level config node. Using the following code to create the observe feature also applies any health-related configuration settings to the custom health observer. Notice the added line just before the `HealthObserver.Build` `build()` invocation near the end of the example code.
+
+[source.java]
+.Apply health configuration to your custom health observer
+----
+ObserveFeature observe = ObserveFeature.builder()
+        .config(config.get("server.features.observe"))
+        .addObserver(HealthObserver.builder()
+                             .endpoint("/myhealth")
+                             .details(true)
+                             .addCheck(() -> HealthCheckResponse.builder()
+                                               .status(System.currentTimeMillis() - serverStartTime.get() >= 8000)
+                                               .detail("time", System.currentTimeMillis())
+                                               .build(),
+                                       HealthCheckType.STARTUP,
+                                       "warmedUp")
+                             .config(config.get("server.features.observe.observers.health")) // <1>
+                             .build()
+        )
+        .build();
+----
+<1> Find and apply any health-related settings from configuration at the `server.features.observe.observers.health` config key.
+
+Your code decides what config key to use for retrieving the configuration. Recall earlier, before adding custom health checks, you added a config section for health--to set `details` to `true`--at `server.features.observe.observers.health`. Helidon used that configuration to set up the health observer _it_ created automatically. To be consistent for your users, it's a good idea for your application code, as it preares a custom `HealthObserver`, to look in the same place Helidon does for health config.
+
+Order is important. Here, the code first sets `details` to `true` explicitly and later applies configuration. If your end user sets `details` in the `server.features.observe.observers.health` config to `false`, that setting overrides the hard-coded `true` setting in the code _because of where in the code you apply the configuration_. Try changing the `details` value to `false` in the config file and then stop, rebuild, and rerun the application. Access the health endpoint and notice that the output is no longer detailed.
+
+In general, most applications should apply settings from config _after_ assigning any settings in the code so users have the final say, but there might be exceptions in your particular case.
 
 === Using Liveness, Readiness, and Startup Health Checks with Kubernetes
 

--- a/docs/se/health.adoc
+++ b/docs/se/health.adoc
@@ -29,7 +29,8 @@ include::{rootdir}/includes/se.adoc[]
 - <<Overview, Overview>>
 - <<Maven Coordinates, Maven Coordinates>>
 - <<API, API>>
-** <<Built-In Health Checks, Built-In Health Checks>>
+** <<Enabling Health Support (and Built-in Health Checks) in Your Application, Enabling Health Support>>
+** <<Writing Custom Health Checks, Writing Custom Health Checks>>
 ** <<Kubernetes Probes, Kubernetes Probes>>
 ** <<Troubleshooting Probes, Troubleshooting Probes>>
 - <<Configuration, Configuration>>
@@ -40,7 +41,7 @@ include::{rootdir}/includes/se.adoc[]
 
 == Overview
 
-It’s a good practice to monitor your microservice’s health, to ensure that it is
+It’s a good practice to monitor your microservice’s health to ensure that it is
 available and performs correctly.
 Applications implement health checks to expose health status that is collected
 at regular intervals by external tooling, such as orchestrators like
@@ -60,8 +61,8 @@ include::{rootdir}/includes/dependencies.adoc[]
 [source,xml]
 ----
 <dependency>
-    <groupId>io.helidon.health</groupId>
-    <artifactId>helidon-health</artifactId>
+    <groupId>io.helidon.webserver.observe</groupId>
+    <artifactId>helidon-webserver-observe-health</artifactId>
 </dependency>
 ----
 
@@ -76,46 +77,161 @@ Optional dependency to use built-in health checks:
 ----
 
 == API
-To add custom health checks to your application, you need to
 
-* write the code which performs the health checks, and
-* make those custom health checks known to Helidon.
+=== Enabling Health Support (and Built-in Health Checks) in Your Application
+The health subsystem is part of Helidon's observability support. As a result, your application includes health support by default provided your project meets several conditions:
+
+* Your project depends on the `helidon-webserver-observe-health` component as described above.
+* (Optional) Your project depends on the `helidon-health-checks` component (if you want Helidon's built-in health checks).
+* Your code allows the webserver's automatic feature discovery (enabled by default).
+* Your code allows the observe feature's automatic observer discovery (also enabled by default).
+
+If you disable either type of automatic discovery you can add the observe feature to the webserver explicitly and you can add the health observer to the observe feature explicitly, customizing the behavior of each programmatically if you wish.
+You can also use configuration to tailor some of the behavior of the health component (such as changing the URI path from `/observe/health` to something else).
 
 === Writing Custom Health Checks
+In many cases, the ability of your application to do its job depends on conditions known only to your application: for example, whether certain external resources such as databases are available.
+You can create custom health checks which reflect those conditions and add them to Helidon's overall health assessment of your application.
 
-A health check is a Java functional interface that returns a
-`HealthCheckResponse` instance. You can create custom health checks in several ways, among them:
+A health check is a Java functional interface that returns a new
+`HealthCheckResponse` instance each time Helidon queries the health check.
+Each health check also has a fixed name and a fixed health check type (start-up, liveness, or readiness).
 
-* write a class which implements the `HealthCheck` interface,
-* write an in-line lambda expression, or
-* use a method reference a method with the double colon operator `::`.
+Your code registers a custom health check by invoking a method on Helidon-provided types in one of the following ways:
+
+* Pass the name and type of the health check and a `Supplier` of a `HealthCheckResponse` such as a method reference or a lambda expression.
+* Pass an instance of a class which implements the `HealthCheck` interface.
+
+Within an application different techniques might make sense for different custom health checks, depending on the complexity of the logic for computing the status for each check.
+The various styles are functionally equivalent; for a given custom health check choose the style which enhances the readability and clarity of your code.
+The examples below, in no particular order, implement the same custom health check functionality in different ways to illustrate.
+
+==== Option 1: Using a `HealthCheckResponse` supplier method
+If you gather the logic for computing the health check response into a method you can use a method reference to register the health check.
 
 [source,java]
-.Health check with a lambda expression:
+.Declaring a health check response supplier method
 ----
-Supplier<HealthCheckResponse> hcr = () -> HealthCheckResponse
-                .builder()
-                .detail("exampleValue", "looking-good")
-                .status(HealthCheckResponse.Status.UP) // always "up"
-                .build();
+static HealthCheckResponse slowStartLivenessResponse() {
+    long now = System.currentTimeMillis();
+    return HealthCheckResponse.builder()
+            .detail("time", now)
+            .status(now - serverStartTime >= 8000)
+            .build();
+}
 ----
 
 [source,java]
-.Health check with method reference (in class `Main`):
+.Registering a health check using a method reference
 ----
-static HealthCheckResponse exampleHealthCheck() {
-        return HealthCheckResponse
-                .builder()
-                .detail("exampleValue", "looking-good")
-                .status(HealthCheckResponse.Status.UP) // always "up"
-                .build();
+ObserveFeature observe = ObserveFeature.builder()
+                             .config(config.get("server.features.observe")) // <1>
+                             .addObserver(HealthObserver.builder()          // <2>
+                             .useSystemServices(true) // Include Helidon-provided health checks.
+                             .addCheck(Main::slowStartLivenessResponse, // <3>
+                                       HealthCheckType.READINESS,       // <4>
+                                       "live-after-8-seconds")          // <5>
+        .build();
+----
+<1> Apply configuration to auto-discovered observers (e.g., health, metrics).
+<2> Augment the web server by adding the `ObserveFeature` containing the `HealthObserver`. This replaces the auto-discovered health observer.
+<3> Add the custom health check, passing a reference to the method which returns the health check responses.
+<4> Set the type of the custom health check.
+<5> Set the name of the custom health check.
+
+==== Option 2: Using an in-line lambda expression
+If the logic for computing the health check response is fairly simple, express it as an in-line lambda when you register the health check.
+
+[source,java]
+.Registering a health check using an in-line lambda expression
+----
+ObserveFeature observe = ObserveFeature.builder()
+        .config(config.get("server.features.observe"))
+        .addObserver(HealthObserver.builder()                                              // <1>
+                             .useSystemServices(true) // Include Helidon-provided health checks.
+                             .addCheck(() -> HealthCheckResponse.builder()                 // <2>
+                                               .status(System.currentTimeMillis() - serverStartTime >= 8000) // <3>
+                                               .detail("time", System.currentTimeMillis()) // <4>
+                                               .build(),                                   // <5>
+                                       HealthCheckType.READINESS,                          // <6>
+                                       "live-after-8-seconds")                             // <7>
+                            .build())
+        .build();
+----
+<1> Augment the web server by adding the `ObserveFeature` containing the `HealthObserver`.
+<2> Add the custom health check passing a lambda expression supplying the health check response.
+<3> In the lambda, set the health check response status.
+<4> Still in the lambda, set a detail associated with the health check response.
+<5> Still in the lambda, build the health check response.
+<6> Set the type of the custom health check.
+<7> Set the name of the custom health check.
+
+Note that the logic in the lambda expression runs every time Helidon probes the added health check, so the values passed to `status` and `detail` are recomputed every time.
+
+==== Option 3: Using a `HealthCheck` Instance
+If a custom health check requires a lot of information to compute its health check response, it might be clearest to implement it as a class that implements the `HealthCheck` interface.
+Your code instantiates the class with all the information, including references to other data, it might need to compute the response each time Helidon probes it.
+
+This example _is not_ complicated in that way but it's useful to illustrate this technique of writing a custom health check.
+
+[source,java]
+.Declaring a concrete `HealthCheck` implementation
+----
+/**
+ * A custom readiness health check that reports UP 8 seconds after server start-up.
+ */
+class SlowStartHealthCheck implements HealthCheck {     // <1>
+
+    @Override
+    public HealthCheckType type() {
+        return HealthCheckType.READINESS;               // <2>
     }
 
-Supplier<HealthCheckResponse> hcr = Main::exampleHealthCheck;
+    @Override
+    public HealthCheckResponse call() {
+        long now = System.currentTimeMillis();
+        return HealthCheckResponse.builder()
+                .detail("time", now)                    // <3>
+                .status(now - serverStartTime >= 8000)  // <4>
+                .build();
+    }
+}
 ----
-A real health check would compute its status dynamically based on the conditions in the server rather than hard-coding a fixed value.
+<1> Implement the `io.helidon.health.HealthCheck` interface. The default health check name is the simple class name of the implementing class. Your code can override the `name()` method to return a different name. (Not shown in this example)
+<2> The default health check type is `LIVENESS` so this implementation overrides `type()` to declare a `READINESS` check.
+<3> Sets a detail value `time` associated with the response to the current time.
+<4> Reports `DOWN` until at least eight seconds have passed since the server start-up, then reports `UP` thereafter.
 
-=== Adding Custom Health Checks to Helidon
+[source,java]
+.Registering a `HealthCheck` instance
+----
+ObserveFeature observe = ObserveFeature.builder()
+        .config(config.get("server.features.observe"))
+        .addObserver(HealthObserver.builder()                     // <1>
+                            .addCheck(new SlowStartHealthCheck()) // <2>
+                            .build())
+        .build();
+----
+<1> Augment the web server by adding the `ObserveFeature` containing the `HealthObserver`.
+<2> Instantiate the custom health check class and add the instance to the `HealthObserver`.
+
+==== Adding Observability (including the Custom Health Checks) to Helidon
+The code examples above prepare the `observe` feature instance using the built-in and custom health checks.
+To activate the health subsystem and other auto-discovered observability subsystems, add that `observe` instance as a feature to the webserver and start the server.
+
+[source,java]
+.Register the observe feature with the server and start it
+----
+WebServer server = WebServer.builder()
+        .featuresDiscoverServices(false)
+        .addFeature(observe) // <1>
+        .routing(Main::routing)
+        .build()
+        .start();
+----
+<1> Add the previously-prepared health observer to the server as a feature
+
+==== Triggering and Interpreting Health Check Output
 
 Health support in Helidon is part of Helidon's observability feature.
 `HealthObserver` is a Helidon-provided observability implementation that contains a collection of
@@ -140,50 +256,42 @@ HTTP `HEAD` requests always return only the status with no payload.
 If you add the Helidon health dependency to your `pom.xml` file, Helidon automatically registers the `HelidonObserver` service and responds to the default `/observe/health` endpoint.
 Further, if you add the built-in health checks dependency, Helidon automatically finds them and adds those checks to the `HealthObserver`.
 
-The following example shows how to register your own custom health checks while building and registering an
-instance of `HealthObserver`:
-
-[source,java]
-.Create and register the health observer feature with a custom health check
-----
-WebServer server = WebServer.builder()
-        .config(config.get("server"))
-        .addFeature(ObserveFeature.create(HealthObserver.builder()                     // <1>
-                                                  .addCheck(hcr,                       // <2>
-                                                            HealthCheckType.READINESS, // <3>
-                                                            "exampleCheck")            // <4>
-                                                  .details(true)                       // <5>
-                                                  .build()))                           // <6>
-        .routing(Main::routing)
-        .build()
-        .start();
-----
-<1> Create a builder for the `HealthObserver`.
-<2> Create and add a custom health check to the builder, passing the supplier of the health check response (the `hcr` variable in this example).
-<3> Set the type of health check.
-<4> Set the name of the health check.
-<5> Set the health observer to include details in the output. (optional)
-<6> Build the `HealthObserver` so it can be added to the observability feature that is registered with the webserver.
-
-Invoke `addCheck` multiple times to add multiple custom health checks.
-
-Here is a sample response to the custom health check registered above:
+Below are parts of health responses which include the custom health check added in the earlier example code.
+This first response shows the health output within the first eight seconds after start-up. Recall that the custom health check will report `DOWN` during that time, so the overall health is `DOWN` and the HTTP response status is `503 Service Unavailable`.
 
 [source,json]
-.JSON response:
+.Response within 8 seconds: HTTP status 503 (not healthy)
 ----
 {
-  "status": "UP",
+  "status": "DOWN",
   "checks": [
-        {
-      "name": "exampleCheck",
-      "status": "UP",
+    {
+      "name": "live-after-8-seconds",
+      "status": "DOWN",
       "data": {
-        "exampleValue": "looking-good"
+        "time": 1701984253071
       }
     },
 ...
 }
+----
+
+The next response shows the health output once the server has been running for at least eight seconds. The custom health check now reports `UP` so the overall health status is also `UP` now and the HTTP status is `200`.
+
+[source,json]
+.Response after 8 seconds: HTTP status 200
+----
+{
+  "status": "UP",
+  "checks": [
+    {
+      "name": "live-after-8-seconds",
+      "status": "UP",
+      "data": {
+        "time": 1701984258292
+      }
+    },
+
 ----
 
 TIP: Balance collecting a lot of information with the need to avoid overloading
@@ -205,15 +313,18 @@ The following table provides a summary of the Health Check API classes.
 checks
 |=======
 
+[[built-in-health-checks-table]]
 === Built-In Health Checks
 
 You can use Helidon-provided health checks to report various
 common health check statuses:
 
-[[built-in-health-checks-table]]
+// Had to move the anchor to the heading above because the rendered page did not define the ID
+// correctly on the table so the link did not work. The link itself looks OK; just no ID generated on the page.
+//[[built-in-health-checks-table]]
 [cols="1,1,3,15,3"]
 |=======
-|Built-in health check |Health check name |JavaDoc |Config properties |Default config value
+|Built-in health check |Health check name |JavaDoc |Config properties (within `server.features.observe.observers.health`) |Default config value
 
 |deadlock detection
 |`deadlock`
@@ -224,16 +335,16 @@ common health check statuses:
 |available disk space
 |`diskSpace`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/DiskSpaceHealthCheck.html[`DiskSpaceHealthCheck`]
-|`helidon.healthCheck.diskSpace.thresholdPercent` +
+|`helidon.health.diskSpace.thresholdPercent` +
 +
-`helidon.healthCheck.diskSpace.path`
+`helidon.health.diskSpace.path`
 | `99.999` +
 +
 `/`
 |available heap memory
 | `heapMemory`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/HeapMemoryHealthCheck.html[`HeapMemoryHealthCheck`]
-|`helidon.healthCheck.heapMemory.thresholdPercent`
+|`helidon.health.heapMemory.thresholdPercent`
 |`98`
 |=======
 
@@ -259,7 +370,7 @@ WebServer server = WebServer.builder()
 ----
 <1> Disables automatic registration of the built-in health checks.
 <2> Adds the specific built-in check(s) you want.
-<3> Adds a custom check.
+<3> Adds a custom check (in a previously-prepared variable `hc`).
 
 You can control the thresholds for built-in health checks in either of two ways:
 
@@ -267,7 +378,7 @@ You can control the thresholds for built-in health checks in either of two ways:
 using their builders instead of using the `HealthChecks` convenience class.
 Follow the JavaDoc links in the <<built-in-health-checks-table,table>> above.
 
-* Using configuration as explained in <<Configuration>>.
+* Using configuration as explained in <<Configuration, Configuration>>.
 
 === Kubernetes Probes
 * <<Liveness Probe, Liveness Probe>>
@@ -387,7 +498,7 @@ health checks by setting the configuration item
 
 === JSON Response Example
 
-Accessing the Helidon-provided `/health` endpoint reports the health of your application
+Accessing the Helidon-provided `/observe/health` endpoint reports the health of your application
 as shown below:
 
 [source,json]
@@ -446,27 +557,14 @@ ObserveFeature observeFeature = ObserveFeature.builder()
                          .addChecks(HealthChecks.healthChecks()) // <2>
                          .build())
     .addObserver(HealthObserver.builder()
-        .useSystemServices(false)
-        .endpoint("/health/ready") // <3>
-        .addCheck(new HealthCheck() { // <4>
-            @Override
-            public String name() {
-                return "database";
-            }
-
-            @Override
-            public HealthCheckResponse call() {
-            return HealthCheckResponse.builder()
-                .status(true)
-                .build();
-            }
-
-            @Override
-            public HealthCheckType type() {
-                return HealthCheckType.READINESS;
-            }
-        })
-        .build())
+                         .useSystemServices(false)
+                         .endpoint("/health/ready") // <3>
+                         .addCheck(() -> HealthCheckResponse.builder() // <4>
+                                      .status(true)
+                                      .build(),
+                              HealthCheckType.READINESS,
+                              "database")
+                         .build())
     .build();
 WebServer server = WebServer.builder()
     .putSocket("@default", socket -> socket

--- a/docs/se/health.adoc
+++ b/docs/se/health.adoc
@@ -107,7 +107,7 @@ The various styles are functionally equivalent; for a given custom health check 
 The examples below, in no particular order, implement the same custom health check functionality in different ways to illustrate.
 
 ==== Option 1: Using a `HealthCheckResponse` supplier method
-If you gather the logic for computing the health check response into a method you can use a method reference to register the health check.
+If you gather the logic for computing the health check response into a method, then you can use a method reference to register the health check.
 
 [source,java]
 .Declaring a health check response supplier method
@@ -125,19 +125,21 @@ static HealthCheckResponse slowStartLivenessResponse() {
 .Registering a health check using a method reference
 ----
 ObserveFeature observe = ObserveFeature.builder()
-                             .config(config.get("server.features.observe")) // <1>
-                             .addObserver(HealthObserver.builder()          // <2>
-                             .useSystemServices(true) // Include Helidon-provided health checks.
-                             .addCheck(Main::slowStartLivenessResponse, // <3>
-                                       HealthCheckType.READINESS,       // <4>
-                                       "live-after-8-seconds")          // <5>
+        .config(config.get("server.features.observe"))                  // <1>
+        .addObserver(HealthObserver.builder()                           // <2>
+                             .useSystemServices(true)                   // <3>
+                             .addCheck(Main::slowStartLivenessResponse, // <4>
+                                       HealthCheckType.LIVENESS,        // <5>
+                                       "live-after-8-seconds")          // <6>
+                             .build())
         .build();
 ----
 <1> Apply configuration to auto-discovered observers (e.g., health, metrics).
 <2> Augment the web server by adding the `ObserveFeature` containing the `HealthObserver`. This replaces the auto-discovered health observer.
-<3> Add the custom health check, passing a reference to the method which returns the health check responses.
-<4> Set the type of the custom health check.
-<5> Set the name of the custom health check.
+<3> Include the Helidon-supplied health checks.
+<4> Add the custom health check, passing a reference to the method which returns the health check responses.
+<5> Set the type of the custom health check.
+<6> Set the name of the custom health check.
 
 ==== Option 2: Using an in-line lambda expression
 If the logic for computing the health check response is fairly simple, express it as an in-line lambda when you register the health check.


### PR DESCRIPTION
### Description
Resolves #7945 

The health doc was significantly out of step with the late coding changes for 4.0.0. This PR addresses a number of problems, including what config key prefix is correct and the code examples to create a custom observe feature and a custom health observer in which to add custom health checks.

### Documentation
This is a doc PR.