### PR TITLE
4.x tuning guide update

### DIFF
--- a/docs/config/io_helidon_webserver_ConnectionConfig.adoc
+++ b/docs/config/io_helidon_webserver_ConnectionConfig.adoc
@@ -70,7 +70,9 @@ Type: link:{javadoc-base-url}/io.helidon.webserver/io/helidon/webserver/Connecti
 
  @return buffer size, in bytes
  @see java.net.StandardSocketOptions#SO_SNDBUF
-|`tcp-no-delay` |boolean |`false` |This option may improve performance on some systems.
+|`tcp-no-delay` |boolean |`false` |Disable Nagle's algorithm by setting
+ TCP_NODELAY to true. This can result in better performance on Mac or newer linux kernels for some
+ payload types.
  Default is `false`.
 
  @return whether to use TCP_NODELAY, defaults to `false`

--- a/docs/includes/guides/performance-tuning.adoc
+++ b/docs/includes/guides/performance-tuning.adoc
@@ -60,8 +60,8 @@ server:
     read-timeout: PT0S     
     connect-timeout: PT0S
     
-    # Default (false) is best for most cases. But can make big differences depending
-    # on workload and OS.
+    # Default (false: Nagle's algorithm enabled) is best for most cases. But for some OS and
+    # workloads enabling TCP_NODELAY (disable Nagle's algorithm) can improve performance.
     tcp-no-delay: true|false
 
     # The default is TCP autotuning which is best for most cases.

--- a/docs/includes/guides/performance-tuning.adoc
+++ b/docs/includes/guides/performance-tuning.adoc
@@ -1,0 +1,80 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+ifndef::rootdir[:rootdir: {docdir}/../..]
+:guidesdir: {rootdir}/{flavor-lc}/guides
+
+== WebServer Tuning
+
+Helidon WebServer is in large part self tuning. It uses default values that will satisfy most use cases,
+and with the adoption of Java virtual threads there is no longer a need to tune pools of platform threads.
+Still, there might be cases where you wish to change configuration options from their default values.
+
+For details on the following options please see:
+
+* xref:../../se/webserver.adoc#_configuration_options[WebServer Configuration]
+* xref:../../config/io_helidon_webserver_ConnectionConfig.adoc[WebServer Connection Configuration]
+* xref:../../config/io_helidon_common_socket_SocketOptions.adoc[WebServer Socket Configuration]
+
+== Summary of Tuning Options
+
+The following `application.yaml` snippet shows some configuration options that can be used to
+tune your application. It is intended to show configuration options in context. Please make sure
+you understand these options before using them. See the documentation referenced above.
+
+[source, yaml]
+.application.yaml snippet
+----
+server:
+  # Depends on the workload and kernel version
+  backlog: NNNN
+  receive-buffer-size: NNNNN
+  write-buffer-size: NNNNN
+  write-queue-length: NN # 0 means direct write
+  
+  # These are used to prevent unbounded resource consumption of the server
+  idle-connection-period: PT2M  # Check idle connections every 2 minutes
+  idle-connection-timeout: PT5M # Close connections that have been idle for 5 minutes
+  max-concurrent-requests: NNNN # Maximum number of concurrent requests. -1 is unlimited.
+  max-tcp-connections: NNNN     # Max number of concurrent tcp connections. -1 is unlimited.
+  max-in-memory-entity: NNNNNN  # Entities smaller than this are buffered in memory vs streamed (bytes)
+  max-payload-size: NNNNNNN     # Reject requests with payload sizes greater than this. -1 is unlimited (bytes)
+
+  # Depends on the workload and kernel version
+  connection-options:
+    # 0 means indefinite (and less clutter on socket impl)
+    read-timeout: PT0S     
+    connect-timeout: PT0S
+    
+    # Can make quite difference between Mac, Linux kernels < 5.15 and Linux kernels > 5.15
+    tcp-no-delay: true|false
+
+    # when set, TCP autotuning is off (auto-tuning is better for variable or large payloads)
+    socket-send-buffer-size: NNNNN     
+    socket-receive-buffer-size: NNNNN
+
+  # Turn off safety features
+  # Carefull with this! Can be dangerous in production!
+  protocols:
+    "http_1_1":
+      validate-request-headers: true|false
+      validate-response-headers: true|false
+      validate-path: true|false
+      recv-log: true|false
+      send-log: true|false
+----

--- a/docs/includes/guides/performance-tuning.adoc
+++ b/docs/includes/guides/performance-tuning.adoc
@@ -41,12 +41,6 @@ you understand these options before using them. See the documentation referenced
 .application.yaml snippet
 ----
 server:
-  # Depends on the workload and kernel version
-  backlog: NNNN
-  receive-buffer-size: NNNNN
-  write-buffer-size: NNNNN
-  write-queue-length: NN # 0 means direct write
-  
   # These are used to prevent unbounded resource consumption of the server
   idle-connection-period: PT2M  # Check idle connections every 2 minutes
   idle-connection-timeout: PT5M # Close connections that have been idle for 5 minutes
@@ -56,20 +50,26 @@ server:
   max-payload-size: NNNNNNN     # Reject requests with payload sizes greater than this. -1 is unlimited (bytes)
 
   # Depends on the workload and kernel version
