### PR TITLE
Inject updates 1

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -408,6 +408,15 @@ public final class Prototype {
     }
 
     /**
+     * Annotated constant of a custom methods type to be added to prototype interface.
+     * The constant will be generated as a reference to the annotated constant (so it must be package local).
+     */
+    @Target(ElementType.FIELD)
+    @Retention(RetentionPolicy.CLASS)
+    public @interface Constant {
+    }
+
+    /**
      * Add additional interfaces to implement by the prototype. Provide correct types (fully qualified) for generics.
      */
     public @interface Implement {
@@ -418,6 +427,5 @@ public final class Prototype {
          */
         String[] value();
     }
-
 }
 

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/AnnotationDataOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/AnnotationDataOption.java
@@ -324,7 +324,7 @@ record AnnotationDataOption(Javadoc javadoc,
 
     /*
     Method name is camel case (such as maxInitialLineLength)
-    result is dash separated and lower cased (such as max-initial-line-length).
+    result is kebab-case (such as max-initial-line-length).
     Note that this same method was created in ConfigUtils in common-config, but since this
     module should not have any dependencies in it a copy was left here as well.
     */

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
@@ -179,6 +179,8 @@ class BuilderCodegen implements CodegenExtension {
         blueprintDef.extendsList()
                 .forEach(classModel::addInterface);
 
+        generateCustomConstants(customMethods, classModel);
+
         TypeName builderTypeName = TypeName.builder()
                 .from(TypeName.create(prototype.fqName() + ".Builder"))
                 .typeArguments(prototype.typeArguments())
@@ -315,6 +317,18 @@ class BuilderCodegen implements CodegenExtension {
                 builder.addContentLine("return new " + ifaceName + ".Builder<>();");
             }
         });
