### PR TITLE
4.x: Upgrade dependency-check-maven and add support for nvdApiKey

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -181,4 +181,50 @@
     <cve>CVE-2022-4245</cve>
 </suppress>
 
+<!--
+    False Positives. These CVEs are against the Brave web browser, not brave-opentracing.
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2022-47932</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2022-47933</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2022-47934</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2021-22929</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2022-30334</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2023-28360</cve>
+</suppress>
+
 </suppressions>

--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -33,9 +33,12 @@ if [ "${PIPELINE}" = "true" ] ; then
     mvn ${MAVEN_ARGS} -f ${WS_DIR}/pom.xml clean install -DskipTests
 fi
 
+# Setting NVD_API_KEY is not required but improves behavior of NVD API throttling
+
 mvn ${MAVEN_ARGS} -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN org.owasp:dependency-check-maven:aggregate \
         -f ${WS_DIR}/pom.xml \
         -Dtop.parent.basedir="${WS_DIR}" \
+        -Dnvd-api-key=${NVD_API_KEY} \
         > ${RESULT_FILE} || die "Error running the Maven command"
 
 grep -i "One or more dependencies were identified with known vulnerabilities" ${RESULT_FILE} \

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>8.4.3</version.plugin.dependency-check>
+        <version.plugin.dependency-check>9.0.4</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
@@ -580,6 +580,7 @@
                         <skipTestScope>true</skipTestScope>
                         <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <nvdApiKey>${nvd-api-key}</nvdApiKey>
                         <excludes>
                             <!-- Exclude stuff we do not deploy -->
                             <exclude>io.helidon.tracing:helidon-tracing-tests</exclude>


### PR DESCRIPTION
### Description

This upgrades dependency-check-maven to 9.0.4. This upgrade is required to ensure scans keep working after Dec 15, 2023 when the NVD will deprecate its data feed in preference to its API.

Users are now encouraged to use an NVD API Key to minimize the impact of API rate limits. See https://github.com/jeremylong/DependencyCheck#900-upgrade-notice

This PR:

* Upgrades dependency-check-maven to 9.0.4
*  Configure the plugin with the <nvdApiKey> configuration option. It is not required
* Udpates owasp-dependency-check.sh to use NVD_API_KEY environment variable and pass it via -Dnvd-api-key=${NVD_API_KEY} . If it is not set everything should still work, just more slowly.
* Suppresses false positives

### Documentation

No impact