+  backlog: NNNN
+  receive-buffer-size: NNNNN
+  write-buffer-size: NNNNN
+  write-queue-length: NN # 0 means direct write
+
   connection-options:
     # 0 means indefinite (and less clutter on socket impl)
     read-timeout: PT0S     
     connect-timeout: PT0S
     
-    # Can make quite difference between Mac, Linux kernels < 5.15 and Linux kernels > 5.15
+    # Default (false) is best for most cases. But can make big differences depending
+    # on workload and OS.
     tcp-no-delay: true|false
 
-    # when set, TCP autotuning is off (auto-tuning is better for variable or large payloads)
+    # The default is TCP autotuning which is best for most cases.
     socket-send-buffer-size: NNNNN     
     socket-receive-buffer-size: NNNNN
 
-  # Turn off safety features
-  # Carefull with this! Can be dangerous in production!
+  # Protocol validation.
+  # Careful with this! Can be dangerous if you turn these off.
   protocols:
     "http_1_1":
       validate-request-headers: true|false

--- a/docs/mp/guides/performance-tuning.adoc
+++ b/docs/mp/guides/performance-tuning.adoc
@@ -25,9 +25,11 @@
 
 include::{rootdir}/includes/mp.adoc[]
 
-In this guide you fill find basic advice for performance tuning of your Helidon application. Most of them target Netty tuning, as Helidon is based on it.
-You should also consider configuring/tuning Java heap size as per any Java application.
+== Introduction
 
+In this guide you fill find basic advice for performance tuning of your Helidon application.
+Most of this concerns tuning Helidon WebServer, but you should also consider configuring/tuning
+Java heap size as per any Java application.
 
 == Use `io.helidon.microprofile.bundles:helidon-microprofile-core`
 
@@ -49,41 +51,5 @@ Use `helidon-microprofile-core` dependency (and not the `helidon-microprofile` d
 </dependency>
 ----
 
+include::{rootdir}/includes/guides/performance-tuning.adoc[]
 
-== Configure Netty worker thread pool size
-
-The Netty worker thread-pool is what handles your incoming requests. It defaults to 2*NCPU. To set it to something else you can set this property in `microprofile-config.properties`:
-
-[source,properties]
-----
-server.worker-count=4
-----
-
-
-=== Configure Helidon server pool size
-
-The Helidon server thread-pool takes requests from Netty and invokes your JAX-RS endpoints.  You can control lts configuration in `microprofile-config.properties`. This is Helidon MP specific only.
-
-[source,properties]
-----
-server.executor-service.core-pool-size: 2
-server.executor-service.max-pool-size: 4
-----
-
-To verify settings increase the log level for Helidon's executor service by adding this to your `logging.properties`:
-
-[source,properties]
-----
-io.helidon.common.configurable.ThreadPool.level=FINE
-----
-
-
-=== Configure Netty's maxOrder (Helidon 2.4.1 or earlier)
-
-In some situations Netty can aggressively allocate memory per request. This has been addressed in recent versions of Helidon and Netty, but if you are running an earlier version set this system property when you start your Helidon application:
-
-```
--Dio.netty.allocator.maxOrder=6
-```
-
-You can try smaller numbers.

--- a/docs/se/guides/performance-tuning.adoc
+++ b/docs/se/guides/performance-tuning.adoc
@@ -25,30 +25,11 @@
 
 include::{rootdir}/includes/se.adoc[]
 
-In this guide you fill find basic advice for performance tuning of your Helidon application. Most of them target Netty tuning, as Helidon is based on it.
-You should also consider configuring/tuning Java heap size as per any Java application.
+== Introduction
 
+In this guide you fill find basic advice for performance tuning of your Helidon application.
+Most of this concerns tuning Helidon WebServer, but you should also consider configuring/tuning
+Java heap size as per any Java application.
 
-== Configure Netty worker thread pool size
+include::{rootdir}/includes/guides/performance-tuning.adoc[]
 
-The Netty worker thread-pool is what handles your incoming requests. It defaults to 2*NCPU. To set it to something else you can set `worker-count` in `resources/application.yaml`:
-
-[source,yaml]
-----
-server:
-  port: 8080
-  host: 0.0.0.0
-  worker-count: 2
-----
-
-
-== Configure Netty's maxOrder (Helidon 2.4.1 or earlier)
-
-In some situations Netty can aggressively allocate memory per request. This has been addressed in recent versions of Helidon and Netty, but if you are running an earlier version set this system property when you start your Helidon application:
-
-[source,bash]
-----
--Dio.netty.allocator.maxOrder=6
-----
-
-You can try smaller numbers.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionConfigBlueprint.java
@@ -107,7 +107,9 @@ interface ConnectionConfigBlueprint {
     boolean reuseAddress();
 
     /**
-     * This option may improve performance on some systems.
+     * Disable <a href="https://en.wikipedia.org/wiki/Nagle%27s_algorithm">Nagle's algorithm</a> by setting
+     * TCP_NODELAY to true. This can result in better performance on Mac or newer linux kernels for some
+     * payload types.
      * Default is {@code false}.
      *
      * @return whether to use TCP_NODELAY, defaults to {@code false}


### PR DESCRIPTION
### Description

See #8102 

This PR removes the old tuning guides (which had incorrect information) and adds new guides than are more placeholders than full fledged documents. We need to decide what, if anything, we need to cover in a new tuning guide.

### Documentation

Provides updates to documentation.