+    }
+
+    private static void generateCustomConstants(CustomMethods customMethods, ClassModel.Builder classModel) {
+        for (CustomConstant customConstant : customMethods.customConstants()) {
+            classModel.addField(constant -> constant
+                    .type(customConstant.fieldType())
+                    .name(customConstant.name())
+                    .javadoc(customConstant.javadoc())
+                    .addContent(customConstant.declaringType())
+                    .addContent(".")
+                    .addContent(customConstant.name()));
+        }
     }
 
     private static void generateCustomMethods(CustomMethods customMethods, ClassModel.Builder classModel) {

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/CustomConstant.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/CustomConstant.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.codegen;
+
+import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.common.types.TypeName;
+
+record CustomConstant(TypeName declaringType, TypeName fieldType, String name, Javadoc javadoc) {
+}

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/CustomMethods.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/CustomMethods.java
@@ -242,17 +242,17 @@ record CustomMethods(List<CustomMethod> factoryMethods,
                     if (!it.elementModifiers().contains(Modifier.STATIC)) {
                         errors.fatal(it,
                                      "A field annotated with @Prototype.Constant must be static, final, "
-                                             + "and at least package local. Not static.");
+                                             + "and at least package local. Field \"" + it.elementName() + "\" is not static.");
                     }
                     if (!it.elementModifiers().contains(Modifier.FINAL)) {
                         errors.fatal(it,
                                      "A field annotated with @Prototype.Constant must be static, final, "
-                                             + "and at least package local. Not final.");
+                                             + "and at least package local. Field \"" + it.elementName() + "\" is not final.");
                     }
                     if (it.accessModifier() == AccessModifier.PRIVATE) {
                         errors.fatal(it,
                                      "A field annotated with @Prototype.Constant must be static, final, "
-                                             + "and at least package local. Private.");
+                                             + "and at least package local. Field \"" + it.elementName() + "\" is private.");
                     }
                     TypeName fieldType = it.typeName();
                     String name = it.elementName();

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/Types.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/Types.java
@@ -47,6 +47,7 @@ final class Types {
     static final TypeName PROTOTYPE_BUILDER_METHOD = TypeName.create("io.helidon.builder.api.Prototype.BuilderMethod");
     static final TypeName PROTOTYPE_PROTOTYPE_METHOD = TypeName.create("io.helidon.builder.api.Prototype.PrototypeMethod");
     static final TypeName PROTOTYPE_BUILDER_DECORATOR = TypeName.create("io.helidon.builder.api.Prototype.BuilderDecorator");
+    static final TypeName PROTOTYPE_CONSTANT = TypeName.create("io.helidon.builder.api.Prototype.Constant");
 
     static final TypeName RUNTIME_PROTOTYPE = TypeName.create("io.helidon.builder.api.RuntimeType.PrototypedBy");
     static final TypeName RUNTIME_PROTOTYPED_BY = TypeName.create("io.helidon.builder.api.RuntimeType.PrototypedBy");

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RuntimeTypeExample.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RuntimeTypeExample.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+
+@RuntimeType.PrototypedBy(RuntimeTypeExampleConfig.class)
+public class RuntimeTypeExample implements RuntimeType.Api<RuntimeTypeExampleConfig> {
+    private final RuntimeTypeExampleConfig prototype;
+
+    private RuntimeTypeExample(RuntimeTypeExampleConfig prototype) {
+        this.prototype = prototype;
+    }
+
+    static RuntimeTypeExample create(RuntimeTypeExampleConfig prototype) {
+        return new RuntimeTypeExample(prototype);
+    }
+
+    static RuntimeTypeExampleConfig.Builder builder() {
+        return RuntimeTypeExampleConfig.builder();
+    }
+
+    static RuntimeTypeExample create(Consumer<RuntimeTypeExampleConfig.Builder> consumer) {
+        return builder().update(consumer).build();
+    }
+
+    @Override
+    public RuntimeTypeExampleConfig prototype() {
+        return prototype;
+    }
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RuntimeTypeExampleConfigBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RuntimeTypeExampleConfigBlueprint.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+interface RuntimeTypeExampleConfigBlueprint extends Prototype.Factory<RuntimeTypeExample> {
+    String type();
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RuntimeTypeExampleInterface.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RuntimeTypeExampleInterface.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+
+@RuntimeType.PrototypedBy(RuntimeTypeExampleInterfaceConfig.class)
+public interface RuntimeTypeExampleInterface extends RuntimeType.Api<RuntimeTypeExampleInterfaceConfig> {
+
+    static RuntimeTypeExampleInterface create(RuntimeTypeExampleInterfaceConfig prototype) {
+        return new AnImplementation(prototype);
+    }
+
+    static RuntimeTypeExampleInterfaceConfig.Builder builder() {
+        return RuntimeTypeExampleInterfaceConfig.builder();
+    }
+
+    static RuntimeTypeExampleInterface create(Consumer<RuntimeTypeExampleInterfaceConfig.Builder> consumer) {
+        return builder().update(consumer).build();
+    }
+
+    class AnImplementation implements RuntimeTypeExampleInterface {
+        private final RuntimeTypeExampleInterfaceConfig prototype;
+
+        private AnImplementation(RuntimeTypeExampleInterfaceConfig prototype) {
+            this.prototype = prototype;
+        }
+
+        @Override
+        public RuntimeTypeExampleInterfaceConfig prototype() {
+            return prototype;
+        }
+    }
+
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RuntimeTypeExampleInterfaceConfigBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/RuntimeTypeExampleInterfaceConfigBlueprint.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+interface RuntimeTypeExampleInterfaceConfigBlueprint extends Prototype.Factory<RuntimeTypeExampleInterface> {
+    String type();
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/RuntimeTypeExampleTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/RuntimeTypeExampleTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test;
+
+import io.helidon.builder.test.testsubjects.RuntimeTypeExample;
+import io.helidon.builder.test.testsubjects.RuntimeTypeExampleConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+
+class RuntimeTypeExampleTest {
+    @Test
+    void sanityCheck() {
+        RuntimeTypeExample runtimeType = RuntimeTypeExampleConfig.builder()
+                .type("type")
+                .build();
+
+        assertThat(runtimeType.prototype().type(), is("type"));
+    }
+}

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptProcessor.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptProcessor.java
@@ -48,9 +48,16 @@ import static java.lang.System.Logger.Level.WARNING;
 public final class AptProcessor extends AbstractProcessor {
     private static final TypeName GENERATOR = TypeName.create(AptProcessor.class);
 
-
     private AptContext ctx;
     private Codegen codegen;
+
+    /**
+     * Only for {@link java.util.ServiceLoader}, to be loaded by compiler.
+     */
+    @Deprecated
+    public AptProcessor() {
+        super();
+    }
 
     @Override
     public SourceVersion getSupportedSourceVersion() {

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/ToAnnotationValueVisitor.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/ToAnnotationValueVisitor.java
@@ -18,6 +18,8 @@ package io.helidon.codegen.apt;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -157,21 +159,11 @@ class ToAnnotationValueVisitor implements AnnotationValueVisitor<Object, Object>
         if (mapBlankArrayToNull && values.isEmpty()) {
             return null;
         } else if (mapToSourceDeclaration) {
-            StringBuilder resultBuilder = new StringBuilder("{");
-
-            for (AnnotationValue val : vals) {
-                Object stringVal = val.accept(this, null);
-                if (stringVal != null) {
-                    if (resultBuilder.length() > 1) {
-                        resultBuilder.append(", ");
-                    }
-                    resultBuilder.append(stringVal);
-                }
-            }
-
-            resultBuilder.append("}");
-
-            return resultBuilder.toString();
+            return vals.stream()
+                    .map(v -> v.accept(this, null))
+                    .filter(Objects::nonNull)
+                    .map(String::valueOf)
+                    .collect(Collectors.joining(", ", "{", "}"));
         }
 
         return values;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/CommonComponent.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/CommonComponent.java
@@ -84,6 +84,7 @@ abstract class CommonComponent extends DescribableComponent {
          * @return updated builder instance
          */
         B javadoc(Javadoc javadoc) {
+            this.javadocBuilder.clear();
             this.javadocBuilder.from(javadoc);
             return identity();
         }

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Field.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Field.java
@@ -272,5 +272,10 @@ public final class Field extends AnnotatedComponent {
         public Builder accessModifier(AccessModifier accessModifier) {
             return super.accessModifier(accessModifier);
         }
+
+        @Override
+        public Builder javadoc(Javadoc javadoc) {
+            return super.javadoc(javadoc);
+        }
     }
 }

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Javadoc.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Javadoc.java
@@ -503,6 +503,23 @@ public final class Javadoc extends ModelComponent {
         }
 
         /**
+         * Remove everything from this builder.
+         *
+         * @return updated builder instance
+         */
+        public Builder clear() {
+            this.generate = false;
+            this.deprecation.clear();
+            this.returnDescription.clear();
+            this.contentBuilder.delete(0, contentBuilder.length());
+            this.parameters.clear();
+            this.genericArguments.clear();
+            this.throwsDesc.clear();
+            this.otherTags.clear();
+            return this;
+        }
+
+        /**
          * Populates this builder with the parsed javadoc data.
          *
          * @param fullJavadocString string format javadoc

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Type.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Type.java
@@ -60,11 +60,16 @@ abstract class Type extends ModelComponent {
 
     private static String extractBoundTypeName(TypeName instance) {
         String name = calcName(instance);
-        StringBuilder nameBuilder = new StringBuilder(name)
-                .append(instance.typeArguments()
-                .stream()
-                .map(TypeName::resolvedName)
-                .collect(Collectors.joining(", ", "<", ">")));
+        StringBuilder nameBuilder = new StringBuilder(name);
+
+        if (!instance.typeArguments().isEmpty()) {
+            nameBuilder.append('<')
+                    .append(instance.typeArguments()
+                                    .stream()
+                                    .map(TypeName::resolvedName)
+                                    .collect(Collectors.joining(", ")))
+                    .append('>');
+        }
 
         if (instance.array()) {
             nameBuilder.append("[]");

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Type.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Type.java
@@ -16,6 +16,7 @@
 package io.helidon.codegen.classmodel;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.helidon.common.types.TypeName;
 
@@ -59,20 +60,11 @@ abstract class Type extends ModelComponent {
 
     private static String extractBoundTypeName(TypeName instance) {
         String name = calcName(instance);
-        StringBuilder nameBuilder = new StringBuilder(name);
-
-        if (!instance.typeArguments().isEmpty()) {
-            nameBuilder.append("<");
-            int i = 0;
-            for (TypeName param : instance.typeArguments()) {
-                if (i > 0) {
-                    nameBuilder.append(", ");
-                }
-                nameBuilder.append(param.resolvedName());
-                i++;
-            }
-            nameBuilder.append(">");
-        }
+        StringBuilder nameBuilder = new StringBuilder(name)
+                .append(instance.typeArguments()
+                .stream()
+                .map(TypeName::resolvedName)
+                .collect(Collectors.joining(", ", "<", ">")));
 
         if (instance.array()) {
             nameBuilder.append("[]");

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypeTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.helidon.codegen.classmodel;
 
 import java.io.IOException;

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypeTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/TypeTest.java
@@ -1,0 +1,59 @@
+package io.helidon.codegen.classmodel;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Set;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TypeTest {
+    @Test
+    void testPlainType() throws IOException {
+        assertThat(write(TypeNames.STRING), is("java.lang.String"));
+    }
+
+    @Test
+    void testGenericType() throws IOException {
+        assertThat(write(TypeName.builder(TypeNames.LIST)
+                                 .addTypeArgument(TypeNames.STRING)
+                                 .build()), is("java.util.List<java.lang.String>"));
+    }
+
+    @Test
+    void testNestedGenericType() throws IOException {
+        assertThat(write(TypeName.builder(TypeNames.LIST)
+                                 .addTypeArgument(TypeName.builder(TypeNames.SUPPLIER)
+                                                          .addTypeArgument(TypeNames.STRING)
+                                                          .build())
+                                 .build()), is("java.util.List<java.util.function.Supplier<java.lang.String>>"));
+    }
+
+    @Test
+    void testWildcardType() throws IOException {
+        assertThat(write(TypeName.builder(TypeNames.SUPPLIER)
+                                 .addTypeArgument(TypeName.builder(TypeName.create(
+                                                 "io.helidon.inject.api.InjectionPointInfo"))
+                                                          .wildcard(true)
+                                                          .build())
+                                 .build()),
+                   is("java.util.function.Supplier<? extends io.helidon.inject.api.InjectionPointInfo>"));
+    }
+
+    private String write(TypeName typeName) throws IOException {
+        Type classModelType = Type.fromTypeName(typeName);
+        StringWriter stringWriter = new StringWriter();
+        ModelWriter modelWriter = new ModelWriter(stringWriter, "");
+        classModelType.writeComponent(modelWriter, Set.of(), ImportOrganizer.builder()
+                .packageName("io.helidon.tests")
+                .typeName("MyType")
+                .build(), ClassType.CLASS);
+
+        return stringWriter.toString();
+    }
+}

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenUtil.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenUtil.java
@@ -73,6 +73,8 @@ public final class CodegenUtil {
                 }
             } else if (Character.isLowerCase(aChar)) {
                 result.append(aChar);
+            } else if (Character.isDigit(aChar)) {
+                result.append(aChar);
             } else {
                 // not a character, replace with underscore
                 result.append('_');

--- a/codegen/codegen/src/main/java/io/helidon/codegen/ListOptionImpl.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/ListOptionImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import io.helidon.common.GenericType;
+
+final class ListOptionImpl<T> implements Option<List<T>> {
+    private final String name;
+    private final String description;
+    private final List<T> defaultValue;
+    private final Function<String, T> mapFunction;
+    private final GenericType<List<T>> type;
+
+    ListOptionImpl(String name,
+                   String description,
+                   List<T> defaultValue,
+                   Function<String, T> mapFunction,
+                   GenericType<List<T>> type) {
+        this.name = name;
+        this.description = description;
+        this.defaultValue = defaultValue;
+        this.mapFunction = mapFunction;
+        this.type = type;
+    }
+
+    @Override
+    public GenericType<List<T>> type() {
+        return type;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String description() {
+        return description;
+    }
+
+    @Override
+    public List<T> defaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public Optional<List<T>> findValue(CodegenOptions options) {
+        return options.option(name)
+                .map(it -> it.split(","))
+                .map(this::toList);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ListOptionImpl<?> option)) {
+            return false;
+        }
+        return Objects.equals(name, option.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    private List<T> toList(String[] strings) {
+        return Stream.of(strings)
+                .map(String::trim)
+                .map(mapFunction)
+                .toList();
+    }
+}

--- a/codegen/codegen/src/main/java/io/helidon/codegen/Option.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/Option.java
@@ -16,7 +16,9 @@
 
 package io.helidon.codegen;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import io.helidon.common.GenericType;
@@ -68,13 +70,13 @@ public interface Option<T> {
     /**
      * Create a new option with a custom mapper.
      *
-     * @param name name of the option
-     * @param description description of the option
+     * @param name         name of the option
+     * @param description  description of the option
      * @param defaultValue default value
-     * @param mapper mapper from string
-     * @param type type of the option
+     * @param mapper       mapper from string
+     * @param type         type of the option
+     * @param <T>          type of the option
      * @return a new option that can be used to load value from {@link io.helidon.codegen.CodegenOptions}
-     * @param <T> type of the option
      */
     static <T> Option<T> create(String name,
                                 String description,
@@ -82,6 +84,44 @@ public interface Option<T> {
                                 Function<String, T> mapper,
                                 GenericType<T> type) {
         return new OptionImpl<>(name, description, defaultValue, mapper, type);
+    }
+
+    /**
+     * Create a new option that has a set of values, with a custom mapper.
+     *
+     * @param name         name of the option
+     * @param description  description of the option
+     * @param defaultValue default value
+     * @param mapper       mapper from string
+     * @param type         type of the option
+     * @param <T>          type of the option
+     * @return a new option that can be used to load value from {@link io.helidon.codegen.CodegenOptions}
+     */
+    static <T> Option<Set<T>> createSet(String name,
+                                        String description,
+                                        Set<T> defaultValue,
+                                        Function<String, T> mapper,
+                                        GenericType<Set<T>> type) {
+        return new SetOptionImpl<>(name, description, defaultValue, mapper, type);
+    }
+
+    /**
+     * Create a new option that has a list of values, with a custom mapper.
+     *
+     * @param name         name of the option
+     * @param description  description of the option
+     * @param defaultValue default value
+     * @param mapper       mapper from string
+     * @param type         type of the option
+     * @param <T>          type of the option
+     * @return a new option that can be used to load value from {@link io.helidon.codegen.CodegenOptions}
+     */
+    static <T> Option<List<T>> createList(String name,
+                                          String description,
+                                          List<T> defaultValue,
+                                          Function<String, T> mapper,
+                                          GenericType<List<T>> type) {
+        return new ListOptionImpl<>(name, description, defaultValue, mapper, type);
     }
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/SetOptionImpl.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/SetOptionImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.helidon.common.GenericType;
+
+final class SetOptionImpl<T> implements Option<Set<T>> {
+    private final String name;
+    private final String description;
+    private final Set<T> defaultValue;
+    private final Function<String, T> mapFunction;
+    private final GenericType<Set<T>> type;
+
+    SetOptionImpl(String name,
+                  String description,
+                  Set<T> defaultValue,
+                  Function<String, T> mapFunction,
+                  GenericType<Set<T>> type) {
+        this.name = name;
+        this.description = description;
+        this.defaultValue = defaultValue;
+        this.mapFunction = mapFunction;
+        this.type = type;
+    }
+
+    @Override
+    public GenericType<Set<T>> type() {
+        return type;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String description() {
+        return description;
+    }
+
+    @Override
+    public Set<T> defaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public Optional<Set<T>> findValue(CodegenOptions options) {
+        return options.option(name)
+                .map(it -> it.split(","))
+                .map(this::toSet);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SetOptionImpl<?> option)) {
+            return false;
+        }
+        return Objects.equals(name, option.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    private Set<T> toSet(String[] strings) {
+        return Stream.of(strings)
+                .map(String::trim)
+                .map(mapFunction)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/codegen/codegen/src/test/java/io/helidon/codegen/CodegenUtilTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/CodegenUtilTest.java
@@ -38,6 +38,7 @@ class CodegenUtilTest {
             myMethod MY_METHOD
             MY_METHOD MY_METHOD
             some-value SOME_VALUE
+            methodIA2 METHOD_IA2
             """, delimiter = ' ')
     void testConstantName(String source, String expected) {
         String actual = CodegenUtil.toConstantName(source);

--- a/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanTypeInfoFactory.java
+++ b/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanTypeInfoFactory.java
@@ -557,7 +557,7 @@ public final class ScanTypeInfoFactory extends TypeInfoFactoryBase {
                     boolean fromCache = true;
                     if (meta == null) {
                         fromCache = false;
-                        ClassInfo classInfo = ctx.scanResult().getClassInfo(it.fqName());
+                        ClassInfo classInfo = ctx.scanResult().getClassInfo(it.name());
                         if (classInfo != null) {
                             List<Annotation> metaAnnotations = createAnnotations(ctx,
                                                                                  classInfo.getAnnotationInfo(),

--- a/common/config/src/main/java/io/helidon/common/config/Config.java
+++ b/common/config/src/main/java/io/helidon/common/config/Config.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 
 /**
  * Immutable tree-structured configuration.
- *
+ * <p>
  * See {@link ConfigValue}.
  */
 public interface Config {

--- a/common/types/src/main/java/io/helidon/common/types/TypeNameBlueprint.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeNameBlueprint.java
@@ -179,6 +179,15 @@ interface TypeNameBlueprint {
     }
 
     /**
+     * Indicates whether this type is a {@link java.util.function.Supplier}.
+     *
+     * @return if this is a supplier
+     */
+    default boolean isSupplier() {
+        return TypeNames.SUPPLIER.fqName().equals(fqName());
+    }
+
+    /**
      * Simple class name with generic declaration (if part of this name).
      *
      * @return class name with generics, such as {@code Consumer<java.lang.String>}, or {@code Consumer<T>}

--- a/common/types/src/main/java/io/helidon/common/types/TypeNameSupport.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeNameSupport.java
@@ -20,14 +20,58 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import io.helidon.builder.api.Prototype;
 
-import static io.helidon.common.types.TypeNames.PRIMITIVES;
-
 final class TypeNameSupport {
+    private static final TypeName PRIMITIVE_BOOLEAN = TypeName.create(boolean.class);
+    private static final TypeName PRIMITIVE_BYTE = TypeName.create(byte.class);
+    private static final TypeName PRIMITIVE_SHORT = TypeName.create(short.class);
+    private static final TypeName PRIMITIVE_INT = TypeName.create(int.class);
+    private static final TypeName PRIMITIVE_LONG = TypeName.create(long.class);
+    private static final TypeName PRIMITIVE_CHAR = TypeName.create(char.class);
+    private static final TypeName PRIMITIVE_FLOAT = TypeName.create(float.class);
+    private static final TypeName PRIMITIVE_DOUBLE = TypeName.create(double.class);
+    private static final TypeName PRIMITIVE_VOID = TypeName.create(void.class);
+    private static final TypeName BOXED_BOOLEAN = TypeName.create(Boolean.class);
+    private static final TypeName BOXED_BYTE = TypeName.create(Byte.class);
+    private static final TypeName BOXED_SHORT = TypeName.create(Short.class);
+    private static final TypeName BOXED_INT = TypeName.create(Integer.class);
+    private static final TypeName BOXED_LONG = TypeName.create(Long.class);
+    private static final TypeName BOXED_CHAR = TypeName.create(Character.class);
+    private static final TypeName BOXED_FLOAT = TypeName.create(Float.class);
+    private static final TypeName BOXED_DOUBLE = TypeName.create(Double.class);
+    private static final TypeName BOXED_VOID = TypeName.create(Void.class);
+
+    // as type names need this class to be initialized, let's have a copy of these
+    private static final Map<String, TypeName> PRIMITIVES = Map.of(
+            "boolean", PRIMITIVE_BOOLEAN,
+            "byte", PRIMITIVE_BYTE,
+            "short", PRIMITIVE_SHORT,
+            "int", PRIMITIVE_INT,
+            "long", PRIMITIVE_LONG,
+            "char", PRIMITIVE_CHAR,
+            "float", PRIMITIVE_FLOAT,
+            "double", PRIMITIVE_DOUBLE,
+            "void", PRIMITIVE_VOID
+    );
+
+    private static final Map<TypeName, TypeName> BOXED_TYPES = Map.of(
+            PRIMITIVE_BOOLEAN, BOXED_BOOLEAN,
+            PRIMITIVE_BYTE, BOXED_BYTE,
+            PRIMITIVE_SHORT, BOXED_SHORT,
+            PRIMITIVE_INT, BOXED_INT,
+            PRIMITIVE_LONG, BOXED_LONG,
+            PRIMITIVE_CHAR, BOXED_CHAR,
+            PRIMITIVE_FLOAT, BOXED_FLOAT,
+            PRIMITIVE_DOUBLE, BOXED_DOUBLE,
+            PRIMITIVE_VOID, BOXED_VOID
+    );
+
     private TypeNameSupport() {
     }
 
@@ -55,7 +99,8 @@ final class TypeNameSupport {
      */
     @Prototype.PrototypeMethod
     static TypeName boxed(TypeName original) {
-        return TypeNames.boxed(original);
+        return Optional.ofNullable(BOXED_TYPES.get(original))
+                .orElse(original);
     }
 
     @Prototype.PrototypeMethod

--- a/common/types/src/main/java/io/helidon/common/types/TypeNames.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeNames.java
@@ -16,6 +16,7 @@
 
 package io.helidon.common.types;
 
+import java.lang.annotation.Retention;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -64,6 +65,11 @@ public final class TypeNames {
      * Type name for {@link java.time.Duration}.
      */
     public static final TypeName DURATION = TypeName.create(Duration.class);
+    /**
+     * Type name for {@link java.lang.annotation.Retention}.
+     */
+    public static final TypeName RETENTION = TypeName.create(Retention.class);
+
     /*
     Primitive types and their boxed counterparts
      */
@@ -151,36 +157,19 @@ public final class TypeNames {
      * Type name of typed element info.
      */
     public static final TypeName TYPED_ELEMENT_INFO = TypeName.create(TypedElementInfo.class);
-
-    static final Map<String, TypeName> PRIMITIVES = Map.of(
-            "boolean", PRIMITIVE_BOOLEAN,
-            "byte", PRIMITIVE_BYTE,
-            "short", PRIMITIVE_SHORT,
-            "int", PRIMITIVE_INT,
-            "long", PRIMITIVE_LONG,
-            "char", PRIMITIVE_CHAR,
-            "float", PRIMITIVE_FLOAT,
-            "double", PRIMITIVE_DOUBLE,
-            "void", PRIMITIVE_VOID
-    );
-
-    private static final Map<TypeName, TypeName> BOXED_TYPES = Map.of(
-            PRIMITIVE_BOOLEAN, BOXED_BOOLEAN,
-            PRIMITIVE_BYTE, BOXED_BYTE,
-            PRIMITIVE_SHORT, BOXED_SHORT,
-            PRIMITIVE_INT, BOXED_INT,
-            PRIMITIVE_LONG, BOXED_LONG,
-            PRIMITIVE_CHAR, BOXED_CHAR,
-            PRIMITIVE_FLOAT, BOXED_FLOAT,
-            PRIMITIVE_DOUBLE, BOXED_DOUBLE,
-            PRIMITIVE_VOID, BOXED_VOID
-    );
+    /**
+     * Helidon annotation type.
+     */
+    public static final TypeName ANNOTATION = TypeName.create(Annotation.class);
+    /**
+     * Helidon element kind (enum).
+     */
+    public static final TypeName ELEMENT_KIND = TypeName.create(ElementKind.class);
+    /**
+     * Helidon access modifier (enum).
+     */
+    public static final TypeName ACCESS_MODIFIER = TypeName.create(AccessModifier.class);
 
     private TypeNames() {
-    }
-
-    static TypeName boxed(TypeName original) {
-        return Optional.ofNullable(BOXED_TYPES.get(original))
-                .orElse(original);
     }
 }

--- a/common/types/src/test/java/io/helidon/common/types/TypedElementInfoTest.java
+++ b/common/types/src/test/java/io/helidon/common/types/TypedElementInfoTest.java
@@ -23,14 +23,91 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class TypedElementInfoTest {
-
     @Test
     void declarations() {
         assertThat(TypedElementInfo.builder()
                            .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(boolean.class))
+                           .build()
+                           .toString(),
+                   is("boolean arg"));
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(byte.class))
+                           .build().toString(),
+                   is("byte arg"));
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(short.class))
+                           .build().toString(),
+                   is("short arg"));
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(int.class))
+                           .build().toString(),
+                   is("int arg"));
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(long.class))
+                           .build().toString(),
+                   is("long arg"));
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(char.class))
+                           .build().toString(),
+                   is("char arg"));
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(float.class))
+                           .build().toString(),
+                   is("float arg"));
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(double.class))
+                           .build().toString(),
+                   is("double arg"));
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
+                           .kind(ElementKind.PARAMETER)
+                           .typeName(create(void.class))
+                           .build().toString(),
+                   is("void arg"));
+
+        assertThat(TypedElementInfo.builder()
+                           .enclosingType(create("MyClass"))
+                           .elementName("hello")
+                           .typeName(create(void.class))
+                           .kind(ElementKind.METHOD)
+                           .addParameterArgument(TypedElementInfo.builder()
+                                                         .elementName("arg1")
+                                                         .typeName(create(String.class))
+                                                         .kind(ElementKind.PARAMETER)
+                                                         .build())
+                           .addParameterArgument(TypedElementInfo.builder()
+                                                         .elementName("arg2")
+                                                         .typeName(create(int.class))
+                                                         .kind(ElementKind.PARAMETER)
+                                                         .build())
+                           .build().toString(),
+                   is("MyClass::void hello(java.lang.String arg1, int arg2)"));
+    }
+
+    @Test
+    void declarationsToBeRemoved() {
+        assertThat(TypedElementInfo.builder()
+                           .elementName("arg")
                            .elementTypeKind(TypeValues.KIND_PARAMETER)
                            .typeName(create(boolean.class))
-                           .build().toString(),
+                           .build()
+                           .toString(),
                    is("boolean arg"));
         assertThat(TypedElementInfo.builder()
                            .elementName("arg")

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <version.lib.vertx-core>4.3.8</version.lib.vertx-core>
         <version.lib.wiremock>2.26.3</version.lib.wiremock>
         <version.lib.commons-lang3>3.10</version.lib.commons-lang3>
-        <version.lib.classgraph>4.8.154</version.lib.classgraph>
+        <version.lib.classgraph>4.8.165</version.lib.classgraph>
         <!--
         !Version statement! - end
         -->


### PR DESCRIPTION
### Description
Review fixes from previous PR
Support for custom constants in builder
Support for List and Set codegen options
Type info factory fixes for both APT and classpath scanning (was using wrong type names, one requires $ for nested, one .)
Fixed `toConstant` utility method

Fixes in class model:

- javadoc is now correctly cleared in common component (aligned with javadoc)
- Type test
- Field can now accept Javadoc instance
