### PR TITLE
3.x - Slightly relax a unit test to avoid test ordering issues

### DIFF
--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestStereotypes.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestStereotypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestStereotypes.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestStereotypes.java
@@ -70,6 +70,6 @@ class TestStereotypes {
 
         SimpleTimer simpleTimer = metricRegistry.getSimpleTimer(new MetricID(StereotypeB.SIMPLE_TIMER_NAME));
         assertThat("Simple timer registered via stereotype", simpleTimer, notNullValue());
-        assertThat("Simple timer count", simpleTimer.getCount(), equalTo(1L));
+        assertThat("Simple timer count", simpleTimer.getCount(), greaterThanOrEqualTo(1L));
     }
 }


### PR DESCRIPTION
### Description
Resolves #8123 

The purpose of the test is to make sure that a metric is registered and updated via a stereotype annotation which itself bears metrics annotations.

The counter value associated with the simple timer in the failing test can be updated multiple times during the course of all units tests (because it is on a bean).

The change in the PR slightly relaxes the test to make sure the simple timer's counter is AT LEAST 1 instead of exactly 1. If it is non-zero then clearly the meter was, in fact, registered and updated, satisfying the purpose of the test.


### Documentation
Test bug fix. No doc impact.