### PR TITLE
4.x: Inject: new modules

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1354,6 +1354,11 @@
             </dependency>
             <dependency>
                 <groupId>io.helidon.inject</groupId>
+                <artifactId>helidon-inject</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.inject</groupId>
                 <artifactId>helidon-inject-api</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
@@ -1384,6 +1389,16 @@
             </dependency>
 
             <!-- Injection Config-Driven related -->
+            <dependency>
+                <groupId>io.helidon.inject.configdriven</groupId>
+                <artifactId>helidon-inject-configdriven-service</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.inject.configdriven</groupId>
+                <artifactId>helidon-inject-configdriven</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
             <dependency>
                 <groupId>io.helidon.inject.configdriven</groupId>
                 <artifactId>helidon-inject-configdriven-api</artifactId>

--- a/inject/configdriven/configdriven/pom.xml
+++ b/inject/configdriven/configdriven/pom.xml
@@ -49,32 +49,6 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>io.helidon.inject</groupId>
-            <artifactId>helidon-inject-testing</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.common.testing</groupId>
-            <artifactId>helidon-common-testing-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/inject/configdriven/configdriven/pom.xml
+++ b/inject/configdriven/configdriven/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.inject.configdriven</groupId>
+        <artifactId>helidon-inject-configdriven-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-inject-configdriven</artifactId>
+    <name>Helidon Injection Config-Driven</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.inject</groupId>
+            <artifactId>helidon-inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.inject.configdriven</groupId>
+            <artifactId>helidon-inject-configdriven-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.helidon.inject</groupId>
+            <artifactId>helidon-inject-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.common.features</groupId>
+                        <artifactId>helidon-common-features-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/CbrActivatorProvider.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/CbrActivatorProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import io.helidon.inject.Activator;
+import io.helidon.inject.Services;
+import io.helidon.inject.service.ServiceDescriptor;
+import io.helidon.inject.spi.ActivatorProvider;
+
+/**
+ * {@link java.util.ServiceLoader} service implementation of a custom activator provider used only to initialize
+ * Config bean registry.
+ */
+public class CbrActivatorProvider implements ActivatorProvider {
+    /**
+     * Required default constructor.
+     *
+     * @deprecated required by {@link java.util.ServiceLoader}
+     */
+    @Deprecated
+    public CbrActivatorProvider() {
+    }
+
+    @Override
+    public String id() {
+        return CbrServiceDescriptor.CBR_RUNTIME_ID;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> Activator<T> activator(Services services, ServiceDescriptor<T> descriptor) {
+        if (!(descriptor instanceof CbrServiceDescriptor cbrDescriptor)) {
+            throw new IllegalArgumentException("Config Driven Activator only supports descriptors of its own type,"
+                                                       + " invalid descriptor provided: "
+                                                       + descriptor.infoType().fqName());
+        }
+        return (Activator<T>) new CbrProvider(services, cbrDescriptor);
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/CbrProvider.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/CbrProvider.java
@@ -45,7 +45,7 @@ class CbrProvider extends ServiceProviderBase<ConfigBeanRegistryImpl>
             ConfigBeanRegistryImpl cbr = ConfigBeanRegistryImpl.CONFIG_BEAN_REGISTRY.get();
             if (services.limitRuntimePhase() == Phase.ACTIVE) {
                 // we can lookup from the registry, as services can be activated
-                cbr.initialize(services.find(Config.class)
+                cbr.initialize(services.first(Config.class)
                                        .map(Supplier::get)
                                        .orElseGet(GlobalConfig::config));
             } else {

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/CbrProvider.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/CbrProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.util.function.Supplier;
+
+import io.helidon.common.config.Config;
+import io.helidon.common.config.GlobalConfig;
+import io.helidon.inject.ActivationPhaseReceiver;
+import io.helidon.inject.Phase;
+import io.helidon.inject.ServiceProvider;
+import io.helidon.inject.ServiceProviderBase;
+import io.helidon.inject.Services;
+import io.helidon.inject.service.ServiceDescriptor;
+
+class CbrProvider extends ServiceProviderBase<ConfigBeanRegistryImpl>
+        implements ServiceProvider<ConfigBeanRegistryImpl>,
+                   ActivationPhaseReceiver {
+    private final Services services;
+
+    protected CbrProvider(Services services,
+                          ServiceDescriptor<ConfigBeanRegistryImpl> serviceSource) {
+        super(services, serviceSource);
+        this.services = services;
+    }
+
+    @Override
+    public void onPhaseEvent(Phase phase) {
+
+        if (phase == Phase.POST_BIND_ALL_MODULES) {
+            ConfigBeanRegistryImpl cbr = ConfigBeanRegistryImpl.CONFIG_BEAN_REGISTRY.get();
+            if (services.limitRuntimePhase() == Phase.ACTIVE) {
+                // we can lookup from the registry, as services can be activated
+                cbr.initialize(services.find(Config.class)
+                                       .map(Supplier::get)
+                                       .orElseGet(GlobalConfig::config));
+            } else {
+                // we cannot use registry
+                cbr.initialize(GlobalConfig.config());
+            }
+        }
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/CbrServiceDescriptor.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/CbrServiceDescriptor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.util.Set;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.InjectTypes;
+import io.helidon.inject.service.InjectionContext;
+import io.helidon.inject.service.InterceptionMetadata;
+import io.helidon.inject.service.ServiceDescriptor;
+
+/**
+ * A descriptor for config driven registry. Must be public, as other services that inject to it may need to
+ * use this type.
+ * For most services, such a type is code generated.
+ */
+public class CbrServiceDescriptor implements ServiceDescriptor<ConfigBeanRegistryImpl> {
+    /**
+     * Singleton instance bound to binder.
+     */
+    public static final CbrServiceDescriptor INSTANCE = new CbrServiceDescriptor();
+    static final String CBR_RUNTIME_ID = "CBR_CONFIG_DRIVEN";
+    private static final TypeName TYPE = TypeName.create(ConfigBeanRegistryImpl.class);
+    private static final TypeName CBR_TYPE = TypeName.create(ConfigBeanRegistry.class);
+    private static final TypeName INFO_TYPE = TypeName.create(CbrServiceDescriptor.class);
+    private static final Set<TypeName> CONTRACTS = Set.of(CBR_TYPE);
+
+    @Override
+    public String runtimeId() {
+        return CBR_RUNTIME_ID;
+    }
+
+    @Override
+    public TypeName serviceType() {
+        return TYPE;
+    }
+
+    @Override
+    public TypeName infoType() {
+        return INFO_TYPE;
+    }
+
+    @Override
+    public Set<TypeName> contracts() {
+        return CONTRACTS;
+    }
+
+    @Override
+    public Object instantiate(InjectionContext ctx, InterceptionMetadata interceptionMetadata) {
+        return ConfigBeanRegistry.instance();
+    }
+
+    @Override
+    public Set<TypeName> scopes() {
+        return Set.of(InjectTypes.SINGLETON);
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanRegistry.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.configdriven.service.NamedInstance;
+
+/**
+ * Manages the set of active {@link io.helidon.inject.configdriven.service.ConfigBean}'s,
+ * along with whether the application is
+ * configured to support dynamic aspects (i.e., dynamic in content, dynamic in lifecycle, etc.).
+ */
+public interface ConfigBeanRegistry {
+    /**
+     * Config bean registry instance for the current VM.
+     *
+     * @return config bean registry
+     */
+    static ConfigBeanRegistry instance() {
+        return ConfigBeanRegistryImpl.CONFIG_BEAN_REGISTRY.get();
+    }
+
+    /**
+     * The config bean registry is initialized as part of Helidon Injection's initialization, which happens when the service
+     * registry is initialized and bound.
+     *
+     * @return true if the config bean registry has been initialized
+     */
+    boolean ready();
+
+    /**
+     * All active configuration beans (including default instances).
+     *
+     * @return map of all configuration beans, key is the config bean class, values are named instances
+     */
+    Map<TypeName, List<NamedInstance<?>>> allConfigBeans();
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanRegistryDescriptor.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanRegistryDescriptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.util.Set;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.InjectTypes;
+import io.helidon.inject.service.ServiceInfo;
+
+/**
+ * Service descriptor for {@link ConfigBeanRegistry}.
+ */
+public final class ConfigBeanRegistryDescriptor implements ServiceInfo {
+    /**
+     * Singleton instance of this descriptor.
+     */
+    public static final ConfigBeanRegistryDescriptor INSTANCE = new ConfigBeanRegistryDescriptor();
+
+    private static final TypeName TYPE = TypeName.create(ConfigBeanRegistryDescriptor.class);
+    private static final TypeName CBR_TYPE = TypeName.create(ConfigBeanRegistry.class);
+    private static final Set<TypeName> CONTRACTS = Set.of(CBR_TYPE);
+
+    private ConfigBeanRegistryDescriptor() {
+    }
+
+    @Override
+    public TypeName serviceType() {
+        return CBR_TYPE;
+    }
+
+    @Override
+    public TypeName infoType() {
+        return TYPE;
+    }
+
+    @Override
+    public Set<TypeName> contracts() {
+        return CONTRACTS;
+    }
+
+    @Override
+    public Set<TypeName> scopes() {
+        return Set.of(InjectTypes.SINGLETON);
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanRegistryImpl.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanRegistryImpl.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.lang.System.Logger.Level;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.helidon.common.LazyValue;
+import io.helidon.common.config.Config;
+import io.helidon.common.config.ConfigException;
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.InjectionException;
+import io.helidon.inject.InjectionServiceProviderException;
+import io.helidon.inject.Resettable;
+import io.helidon.inject.ResettableHandler;
+import io.helidon.inject.configdriven.service.ConfigBeanFactory;
+import io.helidon.inject.configdriven.service.NamedInstance;
+import io.helidon.inject.service.Qualifier;
+
+/**
+ * The default implementation for {@link ConfigBeanRegistry}.
+ */
+@SuppressWarnings("unchecked")
+class ConfigBeanRegistryImpl implements ConfigBeanRegistry, Resettable {
+    static final LazyValue<ConfigBeanRegistryImpl> CONFIG_BEAN_REGISTRY = LazyValue.create(ConfigBeanRegistryImpl::new);
+
+    private static final System.Logger LOGGER = System.getLogger(ConfigBeanRegistryImpl.class.getName());
+
+    private final AtomicBoolean registeredForReset = new AtomicBoolean();
+    private final AtomicBoolean initializing = new AtomicBoolean();
+
+    // map of config bean types to their factories (only for used config beans, that have a config driven service associated)
+    private final Map<TypeName, ConfigBeanFactory<?>> configBeanFactories = new ConcurrentHashMap<>();
+    // map of config bean types to the config driven types
+    private final Map<TypeName, Set<TypeName>> configDrivenByConfigBean = new ConcurrentHashMap<>();
+    private final Map<TypeName, ConfiguredServiceProvider<?, ?>> configDrivenFactories = new ConcurrentHashMap<>();
+    // map of config bean types to instances (list may be empty if no instance exists)
+    private final Map<TypeName, List<NamedInstance<?>>> configBeanInstances = new ConcurrentHashMap<>();
+
+    private CountDownLatch initialized = new CountDownLatch(1);
+
+    ConfigBeanRegistryImpl() {
+    }
+
+    @Override
+    public Map<TypeName, List<NamedInstance<?>>> allConfigBeans() {
+        return Map.copyOf(configBeanInstances);
+    }
+
+    @Override
+    public void reset(boolean deep) {
+        if (LOGGER.isLoggable(Level.DEBUG)) {
+            LOGGER.log(Level.DEBUG, "Resetting");
+        }
+        configBeanFactories.clear();
+        configDrivenByConfigBean.clear();
+        configDrivenFactories.clear();
+        configBeanInstances.clear();
+        initializing.set(false);
+        initialized = new CountDownLatch(1);
+        registeredForReset.set(false);
+    }
+
+    @Override
+    public boolean ready() {
+        return isInitialized();
+    }
+
+    /**
+     * Binds a {@link io.helidon.inject.configdriven.ConfiguredServiceProvider} to the
+     * {@link io.helidon.inject.configdriven.service.ConfigBean} annotation it is configured by.
+     *
+     * @param configuredServiceProvider the configured service provider
+     * @param configuredByQualifier     the qualifier associated with the
+     *                                  {@link io.helidon.inject.configdriven.service.ConfigBean}
+     * @throws io.helidon.common.config.ConfigException if the bind operation encountered an error
+     */
+    void bind(ConfiguredServiceProvider<?, ?> configuredServiceProvider,
+              Qualifier configuredByQualifier) {
+        Objects.requireNonNull(configuredServiceProvider);
+        Objects.requireNonNull(configuredByQualifier);
+
+        if (initializing.get()) {
+            throw new ConfigException("Unable to bind config post initialization: "
+                                              + configuredServiceProvider.description());
+        }
+
+        TypeName configBeanType = configuredServiceProvider.configBeanType();
+        TypeName configDrivenType = configuredServiceProvider.serviceType();
+
+        if (LOGGER.isLoggable(Level.DEBUG)) {
+            LOGGER.log(Level.DEBUG, "Binding " + configDrivenType
+                    + " with " + configuredByQualifier.value());
+        }
+
+        if (!configDrivenByConfigBean.computeIfAbsent(configBeanType, it -> new LinkedHashSet<>())
+                .add(configDrivenType)) {
+            assert (true) : "duplicate service provider initialization occurred: " + configBeanType + ", " + configDrivenType;
+        }
+        configDrivenFactories.put(configDrivenType, configuredServiceProvider);
+        configBeanFactories.put(configBeanType, configuredServiceProvider);
+    }
+
+    void initialize(Config config) {
+        Objects.requireNonNull(config);
+
+        if (registeredForReset.compareAndSet(false, true)) {
+            CbrResettableHandler.addRegistry(this);
+        }
+        try {
+            if (initializing.getAndSet(true)) {
+                // all threads should wait for the leader (and the config bean registry) to have been fully initialized
+                initialized.await();
+                return;
+            }
+
+            LOGGER.log(Level.DEBUG, "Initializing");
+            doInitialize(config);
+            // we are now ready and initialized
+            initialized.countDown();
+        } catch (InjectionException e) {
+            throw e;
+        } catch (Throwable t) {
+            LOGGER.log(Level.ERROR, "Failed to initialize ConfigDrivenRegistry", t);
+            throw new InjectionServiceProviderException("Error while initializing config bean registry", t);
+        }
+    }
+
+    protected boolean isInitialized() {
+        return (0 == initialized.getCount());
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void doInitialize(Config rootConfiguration) {
+        if (configBeanFactories.isEmpty()) {
+            LOGGER.log(Level.DEBUG, "No config driven services found");
+            return;
+        }
+
+        for (ConfigBeanFactory<?> beanFactory : configBeanFactories.values()) {
+            TypeName configBeanType = beanFactory.configBeanType();
+            List<? extends NamedInstance<?>> configBeans = beanFactory.createConfigBeans(rootConfiguration);
+            for (NamedInstance<?> configBean : configBeans) {
+                configBeanInstances.computeIfAbsent(configBeanType, type -> new ArrayList<>())
+                        .add(configBean);
+            }
+
+            Set<TypeName> configDrivenTypes = configDrivenByConfigBean.get(configBeanType);
+            if (configDrivenTypes == null) {
+                LOGGER.log(Level.WARNING, "Unexpected state of config bean registry, "
+                        + "config bean does not have any config driven types. Config bean type: " + configBeanType);
+                continue;
+            }
+
+            // for each config driven type, create new instances for each discovered config bean
+            for (TypeName configDrivenType : configDrivenTypes) {
+                ConfiguredServiceProvider<?, ?> configuredServiceProvider = configDrivenFactories.get(configDrivenType);
+                if (configuredServiceProvider == null) {
+                    LOGGER.log(Level.WARNING, "Unexpected state of config bean registry, "
+                            + "config driven does not have associated service provider. Config bean type: "
+                            + configBeanType);
+                    continue;
+                }
+                for (NamedInstance configBean : configBeans) {
+                    // now we have a tuple of a config bean instance and a config driven service provider
+                    configuredServiceProvider.registerConfigBean(configBean);
+                }
+            }
+        }
+    }
+
+    private static final class CbrResettableHandler extends ResettableHandler {
+        @Deprecated
+        private CbrResettableHandler() {
+        }
+
+        private static void addRegistry(Resettable resettable) {
+            ResettableHandler.addResettable(resettable);
+        }
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanServiceInfo.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanServiceInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.util.Set;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.InjectTypes;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceInfo;
+
+class ConfigBeanServiceInfo implements ServiceInfo {
+    private final TypeName beanType;
+    private final Set<Qualifier> qualifiers;
+
+    ConfigBeanServiceInfo(TypeName beanType, String name) {
+        this.beanType = beanType;
+        this.qualifiers = Set.of(Qualifier.createNamed(name));
+    }
+
+    @Override
+    public TypeName serviceType() {
+        return beanType;
+    }
+
+    @Override
+    public Set<Qualifier> qualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public Set<TypeName> scopes() {
+        return Set.of(InjectTypes.SINGLETON);
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanServiceProvider.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigBeanServiceProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.util.Optional;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.ContextualServiceQuery;
+import io.helidon.inject.Phase;
+import io.helidon.inject.ServiceProvider;
+import io.helidon.inject.service.ServiceInfo;
+
+class ConfigBeanServiceProvider<CB> implements ServiceProvider<CB> {
+    private final ConfigBeanServiceInfo serviceInfo;
+    private final CB instance;
+    private final String id;
+
+    ConfigBeanServiceProvider(TypeName beanType, CB instance, String id) {
+        this.instance = instance;
+        this.id = id;
+        this.serviceInfo = new ConfigBeanServiceInfo(beanType, id);
+    }
+
+    @Override
+    public Optional<CB> first(ContextualServiceQuery query) {
+        return Optional.of(instance);
+    }
+
+    @Override
+    public String id() {
+        return ServiceProvider.super.id() + "{" + id + "}";
+    }
+
+    @Override
+    public String description() {
+        return serviceInfo().serviceType().classNameWithEnclosingNames() + "{" + id + "}:ACTIVE";
+    }
+
+    @Override
+    public ServiceInfo serviceInfo() {
+        return serviceInfo;
+    }
+
+    @Override
+    public Phase currentActivationPhase() {
+        return Phase.ACTIVE;
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigDrivenActivatorProvider.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigDrivenActivatorProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import io.helidon.common.Weighted;
+import io.helidon.inject.Activator;
+import io.helidon.inject.Services;
+import io.helidon.inject.service.ServiceDescriptor;
+import io.helidon.inject.spi.ActivatorProvider;
+
+/**
+ * A {@link java.util.ServiceLoader} provider implementation of an {@link io.helidon.inject.spi.ActivatorProvider} that
+ * supports config driven beans.
+ */
+public class ConfigDrivenActivatorProvider implements ActivatorProvider, Weighted {
+    /**
+     * Required default constructor.
+     *
+     * @deprecated required by {@link java.util.ServiceLoader}
+     */
+    @Deprecated
+    public ConfigDrivenActivatorProvider() {
+    }
+
+    @Override
+    public String id() {
+        return "CONFIG_DRIVEN";
+    }
+
+    @Override
+    public <T> Activator<T> activator(Services services, ServiceDescriptor<T> descriptor) {
+        return ConfigDrivenServiceProvider.create(services, descriptor);
+    }
+
+    @Override
+    public double weight() {
+        // less than default, so others can override it
+        return Weighted.DEFAULT_WEIGHT - 10;
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigDrivenInjectModule.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigDrivenInjectModule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import io.helidon.inject.service.ModuleComponent;
+import io.helidon.inject.service.ServiceBinder;
+
+/**
+ * An explicit and manually implemented module component, as we are doing a bit of unusual work with config bean registry.
+ */
+public class ConfigDrivenInjectModule implements ModuleComponent {
+    /**
+     * Constructor for ServiceLoader.
+     *
+     * @deprecated for use by Java ServiceLoader, do not use directly
+     */
+    @Deprecated
+    public ConfigDrivenInjectModule() {
+        super();
+    }
+
+    @Override
+    public String name() {
+        return "io.helidon.inject.configdriven";
+    }
+
+    @Override
+    public void configure(ServiceBinder binder) {
+        binder.bind(CbrServiceDescriptor.INSTANCE);
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigDrivenInstanceProvider.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigDrivenInstanceProvider.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.ActivationRequest;
+import io.helidon.inject.InjectionResolver;
+import io.helidon.inject.InjectionServiceProviderException;
+import io.helidon.inject.Lookup;
+import io.helidon.inject.ServiceProvider;
+import io.helidon.inject.ServiceProviderBase;
+import io.helidon.inject.Services;
+import io.helidon.inject.service.InjectionContext;
+import io.helidon.inject.service.Ip;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceDescriptor;
+
+class ConfigDrivenInstanceProvider<T, CB>
+        extends ServiceProviderBase<T>
+        implements InjectionResolver {
+
+    private final CB beanInstance;
+    private final String instanceId;
+    private final ConfigDrivenServiceProvider<T, CB> root;
+    private final TypeName configBeanType;
+    private final Set<Qualifier> qualifiers;
+
+    ConfigDrivenInstanceProvider(Services services,
+                                 ServiceDescriptor<T> descriptor,
+                                 ConfigDrivenServiceProvider<T, CB> root,
+                                 String name,
+                                 CB instance) {
+        super(services, descriptor);
+
+        this.configBeanType = root.configBeanType();
+        this.beanInstance = instance;
+        this.instanceId = name;
+        this.root = root;
+        this.qualifiers = Set.of(Qualifier.createNamed(name));
+    }
+
+    @Override
+    public boolean isRootProvider() {
+        return false;
+    }
+
+    @Override
+    public Optional<ServiceProvider<?>> rootProvider() {
+        return Optional.of(root);
+    }
+
+    // note that all responsibilities to resolve is delegated to the root provider
+    @Override
+    public Optional<Object> resolve(Ip ipInfo,
+                                    Services services,
+                                    ServiceProvider<?> serviceProvider,
+                                    boolean resolveIps) {
+
+        Lookup dep = Lookup.create(ipInfo);
+        Lookup criteria = Lookup.builder()
+                .addContract(configBeanType)
+                .build();
+        if (!dep.matchesContracts(criteria)) {
+            return Optional.empty();    // we are being injected with neither a config bean nor a service that matches ourselves
+        }
+
+        // if we are here then we are asking for a config bean for ourselves, or a managed instance
+        if (!dep.qualifiers().isEmpty()) {
+            throw new InjectionServiceProviderException("cannot use qualifiers while injecting config beans for self", this);
+        }
+
+        return Optional.of(beanInstance);
+    }
+
+    @Override
+    public String toString() {
+        return "Config Driven Instance for: " + serviceInfo().serviceType().fqName() + "{" + instanceId
+                + "}[" + currentActivationPhase() + "]";
+    }
+
+    @Override
+    public Set<Qualifier> qualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    protected String id(boolean fq) {
+        return super.id(fq) + "{" + instanceId + "}";
+    }
+
+    @Override
+    protected void prepareDependency(Services services, Map<Ip, Supplier<?>> injectionPlan, Ip dependency) {
+        // it the type is this bean's type and it does not have any additional qualifier,
+        // inject instance
+
+        if (dependency.contract().equals(configBeanType) && dependency.qualifiers().isEmpty()) {
+            // we are injecting the config bean that drives this instance
+            injectionPlan.put(dependency, () -> beanInstance);
+            return;
+        }
+
+        super.prepareDependency(services, injectionPlan, dependency);
+    }
+
+    @Override
+    protected void injectionContext(InjectionContext injectionContext) {
+        super.injectionContext(injectionContext);
+    }
+
+    CB beanInstance() {
+        return beanInstance;
+    }
+
+    void activate() {
+        super.activate(ActivationRequest.builder()
+                               .targetPhase(services().limitRuntimePhase())
+                               .build());
+    }
+
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigDrivenServiceProvider.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfigDrivenServiceProvider.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import io.helidon.common.config.Config;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.Annotations;
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.ActivationPhaseReceiver;
+import io.helidon.inject.ActivationRequest;
+import io.helidon.inject.ActivationResult;
+import io.helidon.inject.ActivationStatus;
+import io.helidon.inject.Activator;
+import io.helidon.inject.ContextualServiceQuery;
+import io.helidon.inject.DeActivationRequest;
+import io.helidon.inject.HelidonInjectionContext;
+import io.helidon.inject.InjectionResolver;
+import io.helidon.inject.InjectionServiceProviderException;
+import io.helidon.inject.Lookup;
+import io.helidon.inject.Phase;
+import io.helidon.inject.ServiceInjectionPlanBinder;
+import io.helidon.inject.ServiceProvider;
+import io.helidon.inject.ServiceProviderBase;
+import io.helidon.inject.ServiceProviderProvider;
+import io.helidon.inject.Services;
+import io.helidon.inject.configdriven.service.ConfigBeanFactory;
+import io.helidon.inject.configdriven.service.ConfigDriven;
+import io.helidon.inject.configdriven.service.NamedInstance;
+import io.helidon.inject.service.InjectionContext;
+import io.helidon.inject.service.Ip;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceDescriptor;
+
+import static java.lang.System.Logger.Level.DEBUG;
+
+class ConfigDrivenServiceProvider<T, CB> extends ServiceProviderBase<T>
+        implements ConfiguredServiceProvider<T, CB>,
+                   InjectionResolver,
+                   ServiceProviderProvider,
+                   ActivationPhaseReceiver,
+                   Activator<T> {
+    private static final System.Logger LOGGER = System.getLogger(ConfigDrivenServiceProvider.class.getName());
+    private static final Qualifier EMPTY_CONFIGURED_BY = Qualifier.create(ConfigDriven.class);
+
+    private final AtomicBoolean registeredWithCbr = new AtomicBoolean();
+    // map of name to config driven service provider
+    private final Map<String, ConfigDrivenInstanceProvider<T, CB>> managedConfiguredServicesMap
+            = new ConcurrentHashMap<>();
+    private final List<ConfigBeanServiceProvider<CB>> managedConfigBeans = new ArrayList<>();
+    private final Set<Qualifier> qualifiers;
+    private final ServiceDescriptor<T> descriptor;
+
+    private volatile ConfigDrivenBinderImpl cdInjectionContext;
+
+    ConfigDrivenServiceProvider(Services services, ServiceDescriptor<T> descriptor) {
+        super(services, descriptor);
+
+        this.descriptor = descriptor;
+        Set<Qualifier> qualifiers = new LinkedHashSet<>(descriptor.qualifiers());
+        qualifiers.add(Qualifier.WILDCARD_NAMED);
+        this.qualifiers = Set.copyOf(qualifiers);
+    }
+
+    static <T> Activator<T> create(Services services, ServiceDescriptor<T> descriptor) {
+        return new ConfigDrivenServiceProvider<>(services, descriptor);
+    }
+
+    @Override
+    public boolean isProvider() {
+        // this is a provider of config beans, not the target instance
+        return true;
+    }
+
+    // note that all responsibilities to resolve is delegated to the root provider
+    @Override
+    public Optional<Object> resolve(Ip ipInfo,
+                                    Services services,
+                                    ServiceProvider<?> serviceProvider,
+                                    boolean resolveIps) {
+        if (resolveIps) {
+            // too early to resolve...
+            return Optional.empty();
+        }
+
+        Lookup dep = Lookup.create(ipInfo);
+        Lookup criteria = Lookup.builder()
+                .addContract(configBeanType())
+                .build();
+        if (!dep.matchesContracts(criteria)) {
+            return Optional.empty();    // we are being injected with neither a config bean nor a service that matches ourselves
+        }
+
+        // if we are here then we are asking for a config bean for ourselves, or a managed instance
+        if (!dep.qualifiers().isEmpty()) {
+            throw new InjectionServiceProviderException("Cannot use qualifiers while injecting config beans for self", this);
+        }
+
+        return Optional.of(configBeanType());
+    }
+
+    /**
+     * Called during initialization to register a loaded config bean.
+     *
+     * @param configBean the config bean
+     */
+    @Override
+    public void registerConfigBean(NamedInstance<CB> configBean) {
+        Objects.requireNonNull(configBean);
+
+        ConfigBeanServiceProvider<CB> configBeanProvider = new ConfigBeanServiceProvider<>(configBeanType(),
+                                                                                           configBean.instance(),
+                                                                                           configBean.name());
+        managedConfigBeans.add(configBeanProvider);
+
+        ConfigDrivenInstanceProvider<T, CB> cdInstanceProvider
+                = new ConfigDrivenInstanceProvider<>(services(),
+                                                     descriptor,
+                                                     this,
+                                                     configBean.name(),
+                                                     configBean.instance());
+        Object prev = managedConfiguredServicesMap.put(configBean.name(),
+                                                       cdInstanceProvider);
+
+        if (cdInjectionContext != null) {
+            cdInstanceProvider.injectionContext(cdInjectionContext.forInstance(cdInstanceProvider));
+        }
+
+        assert (prev == null);
+    }
+
+    @Override
+    public List<ServiceProvider<?>> serviceProviders(Lookup criteria,
+                                                     boolean wantThis,
+                                                     boolean thisAlreadyMatches) {
+        /*
+        the request may be for either:
+        - Root service provider (the config driven type)
+        - Managed service provider (driven by config beans)
+        - Config bean itself
+        */
+
+        Set<Qualifier> qualifiers = criteria.qualifiers();
+        Optional<? extends Annotation> configuredByQualifier = Annotations
+                .findFirst(EMPTY_CONFIGURED_BY.typeName(), qualifiers);
+        boolean hasValue = configuredByQualifier.isPresent()
+                && !(configuredByQualifier.get().value().orElse("").isBlank());
+        boolean blankCriteria = qualifiers.isEmpty()
+                && criteria.qualifiers().isEmpty()
+                && criteria.serviceType().isEmpty()
+                && criteria.contracts().isEmpty();
+        boolean managedQualify = !managedConfiguredServicesMap.isEmpty()
+                && (blankCriteria || hasValue || configuredByQualifier.isEmpty());
+        boolean rootQualifies = wantThis
+                && (
+                blankCriteria
+                        || (
+                        managedConfiguredServicesMap.isEmpty()
+                                && (
+                                qualifiers.isEmpty()
+                                        || qualifiers.contains(Qualifier.WILDCARD_NAMED))
+                                || (!hasValue && configuredByQualifier.isPresent())));
+
+        boolean serviceTypeMatch = criteria.matches(this);
+        if (managedQualify) {
+            List<ServiceProvider<?>> result = new ArrayList<>();
+
+            if (criteria.contracts().contains(configBeanType())) {
+                for (ConfigBeanServiceProvider<CB> managedConfigBean : managedConfigBeans) {
+                    if (criteria.matches(managedConfigBean)) {
+                        result.add(managedConfigBean);
+                    }
+                }
+            }
+            if (serviceTypeMatch) {
+                result.addAll(new ArrayList<>(managedServiceProviders(criteria)
+                                                      .values()));
+            }
+
+            if (rootQualifies && serviceTypeMatch) {
+                if (thisAlreadyMatches || criteria.matches(this)) {
+                    result.add(this);
+                }
+                // no need to sort using the comparator here since we should already be in the proper order...
+                return result;
+            } else {
+                return result;
+            }
+        } else if (rootQualifies && (thisAlreadyMatches || criteria.matches(this))) {
+            if (!hasValue && managedConfiguredServicesMap.isEmpty()) {
+                return List.of(this);
+            }
+            return List.of(this);
+        }
+
+        return List.of();
+    }
+
+    @Override
+    public Map<String, ConfigDrivenInstanceProvider<?, CB>> managedServiceProviders(Lookup criteria) {
+        // managed instances are always named, so the criteria must provide either wildcard named qualifier
+        // or we add @default name (if none)
+
+        Map<String, ConfigDrivenInstanceProvider<?, CB>> map = managedConfiguredServicesMap.entrySet()
+                .stream()
+                .filter(e -> criteria.matches(e.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        if (map.size() <= 1) {
+            return map;
+        }
+
+        Map<String, ConfigDrivenInstanceProvider<?, CB>> result = new TreeMap<>(NamedInstance.nameComparator());
+        result.putAll(map);
+        return result;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<T> first(ContextualServiceQuery query) {
+        // we are root provider
+        if (currentActivationPhase() != Phase.ACTIVE) {
+            // we know the activator is present, as we send it through constructor...
+            ActivationResult res = super.activate(ActivationRequest.builder()
+                                                          .targetPhase(services().limitRuntimePhase())
+                                                          .build());
+            if (res.failure()) {
+                if (query.expected()) {
+                    throw new InjectionServiceProviderException("Activation failed: " + res, this);
+                }
+                return Optional.empty();
+            }
+        }
+
+        List<ServiceProvider<?>> qualifiedProviders = serviceProviders(query, false, true);
+        for (ServiceProvider<?> qualifiedProvider : qualifiedProviders) {
+            assert (this != qualifiedProvider);
+            Optional<?> serviceOrProvider = qualifiedProvider.first(query);
+            if (serviceOrProvider.isPresent()) {
+                return (Optional<T>) serviceOrProvider;
+            }
+        }
+
+        if (query.expected()) {
+            throw new InjectionServiceProviderException("Expected to find a match", this);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<T> list(ContextualServiceQuery query) {
+        // we are root
+        Map<String, ConfigDrivenInstanceProvider<?, CB>> matching = managedServiceProviders(query);
+        if (!matching.isEmpty()) {
+            List<?> result = matching.values().stream()
+                    .map(it -> it.first(query))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            if (!result.isEmpty()) {
+                return (List<T>) result;
+            }
+        }
+
+        if (!query.expected()) {
+            return List.of();
+        }
+
+        throw new InjectionServiceProviderException("Expected to return a non-null instance for: "
+                                                            + query.injectionPoint()
+                                                            + "; with criteria matching: " + query, this);
+    }
+
+    @Override
+    public void onPhaseEvent(Phase phase) {
+
+        if (phase == Phase.POST_BIND_ALL_MODULES) {
+            ActivationResult.Builder res = ActivationResult.builder();
+
+            if (Phase.INIT == currentActivationPhase()) {
+                stateTransitionStart(res, Phase.PENDING);
+            }
+        } else if (phase == Phase.FINAL_RESOLVE) {
+            // post-initialize ourselves
+            if (drivesActivation()) {
+                activate(ActivationRequest.builder()
+                                 .targetPhase(services().limitRuntimePhase())
+                                 .build());
+            }
+
+            resolveConfigDrivenServices();
+        } else if (phase == Phase.SERVICES_READY) {
+            activateConfigDrivenServices();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<NamedInstance<CB>> createConfigBeans(Config config) {
+        // we know this is the case, as otherwise the ID would be wrong
+        ConfigBeanFactory<CB> factory = (ConfigBeanFactory<CB>) serviceInfo();
+        return factory.createConfigBeans(config);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean drivesActivation() {
+        return ((ConfigBeanFactory<CB>) serviceInfo()).drivesActivation();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public TypeName configBeanType() {
+        // we know this is the case, as otherwise the ID would be wrong
+        ConfigBeanFactory<CB> factory = (ConfigBeanFactory<CB>) serviceInfo();
+        return factory.configBeanType();
+    }
+
+    @Override
+    public Set<Qualifier> qualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public Optional<ServiceInjectionPlanBinder.Binder> injectionPlanBinder() {
+        if (injectionContext().isPresent()) {
+            LOGGER.log(System.Logger.Level.WARNING,
+                       "this service provider already has an injection plan (which is unusual here): " + this);
+        }
+        return Optional.of(new ConfigDrivenBinderImpl(services(), this));
+    }
+
+    boolean hasManagedServices() {
+        return !managedConfigBeans.isEmpty();
+    }
+
+    @Override
+    protected String id(boolean fq) {
+        return super.id(fq) + "{root}";
+    }
+
+    @Override
+    protected void prepareDependency(Services services, Map<Ip, Supplier<?>> injectionPlan, Ip dependency) {
+        // do nothing, config driven root service CANNOT be instantiated, as it does not have
+        // a config bean to inject
+    }
+
+    @Override
+    protected void construct(ActivationRequest req, ActivationResult.Builder res) {
+        // do nothing, config driven root service CANNOT be instantiated, as it does not have a config bean
+
+        if (!(hasManagedServices() && drivesActivation())) {
+            stateTransitionStart(res, Phase.PENDING);
+        } else {
+            stateTransitionStart(res, Phase.CONSTRUCTING);
+        }
+    }
+
+    @Override
+    protected void init(ActivationRequest req, ActivationResult.Builder res) {
+        super.init(req, res);
+        if (registeredWithCbr.compareAndSet(false, true)) {
+            ConfigBeanRegistryImpl cbr = ConfigBeanRegistryImpl.CONFIG_BEAN_REGISTRY.get();
+            if (cbr != null) {
+                Optional<Qualifier> configuredByQualifier = serviceInfo().qualifiers().stream()
+                        .filter(q -> q.typeName().name().equals(ConfigDriven.class.getName()))
+                        .findFirst();
+                assert (configuredByQualifier.isPresent());
+                cbr.bind(this, configuredByQualifier.get());
+            }
+        }
+    }
+
+    @Override
+    protected void preDestroy(DeActivationRequest req, ActivationResult.Builder res) {
+        // we never have an instance (this is a config driven root)
+        // but we do have child instances
+        for (ConfigDrivenInstanceProvider<T, CB> value : managedConfiguredServicesMap.values()) {
+            ActivationResult result = value.deactivate(req);
+            if (result.failure() && !(res.finishingStatus().map(it -> it != ActivationStatus.FAILURE).orElse(false))) {
+                // record first failure
+                res.serviceProvider(value);
+                res.finishingStatus(result.finishingStatus());
+            }
+        }
+    }
+
+    void resolveConfigDrivenServices() {
+        if (managedConfiguredServicesMap.isEmpty()) {
+            if (LOGGER.isLoggable(DEBUG)) {
+                LOGGER.log(DEBUG, "No configured services for: " + description());
+            }
+            return;
+        }
+
+        // accept and resolve config
+        managedConfiguredServicesMap.values().forEach(csp -> {
+            if (LOGGER.isLoggable(DEBUG)) {
+                LOGGER.log(DEBUG, "Resolving config for " + csp);
+            }
+
+            csp.activate(ActivationRequest.builder()
+                                 .targetPhase(Phase.INIT)
+                                 .build());
+        });
+
+    }
+
+    void activateConfigDrivenServices() {
+        if (managedConfiguredServicesMap.isEmpty()) {
+            return;
+        }
+
+        if (!drivesActivation()) {
+            if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+                LOGGER.log(System.Logger.Level.DEBUG, "drivesActivation disabled for: " + description());
+            }
+            return;
+        }
+
+        managedConfiguredServicesMap.values().forEach(ConfigDrivenInstanceProvider::activate);
+    }
+
+    static class ConfigDrivenBinderImpl extends ServiceProviderBase.ServiceInjectBinderImpl {
+        private final ConfigDrivenServiceProvider<?, ?> self;
+        private final List<RuntimeBind> beanInstanceBindings = new ArrayList<>();
+
+        ConfigDrivenBinderImpl(Services services, ConfigDrivenServiceProvider<?, ?> self) {
+            super(services, self);
+            this.self = self;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBind(Ip id, boolean useProvider, Class<?> serviceType) {
+
+            if (id.contract().equals(self.configBeanType()) && id.qualifiers().isEmpty()) {
+                beanInstanceBindings.add(new RuntimeBind(id, useProvider, false));
+                return this;
+            }
+
+            return super.runtimeBind(id, useProvider, serviceType);
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBindOptional(Ip id, boolean useProvider, Class<?> serviceType) {
+
+            if (id.contract().equals(self.configBeanType()) && id.qualifiers().isEmpty()) {
+                beanInstanceBindings.add(new RuntimeBind(id, useProvider, false));
+                return this;
+            }
+
+            return super.runtimeBindOptional(id, useProvider, serviceType);
+        }
+
+        @Override
+        public void commit() {
+            super.commit();
+
+            self.cdInjectionContext = this;
+        }
+
+        InjectionContext forInstance(ConfigDrivenInstanceProvider<?, ?> provider) {
+            Map<Ip, Supplier<?>> copy = new HashMap<>(injectionPlan());
+            for (RuntimeBind beanInstanceBinding : beanInstanceBindings) {
+                Supplier<?> supplier;
+                if (beanInstanceBinding.optional()) {
+                    if (beanInstanceBinding.provider()) {
+                        supplier = () -> Optional.of(provider);
+                    } else {
+                        supplier = () -> Optional.of(provider.beanInstance());
+                    }
+                } else {
+                    if (beanInstanceBinding.provider()) {
+                        supplier = () -> provider;
+                    } else {
+                        supplier = provider::beanInstance;
+                    }
+                }
+                copy.put(beanInstanceBinding.id(), supplier);
+            }
+
+            return HelidonInjectionContext.create(copy);
+        }
+
+        private record RuntimeBind(Ip id, boolean provider, boolean optional) {
+        }
+    }
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfiguredServiceProvider.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/ConfiguredServiceProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven;
+
+import io.helidon.inject.ServiceProvider;
+import io.helidon.inject.configdriven.service.ConfigBeanFactory;
+import io.helidon.inject.configdriven.service.NamedInstance;
+
+/**
+ * An extension to {@link ServiceProvider} that represents a config-driven service.
+ *
+ * @param <T>  the type of this service provider manages
+ * @param <CB> the type of config beans that this service is configured by
+ */
+public interface ConfiguredServiceProvider<T, CB> extends ServiceProvider<T>, ConfigBeanFactory<CB> {
+
+    /**
+     * Returns the config bean associated with this managed service provider.
+     *
+     * @return the config bean associated with this managed service provider
+     * @throws NullPointerException if this is the root provider
+     */
+    default CB configBean() {
+        throw new NullPointerException("Requesting a config bean from a root provider: " + serviceType().fqName());
+    }
+
+    /**
+     * Register a named config bean as a child of this root provider.
+     *
+     * @param configBean config bean that drives an instance
+     */
+    void registerConfigBean(NamedInstance<CB> configBean);
+}

--- a/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/package-info.java
+++ b/inject/configdriven/configdriven/src/main/java/io/helidon/inject/configdriven/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Config-driven Services API.
+ */
+package io.helidon.inject.configdriven;

--- a/inject/configdriven/configdriven/src/main/java/module-info.java
+++ b/inject/configdriven/configdriven/src/main/java/module-info.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.Preview;
+
+/**
+ * Injection Config-Driven Services Module.
+ */
+@Feature(value = "Config Driven",
+         since = "4.0.0",
+         path = {"Inject", "Config Driven"},
+         description = "Config Driven Services")
+@Preview
+module io.helidon.inject.configdriven {
+    requires static io.helidon.common.features.api;
+
+    requires transitive io.helidon.builder.api;
+    requires transitive io.helidon.common.types;
+    requires transitive io.helidon.common.config;
+    requires transitive io.helidon.inject;
+    requires transitive io.helidon.inject.configdriven.service;
+
+    exports io.helidon.inject.configdriven;
+
+    provides io.helidon.inject.spi.ActivatorProvider
+            with io.helidon.inject.configdriven.ConfigDrivenActivatorProvider,
+                    io.helidon.inject.configdriven.CbrActivatorProvider;
+
+    provides io.helidon.inject.service.ModuleComponent
+            with io.helidon.inject.configdriven.ConfigDrivenInjectModule;
+}

--- a/inject/configdriven/pom.xml
+++ b/inject/configdriven/pom.xml
@@ -34,6 +34,8 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>service</module>
+        <module>configdriven</module>
         <module>api</module>
         <module>codegen</module>
         <module>processor</module>

--- a/inject/configdriven/service/pom.xml
+++ b/inject/configdriven/service/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.inject.configdriven</groupId>
+        <artifactId>helidon-inject-configdriven-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-inject-configdriven-service</artifactId>
+    <name>Helidon Injection Config-Driven Service</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.inject</groupId>
+            <artifactId>helidon-inject-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/ConfigBean.java
+++ b/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/ConfigBean.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven.service;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.helidon.inject.service.Injection;
+
+/**
+ * This configured prototype should be acting as a config bean. This means that if appropriate configuration
+ * exists (must be a root configured type with a defined prefix), an instance will be created from that configuration.
+ * Additional setup is possible to ensure an instance even if not present in config, and to create default (unnamed) instance.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target(java.lang.annotation.ElementType.TYPE)
+@Injection.Qualifier
+public @interface ConfigBean {
+    /**
+     * An instance of this bean will be created if there are no instances discovered by the configuration provider(s) post
+     * startup, and will use all default values annotated using {@code ConfiguredOptions} from the bean interface methods.
+     * <p>
+     * The default value is {@code false}.
+     *
+     * @return the default config bean instance using defaults
+     */
+    boolean atLeastOne() default false;
+
+    /**
+     * Determines whether there can be more than one bean instance of this type.
+     * <p>
+     * If false then only 0..1 behavior will be permissible for active beans in the config registry. If true then {@code > 1}
+     * instances will be permitted.
+     * <p>
+     * Note: this attribute is dynamic in nature, and therefore cannot be validated at compile time. All violations found to this
+     * policy will be observed during <i>Services</i> activation.
+     * <p>
+     * The default value is {@code false}.
+     *
+     * @return true if repeatable
+     */
+    boolean repeatable() default false;
+
+    /**
+     * There will always be an instance created with defaults, that will not be named.
+     * <p>
+     * The default value is {@code false}.
+     *
+     * @return use the default config instance
+     */
+    boolean wantDefault() default false;
+}

--- a/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/ConfigBeanFactory.java
+++ b/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/ConfigBeanFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+import io.helidon.common.config.Config;
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.Injection;
+
+/**
+ * Used from generated code.
+ * Represents the required information to handle config beans, either from
+ * {@link io.helidon.inject.configdriven.service.ConfigBean}
+ * annotation, or from other means.
+ *
+ * @param <T> type of the config bean
+ */
+public interface ConfigBeanFactory<T> {
+    /**
+     * Create instances from configuration.
+     *
+     * @param config configuration to use (root configuration instance)
+     * @return list of config bean instances
+     */
+    List<NamedInstance<T>> createConfigBeans(Config config);
+
+    /**
+     * Type of config bean.
+     *
+     * @return bean type
+     */
+    TypeName configBeanType();
+
+    /**
+     * Whether the discovered config beans drive activation of their associated service.
+     *
+     * @return whether the config beans drive activation
+     */
+    boolean drivesActivation();
+
+    /**
+     * Creates a list of named instances from the provided configuration instance (must exist).
+     *
+     * @param config      configuration to analyze and use to create beans
+     * @param wantDefault whether a default instance is wanted (will be created only based on default values)
+     * @param factory     factory to create an instance from a config node
+     * @return list of created named instances
+     */
+    default List<NamedInstance<T>> createRepeatableBeans(Config config,
+                                                         boolean wantDefault,
+                                                         Function<Config, T> factory) {
+
+        Objects.requireNonNull(config, "Config must not be null");
+        Objects.requireNonNull(factory, "Config bean factory must not be null");
+
+        Map<String, NamedInstance<T>> instances = new TreeMap<>(NamedInstance.nameComparator());
+
+        List<Config> childNodes = config.asNodeList().orElseGet(List::of);
+        boolean isList = config.isList();
+
+        for (Config childNode : childNodes) {
+            String name = childNode.name(); // by default use the current node name - for lists, this would be the index
+            name = isList ? childNode.get("name").asString().orElse(name) : name; // use "name" node if list and present
+            instances.put(name, new NamedInstance<>(factory.apply(childNode), name));
+        }
+
+        if (wantDefault && !instances.containsKey(Injection.Named.DEFAULT_NAME)) {
+            instances.put(Injection.Named.DEFAULT_NAME,
+                          new NamedInstance<>(factory.apply(Config.empty()), Injection.Named.DEFAULT_NAME));
+        }
+
+        return List.copyOf(instances.values());
+    }
+}

--- a/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/ConfigDriven.java
+++ b/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/ConfigDriven.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven.service;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.helidon.inject.service.Injection;
+
+/**
+ * A config driven service is based on a prototype that is configured from the root of configuration
+ * (see {@code Configured} in {@code helidon-config-metadata}).
+ * <p>
+ * The annotation is placed on the service implementation (not contract, as we need to understand which type to
+ * instantiate), and the prototype is expected to be one of the constructor parameters (annotated with {@code @Inject}).
+ * In case the configured prototype is repeatable, each instance will be named according to the name specified in configuration
+ * either through {@code name} property, or the config node name.
+ * <p>
+ * Example:
+ * <pre>
+ * &#064;ConfigDriven(value = ServerConfig.class, activateByDefault  = true, atLeastOne = true)
+ * class ServerImpl {
+ *   &#064;Inject
+ *   ServerImpl(ServerConfig sc) {
+ *   }
+ * }
+ * </pre>
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target(java.lang.annotation.ElementType.TYPE)
+@Injection.Qualifier
+public @interface ConfigDriven {
+    /**
+     * The prototype class that drives this config driven.
+     *
+     * @return the prototype that is configured
+     */
+    Class<?> value();
+
+    /**
+     * Determines whether this instance will be activated if created.
+     * The default value is {@code false}.
+     *
+     * @return true if the presence of the config bean has an activation affect
+     */
+    boolean activateByDefault() default false;
+}

--- a/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/NamedInstance.java
+++ b/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/NamedInstance.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.configdriven.service;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import io.helidon.inject.service.Injection;
+
+/**
+ * Instance, that can be (possibly) named.
+ *
+ * @param instance instance of config bean
+ * @param name     the instance may have a name, if this is the default (not named), the name is set to
+ *                 {@value io.helidon.inject.service.Injection.Named#DEFAULT_NAME}
+ * @param <T>      type of the instance
+ */
+public record NamedInstance<T>(T instance, String name) {
+    private static final NameComparator COMPARATOR_INSTANCE = new NameComparator();
+
+    /**
+     * Comparator of names, {@link io.helidon.inject.service.Injection.Named#DEFAULT_NAME} name is always first.
+     *
+     * @return name comparator
+     */
+    public static Comparator<String> nameComparator() {
+        return COMPARATOR_INSTANCE;
+    }
+
+    private static class NameComparator implements Comparator<String>, Serializable {
+        @Override
+        public int compare(String str1, String str2) {
+            int result = str1.compareTo(str2);
+
+            if (result == 0) {
+                return result;
+            }
+            // @default is desired to be first in the list
+            if (Injection.Named.DEFAULT_NAME.equals(str1)) {
+                return -1;
+            } else if (Injection.Named.DEFAULT_NAME.equals(str2)) {
+                return 1;
+            }
+
+            return result;
+        }
+    }
+}

--- a/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/package-info.java
+++ b/inject/configdriven/service/src/main/java/io/helidon/inject/configdriven/service/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Injection Config-Driven Service API.
+ */
+package io.helidon.inject.configdriven.service;

--- a/inject/configdriven/service/src/main/java/module-info.java
+++ b/inject/configdriven/service/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon Injection Config-Driven ConfiguredBy API Module.
+ */
+module io.helidon.inject.configdriven.service {
+
+    requires io.helidon.common.config;
+    requires io.helidon.inject.service;
+
+    exports io.helidon.inject.configdriven.service;
+}

--- a/inject/inject/pom.xml
+++ b/inject/inject/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.inject</groupId>
+        <artifactId>helidon-inject-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-inject</artifactId>
+    <name>Helidon Injection</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.inject</groupId>
+            <artifactId>helidon-inject-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.builder</groupId>
+            <artifactId>helidon-builder-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.config</groupId>
+                            <artifactId>helidon-config-metadata-processor</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.config</groupId>
+                        <artifactId>helidon-config-metadata-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/inject/inject/src/main/java/io/helidon/inject/ActivationPhaseReceiver.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ActivationPhaseReceiver.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+/**
+ * A receiver of events from the {@link io.helidon.inject.Services} registry and providers held by the service registry.
+ * <p>
+ * Note that only {@link io.helidon.inject.ServiceProvider}'s implement this contract that are also bound to the global
+ * {@link io.helidon.inject.Services} registry are currently capable of receiving events.
+ *
+ * @see io.helidon.inject.ServiceProviderBindable
+ */
+public interface ActivationPhaseReceiver {
+
+    /**
+     * Called when there is an event transition within the service registry.
+     *
+     * @param phase the phase
+     */
+    void onPhaseEvent(Phase phase);
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ActivationRequestBlueprint.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ActivationRequestBlueprint.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Request to activate a service.
+ */
+@Prototype.Blueprint(decorator = ActivationRequestSupport.BuilderDecorator.class)
+interface ActivationRequestBlueprint {
+    /**
+     * The phase to start activation. Typically, this should be left as the default (i.e., PENDING).
+     *
+     * @return phase to start
+     */
+    Optional<Phase> startingPhase();
+
+    /**
+     * Ultimate target phase for activation.
+     * <p>
+     * Defaults to {@link io.helidon.inject.InjectionConfig#limitRuntimePhase()}.
+     *
+     * @return phase to target
+     */
+    Phase targetPhase();
+
+    /**
+     * Whether to throw an exception on failure to activate, or return an error activation result on activation.
+     *
+     * @return whether to throw on failure
+     */
+    @Option.DefaultBoolean(true)
+    boolean throwIfError();
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ActivationRequestSupport.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ActivationRequestSupport.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.builder.api.Prototype;
+
+final class ActivationRequestSupport {
+    private ActivationRequestSupport() {
+    }
+
+    static class BuilderDecorator implements Prototype.BuilderDecorator<ActivationRequest.BuilderBase<?, ?>> {
+        BuilderDecorator() {
+        }
+
+        @Override
+        public void decorate(ActivationRequest.BuilderBase<?, ?> target) {
+            if (target.targetPhase().isEmpty()) {
+                target.targetPhase(InjectionServices.instance().config().limitRuntimePhase());
+            }
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ActivationResultBlueprint.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ActivationResultBlueprint.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Represents the result of a service activation or deactivation.
+ *
+ * @see Activator
+ **/
+@Prototype.Blueprint
+interface ActivationResultBlueprint {
+
+    /**
+     * The service provider undergoing activation or deactivation.
+     *
+     * @return the service provider generating the result
+     */
+    ServiceProvider<?> serviceProvider();
+
+    /**
+     * The activation phase that was found at onset of the phase transition.
+     *
+     * @return the starting phase
+     */
+    @Option.Default("INIT")
+    Phase startingActivationPhase();
+
+    /**
+     * The activation phase that was requested at the onset of the phase transition.
+     *
+     * @return the target, desired, ultimate phase requested
+     */
+    @Option.Default("INIT")
+    Phase targetActivationPhase();
+
+    /**
+     * The activation phase we finished successfully on, or are otherwise currently in if not yet finished.
+     *
+     * @return the finishing phase
+     */
+    Phase finishingActivationPhase();
+
+    /**
+     * How did the activation finish.
+     *
+     * @return the finishing status
+     */
+    ActivationStatus finishingStatus();
+
+    /**
+     * Any throwable/exceptions that were observed during activation.
+     *
+     * @return any captured error
+     */
+    Optional<Throwable> error();
+
+    /**
+     * Returns true if this result was successful.
+     *
+     * @return true if successful
+     */
+    default boolean success() {
+        return finishingStatus() != ActivationStatus.FAILURE;
+    }
+
+    /**
+     * Returns true if this result was unsuccessful.
+     *
+     * @return true if unsuccessful
+     */
+    default boolean failure() {
+        return !success();
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ActivationStatus.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ActivationStatus.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+/**
+ * The activation status.
+ *
+ * @see io.helidon.inject.Activator
+ */
+public enum ActivationStatus {
+
+    /**
+     * The service has been activated and is fully ready to receive requests.
+     */
+    SUCCESS,
+
+    /**
+     * The service has been activated but is still being started asynchronously, and is not fully ready yet to receive requests.
+     * Important note: This is NOT health related - Health is orthogonal to service bindings/activation and readiness.
+     */
+    WARNING_SUCCESS_BUT_NOT_READY,
+
+    /**
+     * A general warning during lifecycle.
+     */
+    WARNING_GENERAL,
+
+    /**
+     * Failed to activate to the given phase.
+     */
+    FAILURE
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/Activator.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Activator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+/**
+ * Activators are responsible for lifecycle creation and lazy activation of service providers.
+ * They are responsible for taking the
+ * {@link io.helidon.inject.ServiceProvider}'s managed service instance from {@link io.helidon.inject.Phase#PENDING}
+ * through {@link io.helidon.inject.Phase#POST_CONSTRUCTING} (i.e., including any
+ * {@link io.helidon.inject.service.Injection.PostConstruct} invocations, etc.), and finally into the
+ * {@link io.helidon.inject.Phase#ACTIVE} phase.
+ * <p>
+ * Assumption:
+ * <ol>
+ *  <li>Each {@link io.helidon.inject.ServiceProvider} managing its backing service will have an activator strategy conforming
+ *  to the DI
+ *  specification.</li>
+ * </ol>
+ * Activation includes:
+ * <ol>
+ *  <li>Management of the service's {@link io.helidon.inject.Phase}.</li>
+ *  <li>Control over creation (i.e., invoke the constructor non-reflectively).</li>
+ *  <li>Control over gathering the service requisite dependencies (ctor, field, setters) and optional activation of those.</li>
+ *  <li>Invocation of any {@link io.helidon.inject.service.Injection.PostConstruct} method.</li>
+ * </ol>
+ *
+ * The activator also supports the inverse process of deactivation, where any
+ * {@link io.helidon.inject.service.Injection.PreDestroy}
+ * methods may be called, and which moves the service to a terminal {@link io.helidon.inject.Phase#DESTROYED phase}.
+ *
+ * @param <T> type of the service provided by the activated service provider
+ */
+public interface Activator<T> {
+
+    /**
+     * Activate a managed service/provider.
+     *
+     * @param activationRequest activation request
+     * @return the result of the activation
+     */
+    ActivationResult activate(ActivationRequest activationRequest);
+
+    /**
+     * Deactivate a managed service. This will trigger any {@link io.helidon.inject.service.Injection.PreDestroy} method on the
+     * underlying service type instance. The service will read terminal {@link io.helidon.inject.Phase#DESTROYED}
+     * phase, regardless of its activation status.
+     *
+     * @param request deactivation request
+     * @return the result
+     */
+    ActivationResult deactivate(DeActivationRequest request);
+
+    /**
+     * Service provider managed by this activator.
+     *
+     * @return service provider
+     */
+    ServiceProvider<T> serviceProvider();
+}

--- a/inject/inject/src/main/java/io/helidon/inject/Application.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Application.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.inject.service.Injection;
+
+/**
+ * An Application instance, if available at runtime, will be expected to provide a plan for all service provider's injection
+ * points.
+ * <p>
+ * Implementations of this contract are normally code generated, although then can be programmatically written by the developer
+ * for special cases.
+ * <p>
+ * Note: instances of this type are not eligible for injection.
+ *
+ * @see io.helidon.inject.service.ModuleComponent
+ */
+@Injection.Contract
+public interface Application {
+
+    /**
+     * Called by the provider implementation at bootstrapping time to bind all injection plans to each and every service provider.
+     *
+     * @param binder the binder used to register the service provider injection plans
+     */
+    void configure(ServiceInjectionPlanBinder binder);
+
+    /**
+     * Name for this instance.
+     *
+     * @return the name associated with this instance
+     */
+    String name();
+}

--- a/inject/inject/src/main/java/io/helidon/inject/BoundServiceProvider.java
+++ b/inject/inject/src/main/java/io/helidon/inject/BoundServiceProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.LazyValue;
+import io.helidon.inject.service.Ip;
+
+/**
+ * A service provider bound to another service provider for an injection point.
+ *
+ * @param <T> type of the provided service
+ */
+class BoundServiceProvider<T> extends DescribedServiceProvider<T> implements ServiceProvider<T> {
+    private final ServiceProvider<T> binding;
+    private final LazyValue<T> instance;
+    private final LazyValue<List<T>> instances;
+
+    private BoundServiceProvider(ServiceProvider<T> binding, Ip injectionPoint) {
+        super(binding.serviceInfo());
+
+        this.binding = binding;
+        ContextualServiceQuery query = ContextualServiceQuery.builder()
+                .from(Lookup.create(injectionPoint))
+                .injectionPoint(injectionPoint)
+                .expected(false)
+                .build();
+        this.instance = LazyValue.create(() -> binding.first(query).orElse(null));
+        this.instances = LazyValue.create(() -> binding.list(query));
+    }
+
+    /**
+     * Creates a bound service provider to a specific binding.
+     *
+     * @param binding the bound service provider
+     * @param ipId    the binding context
+     * @return the service provider created, wrapping the binding delegate provider
+     */
+    static <V> ServiceProvider<V> create(ServiceProvider<V> binding,
+                                         Ip ipId) {
+
+        if (binding instanceof ServiceProviderBase<V> base) {
+            if (!base.isProvider()) {
+                return binding;
+            }
+        }
+        return new BoundServiceProvider<>(binding, ipId);
+    }
+
+    @Override
+    public String toString() {
+        return binding.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return binding.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object another) {
+        return (another instanceof ServiceProvider && binding.equals(another));
+    }
+
+    @Override
+    public Optional<T> first(ContextualServiceQuery query) {
+        return Optional.ofNullable(instance.get());
+    }
+
+    @Override
+    public List<T> list(ContextualServiceQuery query) {
+        return instances.get();
+    }
+
+    @Override
+    public String id() {
+        return binding.id();
+    }
+
+    @Override
+    public String description() {
+        return binding.description();
+    }
+
+    @Override
+    public boolean isProvider() {
+        return binding.isProvider();
+    }
+
+    @Override
+    public Phase currentActivationPhase() {
+        return binding.currentActivationPhase();
+    }
+
+    @Override
+    public Optional<ServiceProviderBindable<T>> serviceProviderBindable() {
+        return Optional.of((ServiceProviderBindable<T>) binding);
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ContextualServiceQueryBlueprint.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ContextualServiceQueryBlueprint.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.inject.service.Ip;
+
+/**
+ * Combines the {@link Lookup} criteria along with
+ * the {@link io.helidon.inject.service.Ip} context
+ * that the query applies to.
+ *
+ * @see io.helidon.inject.InjectionPointProvider
+ */
+@Prototype.Blueprint
+@Prototype.CustomMethods(ContextualServiceQuerySupport.CustomMethods.class)
+interface ContextualServiceQueryBlueprint extends LookupBlueprint {
+    /**
+     * Optionally, the injection point context this search applies to.
+     *
+     * @return the optional injection point context info
+     */
+    Optional<Ip> injectionPoint();
+
+    /**
+     * Set to true if there is an expectation that there is at least one match result from the search.
+     *
+     * @return true if it is expected there is at least a single match result
+     */
+    boolean expected();
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ContextualServiceQuerySupport.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ContextualServiceQuerySupport.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Objects;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.inject.service.Ip;
+
+final class ContextualServiceQuerySupport {
+    private ContextualServiceQuerySupport() {
+    }
+
+    static final class CustomMethods {
+        /**
+         * Denotes a match to any (default) service, but required to be matched to at least one.
+         */
+        @Prototype.Constant
+        static final ContextualServiceQuery REQUIRED = createRequired();
+        /**
+         * Denotes a match to any (default) service.
+         */
+        @Prototype.Constant
+        static final ContextualServiceQuery EMPTY = createEmpty();
+        private CustomMethods() {
+        }
+
+        /**
+         * Creates a contextual service query given the injection point info.
+         *
+         * @param injectionPoint the injection point info
+         * @param expected       true if the query is expected to at least have a single match
+         * @return the query
+         */
+        @Prototype.FactoryMethod
+        static ContextualServiceQuery create(Ip injectionPoint,
+                                             boolean expected) {
+            Objects.requireNonNull(injectionPoint);
+            return ContextualServiceQuery.builder()
+                    .from(Lookup.create(injectionPoint))
+                    .expected(expected)
+                    .injectionPoint(injectionPoint)
+                    .build();
+        }
+
+        private static ContextualServiceQuery createRequired() {
+            return ContextualServiceQuery.builder()
+                    .from(Lookup.EMPTY)
+                    .expected(true)
+                    .build();
+        }
+
+        private static ContextualServiceQuery createEmpty() {
+            return ContextualServiceQuery.builder()
+                    .from(Lookup.EMPTY)
+                    .build();
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/DeActivationRequestBlueprint.java
+++ b/inject/inject/src/main/java/io/helidon/inject/DeActivationRequestBlueprint.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Request to deactivate a {@link ServiceProvider}.
+ */
+@Prototype.Blueprint
+interface DeActivationRequestBlueprint {
+    /**
+     * Whether to throw an exception on failure, or return it as part of the result.
+     *
+     * @return throw on failure
+     */
+    @Option.DefaultBoolean(true)
+    boolean throwIfError();
+}

--- a/inject/inject/src/main/java/io/helidon/inject/DescribedServiceProvider.java
+++ b/inject/inject/src/main/java/io/helidon/inject/DescribedServiceProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.inject.service.ServiceInfo;
+
+/**
+ * A service provider based on a descriptor.
+ * The descriptor will be used to obtain all values inherited from {@link io.helidon.inject.service.ServiceInfo}.
+ *
+ * @param <T> type of the provided service
+ */
+public abstract class DescribedServiceProvider<T> implements ServiceProvider<T> {
+    private final ServiceInfo serviceInfo;
+
+    /**
+     * Creates a new instance with the delegate descriptor.
+     *
+     * @param serviceInfo descriptor to delegate to
+     */
+    protected DescribedServiceProvider(ServiceInfo serviceInfo) {
+        this.serviceInfo = serviceInfo;
+    }
+
+    @Override
+    public ServiceInfo serviceInfo() {
+        return serviceInfo;
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/HelidonInjectionContext.java
+++ b/inject/inject/src/main/java/io/helidon/inject/HelidonInjectionContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+
+import io.helidon.inject.service.InjectionContext;
+import io.helidon.inject.service.Ip;
+
+/**
+ * A context for obtaining injection point values in a {@link io.helidon.inject.service.ServiceDescriptor}.
+ * This context is pre-filled with the correct providers either based on an {@link io.helidon.inject.Application},
+ * or based on analysis during activation of a service provider.
+ *
+ * @see io.helidon.inject.service.InjectionContext
+ */
+public class HelidonInjectionContext implements InjectionContext {
+    private final Map<Ip, Supplier<?>> injectionPlans;
+
+    private HelidonInjectionContext(Map<Ip, Supplier<?>> injectionPlans) {
+        this.injectionPlans = injectionPlans;
+    }
+
+    /**
+     * Create an injection context based on a map of providers.
+     * The type guarantee must be ensured by caller of this method (that each supplier matches the exact type
+     * expected by the injection point). No further checks are done. Any invalid supplier would result in a
+     * runtime {@link java.lang.ClassCastException}!
+     *
+     * @param injectionPlan map of injection points to a provider that satisfies that injection point
+     * @return a new injection context
+     */
+    public static InjectionContext create(Map<Ip, Supplier<?>> injectionPlan) {
+        return new HelidonInjectionContext(injectionPlan);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T param(Ip paramId) {
+        Supplier<?> injectionSupplier = injectionPlans.get(paramId);
+        if (injectionSupplier == null) {
+            throw new NoSuchElementException("Cannot resolve injection id " + paramId + " for service "
+                                                     + paramId.service().fqName()
+                                                     + ", this dependency was not declared in "
+                                                     + "the service descriptor");
+        }
+
+        return (T) injectionSupplier.get();
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectActivatorProvider.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectActivatorProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.common.Weighted;
+import io.helidon.inject.service.ServiceDescriptor;
+import io.helidon.inject.service.ServiceInfo;
+import io.helidon.inject.spi.ActivatorProvider;
+
+/**
+ * Provider that supports the default runtime id.
+ */
+class InjectActivatorProvider implements ActivatorProvider, Weighted {
+    InjectActivatorProvider() {
+    }
+
+    @Override
+    public String id() {
+        return ServiceInfo.INJECTION_RUNTIME_ID;
+    }
+
+    @Override
+    public <T> Activator<T> activator(Services services, ServiceDescriptor<T> descriptor) {
+        return InjectServiceProvider.create(services, descriptor);
+    }
+
+    @Override
+    public double weight() {
+        // less than default, so others can override it
+        return Weighted.DEFAULT_WEIGHT - 10;
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectServiceProvider.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectServiceProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.inject.service.ServiceDescriptor;
+
+class InjectServiceProvider<T> extends ServiceProviderBase<T> {
+    protected InjectServiceProvider(Services services, ServiceDescriptor<T> serviceSource) {
+        super(services, serviceSource);
+    }
+
+    static <T> Activator<T> create(Services services, ServiceDescriptor<T> descriptor) {
+        return new InjectServiceProvider<>(services, descriptor);
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectTypes.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectTypes.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.Injection;
+
+/**
+ * {@link io.helidon.common.types.TypeName} that are commonly needed at runtime.
+ *
+ * @see io.helidon.common.types.TypeNames
+ */
+public final class InjectTypes {
+    /**
+     * Helidon {@link io.helidon.inject.service.Injection.Singleton}.
+     */
+    public static final TypeName SINGLETON = TypeName.create(Injection.Singleton.class);
+    /**
+     * Helidon {@link io.helidon.inject.service.Injection.Named}.
+     */
+    public static final TypeName NAMED = TypeName.create(Injection.Named.class);
+
+    private InjectTypes() {
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionApplicationActivator.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionApplicationActivator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Set;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceDescriptor;
+
+/**
+ * Support for {@link Application} as a service provider. This activator manages service provider that
+ * always returns the same {@link io.helidon.inject.Application} instance.
+ * <p>
+ * As applications cannot be injected, so the service descriptor does not need to be public.
+ */
+class InjectionApplicationActivator extends ServiceProviderBase<Application> {
+
+    private final String appName;
+
+    private InjectionApplicationActivator(Services services,
+                                          ServiceDescriptor<Application> descriptor,
+                                          String appName) {
+        super(services, descriptor);
+        this.appName = appName;
+    }
+
+    static InjectionApplicationActivator create(Services services,
+                                                Application app,
+                                                String appName) {
+
+        Set<Qualifier> qualifiers = Set.of(Qualifier.createNamed(appName));
+        ServiceDescriptor<Application> descriptor = new AppServiceDescriptor(app.getClass(), qualifiers, appName);
+        InjectionApplicationActivator activator = new InjectionApplicationActivator(services,
+                                                                                    descriptor,
+                                                                                    appName);
+
+        activator.state(Phase.ACTIVE, app);
+        return activator;
+    }
+
+    @Override
+    public String toString() {
+        return "Activator for application \"" + appName + "\"";
+    }
+
+    private static class AppServiceDescriptor implements ServiceDescriptor<Application> {
+        private static final TypeName APP_TYPE = TypeName.create(Application.class);
+        private final TypeName appType;
+        private final Set<Qualifier> qualifiers;
+        private final String appName;
+
+        private AppServiceDescriptor(Class<?> appClass, Set<Qualifier> qualifiers, String appName) {
+            this.appType = TypeName.create(appClass);
+            this.qualifiers = qualifiers;
+            this.appName = appName;
+        }
+
+        @Override
+        public TypeName serviceType() {
+            return appType;
+        }
+
+        @Override
+        public Set<TypeName> contracts() {
+            return Set.of(APP_TYPE);
+        }
+
+        @Override
+        public Set<Qualifier> qualifiers() {
+            return qualifiers;
+        }
+
+        @Override
+        public Set<TypeName> scopes() {
+            return Set.of(InjectTypes.SINGLETON);
+        }
+
+        @Override
+        public String toString() {
+            return "Service descriptor of application \"" + appName + "\"";
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionConfigBlueprint.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionConfigBlueprint.java
@@ -40,7 +40,7 @@ interface InjectionConfigBlueprint {
 
     /**
      * Flag indicating whether service lookups
-     * (i.e., via {@link io.helidon.inject.Services#find(Lookup)}) are cached.
+     * (i.e., via {@link io.helidon.inject.Services#first(Lookup)}) are cached.
      *
      * @return the flag indicating whether service lookups are cached, defaults to {@code false}
      */

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionConfigBlueprint.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionConfigBlueprint.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Helidon Inject configuration options.
+ */
+@Prototype.Blueprint
+@Prototype.Configured("inject")
+interface InjectionConfigBlueprint {
+    /**
+     * In certain conditions Injection services should be initialized but not started (i.e., avoiding calls to
+     * {@code PostConstruct}
+     * etc.). This can be used in special cases where the normal Injection startup should limit lifecycle up to a given phase.
+     * Normally
+     * one should not use this feature - it is mainly used in Injection tooling (e.g., the injection maven-plugin).
+     *
+     * @return the phase to stop at during lifecycle
+     */
+    @Option.Configured
+    @Option.Default("ACTIVE")
+    Phase limitRuntimePhase();
+
+    /**
+     * Flag indicating whether service lookups
+     * (i.e., via {@link io.helidon.inject.Services#find(Lookup)}) are cached.
+     *
+     * @return the flag indicating whether service lookups are cached, defaults to {@code false}
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean serviceLookupCaching();
+
+    /**
+     * Flag indicating whether the services registry permits dynamic behavior.
+     *
+     * @return the flag indicating whether the services registry supports dynamic updates of the service registry,
+     *         defaults to {@code false}
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean permitsDynamic();
+
+    /**
+     * Flag indicating whether compile-time generated {@link io.helidon.inject.Application}'s
+     * should be used at Injection's startup initialization.
+     * Even if set to {@code true}, this is effective only if an Application was generated using Helidon Inject Maven Plugin.
+     *
+     * @return the flag indicating whether the provider is permitted to use Application generated code from compile-time,
+     *         defaults to {@code true}
+     * @see io.helidon.inject.Application
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(true)
+    boolean useApplication();
+
+    /**
+     * Flag indicating whether {@link io.helidon.inject.service.ModuleComponent} is discovered from the
+     * classpath (expected to be code generated, uses {@link java.util.ServiceLoader}).
+     * Note that if this is disabled, the registry will be empty, and unless {@link #permitsDynamic()} is allowed,
+     * it will have no function.
+     *
+     * @return the flag indicating whether the provider should use modules to bind services
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(true)
+    boolean useModules();
+
+    /**
+     * Flag indicating whether runtime interception is enabled.
+     * If set to {@code false}, methods will be invoked without any interceptors, even if interceptors are available.
+     *
+     * @return whether to intercept calls at runtime, defaults to {@code true}
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(true)
+    boolean interceptionEnabled();
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionException.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+/**
+ * A general exception indicating that something failed related to Injection.
+ */
+public class InjectionException extends RuntimeException {
+
+    /**
+     * A general purpose exception from the Injection Framework.
+     *
+     * @param msg the message
+     */
+    public InjectionException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * A general purpose exception from the Injection framework.
+     *
+     * @param msg   the message
+     * @param cause the root cause
+     */
+    public InjectionException(String msg,
+                              Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionModuleActivator.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionModuleActivator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Set;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.ModuleComponent;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceDescriptor;
+
+/**
+ * Support for {@link io.helidon.inject.service.ModuleComponent} as a service provider.
+ * This activator manages service provider that
+ * always returns the same {@link io.helidon.inject.service.ModuleComponent} instance.
+ * <p>
+ * As modules cannot be injected, so the service descriptor does not need to be public.
+ */
+class InjectionModuleActivator extends ServiceProviderBase<ModuleComponent> {
+
+    InjectionModuleActivator(Services services,
+                             ServiceDescriptor<ModuleComponent> descriptor) {
+        super(services, descriptor);
+    }
+
+    static InjectionModuleActivator create(Services services,
+                                           ModuleComponent module,
+                                           String moduleName) {
+
+        Set<Qualifier> qualifiers = Set.of(Qualifier.createNamed(moduleName));
+        ServiceDescriptor<ModuleComponent> descriptor = new ModuleServiceDescriptor(module.getClass(), qualifiers);
+        InjectionModuleActivator activator = new InjectionModuleActivator(services,
+                                                                          descriptor);
+
+        activator.state(Phase.ACTIVE, module);
+
+        return activator;
+    }
+
+    private static class ModuleServiceDescriptor implements ServiceDescriptor<ModuleComponent> {
+        private static final TypeName MODULE_TYPE = TypeName.create(ModuleComponent.class);
+
+        private final TypeName moduleType;
+        private final Set<Qualifier> qualifiers;
+
+        private ModuleServiceDescriptor(Class<?> moduleClass, Set<Qualifier> qualifiers) {
+            this.moduleType = TypeName.create(moduleClass);
+            this.qualifiers = qualifiers;
+        }
+
+        @Override
+        public TypeName serviceType() {
+            return moduleType;
+        }
+
+        @Override
+        public Set<TypeName> contracts() {
+            return Set.of(MODULE_TYPE);
+        }
+
+        @Override
+        public Set<Qualifier> qualifiers() {
+            return qualifiers;
+        }
+
+        @Override
+        public Set<TypeName> scopes() {
+            return Set.of(InjectTypes.SINGLETON);
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionPointProvider.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionPointProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Provides ability to contextualize the injected service by the target receiver of the injection point dynamically
+ * at runtime. This API will provide service instances of type {@code T}. These services may be singleton, or created based upon
+ * scoping cardinality that is defined by the provider implementation of the given type. This is why the javadoc reads "get (or
+ * create)".
+ * <p>
+ * The ordering of services, and the preferred service itself, is determined by the same as documented for
+ * {@link io.helidon.inject.Services}.
+ *
+ * @param <T> the type that the provider produces
+ */
+public interface InjectionPointProvider<T> extends Supplier<T> {
+
+    /**
+     * Get (or create) an instance of this service type using default/empty criteria and context.
+     *
+     * @return the best service provider matching the criteria
+     * @throws io.helidon.inject.InjectionException if resolution fails to resolve a match
+     */
+    @Override
+    default T get() {
+        return first(ContextualServiceQuery.REQUIRED)
+                .orElseThrow(this::couldNotFindMatch);
+    }
+
+    /**
+     * Get (or create) an instance of this service type for the given injection point context. This is logically the same
+     * as using the first element of the result from calling {@link #list(io.helidon.inject.ContextualServiceQuery)}.
+     *
+     * @param query the service query
+     * @return the best service provider matching the criteria
+     * @throws io.helidon.inject.InjectionException if expected=true and resolution fails to resolve a match
+     */
+    Optional<T> first(ContextualServiceQuery query);
+
+    /**
+     * Get (or create) a list of instances matching the criteria for the given injection point context.
+     *
+     * @param query the service query
+     * @return the resolved services matching criteria for the injection point in order of weight, or null if the context is not
+     *         supported
+     */
+    default List<T> list(ContextualServiceQuery query) {
+        return first(query).map(List::of).orElseGet(List::of);
+    }
+
+    private InjectionException couldNotFindMatch() {
+        if (this instanceof ServiceProvider<?> sp) {
+            return new InjectionServiceProviderException("Expected to find a match", sp);
+        }
+        return new InjectionException("Expected to find a match for " + this);
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionResolver.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Optional;
+
+import io.helidon.inject.service.Ip;
+
+/**
+ * Implementors of this contract can assist with resolving injection points.
+ * A {@link io.helidon.inject.ServiceProvider} is expected to implement this interface.
+ */
+public interface InjectionResolver {
+
+    /**
+     * Attempts to resolve the injection point info for a given service provider.
+     * <p>
+     * There are two modes that injection resolvers run through.
+     * Phase 1 (resolveIps=false) is during the time when the injection plan is being formulated. This is the time we need
+     * to identify which {@link ServiceProvider} instances qualify.
+     * Phase 2 (resolveIps=true) is during actual resolution, and typically comes during the service activation lifecycle.
+     *
+     * @param ipInfo            the injection point being resolved
+     * @param injectionServices the services registry
+     * @param serviceProvider   the service provider this pertains to
+     * @param resolveIps        flag indicating whether injection points should be resolved
+     * @return the resolution for the plan or the injection point, or empty if unable to resolve the injection point context
+     */
+    Optional<Object> resolve(Ip ipInfo,
+                             Services injectionServices,
+                             ServiceProvider<?> serviceProvider,
+                             boolean resolveIps);
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionServiceProviderException.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionServiceProviderException.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An exception relative to a {@link io.helidon.inject.ServiceProvider}.
+ */
+public class InjectionServiceProviderException extends InjectionException {
+
+    /**
+     * The service provider this exception pertains.
+     */
+    private final ServiceProvider<?> serviceProvider;
+
+    /**
+     * A general purpose exception from the Injection framework.
+     *
+     * @param msg the message
+     */
+    public InjectionServiceProviderException(String msg) {
+        super(msg);
+        this.serviceProvider = null;
+    }
+
+    /**
+     * A general purpose exception from the Injection framework.
+     *
+     * @param msg   the message
+     * @param cause the root cause
+     */
+    public InjectionServiceProviderException(String msg,
+                                             Throwable cause) {
+        super(msg, cause);
+
+        if (cause instanceof InjectionServiceProviderException exc) {
+            this.serviceProvider = exc.serviceProvider().orElse(null);
+        } else {
+            this.serviceProvider = null;
+        }
+    }
+
+    /**
+     * A general purpose exception from the Injection framework.
+     *
+     * @param msg             the message
+     * @param serviceProvider the service provider
+     */
+    public InjectionServiceProviderException(String msg,
+                                             ServiceProvider<?> serviceProvider) {
+        super(msg);
+        Objects.requireNonNull(serviceProvider);
+        this.serviceProvider = serviceProvider;
+    }
+
+    /**
+     * A general purpose exception from the Injection framework.
+     *
+     * @param msg             the message
+     * @param cause           the root cause
+     * @param serviceProvider the service provider
+     */
+    public InjectionServiceProviderException(String msg,
+                                             Throwable cause,
+                                             ServiceProvider<?> serviceProvider) {
+        super(msg, cause);
+        Objects.requireNonNull(serviceProvider);
+        this.serviceProvider = serviceProvider;
+    }
+
+    /**
+     * The service provider that this exception pertains to, or empty if not related to any particular provider.
+     *
+     * @return the optional / contextual service provider
+     */
+    public Optional<ServiceProvider<?>> serviceProvider() {
+        return Optional.ofNullable(serviceProvider);
+    }
+
+    @Override
+    public String getMessage() {
+        return super.getMessage()
+                + (serviceProvider == null ? "" : (": service provider: " + serviceProvider));
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionServices.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionServices.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Map;
+import java.util.Objects;
+
+import io.helidon.common.types.TypeName;
+
+/**
+ * A factory for service registry. The global services can be accessed through {@link #instance()}.
+ */
+public interface InjectionServices {
+    /**
+     * Configure the bootstrap of injection. This method must be called before obtaining an instance
+     * of {@link io.helidon.inject.Services}, otherwise it will be ignored.
+     *
+     * @param config injection configuration
+     */
+    static void configure(InjectionConfig config) {
+        Objects.requireNonNull(config);
+        InjectionServicesImpl.configure(config);
+    }
+
+    /**
+     * The singleton instance of injection services.
+     *
+     * @return injection services
+     */
+    static InjectionServices instance() {
+        return InjectionServicesImpl.instance();
+    }
+
+    /**
+     * The service registry.
+     *
+     * @return the services registry
+     */
+    Services services();
+
+    /**
+     * The governing configuration.
+     *
+     * @return the config
+     */
+    InjectionConfig config();
+
+    /**
+     * Attempts to perform a graceful {@link io.helidon.inject.Activator#deactivate(DeActivationRequest)} on all managed
+     * service instances in the {@link Services} registry.
+     * Deactivation is handled within the current thread.
+     * <p>
+     * This method will return a map of all service types that were deactivated to
+     * its deactivation result.
+     * <p>
+     * The deactivation will be in reverse
+     * order of {@link io.helidon.inject.service.Injection.RunLevel} from the highest value down to the lowest value.
+     * If two services share the same {@link io.helidon.inject.service.Injection.RunLevel} value then the ordering will be
+     * based on service {@link io.helidon.common.Weight} (in ascending order), and then on service name.
+     * <p>
+     * When shutdown returns, it is guaranteed that all services were shutdown, or failed to achieve shutdown.
+     *
+     * @return a map of all managed service types deactivated to results of deactivation, or empty if shutdown is not supported;
+     *         note that the response will only contain services that were activated and that have a
+     *         {@link io.helidon.inject.service.Injection.Singleton} scope
+     */
+    Map<TypeName, ActivationResult> shutdown();
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InjectionServicesImpl.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InjectionServicesImpl.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.lang.System.Logger.Level;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+import io.helidon.common.HelidonServiceLoader;
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.ModuleComponent;
+import io.helidon.inject.service.ServiceInfo;
+
+class InjectionServicesImpl extends ResettableHandler implements InjectionServices {
+    private static final System.Logger LOGGER = System.getLogger(InjectionServices.class.getName());
+    private static final ReadWriteLock INSTANCE_LOCK = new ReentrantReadWriteLock();
+    private static final AtomicReference<InjectionConfig> CONFIG = new AtomicReference<>();
+
+    private static volatile InjectionServicesImpl instance;
+
+    private final State state = State.create(Phase.INIT);
+    private final ReentrantReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
+    private final InjectionConfig config;
+
+    private volatile ServicesImpl services;
+
+    private InjectionServicesImpl(InjectionConfig config) {
+        this.config = config;
+    }
+
+    static InjectionServices instance() {
+        Lock lock = INSTANCE_LOCK.readLock();
+        try {
+            lock.lock();
+            if (instance != null) {
+                return instance;
+            }
+        } finally {
+            lock.unlock();
+        }
+        lock = INSTANCE_LOCK.writeLock();
+        try {
+            lock.lock();
+            InjectionConfig config = CONFIG.get();
+            if (config == null) {
+                config = InjectionConfig.create();
+            }
+            InjectionServicesImpl newInstance = new InjectionServicesImpl(config);
+            ResettableHandler.addResettable(new ResetInjectionServices(newInstance));
+
+            InjectionServicesImpl.instance = newInstance;
+
+            return newInstance;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    static void configure(InjectionConfig config) {
+        CONFIG.set(config);
+    }
+
+    @Override
+    public Services services() {
+        Lock readLock = lifecycleLock.readLock();
+        try {
+            readLock.lock();
+            if (services != null) {
+                return services;
+            }
+        } finally {
+            readLock.unlock();
+        }
+
+        Lock writeLock = lifecycleLock.writeLock();
+        try {
+            writeLock.lock();
+            if (services != null) {
+                return services;
+            }
+            state.currentPhase(Phase.ACTIVATION_STARTING);
+            services = new ServicesImpl(this, state);
+            services.bindSelf();
+
+            if (config.useModules()) {
+                List<ModuleComponent> modules = findModules();
+                modules.forEach(services::bind);
+            }
+
+            state.currentPhase(Phase.GATHERING_DEPENDENCIES);
+            if (config.useApplication()) {
+                List<Application> apps = findApplications();
+                apps.forEach(services::bind);
+            }
+
+            List<ActivationPhaseReceiver> phaseReceivers = services.allProviders()
+                    .stream()
+                    .filter(sp -> sp instanceof ActivationPhaseReceiver)
+                    .map(ActivationPhaseReceiver.class::cast)
+                    .toList();
+
+            state.currentPhase(Phase.POST_BIND_ALL_MODULES);
+            phaseReceivers.forEach(sp -> sp.onPhaseEvent(Phase.POST_BIND_ALL_MODULES));
+
+            state.currentPhase(Phase.FINAL_RESOLVE);
+            phaseReceivers.forEach(sp -> sp.onPhaseEvent(Phase.FINAL_RESOLVE));
+
+            state.currentPhase(Phase.SERVICES_READY);
+            phaseReceivers.forEach(sp -> sp.onPhaseEvent(Phase.SERVICES_READY));
+
+            state.finished(true);
+
+            return services;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public InjectionConfig config() {
+        return config;
+    }
+
+    @Override
+    public Map<TypeName, ActivationResult> shutdown() {
+        Lock lock = lifecycleLock.writeLock();
+        try {
+            lock.lock();
+            if (services == null) {
+                return Map.of();
+            }
+            State currentState = state.clone().currentPhase(Phase.PRE_DESTROYING);
+            return doShutdown(services, currentState);
+        } finally {
+            services = null;
+            lock.unlock();
+        }
+    }
+
+    private static Map<TypeName, ActivationResult> doShutdown(ServicesImpl services, State state) {
+        Map<TypeName, ActivationResult> result = new LinkedHashMap<>();
+
+        state.currentPhase(Phase.DESTROYED);
+
+        // next get all services that are beyond INIT state, and sort by runlevel order, and shut those down also
+        List<ServiceProvider<?>> serviceProviders = services.allProviders();
+        serviceProviders = serviceProviders.stream()
+                .filter(sp -> sp.currentActivationPhase().eligibleForDeactivation())
+                .collect(Collectors.toList()); // must be a mutable list, as we sort it in next step
+        serviceProviders.sort(shutdownComparator());
+        doFinalShutdown(services, serviceProviders, result);
+
+        return result;
+    }
+
+    private static Comparator<? super ServiceProvider<?>> shutdownComparator() {
+        return Comparator.comparingInt(ServiceInfo::runLevel)
+                .thenComparing(ServiceInfo::weight);
+    }
+
+    private static void doFinalShutdown(ServicesImpl services,
+                                        Collection<ServiceProvider<?>> serviceProviders,
+                                        Map<TypeName, ActivationResult> map) {
+        for (ServiceProvider<?> csp : serviceProviders) {
+            Phase startingActivationPhase = csp.currentActivationPhase();
+            try {
+                Activator<?> activator;
+                Optional<Activator<?>> activatorOptional = services.activator(csp);
+                if (activatorOptional.isPresent()) {
+                    activator = activatorOptional.get();
+                } else {
+                    if (csp instanceof Activator<?> cspa) {
+                        activator = cspa;
+                    } else {
+                        ActivationResult result = ActivationResult.builder()
+                                .serviceProvider(csp)
+                                .startingActivationPhase(startingActivationPhase)
+                                .targetActivationPhase(Phase.DESTROYED)
+                                .finishingActivationPhase(csp.currentActivationPhase())
+                                .finishingStatus(ActivationStatus.FAILURE)
+                                .error(new InjectionException("Failed to discover activator for the service provider,"
+                                                                      + " cannot shut down"))
+                                .build();
+                        map.put(csp.serviceType(), result);
+                        continue;
+                    }
+                }
+                ActivationResult result = activator.deactivate(DeActivationRequest.builder()
+                                                                       .throwIfError(false)
+                                                                       .build());
+                map.put(csp.serviceType(), result);
+            } catch (Throwable t) {
+                LOGGER.log(Level.WARNING, "Failed to deactivate service provider: " + csp, t);
+                ActivationResult result = ActivationResult.builder()
+                        .serviceProvider(csp)
+                        .startingActivationPhase(startingActivationPhase)
+                        .targetActivationPhase(Phase.DESTROYED)
+                        .finishingActivationPhase(csp.currentActivationPhase())
+                        .finishingStatus(ActivationStatus.FAILURE)
+                        .error(t)
+                        .build();
+                map.put(csp.serviceType(), result);
+            }
+        }
+    }
+
+    private List<Application> findApplications() {
+        return HelidonServiceLoader.create(ServiceLoader.load(Application.class))
+                .asList();
+    }
+
+    private List<ModuleComponent> findModules() {
+        return HelidonServiceLoader.create(ServiceLoader.load(ModuleComponent.class))
+                .asList();
+    }
+
+    private static class ResetInjectionServices implements Resettable {
+
+        private final InjectionServicesImpl instance;
+
+        private ResetInjectionServices(InjectionServicesImpl instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public void reset(boolean deep) {
+            // first reset the singleton instance (so a new singleton can be created with different config)
+            Lock writeLock = INSTANCE_LOCK.writeLock();
+            try {
+                writeLock.lock();
+                InjectionServicesImpl.CONFIG.set(null);
+                InjectionServicesImpl.instance = null;
+            } finally {
+                writeLock.unlock();
+            }
+
+            // now reset this instance
+            Lock lock = instance.lifecycleLock.writeLock();
+            try {
+                lock.lock();
+
+                if (!instance.config.permitsDynamic()) {
+                    throw new IllegalStateException(
+                            "Attempting to rest InjectionServices that do not support dynamic updates. Set option "
+                                    + "permitsDynamic, "
+                                    + "or configuration option 'inject.permits-dynamic=true' to enable");
+                }
+
+                instance.services = null;
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InterceptionMetadataImpl.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InterceptionMetadataImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypedElementInfo;
+import io.helidon.inject.service.Interception;
+import io.helidon.inject.service.InterceptionMetadata;
+import io.helidon.inject.service.InvocationContext;
+import io.helidon.inject.service.Invoker;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceInfo;
+
+class InterceptionMetadataImpl implements InterceptionMetadata {
+    private final Services services;
+
+    InterceptionMetadataImpl(Services services) {
+        this.services = services;
+    }
+
+    @Override
+    public <T> Invoker<T> createInvoker(ServiceInfo serviceInfo,
+                                        Set<Qualifier> typeQualifiers,
+                                        List<Annotation> typeAnnotations,
+                                        TypedElementInfo element,
+                                        Invoker<T> targetInvoker,
+                                        Set<Class<? extends Throwable>> checkedExceptions) {
+        var interceptors = interceptors(
+                typeAnnotations,
+                element);
+        if (interceptors.isEmpty()) {
+            return targetInvoker;
+        } else {
+            return params -> Invocation.createInvokeAndSupply(InvocationContext.builder()
+                                                                      .serviceInfo(serviceInfo)
+                                                                      .typeAnnotations(typeAnnotations)
+                                                                      .elementInfo(element)
+                                                                      .build(),
+                                                              interceptors,
+                                                              targetInvoker,
+                                                              params,
+                                                              checkedExceptions);
+        }
+    }
+
+    private List<Supplier<Interception.Interceptor>> interceptors(List<Annotation> typeAnnotations,
+                                                                  TypedElementInfo element) {
+        if (!services.injectionServices().config().interceptionEnabled()) {
+            return List.of();
+        }
+
+        // need to find all interceptors for the providers (ordered by weight)
+        List<ServiceProvider<Interception.Interceptor>> allInterceptors;
+
+        if (services instanceof ServicesImpl si) {
+            allInterceptors = si.interceptors();
+        } else {
+            allInterceptors = services.serviceProviders(Lookup.builder()
+                                                                .addContract(Interception.Interceptor.class)
+                                                                .addQualifier(Qualifier.WILDCARD_NAMED)
+                                                                .build());
+        }
+
+        List<Supplier<Interception.Interceptor>> result = new ArrayList<>();
+
+        for (ServiceProvider<Interception.Interceptor> interceptor : allInterceptors) {
+            if (applicable(typeAnnotations, interceptor)) {
+                result.add(interceptor);
+                continue;
+            }
+            if (applicable(element.annotations(), interceptor)) {
+                result.add(interceptor);
+            }
+        }
+
+        return result;
+    }
+
+    private boolean applicable(List<Annotation> typeAnnotations, ServiceProvider<Interception.Interceptor> interceptor) {
+        for (Annotation typeAnnotation : typeAnnotations) {
+            if (interceptor.qualifiers().contains(Qualifier.createNamed(typeAnnotation.typeName().fqName()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InterceptionMetadataImpl.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InterceptionMetadataImpl.java
@@ -74,7 +74,7 @@ class InterceptionMetadataImpl implements InterceptionMetadata {
         if (services instanceof ServicesImpl si) {
             allInterceptors = si.interceptors();
         } else {
-            allInterceptors = services.serviceProviders(Lookup.builder()
+            allInterceptors = services.allProviders(Lookup.builder()
                                                                 .addContract(Interception.Interceptor.class)
                                                                 .addQualifier(Qualifier.WILDCARD_NAMED)
                                                                 .build());

--- a/inject/inject/src/main/java/io/helidon/inject/Invocation.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Invocation.java
@@ -165,14 +165,14 @@ class Invocation<V> implements Interception.Interceptor.Chain<V> {
                     throw t;
                 }
 
-                throw (interceptorProvider instanceof ServiceProvider)
-                        ? new InvocationException("Error in interceptor chain processing",
-                                                  t,
-                                                  (ServiceProvider<?>) interceptorProvider,
-                                                  call == null)
-                        : new InvocationException("Error in interceptor chain processing",
-                                                  t,
-                                                  call == null);
+                String message = "Error in interceptor chain processing";
+                boolean called = call == null;
+
+                if (interceptor instanceof ServiceProvider<?> sp) {
+                    throw new InvocationException(message, t, sp, called);
+                } else {
+                    throw new InvocationException(message, t, called);
+                }
             }
         }
 

--- a/inject/inject/src/main/java/io/helidon/inject/Invocation.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Invocation.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypedElementInfo;
+import io.helidon.inject.service.Interception;
+import io.helidon.inject.service.InvocationContext;
+import io.helidon.inject.service.Invoker;
+import io.helidon.inject.service.ServiceInfo;
+
+/**
+ * Handles the invocation of {@link io.helidon.inject.service.Interception.Interceptor} methods.
+ * Note that upon a successful call to the {@link io.helidon.inject.service.Interception.Interceptor.Chain#proceed(Object[])} or
+ * to the ultimate
+ * target, the invocation will be prevented from being executed again.
+ *
+ * @param <V> the invocation type
+ * @see io.helidon.inject.service.InvocationContext
+ */
+class Invocation<V> implements Interception.Interceptor.Chain<V> {
+    private final InvocationContext ctx;
+    private final List<Supplier<Interception.Interceptor>> interceptors;
+    private final Set<Class<? extends Throwable>> checkedExceptions;
+    private int interceptorPos;
+    private Invoker<V> call;
+
+    private Invocation(InvocationContext ctx,
+                       List<Supplier<Interception.Interceptor>> interceptors,
+                       Invoker<V> call,
+                       Set<Class<? extends Throwable>> checkedExceptions) {
+        this.ctx = ctx;
+        this.call = call;
+        this.interceptors = List.copyOf(interceptors);
+        this.checkedExceptions = checkedExceptions;
+    }
+
+    /**
+     * Creates an instance of {@link io.helidon.inject.Invocation} and invokes it in this context.
+     *
+     * @param descriptor      service descriptor
+     * @param typeAnnotations type level annotations
+     * @param element         element being invoked
+     * @param call            the call to the base service provider's method
+     * @param args            the call arguments
+     * @param <V>             the type returned from the method element
+     * @return the invocation instance
+     * @throws io.helidon.inject.InvocationException if there are errors during invocation chain processing
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static <V> V createInvokeAndSupply(ServiceInfo descriptor,
+                                              List<Annotation> typeAnnotations,
+                                              TypedElementInfo element,
+                                              List<Supplier<Interception.Interceptor>> interceptors,
+                                              Invoker<V> call,
+                                              Object... args) {
+        Objects.requireNonNull(descriptor);
+        Objects.requireNonNull(typeAnnotations);
+        Objects.requireNonNull(element);
+        Objects.requireNonNull(interceptors);
+        Objects.requireNonNull(call);
+        Objects.requireNonNull(args);
+
+        InvocationContext ctx = InvocationContext.builder()
+                .serviceInfo(descriptor)
+                .typeAnnotations(typeAnnotations)
+                .elementInfo(element)
+                .build();
+
+        try {
+            if (interceptors.isEmpty()) {
+                return call.invoke(args);
+            } else {
+                return (V) new Invocation(ctx, interceptors, call, Set.of()).proceed(args);
+            }
+        } catch (InvocationException e) {
+            throw e;
+        } catch (Throwable t) {
+            // this method does not support checked exceptions
+            // (and as a result, we do not support checked exceptions in intercepted constructors)
+            throw new InvocationException("Error in interceptor chain processing", t, true);
+        }
+    }
+
+    /**
+     * Creates an instance of {@link io.helidon.inject.Invocation} and invokes it in this context.
+     *
+     * @param ctx               the invocation context
+     * @param call              the call to the base service provider's method
+     * @param args              the call arguments
+     * @param checkedExceptions expected exception types
+     * @param <V>               the type returned from the method element
+     * @return the invocation instance
+     * @throws InvocationException if there are errors during invocation chain processing
+     * @throws Exception           any checked exception declared by the method itself
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static <V> V createInvokeAndSupply(InvocationContext ctx,
+                                       List<? extends Supplier<Interception.Interceptor>> interceptors,
+                                       Invoker<V> call,
+                                       Object[] args,
+                                       Set<Class<? extends Throwable>> checkedExceptions) throws Exception {
+        Objects.requireNonNull(ctx);
+        Objects.requireNonNull(call);
+        Objects.requireNonNull(args);
+        Objects.requireNonNull(checkedExceptions);
+
+        if (interceptors.isEmpty()) {
+            try {
+                return call.invoke(args);
+            } catch (Throwable t) {
+                if (shouldThrow(checkedExceptions, t.getClass())) {
+                    throw t;
+                }
+                throw new InvocationException("Error in interceptor chain processing", t, true);
+            }
+        } else {
+            return (V) new Invocation(ctx, interceptors, call, checkedExceptions).proceed(args);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(ctx.elementInfo());
+    }
+
+    @Override
+    public V proceed(Object... args) throws Exception {
+        if (this.call == null) {
+            throw new InvocationException("Duplicate invocation, or unknown call type: " + this, true);
+        }
+
+        if (interceptorPos < interceptors.size()) {
+            Supplier<Interception.Interceptor> interceptorProvider = interceptors.get(interceptorPos);
+            Interception.Interceptor interceptor = interceptorProvider.get();
+            interceptorPos++;
+            try {
+                return interceptor.proceed(ctx, this, args);
+            } catch (RuntimeException e) {
+                interceptorPos--;
+                throw e;
+            } catch (Throwable t) {
+                interceptorPos--;
+
+                if (shouldThrow(checkedExceptions, t.getClass())) {
+                    throw t;
+                }
+
+                throw (interceptorProvider instanceof ServiceProvider)
+                        ? new InvocationException("Error in interceptor chain processing",
+                                                  t,
+                                                  (ServiceProvider<?>) interceptorProvider,
+                                                  call == null)
+                        : new InvocationException("Error in interceptor chain processing",
+                                                  t,
+                                                  call == null);
+            }
+        }
+
+        Invoker<V> call = this.call;
+        this.call = null;
+
+        try {
+            return call.invoke(args);
+        } catch (InvocationException e) {
+            if (e.targetWasCalled()) {
+                // allow the call to happen again
+                this.call = call;
+            }
+            throw e;
+        } catch (RuntimeException e) {
+            this.call = call;
+            throw e;
+        } catch (Throwable t) {
+            // allow the call to happen again
+            this.call = call;
+            if (shouldThrow(checkedExceptions, t.getClass())) {
+                // do not wrap, declared checked exception
+                throw t;
+            }
+            // wrap, unexpected exception/throwable
+            throw new InvocationException("Error in interceptor chain processing", t, true);
+        }
+    }
+
+    private static boolean shouldThrow(Set<Class<? extends Throwable>> checked, Class<? extends Throwable> t) {
+        if (checked.contains(t)) {
+            return true;
+        }
+        for (Class<? extends Throwable> aClass : checked) {
+            if (aClass.isAssignableFrom(t)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/InvocationException.java
+++ b/inject/inject/src/main/java/io/helidon/inject/InvocationException.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+/**
+ * Wraps any checked exceptions that are thrown during the {@link io.helidon.inject.service.Interception.Interceptor} invocations.
+ */
+public class InvocationException extends InjectionServiceProviderException {
+
+    /**
+     * Tracks whether the target being intercepted was called once successfully - meaning that the target was called and it
+     * did not result in any exception being thrown.
+     */
+    private final boolean targetWasCalled;
+
+    /**
+     * Constructor.
+     *
+     * @param msg             the message
+     * @param targetWasCalled set to true if the target of interception was ultimately called successfully
+     */
+    public InvocationException(String msg,
+                               boolean targetWasCalled) {
+        super(msg);
+        this.targetWasCalled = targetWasCalled;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param msg             the message
+     * @param cause           the root cause
+     * @param targetWasCalled set to true if the target of interception was ultimately called successfully
+     */
+    public InvocationException(String msg,
+                               Throwable cause,
+                               boolean targetWasCalled) {
+        super(msg, cause);
+        this.targetWasCalled = targetWasCalled;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param msg             the message
+     * @param cause           the root cause
+     * @param serviceProvider the service provider
+     * @param targetWasCalled set to true if the target of interception was ultimately called successfully
+     */
+    public InvocationException(String msg,
+                               Throwable cause,
+                               ServiceProvider<?> serviceProvider,
+                               boolean targetWasCalled) {
+        super(msg, cause, serviceProvider);
+        this.targetWasCalled = targetWasCalled;
+    }
+
+    /**
+     * Returns true if the final target of interception was ultimately called.
+     *
+     * @return if the target being intercepted was ultimately called successfully
+     */
+    public boolean targetWasCalled() {
+        return targetWasCalled;
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/LookupBlueprint.java
+++ b/inject/inject/src/main/java/io/helidon/inject/LookupBlueprint.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceInfo;
+
+/**
+ * Criteria to discover services.
+ *
+ * @see io.helidon.inject.Services
+ */
+@Prototype.Blueprint
+@Prototype.CustomMethods(ServiceInfoCriteriaSupport.CustomMethods.class)
+interface LookupBlueprint {
+
+    /**
+     * The managed service implementation type name.
+     *
+     * @return the service type name
+     */
+    Optional<TypeName> serviceType();
+
+    /**
+     * The managed service assigned Scope's.
+     *
+     * @return the service scope type name
+     */
+    @Option.Singular
+    Set<TypeName> scopes();
+
+    /**
+     * The managed service assigned Qualifier's.
+     *
+     * @return the service qualifiers
+     */
+    @Option.Singular
+    Set<Qualifier> qualifiers();
+
+    /**
+     * The managed services advertised types (i.e., typically its interfaces, can be through
+     * {@link io.helidon.inject.service.Injection.ExternalContracts}).
+     *
+     * @return the service contracts implemented
+     */
+    @Option.Singular
+    Set<TypeName> contracts();
+
+    /**
+     * The optional {@link io.helidon.inject.service.Injection.RunLevel} ascribed to the service.
+     *
+     * @return the service's run level
+     */
+    Optional<Integer> runLevel();
+
+    /**
+     * Weight that was declared on the type itself.
+     *
+     * @return the declared weight
+     */
+    Optional<Double> weight();
+
+    /**
+     * Whether to include abstract type service providers.
+     *
+     * @return whether to include abstract classes and interfaces
+     */
+    @Option.DefaultBoolean(false)
+    boolean includeAbstract();
+
+    /**
+     * Determines whether this service info matches the criteria for injection.
+     * Matches is a looser form of equality check than {@code equals()}. If a service matches criteria
+     * it is generally assumed to be viable for assignability.
+     *
+     * @param criteria the criteria to compare against
+     * @return true if the criteria provided matches this instance
+     */
+    default boolean matches(Lookup criteria) {
+        return matchesContracts(criteria)
+                && matchesAbstract(includeAbstract(), criteria.includeAbstract())
+                && scopes().containsAll(criteria.scopes())
+                && Qualifiers.matchesQualifiers(qualifiers(), criteria.qualifiers())
+                && matches(runLevel(), criteria.runLevel());
+        //                && matchesWeight(this, criteria) -- intentionally not checking weight here!
+    }
+
+    /**
+     * Determines whether this service info criteria matches the service descriptor.
+     * Matches is a looser form of equality check than {@code equals()}. If a service matches criteria
+     * it is generally assumed to be viable for assignability.
+     *
+     * @param serviceInfo to compare with
+     * @return true if this criteria matches the service descriptor
+     */
+    default boolean matches(ServiceInfo serviceInfo) {
+        if (this == ServiceInfoCriteriaSupport.CustomMethods.EMPTY) {
+            return !serviceInfo.isAbstract();
+        }
+
+        boolean matches = matches(serviceInfo.serviceType(), this.serviceType());
+        if (matches && this.serviceType().isEmpty()) {
+            matches = serviceInfo.contracts().containsAll(this.contracts())
+                    || this.contracts().contains(serviceInfo.serviceType());
+        }
+        return matches
+                && matchesAbstract(includeAbstract(), serviceInfo.isAbstract())
+                && serviceInfo.scopes().containsAll(this.scopes())
+                && Qualifiers.matchesQualifiers(serviceInfo.qualifiers(), this.qualifiers())
+                && matchesWeight(serviceInfo, this)
+                && matches(serviceInfo.runLevel(), this.runLevel());
+    }
+
+    /**
+     * Determines whether the provided criteria match just the contracts portion of the provided criteria. Note that
+     * it is expected any external contracts have been consolidated into the regular contract section.
+     *
+     * @param criteria the criteria to compare against
+     * @return true if the criteria provided matches this instance from only the contracts point of view
+     */
+    default boolean matchesContracts(Lookup criteria) {
+        if (criteria == ServiceInfoCriteriaSupport.CustomMethods.EMPTY) {
+            return true;
+        }
+
+        boolean matches = matches(serviceType(), criteria.serviceType());
+        if (matches && criteria.serviceType().isEmpty()) {
+            matches = contracts().containsAll(criteria.contracts());
+        }
+        return matches;
+    }
+
+    private static boolean matchesWeight(ServiceInfo src,
+                                         LookupBlueprint criteria) {
+        if (criteria.weight().isEmpty()) {
+            return true;
+        }
+
+        Double srcWeight = src.weight();
+        return (srcWeight.compareTo(criteria.weight().get()) <= 0);
+    }
+
+    private static boolean matches(Object src,
+                                   Optional<?> criteria) {
+
+        return criteria.map(o -> Objects.equals(src, o)).orElse(true);
+
+    }
+
+    private boolean matchesAbstract(boolean criteriaAbstract, boolean isAbstract) {
+        if (criteriaAbstract) {
+            return true;
+        }
+        return !isAbstract;
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/Phase.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Phase.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+/**
+ * Forms a progression of full activation and deactivation.
+ */
+public enum Phase {
+    /**
+     * A new instance has been created, service registry is not yet aware.
+     */
+    CONSTRUCTED(false),
+    /**
+     * Starting state before anything happens activation-wise. Service registry is aware.
+     * Initialization may be done here.
+     */
+    INIT(false),
+
+    /**
+     * Planned to be activated.
+     */
+    PENDING(true),
+
+    /**
+     * Starting to be activated.
+     */
+    ACTIVATION_STARTING(true),
+
+    /**
+     * Gathering dependencies.
+     */
+    GATHERING_DEPENDENCIES(true),
+
+    /**
+     * Constructing.
+     */
+    CONSTRUCTING(true),
+
+    /**
+     * Injecting (fields then methods).
+     */
+    INJECTING(true),
+
+    /**
+     * Calling any post construct method.
+     */
+    POST_CONSTRUCTING(true),
+
+    /**
+     * Finishing post construct method.
+     */
+    ACTIVATION_FINISHING(true),
+
+    /**
+     * Service is active.
+     */
+    ACTIVE(true),
+
+    /**
+     * Called after all modules and services loaded into the service registry.
+     */
+    POST_BIND_ALL_MODULES(true),
+
+    /**
+     * Called after {@link #POST_BIND_ALL_MODULES} to resolve any latent bindings, prior to {@link #SERVICES_READY}.
+     */
+    FINAL_RESOLVE(true),
+
+    /**
+     * The service registry is fully populated and ready.
+     */
+    SERVICES_READY(true),
+
+    /**
+     * About to call pre-destroy.
+     */
+    PRE_DESTROYING(true),
+
+    /**
+     * Destroyed (after calling any pre-destroy).
+     */
+    DESTROYED(false);
+
+    /**
+     * True if this phase is eligible for deactivation/shutdown.
+     */
+    private final boolean eligibleForDeactivation;
+
+    Phase(boolean eligibleForDeactivation) {
+        this.eligibleForDeactivation = eligibleForDeactivation;
+    }
+
+    /**
+     * Determines whether this phase passes the gate for whether deactivation (PreDestroy) can be called.
+     *
+     * @return true if this phase is eligible to be included in shutdown processing
+     * @see io.helidon.inject.InjectionServices#shutdown()
+     */
+    public boolean eligibleForDeactivation() {
+        return eligibleForDeactivation;
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/Qualifiers.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Qualifiers.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.helidon.common.types.Annotation;
+import io.helidon.inject.service.Injection;
+import io.helidon.inject.service.Qualifier;
+
+/**
+ * Utility methods for qualifiers.
+ */
+final class Qualifiers {
+    private Qualifiers() {
+    }
+
+    /**
+     * Matches qualifier collections.
+     *
+     * @param src      the target service info to evaluate
+     * @param criteria the criteria to compare against
+     * @return true if the criteria provided matches this instance
+     */
+    static boolean matchesQualifiers(Collection<Qualifier> src,
+                                     Collection<Qualifier> criteria) {
+        if (criteria.isEmpty()) {
+            // the criteria does not care about qualifiers at all
+            return true;
+        }
+
+        if (src.isEmpty()) {
+            // neither defines qualifiers
+            return false;
+        }
+
+        // criteria has a qualifier while service does not
+        // only return true if criteria contains ONLY wildcard named qualifier
+        if (criteria.size() == 1 && criteria.contains(Qualifier.WILDCARD_NAMED)) {
+            return true;
+        }
+
+        if (src.contains(Qualifier.WILDCARD_NAMED)) {
+            // if provider has any name, and criteria ONLY asks for named, we match
+            if (criteria.stream()
+                    .allMatch(it -> it.typeName().equals(InjectTypes.NAMED))) {
+                return true;
+            }
+        }
+
+        for (Qualifier criteriaQualifier : criteria) {
+            if (src.contains(criteriaQualifier)) {
+                // NOP;
+                continue;
+            } else if (criteriaQualifier.typeName().equals(Injection.Named.TYPE_NAME)) {
+                if (criteriaQualifier.equals(Qualifier.WILDCARD_NAMED)
+                        || criteriaQualifier.value().isEmpty()) {
+                    // any Named qualifier will match ...
+                    boolean hasSameTypeAsCriteria = src.stream()
+                            .anyMatch(q -> q.typeName().equals(criteriaQualifier.typeName()));
+                    if (hasSameTypeAsCriteria) {
+                        continue;
+                    }
+                } else if (src.contains(Qualifier.WILDCARD_NAMED)) {
+                    continue;
+                }
+                return false;
+            } else if (criteriaQualifier.value().isEmpty()) {
+                Set<Annotation> sameTypeAsCriteriaSet = src.stream()
+                        .filter(q -> q.typeName().equals(criteriaQualifier.typeName()))
+                        .collect(Collectors.toSet());
+                if (sameTypeAsCriteriaSet.isEmpty()) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/Resettable.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Resettable.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+/**
+ * Implementors of this contract are capable of resetting the state of itself (i.e., clears cache, log entries, etc.).
+ */
+@FunctionalInterface
+public interface Resettable {
+
+    /**
+     * Resets the state of this object.
+     *
+     * @param deep true to iterate over any contained objects, to reflect the reset into the retained object
+     */
+    void reset(boolean deep);
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ResettableHandler.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ResettableHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Support for resetting (mostly from testing).
+ * The intended behavior is to have a single service registry for the duration of the runtime of JVM.
+ * Helidon applications are designed that way.
+ */
+public class ResettableHandler {
+    private static final Lock RESETTABLES_LOCK = new ReentrantLock();
+    private static final List<Resettable> RESETTABLES = new ArrayList<>();
+
+    /**
+     * Protected constructor to allow creation of subclasses that need to support reset.
+     */
+    protected ResettableHandler() {
+    }
+
+    /**
+     * Resets the bootstrap state.
+     */
+    protected static void reset() {
+        try {
+            RESETTABLES_LOCK.lock();
+            RESETTABLES.forEach(it -> it.reset(true));
+            RESETTABLES.clear();
+        } finally {
+            RESETTABLES_LOCK.unlock();
+        }
+    }
+
+    /**
+     * Register a resettable instance. When {@link #reset()} is called, this instance is removed from the list.
+     *
+     * @param instance resettable type that can be reset during testing
+     */
+    protected static void addResettable(Resettable instance) {
+        try {
+            RESETTABLES_LOCK.lock();
+            RESETTABLES.add(instance);
+        } finally {
+            RESETTABLES_LOCK.unlock();
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceInfoCriteriaSupport.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceInfoCriteriaSupport.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.Ip;
+
+final class ServiceInfoCriteriaSupport {
+    private ServiceInfoCriteriaSupport() {
+    }
+
+    static final class CustomMethods {
+        /**
+         * Empty criteria would match anything and everything except for abstract types.
+         */
+        @Prototype.Constant
+        static final Lookup EMPTY = createEmpty();
+
+        private CustomMethods() {
+        }
+
+        /**
+         * Create service info criteria for lookup from this injection point information.
+         *
+         * @param ipId injection point id to create criteria for
+         * @return criteria to lookup matching services
+         */
+        @Prototype.FactoryMethod
+        static Lookup create(Ip ipId) {
+            return Lookup.builder()
+                    .qualifiers(ipId.qualifiers())
+                    .addContract(ipId.contract())
+                    .build();
+        }
+
+        /**
+         * Create service info criteria for lookup from a contract type.
+         *
+         * @param contract a single contract to base the criteria on
+         * @return criteria to lookup matching services
+         */
+        @Prototype.FactoryMethod
+        static Lookup create(Class<?> contract) {
+            return Lookup.builder()
+                    .addContract(contract)
+                    .build();
+        }
+
+        /**
+         * The managed services advertised types (i.e., typically its interfaces).
+         *
+         * @param builder  builder instance
+         * @param contract the service contracts implemented
+         * @see #contracts()
+         */
+        @Prototype.BuilderMethod
+        static void addContract(Lookup.BuilderBase<?, ?> builder, Class<?> contract) {
+            builder.addContract(TypeName.create(contract));
+        }
+
+        /**
+         * The managed service implementation type.
+         *
+         * @param builder  builder instance
+         * @param contract the service type
+         */
+        @Prototype.BuilderMethod
+        static void serviceType(Lookup.BuilderBase<?, ?> builder, Class<?> contract) {
+            builder.serviceType(TypeName.create(contract));
+        }
+
+        private static Lookup createEmpty() {
+            return Lookup.builder().build();
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceInjectionPlanBinder.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceInjectionPlanBinder.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import io.helidon.inject.service.Ip;
+import io.helidon.inject.service.ServiceInfo;
+
+/**
+ * Responsible for registering the injection plan to the services in the service registry.
+ */
+public interface ServiceInjectionPlanBinder {
+
+    /**
+     * Bind an injection plan to a service provider instance.
+     *
+     * @param serviceInfo the service to receive the injection plan.
+     * @return the binder to use for binding the injection plan to the service provider
+     */
+    Binder bindTo(ServiceInfo serviceInfo);
+
+    /**
+     * Bind all discovered interceptors.
+     *
+     * @param serviceInfos interceptor services
+     */
+    void interceptors(ServiceInfo... serviceInfos);
+
+    /**
+     * The binder builder for the service plan.
+     *
+     * @see io.helidon.inject.service.Ip
+     */
+    interface Binder {
+
+        /**
+         * Binds a single service provider to the injection point identified by the id.
+         * It is assumed that the caller of this is aware of the proper cardinality for each injection point.
+         *
+         * @param id          the injection point identity
+         * @param useProvider whether we inject a provider or provided
+         * @param serviceInfo the service provider to bind to this identity.
+         * @return the binder builder
+         */
+        Binder bind(Ip id,
+                    boolean useProvider,
+                    ServiceInfo serviceInfo);
+
+        /**
+         * Bind to an optional field, with zero or one descriptors.
+         *
+         * @param id           injection point identity
+         * @param useProvider  whether we inject a provider or provided
+         * @param serviceInfos the descriptor to bind (zero or one)
+         * @return the binder builder
+         */
+        Binder bindOptional(Ip id,
+                            boolean useProvider,
+                            ServiceInfo... serviceInfos);
+
+        /**
+         * Binds a list of service providers to the injection point identified by the id.
+         * It is assumed that the caller of this is aware of the proper cardinality for each injection point.
+         *
+         * @param id           the injection point identity
+         * @param useProvider  whether we inject a provider or provided
+         * @param serviceInfos service descriptors to bind to this identity (zero or more)
+         * @return the binder builder
+         */
+        Binder bindMany(Ip id,
+                        boolean useProvider,
+                        ServiceInfo... serviceInfos);
+
+        /**
+         * Represents a null bind.
+         * Binding of null values must be allowed in the registry, by default this is not an option.
+         *
+         * @param id the injection point identity
+         * @return the binder builder
+         */
+        Binder bindNull(Ip id);
+
+        /**
+         * Represents injection points that cannot be bound at startup, and instead must rely on a
+         * deferred resolver based binding. Typically, this represents some form of dynamic or configurable instance.
+         *
+         * @param id          the injection point identity
+         * @param useProvider whether to inject provider or service instance
+         * @param serviceType the service type needing to be resolved
+         * @return the binder builder
+         */
+        Binder runtimeBind(Ip id,
+                           boolean useProvider,
+                           Class<?> serviceType);
+
+        /**
+         * Bind an {@link java.util.Optional} injection point at runtime.
+         *
+         * @param id          injection point id
+         * @param useProvider whether to inject provider or service instance
+         * @param serviceType type of service to be discovered at runtime
+         * @return the binder builder
+         */
+        Binder runtimeBindOptional(Ip id,
+                                   boolean useProvider,
+                                   Class<?> serviceType);
+
+        /**
+         * Bind a {@link java.util.List} injection point at runtime.
+         *
+         * @param id          injection point id
+         * @param useProvider whether to inject provider or service instance
+         * @param serviceType type of service to be discovered at runtime
+         * @return the binder builder
+         */
+        Binder runtimeBindMany(Ip id,
+                               boolean useProvider,
+                               Class<?> serviceType);
+
+        /**
+         * Bind a nullable injection point at runtime.
+         *
+         * @param id          injection point id
+         * @param useProvider whether to inject provider or service instance
+         * @param serviceType type of service to be discovered at runtime
+         * @return the binder builder
+         */
+        Binder runtimeBindNullable(Ip id,
+                                   boolean useProvider,
+                                   Class<?> serviceType);
+
+        /**
+         * Commits the bindings for this service provider.
+         */
+        void commit();
+
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceInstance.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceInstance.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.helidon.inject.service.InjectionContext;
+import io.helidon.inject.service.InterceptionMetadata;
+import io.helidon.inject.service.ServiceDescriptor;
+
+interface ServiceInstance<T> extends Supplier<T> {
+    static <T> ServiceInstance<T> create(InterceptionMetadata interceptionMetadata,
+                                         InjectionContext ctx,
+                                         ServiceDescriptor<T> source) {
+        if (source.scopes().contains(InjectTypes.SINGLETON)) {
+            return new SingletonInstance<>(ctx, interceptionMetadata, source);
+        }
+        return new OnDemandInstance<>(ctx, interceptionMetadata, source);
+    }
+
+    static <T> ServiceInstance<T> create(ServiceDescriptor<T> source, T instance) {
+        return new ExplicitInstance<>(source, instance);
+    }
+
+    default void construct() {
+    }
+
+    default void inject() {
+    }
+
+    default void postConstruct() {
+    }
+
+    default void preDestroy() {
+
+    }
+
+    private static <T> T inject(ServiceDescriptor<T> source,
+                                InjectionContext ctx,
+                                InterceptionMetadata interceptionMetadata,
+                                T instance) {
+
+        // using linked set, so we can see in debugging what was injected first
+        Set<String> injected = new LinkedHashSet<>();
+        source.inject(ctx, interceptionMetadata, injected, instance);
+        return instance;
+    }
+
+    class ExplicitInstance<T> implements ServiceInstance<T> {
+        private final ServiceDescriptor<T> source;
+        private final T instance;
+
+        ExplicitInstance(ServiceDescriptor<T> source, T instance) {
+            this.source = source;
+            this.instance = instance;
+        }
+
+        @Override
+        public T get() {
+            return instance;
+        }
+
+        @Override
+        public void preDestroy() {
+            source.preDestroy(instance);
+        }
+    }
+
+    class SingletonInstance<T> implements ServiceInstance<T> {
+        private final InjectionContext ctx;
+        private final InterceptionMetadata interceptionMetadata;
+        private final ServiceDescriptor<T> source;
+
+        private volatile T instance;
+
+        private SingletonInstance(InjectionContext ctx, InterceptionMetadata interceptionMetadata, ServiceDescriptor<T> source) {
+            this.ctx = ctx;
+            this.interceptionMetadata = interceptionMetadata;
+            this.source = source;
+        }
+
+        @Override
+        public T get() {
+            return instance;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void construct() {
+            instance = (T) source.instantiate(ctx, interceptionMetadata);
+        }
+
+        @Override
+        public void inject() {
+            ServiceInstance.inject(source, ctx, interceptionMetadata, instance);
+        }
+
+        @Override
+        public void postConstruct() {
+            source.postConstruct(instance);
+        }
+
+        @Override
+        public void preDestroy() {
+            source.preDestroy(instance);
+        }
+    }
+
+    class OnDemandInstance<T> implements ServiceInstance<T> {
+        private final InjectionContext ctx;
+        private final InterceptionMetadata interceptionMetadata;
+        private final ServiceDescriptor<T> source;
+
+        OnDemandInstance(InjectionContext ctx, InterceptionMetadata interceptionMetadata, ServiceDescriptor<T> source) {
+            this.ctx = ctx;
+            this.interceptionMetadata = interceptionMetadata;
+            this.source = source;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public T get() {
+            T instance = (T) source.instantiate(ctx, interceptionMetadata);
+            return ServiceInstance.inject(source, ctx, interceptionMetadata, instance);
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceProvider.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceProvider.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.Ip;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceInfo;
+
+/**
+ * Provides management lifecycle around services.
+ *
+ * @param <T> the type that this service provider manages
+ */
+public interface ServiceProvider<T> extends ServiceInfo, InjectionPointProvider<T> {
+
+    /**
+     * Identifies the service provider physically and uniquely.
+     *
+     * @return the unique identity of the service provider
+     */
+    default String id() {
+        return serviceInfo().serviceType().fqName();
+    }
+
+    /**
+     * Describe the service provider. This will change based upon activation state.
+     *
+     * @return the logical and immutable description
+     */
+    default String description() {
+        return serviceType().classNameWithEnclosingNames() + "[" + currentActivationPhase() + "]";
+    }
+
+    /**
+     * Does the service provide singletons, does it always produce the same result for every call to {@link #get()}.
+     * I.e., if the managed service implements Provider or
+     * {@link io.helidon.inject.InjectionPointProvider} then this typically is considered not a singleton provider.
+     * I.e., If the managed services is NOT {@link io.helidon.inject.service.Injection.Singleton},
+     * then it will be treated as per request / dependent
+     * scope.
+     * Note that this is similar in nature to RequestScope, except the "official" request scope is bound to the
+     * web request. Here, we are speaking about contextually any caller asking for a new instance of the service in
+     * question. The requester in question will ideally be able to identify itself to this provider via
+     * {@link io.helidon.inject.InjectionPointProvider#first(ContextualServiceQuery)} so that this
+     * provider can properly service the "provide" request.
+     *
+     * @return true if the service provider provides per-request instances for each caller
+     */
+    default boolean isProvider() {
+        return false;
+    }
+
+    /**
+     * Service descriptor. The type is expected to be generated at compile time, and contains only statically known information.
+     * As a result, methods on this type may provide different results than methods on the descriptor returned by this method,
+     * as this type honors runtime state.
+     *
+     * @return descriptor of this service
+     */
+    ServiceInfo serviceInfo();
+
+    /**
+     * The current activation phase for this service provider.
+     *
+     * @return the activation phase
+     */
+    Phase currentActivationPhase();
+
+    /**
+     * The agent/instance to be used for binding this service provider to the injectable application that was code generated.
+     *
+     * @return the service provider that should be used for binding, or empty if this provider does not support binding
+     * @see io.helidon.inject.service.ModuleComponent
+     * @see io.helidon.inject.service.ServiceBinder
+     * @see io.helidon.inject.ServiceProviderBindable
+     */
+    default Optional<ServiceProviderBindable<T>> serviceProviderBindable() {
+        return Optional.empty();
+    }
+
+    @Override
+    default TypeName serviceType() {
+        return serviceInfo().serviceType();
+    }
+
+    @Override
+    default double weight() {
+        return serviceInfo().weight();
+    }
+
+    @Override
+    default String runtimeId() {
+        return serviceInfo().runtimeId();
+    }
+
+    @Override
+    default Set<TypeName> contracts() {
+        return serviceInfo().contracts();
+    }
+
+    @Override
+    default List<Ip> dependencies() {
+        return serviceInfo().dependencies();
+    }
+
+    @Override
+    default Set<Qualifier> qualifiers() {
+        return serviceInfo().qualifiers();
+    }
+
+    @Override
+    default int runLevel() {
+        return serviceInfo().runLevel();
+    }
+
+    @Override
+    default Set<TypeName> scopes() {
+        return serviceInfo().scopes();
+    }
+
+    @Override
+    default TypeName infoType() {
+        return serviceInfo().infoType();
+    }
+
+    @Override
+    default boolean isAbstract() {
+        return serviceInfo().isAbstract();
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceProviderBase.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceProviderBase.java
@@ -464,7 +464,7 @@ public abstract class ServiceProviderBase<T>
      */
     protected void prepareDependency(Services services, Map<Ip, Supplier<?>> injectionPlan, Ip dependency) {
         Lookup criteria = Lookup.create(dependency);
-        List<ServiceProvider<Object>> discovered = services.serviceProviders(criteria)
+        List<ServiceProvider<Object>> discovered = services.allProviders(criteria)
                 .stream()
                 .filter(it -> it != this)
                 .toList();
@@ -772,7 +772,7 @@ public abstract class ServiceProviderBase<T>
                     return this;
                 }
             }
-            Supplier<?> serviceProvider = services.first(serviceType);
+            Supplier<?> serviceProvider = services.get(serviceType);
             injectionPlan.put(injectionPoint, () -> useProvider ? serviceProvider : serviceProvider.get());
             return this;
         }
@@ -792,7 +792,7 @@ public abstract class ServiceProviderBase<T>
                     return this;
                 }
             }
-            Optional<? extends Supplier<?>> serviceProvider = services.find(serviceType);
+            Optional<? extends Supplier<?>> serviceProvider = services.first(serviceType);
             if (serviceProvider.isEmpty()) {
                 injectionPlan.put(injectionPoint, Optional::empty);
             } else {
@@ -823,7 +823,7 @@ public abstract class ServiceProviderBase<T>
         public ServiceInjectionPlanBinder.Binder runtimeBindNullable(Ip injectionPoint,
                                                                      boolean useProvider,
                                                                      Class<?> serviceType) {
-            Optional<? extends Supplier<?>> serviceProvider = services.find(serviceType);
+            Optional<? extends Supplier<?>> serviceProvider = services.first(serviceType);
 
             if (serviceProvider.isEmpty()) {
                 injectionPlan.put(injectionPoint, () -> null);

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceProviderBase.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceProviderBase.java
@@ -1,0 +1,854 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.InjectionContext;
+import io.helidon.inject.service.InterceptionMetadata;
+import io.helidon.inject.service.Ip;
+import io.helidon.inject.service.ServiceDescriptor;
+import io.helidon.inject.service.ServiceInfo;
+
+/**
+ * A base of service providers, taking care of the common responsibilities, such as activation, lookup etc.
+ *
+ * @param <T> type of the provided service
+ */
+public abstract class ServiceProviderBase<T>
+        extends DescribedServiceProvider<T>
+        implements ServiceProviderBindable<T>, ServiceInfo, Activator<T> {
+    static final TypeName SUPPLIER_TYPE = TypeName.create(Supplier.class);
+    private static final System.Logger LOGGER = System.getLogger(ServiceProviderBase.class.getName());
+    private static final TypeName SERVICE_PROVIDER_TYPE = TypeName.create(ServiceProvider.class);
+    private static final TypeName INJECTION_POINT_PROVIDER_TYPE = TypeName.create(InjectionPointProvider.class);
+
+    private final Services services;
+    private final InterceptionMetadata interceptionMetadata;
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+    private final ServiceDescriptor<T> descriptor;
+    private final ActivationRequest defaultActivationRequest;
+
+    private volatile ServiceInstance<T> serviceInstance;
+    private volatile Phase currentPhase = Phase.CONSTRUCTED;
+    private volatile ServiceProvider<?> interceptor;
+    private volatile InjectionContext injectionContext;
+
+    /**
+     * A new service provider base.
+     *
+     * @param services          services this provider belongs to
+     * @param serviceDescriptor service descriptor
+     */
+    protected ServiceProviderBase(Services services,
+                                  ServiceDescriptor<T> serviceDescriptor) {
+        super(serviceDescriptor);
+
+        this.services = services;
+        this.interceptionMetadata = new InterceptionMetadataImpl(services);
+        this.descriptor = serviceDescriptor;
+
+        this.defaultActivationRequest = ActivationRequest.builder()
+                .targetPhase(services.limitRuntimePhase())
+                .build();
+    }
+
+    @Override
+    public ActivationResult activate(ActivationRequest activationRequest) {
+        // acquire write lock, as this is expected to activate
+        Lock lock = rwLock.writeLock();
+        try {
+            lock.lock();
+            if (currentPhase == activationRequest.targetPhase()) {
+                return ActivationResult.builder()
+                        .serviceProvider(this)
+                        .startingActivationPhase(currentPhase)
+                        .finishingActivationPhase(currentPhase)
+                        .targetActivationPhase(currentPhase)
+                        .finishingStatus(ActivationStatus.SUCCESS)
+                        .build();
+            }
+            if (currentPhase.ordinal() > activationRequest.targetPhase().ordinal()) {
+                return ActivationResult.builder()
+                        .serviceProvider(this)
+                        .startingActivationPhase(currentPhase)
+                        .finishingActivationPhase(currentPhase)
+                        .targetActivationPhase(activationRequest.targetPhase())
+                        .finishingStatus(ActivationStatus.FAILURE)
+                        .build();
+            }
+            return doActivate(activationRequest);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public ActivationResult deactivate(DeActivationRequest req) {
+        // acquire write lock, as this is expected to de-activate
+        Lock lock = rwLock.writeLock();
+        try {
+            lock.lock();
+            return doDeactivate(req);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public ServiceProvider<T> serviceProvider() {
+        return this;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public List<T> list(ContextualServiceQuery query) {
+        T serviceOrProvider = get(query.expected());
+
+        Object result;
+        if (contracts().contains(SUPPLIER_TYPE)) {
+            if (contracts().contains(INJECTION_POINT_PROVIDER_TYPE)) {
+                InjectionPointProvider<T> provider = (InjectionPointProvider<T>) serviceOrProvider;
+                result = provider.list(query);
+            } else if (contracts().contains(SERVICE_PROVIDER_TYPE)) {
+                ServiceProvider<T> provider = (ServiceProvider<T>) serviceOrProvider;
+                result = provider.list(query);
+            } else {
+                Supplier<T> provider = (Supplier<T>) serviceOrProvider;
+                result = provider.get();
+            }
+        } else {
+            result = serviceOrProvider;
+        }
+
+        if (result == null) {
+            if (query.expected()) {
+                throw new InjectionServiceProviderException("This managed service instance expected to have been set",
+                                                            this);
+            }
+            return List.of();
+        }
+
+        if (result instanceof List list) {
+            return list;
+        } else {
+            return (List<T>) List.of(result);
+        }
+    }
+
+    @Override
+    public Optional<T> first(ContextualServiceQuery query) {
+        T serviceOrProvider = get(query.expected());
+
+        try {
+            return first(query, serviceOrProvider);
+        } catch (InjectionServiceProviderException ie) {
+            throw ie;
+        } catch (Exception e) {
+            LOGGER.log(System.Logger.Level.ERROR, "Unable to activate: " + infoType().fqName(), e);
+            throw new InjectionServiceProviderException("Unable to activate: " + infoType().fqName(), e, this);
+        }
+    }
+
+    @Override
+    public String id() {
+        return id(true);
+    }
+
+    @Override
+    public String description() {
+        return id(false) + ":" + currentActivationPhase();
+    }
+
+    @Override
+    public Phase currentActivationPhase() {
+        return currentPhase;
+    }
+
+    @Override
+    public Optional<ServiceProviderBindable<T>> serviceProviderBindable() {
+        return Optional.of(this);
+    }
+
+    @Override
+    public void interceptor(ServiceProvider<?> interceptor) {
+        this.interceptor = interceptor;
+    }
+
+    @Override
+    public boolean isIntercepted() {
+        return interceptor != null;
+    }
+
+    @Override
+    public Optional<ServiceProvider<?>> interceptor() {
+        return Optional.ofNullable(interceptor);
+    }
+
+    @Override
+    public Optional<ServiceInjectionPlanBinder.Binder> injectionPlanBinder() {
+        if (injectionContext != null) {
+            LOGGER.log(System.Logger.Level.WARNING,
+                       "this service provider already has an injection plan (which is unusual here): " + this);
+        }
+        return Optional.of(new ServiceInjectBinderImpl(services, this));
+    }
+
+    @Override
+    public String toString() {
+        return description();
+    }
+
+    @Override
+    public boolean isProvider() {
+        return contracts().contains(SUPPLIER_TYPE);
+    }
+
+    /**
+     * Get the value from this service provider.
+     *
+     * @param expected whether the value is expected
+     * @return value, or {@code null} if value is not available and not expected
+     * @throws io.helidon.inject.InjectionServiceProviderException in case the value is not available and expected
+     */
+    protected T get(boolean expected) {
+        Lock lock = rwLock.readLock();
+        try {
+            lock.lock();
+            if (currentPhase == Phase.ACTIVE) {
+                return serviceInstance.get();
+            }
+        } finally {
+            lock.unlock();
+        }
+        ActivationResult res = activate(defaultActivationRequest);
+        if (res.failure() && expected) {
+            throw new InjectionServiceProviderException("Activation failed: " + res, this);
+        }
+        try {
+            lock.lock();
+            return serviceInstance.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Set an explicit phase of activation, and possibly an instance of the service.
+     *
+     * @param phase    phase to set
+     * @param instance instance to set (nullabe!)
+     */
+    protected void state(Phase phase, T instance) {
+        Lock lock = rwLock.writeLock();
+        try {
+            lock.lock();
+            this.currentPhase = phase;
+            if (this.serviceInstance == null) {
+                this.serviceInstance = ServiceInstance.create(descriptor, instance);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Configure current phase.
+     *
+     * @param phase phase to set
+     */
+    protected void phase(Phase phase) {
+        Lock lock = rwLock.writeLock();
+        try {
+            this.currentPhase = phase;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Id of this service provider.
+     *
+     * @param fq use fully qualified name of the service
+     * @return id of this provider
+     */
+    protected String id(boolean fq) {
+        if (fq) {
+            return serviceInfo().serviceType().fqName();
+        }
+        return serviceInfo().serviceType().classNameWithEnclosingNames();
+    }
+
+    /**
+     * Service registry this provider belongs to.
+     *
+     * @return injection services
+     */
+    protected Services services() {
+        return services;
+    }
+
+    /**
+     * Activate based on an activation request.
+     *
+     * @param req activation request
+     * @return activation result
+     */
+    protected ActivationResult doActivate(ActivationRequest req) {
+        Phase initialPhase = this.currentPhase;
+        Phase startingPhase = req.startingPhase().orElse(initialPhase);
+        Phase targetPhase = req.targetPhase();
+        this.currentPhase = startingPhase;
+        Phase finishingPhase = startingPhase;
+
+        ActivationResult.Builder res = ActivationResult.builder()
+                .serviceProvider(this)
+                .startingActivationPhase(initialPhase)
+                .finishingActivationPhase(startingPhase)
+                .targetActivationPhase(targetPhase)
+                .finishingStatus(ActivationStatus.SUCCESS);
+
+        if (targetPhase.ordinal() >= Phase.INIT.ordinal() && initialPhase == Phase.CONSTRUCTED) {
+            init(req, res);
+        }
+        finishingPhase = res.finishingActivationPhase().orElse(finishingPhase);
+
+        if (targetPhase.ordinal() > Phase.ACTIVATION_STARTING.ordinal()) {
+            if (Phase.INIT == startingPhase
+                    || Phase.PENDING == startingPhase
+                    || Phase.ACTIVATION_STARTING == startingPhase
+                    || Phase.DESTROYED == startingPhase) {
+                startLifecycle(req, res);
+            }
+        }
+        finishingPhase = res.finishingActivationPhase().orElse(finishingPhase);
+        if (targetPhase.ordinal() > Phase.GATHERING_DEPENDENCIES.ordinal()
+                && Phase.ACTIVATION_STARTING == finishingPhase) {
+            gatherDependencies(req, res);
+        }
+        finishingPhase = res.finishingActivationPhase().orElse(finishingPhase);
+        if (res.targetActivationPhase().ordinal() >= Phase.CONSTRUCTING.ordinal()
+                && (Phase.GATHERING_DEPENDENCIES == finishingPhase)) {
+            construct(req, res);
+        }
+        finishingPhase = res.finishingActivationPhase().orElse(finishingPhase);
+        if (res.targetActivationPhase().ordinal() >= Phase.INJECTING.ordinal()
+                && (Phase.CONSTRUCTING == finishingPhase)) {
+            inject(req, res);
+        }
+        finishingPhase = res.finishingActivationPhase().orElse(finishingPhase);
+        if (res.targetActivationPhase().ordinal() >= Phase.POST_CONSTRUCTING.ordinal()
+                && (Phase.INJECTING == finishingPhase)) {
+            postConstruct(req, res);
+        }
+        finishingPhase = res.finishingActivationPhase().orElse(finishingPhase);
+        if (res.targetActivationPhase().ordinal() >= Phase.ACTIVATION_FINISHING.ordinal()
+                && (Phase.POST_CONSTRUCTING == finishingPhase)) {
+            finishActivation(req, res);
+        }
+        finishingPhase = res.finishingActivationPhase().orElse(finishingPhase);
+        if (res.targetActivationPhase().ordinal() >= Phase.ACTIVE.ordinal()
+                && (Phase.ACTIVATION_FINISHING == finishingPhase)) {
+            setActive(req, res);
+        }
+
+        return res.build();
+    }
+
+    /**
+     * Deactivate based on request.
+     *
+     * @param req request
+     * @return activation result
+     */
+    protected ActivationResult doDeactivate(DeActivationRequest req) {
+        ActivationResult.Builder res = ActivationResult.builder()
+                .serviceProvider(this)
+                .finishingStatus(ActivationStatus.SUCCESS);
+
+        if (!currentPhase.eligibleForDeactivation()) {
+            stateTransitionStart(res, Phase.DESTROYED);
+            return ActivationResult.builder()
+                    .serviceProvider(this)
+                    .targetActivationPhase(Phase.DESTROYED)
+                    .finishingStatus(ActivationStatus.SUCCESS)
+                    .build();
+        }
+
+        res.startingActivationPhase(this.currentPhase);
+        stateTransitionStart(res, Phase.PRE_DESTROYING);
+        preDestroy(req, res);
+        stateTransitionStart(res, Phase.DESTROYED);
+
+        return res.build();
+    }
+
+    /**
+     * Post construct the instance.
+     *
+     * @param req activation request
+     * @param res activation response builder
+     */
+    protected void postConstruct(ActivationRequest req, ActivationResult.Builder res) {
+        stateTransitionStart(res, Phase.POST_CONSTRUCTING);
+
+        if (serviceInstance != null) {
+            serviceInstance.postConstruct();
+        }
+    }
+
+    /**
+     * Inject the instance.
+     *
+     * @param req activation request
+     * @param res activation response builder
+     */
+    protected void inject(ActivationRequest req, ActivationResult.Builder res) {
+        stateTransitionStart(res, Phase.INJECTING);
+
+        if (serviceInstance != null) {
+            serviceInstance.inject();
+        }
+    }
+
+    /**
+     * Create a new instance of the service (in {@link io.helidon.inject.Phase#CONSTRUCTING}).
+     * If you override this method, you need to override all methods handling instances, such as
+     * {@link #inject(ActivationRequest, io.helidon.inject.ActivationResult.Builder)}.
+     *
+     * @param req activation request
+     * @param res activation response builder
+     * @see #inject(ActivationRequest, io.helidon.inject.ActivationResult.Builder)
+     * @see #postConstruct(ActivationRequest, io.helidon.inject.ActivationResult.Builder)
+     * @see #preDestroy(DeActivationRequest, io.helidon.inject.ActivationResult.Builder)
+     */
+    protected void construct(ActivationRequest req, ActivationResult.Builder res) {
+        stateTransitionStart(res, Phase.CONSTRUCTING);
+
+        // descendant may set an explicit instance, in such a case, we will not re-create it
+        if (serviceInstance == null) {
+            serviceInstance = ServiceInstance.create(interceptionMetadata, injectionContext, descriptor);
+            serviceInstance.construct();
+        }
+    }
+
+    /**
+     * Prepare a dependency.
+     *
+     * @param services      associated services instance
+     * @param injectionPlan injection plan to put the new dependency to
+     * @param dependency    injection point to satisfy
+     */
+    protected void prepareDependency(Services services, Map<Ip, Supplier<?>> injectionPlan, Ip dependency) {
+        Lookup criteria = Lookup.create(dependency);
+        List<ServiceProvider<Object>> discovered = services.serviceProviders(criteria)
+                .stream()
+                .filter(it -> it != this)
+                .toList();
+
+        TypeName ipType = dependency.typeName();
+
+        // now there are a few options - optional, list, and single instance
+        if (discovered.isEmpty()) {
+            if (ipType.isOptional()) {
+                injectionPlan.put(dependency, Optional::empty);
+                return;
+            }
+            if (ipType.isList()) {
+                injectionPlan.put(dependency, List::of);
+                return;
+            }
+            throw new InjectionServiceProviderException("Expected to resolve a service matching "
+                                                                + criteria
+                                                                + " for dependency: " + dependency
+                                                                + ", for service: " + serviceType().fqName(),
+                                                        this);
+        }
+
+        // we have a response
+        if (ipType.isList()) {
+            // is a list needed?
+            TypeName typeOfElements = ipType.typeArguments().getFirst();
+            if (typeOfElements.equals(SUPPLIER_TYPE) || typeOfElements.equals(SERVICE_PROVIDER_TYPE)) {
+                injectionPlan.put(dependency, () -> discovered);
+                return;
+            }
+
+            if (discovered.size() == 1) {
+                injectionPlan.put(dependency, () -> {
+                    Object resolved = discovered.getFirst().get();
+                    if (resolved instanceof List<?>) {
+                        return resolved;
+                    }
+                    return List.of(resolved);
+                });
+                return;
+            }
+
+            injectionPlan.put(dependency, () -> discovered.stream()
+                    .map(ServiceProvider::get)
+                    .toList());
+            return;
+        }
+        if (ipType.isOptional()) {
+            // is an Optional needed?
+            TypeName typeOfElement = ipType.typeArguments().getFirst();
+            if (typeOfElement.equals(SUPPLIER_TYPE) || typeOfElement.equals(SERVICE_PROVIDER_TYPE)) {
+                injectionPlan.put(dependency, () -> Optional.of(discovered.getFirst()));
+                return;
+            }
+
+            injectionPlan.put(dependency, () -> {
+                Optional<?> firstResult = discovered.getFirst().first(ContextualServiceQuery.EMPTY);
+                if (firstResult.isEmpty()) {
+                    return Optional.empty();
+                }
+                Object resolved = firstResult.get();
+                if (resolved instanceof Optional<?>) {
+                    return resolved;
+                }
+                return Optional.ofNullable(resolved);
+            });
+            return;
+        }
+
+        if (ipType.equals(SUPPLIER_TYPE)
+                || ipType.equals(SERVICE_PROVIDER_TYPE)
+                || ipType.equals(INJECTION_POINT_PROVIDER_TYPE)) {
+            // is a provider needed?
+            injectionPlan.put(dependency, discovered::getFirst);
+            return;
+        }
+        // and finally just get the value of the first service
+        injectionPlan.put(dependency, discovered.getFirst()::get);
+    }
+
+    /**
+     * Start transitioning to a state.
+     *
+     * @param res   activation response builder
+     * @param phase phase to transition to
+     */
+    protected void stateTransitionStart(ActivationResult.Builder res, Phase phase) {
+        res.finishingActivationPhase(phase);
+        this.currentPhase = phase;
+    }
+
+    /**
+     * Access to the injection context, if already configured.
+     *
+     * @return injection context
+     */
+    protected Optional<InjectionContext> injectionContext() {
+        return Optional.ofNullable(injectionContext);
+    }
+
+    /**
+     * Configure an injection context.
+     *
+     * @param injectionContext injection context to set
+     */
+    protected void injectionContext(InjectionContext injectionContext) {
+        this.injectionContext = injectionContext;
+    }
+
+    /**
+     * Transition to {@link io.helidon.inject.Phase#INIT}.
+     * Default implementation only sets the current phase and updates phase in response builder.
+     *
+     * @param req activation request
+     * @param res activation response builder
+     */
+    protected void init(ActivationRequest req, ActivationResult.Builder res) {
+        stateTransitionStart(res, Phase.INIT);
+    }
+
+    /**
+     * Pre destroy the service instance.
+     *
+     * @param req activation request
+     * @param res activation response builder
+     */
+    protected void preDestroy(DeActivationRequest req, ActivationResult.Builder res) {
+        if (serviceInstance != null) {
+            serviceInstance.preDestroy();
+            serviceInstance = null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<T> first(ContextualServiceQuery query, T serviceOrProvider) {
+        T service;
+        if (contracts().contains(SUPPLIER_TYPE)) {
+            if (contracts().contains(INJECTION_POINT_PROVIDER_TYPE)) {
+                InjectionPointProvider<T> provider = (InjectionPointProvider<T>) serviceOrProvider;
+                service = provider.first(query).orElse(null);
+            } else if (contracts().contains(SERVICE_PROVIDER_TYPE)) {
+                ServiceProvider<T> provider = (ServiceProvider<T>) serviceOrProvider;
+                service = provider.first(query).orElse(null);
+            } else {
+                Supplier<T> provider = (Supplier<T>) serviceOrProvider;
+                service = provider.get();
+            }
+        } else {
+            service = serviceOrProvider;
+        }
+
+        if (service == null) {
+            if (query.expected()) {
+                throw new InjectionServiceProviderException("This managed service instance expected to have been set",
+                                                            this);
+            }
+            return Optional.empty();
+        }
+        return Optional.of(service);
+    }
+
+    private void setActive(ActivationRequest req, ActivationResult.Builder res) {
+        stateTransitionStart(res, Phase.ACTIVE);
+    }
+
+    private void finishActivation(ActivationRequest req, ActivationResult.Builder res) {
+        stateTransitionStart(res, Phase.ACTIVATION_FINISHING);
+    }
+
+    private void startLifecycle(ActivationRequest req, ActivationResult.Builder res) {
+        stateTransitionStart(res, Phase.ACTIVATION_STARTING);
+    }
+
+    private void gatherDependencies(ActivationRequest req, ActivationResult.Builder res) {
+        stateTransitionStart(res, Phase.GATHERING_DEPENDENCIES);
+
+        List<Ip> servicesDeps = dependencies();
+
+        if (servicesDeps.isEmpty()) {
+            return;
+        }
+
+        if (injectionContext != null) {
+            // obtained from application
+            return;
+        }
+
+        Map<Ip, Supplier<?>> injectionPlan = new HashMap<>();
+
+        for (Ip ipInfo : servicesDeps) {
+            prepareDependency(services, injectionPlan, ipInfo);
+        }
+
+        this.injectionContext = HelidonInjectionContext.create(injectionPlan);
+    }
+
+    /**
+     * An implementation of a service binder.
+     */
+    protected static class ServiceInjectBinderImpl implements ServiceInjectionPlanBinder.Binder {
+        private final ServiceProviderBase<?> self;
+        private final Map<Ip, Supplier<?>> injectionPlan = new HashMap<>();
+        private final Services services;
+
+        /**
+         * Create a new instance of a binder.
+         *
+         * @param services injection services we are bound to
+         * @param self     service provider responsible for this binding
+         */
+        protected ServiceInjectBinderImpl(Services services, ServiceProviderBase<?> self) {
+            this.self = self;
+            this.services = services;
+        }
+
+        @Override
+        public void commit() {
+            self.injectionContext(HelidonInjectionContext.create(injectionPlan));
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder bind(Ip injectionPoint, boolean useProvider, ServiceInfo serviceInfo) {
+            ServiceProvider<?> serviceProvider = BoundServiceProvider.create(services.serviceProvider(serviceInfo),
+                                                                             injectionPoint);
+            if (useProvider) {
+                injectionPlan.put(injectionPoint, () -> serviceProvider);
+            } else {
+                ContextualServiceQuery query = ContextualServiceQuery.builder()
+                        .from(Lookup.create(injectionPoint))
+                        .expected(true)
+                        .build();
+                injectionPlan.put(injectionPoint, () -> mapFromProvider(query, serviceProvider));
+            }
+
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder bindOptional(Ip injectionPoint,
+                                                              boolean useProvider,
+                                                              ServiceInfo... serviceInfos) {
+
+            if (serviceInfos.length == 0) {
+                injectionPlan.put(injectionPoint, Optional::empty);
+            } else {
+                ServiceProvider<?> serviceProvider = BoundServiceProvider.create(services.serviceProvider(serviceInfos[0]),
+                                                                                 injectionPoint);
+                if (useProvider) {
+                    injectionPlan.put(injectionPoint, () -> Optional.of(serviceProvider));
+                } else {
+                    ContextualServiceQuery query = ContextualServiceQuery.builder()
+                            .from(Lookup.create(injectionPoint))
+                            .injectionPoint(injectionPoint)
+                            .build();
+                    injectionPlan.put(injectionPoint, () -> Optional.ofNullable(mapFromProvider(query, serviceProvider)));
+                }
+            }
+
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder bindMany(Ip injectionPoint,
+                                                          boolean useProvider,
+                                                          ServiceInfo... serviceInfos) {
+
+            List<? extends ServiceProvider<?>> providers = Stream.of(serviceInfos)
+                    .map(services::serviceProvider)
+                    .map(it -> BoundServiceProvider.create(it, injectionPoint))
+                    .toList();
+
+            if (useProvider) {
+                injectionPlan.put(injectionPoint, () -> providers);
+            } else {
+                ContextualServiceQuery query = ContextualServiceQuery.builder()
+                        .from(Lookup.create(injectionPoint))
+                        .injectionPoint(injectionPoint)
+                        .expected(true)
+                        .build();
+                injectionPlan.put(injectionPoint, () -> providers.stream()
+                        .flatMap(it -> mapStreamFromProvider(query, it))
+                        .toList());
+            }
+
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder bindNull(Ip injectionPoint) {
+            injectionPlan.put(injectionPoint, () -> null);
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBind(Ip injectionPoint, boolean useProvider, Class<?> serviceType) {
+            if (self instanceof InjectionResolver ir) {
+                Optional<Ip> foundIp = self.dependencies()
+                        .stream()
+                        .filter(it -> it == injectionPoint)
+                        .findFirst();
+
+                if (foundIp.isPresent()) {
+                    injectionPlan.put(injectionPoint, () -> ir.resolve(foundIp.get(), services, self, true).get());
+                    return this;
+                }
+            }
+            Supplier<?> serviceProvider = services.first(serviceType);
+            injectionPlan.put(injectionPoint, () -> useProvider ? serviceProvider : serviceProvider.get());
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBindOptional(Ip injectionPoint,
+                                                                     boolean useProvider,
+                                                                     Class<?> serviceType) {
+            if (self instanceof InjectionResolver ir) {
+                Optional<Ip> foundIp = self.dependencies()
+                        .stream()
+                        .filter(it -> it == injectionPoint)
+                        .findFirst();
+
+                if (foundIp.isPresent()) {
+                    injectionPlan.put(injectionPoint, () -> ir.resolve(foundIp.get(), services, self, true));
+                    return this;
+                }
+            }
+            Optional<? extends Supplier<?>> serviceProvider = services.find(serviceType);
+            if (serviceProvider.isEmpty()) {
+                injectionPlan.put(injectionPoint, Optional::empty);
+            } else {
+                injectionPlan.put(injectionPoint, () -> useProvider
+                        ? serviceProvider
+                        : Optional.of(serviceProvider.get().get()));
+            }
+
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBindMany(Ip injectionPoint, boolean useProvider, Class<?> serviceType) {
+            List<? extends Supplier<?>> providers = services.all(serviceType);
+
+            if (useProvider) {
+                injectionPlan.put(injectionPoint, () -> providers);
+            } else {
+                injectionPlan.put(injectionPoint, () -> providers.stream()
+                        .map(Supplier::get)
+                        .toList());
+            }
+
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBindNullable(Ip injectionPoint,
+                                                                     boolean useProvider,
+                                                                     Class<?> serviceType) {
+            Optional<? extends Supplier<?>> serviceProvider = services.find(serviceType);
+
+            if (serviceProvider.isEmpty()) {
+                injectionPlan.put(injectionPoint, () -> null);
+            } else {
+                injectionPlan.put(injectionPoint, () -> useProvider ? serviceProvider : Optional.of(serviceProvider.get().get()));
+            }
+
+            return this;
+        }
+
+        /**
+         * Current injection plan.
+         *
+         * @return map of injection point ids to a supplier of their values
+         */
+        protected Map<Ip, Supplier<?>> injectionPlan() {
+            return injectionPlan;
+        }
+
+        private Object mapFromProvider(ContextualServiceQuery query, ServiceProvider<?> provider) {
+            return provider.first(query).orElse(null);
+        }
+
+        private Stream<?> mapStreamFromProvider(ContextualServiceQuery query, ServiceProvider<?> provider) {
+            return provider.list(query).stream();
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceProviderBindable.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceProviderBindable.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Optional;
+
+/**
+ * An extension to {@link io.helidon.inject.ServiceProvider} that allows for startup binding from a
+ * {@code Injection$$Application},
+ * and thereby works in conjunction with the {@link io.helidon.inject.service.ServiceBinder} during injection service registry
+ * initialization.
+ * <p>
+ * The only guarantee the provider implementation has is ensuring that {@link io.helidon.inject.service.ModuleComponent}
+ * instances
+ * are bound to the <i>Services</i> instances, as well as informed on the module name.
+ * <p>
+ * Generally this class should be called internally by the framework, and typically occurs only during initialization sequences.
+ *
+ * @param <T> the type that this service provider manages
+ * @see io.helidon.inject.Application
+ * @see io.helidon.inject.ServiceProvider#serviceProviderBindable()
+ */
+public interface ServiceProviderBindable<T> extends ServiceProvider<T> {
+    /**
+     * Returns true if this service provider instance is an {@link io.helidon.inject.service.Interception.Interceptor}.
+     *
+     * @return true if this service provider is an interceptor
+     */
+    default boolean isInterceptor() {
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if this service provider is intercepted.
+     *
+     * @return flag indicating whether this service provider is intercepted
+     */
+    default boolean isIntercepted() {
+        return interceptor().isPresent();
+    }
+
+    /**
+     * Returns the service provider that intercepts this provider.
+     *
+     * @return the service provider that intercepts this provider
+     */
+    Optional<ServiceProvider<?>> interceptor();
+
+    /**
+     * Sets the interceptor for this service provider.
+     *
+     * @param interceptor the interceptor for this provider
+     */
+    default void interceptor(ServiceProvider<?> interceptor) {
+        // NOP; intended to be overridden if applicable
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Gets the root/parent provider for this service. A root/parent provider is intended to manage it's underlying
+     * providers. Note that "root" and "parent" are interchangeable here since there is at most one level of depth that occurs
+     * when {@link io.helidon.inject.ServiceProvider}'s are wrapped by other providers.
+     *
+     * @return the root/parent provider or empty if this instance is the root provider
+     */
+    default Optional<ServiceProvider<?>> rootProvider() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns true if this provider is the root provider.
+     *
+     * @return indicates whether this provider is a root provider - the default is true
+     */
+    default boolean isRootProvider() {
+        return rootProvider().isEmpty();
+    }
+
+    /**
+     * Sets the root/parent provider for this instance.
+     *
+     * @param rootProvider sets the root provider
+     */
+    default void rootProvider(ServiceProvider<T> rootProvider) {
+        // NOP; intended to be overridden if applicable
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * The binder can be provided by the service provider to deterministically set the injection plan at compile-time, and
+     * subsequently loaded at early startup initialization.
+     *
+     * @return binder used for this service provider, or empty if not capable or ineligible of being bound
+     */
+    default Optional<ServiceInjectionPlanBinder.Binder> injectionPlanBinder() {
+        return Optional.empty();
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceProviderComparator.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceProviderComparator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.function.Supplier;
+
+import io.helidon.common.Weights;
+import io.helidon.common.types.TypeName;
+
+/**
+ * A comparator appropriate for service providers, first using its {@link io.helidon.common.Weight} and then service type name
+ * to determine its natural ordering.
+ */
+class ServiceProviderComparator implements Comparator<Supplier<?>>, Serializable {
+    private static final ServiceProviderComparator INSTANCE = new ServiceProviderComparator();
+
+    private ServiceProviderComparator() {
+    }
+
+    /**
+     * Returns a service provider comparator.
+     *
+     * @return the service provider comparator
+     */
+    static ServiceProviderComparator instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public int compare(Supplier<?> p1,
+                       Supplier<?> p2) {
+        if (p1 == p2) {
+            return 0;
+        }
+
+        if (p1 instanceof ServiceProvider
+                && p2 instanceof ServiceProvider) {
+            ServiceProvider<?> sp1 = (ServiceProvider<?>) p1;
+            ServiceProvider<?> sp2 = (ServiceProvider<?>) p2;
+
+            double w1 = sp1.weight();
+            double w2 = sp2.weight();
+            int comp = Double.compare(w1, w2);
+            if (0 != comp) {
+                return -1 * comp;
+            }
+            // secondary ordering based upon its name...
+            TypeName name1 = sp1.serviceType();
+            TypeName name2 = sp2.serviceType();
+            comp = name2.compareTo(name1);
+            return -1 * comp;
+        } else {
+            return Weights.weightComparator().compare(p1, p2);
+        }
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServiceProviderProvider.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServiceProviderProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Instances of these provide lists and maps of {@link io.helidon.inject.ServiceProvider}s.
+ */
+public interface ServiceProviderProvider {
+
+    /**
+     * Returns a list of all matching service providers, potentially including itself in the result.
+     *
+     * @param criteria           the injection point criteria that must match
+     * @param wantThis           if this instance matches criteria, do we want to return this instance as part of the result
+     * @param thisAlreadyMatches an optimization that signals to the implementation that this instance has already
+     *                           matched using the standard service info matching checks
+     * @return the list of service providers matching
+     */
+    List<? extends ServiceProvider<?>> serviceProviders(Lookup criteria,
+                                                        boolean wantThis,
+                                                        boolean thisAlreadyMatches);
+
+    /**
+     * This method will only apply to the managed instances being provided, not to itself as in the case for
+     * {@link #serviceProviders(Lookup, boolean, boolean)}.
+     *
+     * @param criteria the injection point criteria that must match
+     * @return the map of managed service providers matching the criteria, identified by its key/context
+     */
+    Map<String, ? extends ServiceProvider<?>> managedServiceProviders(Lookup criteria);
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/Services.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Services.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.common.Weighted;
+import io.helidon.inject.service.ServiceBinder;
+import io.helidon.inject.service.ServiceInfo;
+
+/**
+ * The service registry. The service registry generally has knowledge about all the services that are available within your
+ * application, along with the contracts (i.e., interfaces) they advertise, the qualifiers that optionally describe them, and oll
+ * of each services' dependencies on other service contracts, etc.
+ * <p>
+ * Collectively these service instances are considered "the managed service instances" under Injection.
+ * <p>
+ * Services are described through a (code generated) {@link io.helidon.inject.service.ServiceDescriptor}, and this registry
+ * will manage their lifecycle as required by their annotations (such as {@link io.helidon.inject.service.Injection.Singleton}).
+ * <p>
+ * This Services interface exposes a read-only set of methods providing access to these "managed service" providers, and
+ * available
+ * via one of the lookup methods provided. Once you resolve the service provider(s), the service provider can be activated by
+ * calling one of its get() methods. This is equivalent to the declarative form just using
+ * {@link io.helidon.inject.service.Injection.Inject} instead.
+ * Note that activation of a service might result in activation chaining. For example, service A injects service B, etc. When
+ * service A is activated then service A's dependencies (i.e., injection points) need to be activated as well. To avoid long
+ * activation chaining, it is recommended to that users strive to use {@link java.util.function.Supplier} injection whenever
+ * possible.
+ * Supplier injection (a) breaks long activation chains from occurring by deferring activation until when those services are
+ * really needed, and (b) breaks circular references that lead to {@link io.helidon.inject.InjectionException} during activation
+ * (i.e., service A injects B, and service B injects A).
+ * <p>
+ * The services are ranked according to the provider's comparator. The Injection framework will rank according to a strategy that
+ * first looks for
+ * {@link io.helidon.common.Weighted}, and finally by the alphabetic ordering according
+ * to the type name (package and class canonical name).
+ */
+public interface Services {
+
+    /**
+     * Default weight used by Helidon Injection components.
+     * It is lower than the default, so it is easy to override service with custom providers.
+     */
+    double INJECT_WEIGHT = Weighted.DEFAULT_WEIGHT - 1;
+
+    /**
+     * Get the first service provider matching the lookup with the expectation that there is a match available.
+     *
+     * @param lookup lookup to use
+     * @param <T>    type of the expected service providers, use {@code Object} if not known
+     * @return the best service provider matching the lookup, cast to the expected type; please use a {@code Object} as the type
+     *         if the result may contain an unknown provider type
+     * @throws io.helidon.inject.InjectionException if resolution fails to resolve a match
+     */
+    default <T> Supplier<T> first(Lookup lookup) {
+        return this.<T>find(lookup)
+                .orElseThrow(() -> new InjectionException("There are no services matching " + lookup));
+    }
+
+    /**
+     * Get the first service provider matching the provided type.
+     *
+     * @param type type of the expected service provider
+     * @param <T>  service type or service contract
+     * @return the best service provider matching the lookup
+     * @throws io.helidon.inject.InjectionException if resolution fails to resolve a match
+     */
+    default <T> Supplier<T> first(Class<T> type) {
+        return this.find(type)
+                .orElseThrow(() -> new InjectionException("There are no services with type (or contract) of " + type.getName()));
+    }
+
+    /**
+     * Find the first service provider matching the lookup with the expectation that there may not be a match available.
+     *
+     * @param lookup lookup to use
+     * @param <T>    type of the expected service providers, use {@code Object} if not known
+     * @return the best service provider matching the lookup, cast to the expected type; please use a {@code Object} as the type
+     *         if the result may contain an unknown provider type
+     */
+    <T> Optional<Supplier<T>> find(Lookup lookup);
+
+    /**
+     * Find the first service provider matching the provided type with the expectation that there may not be a match available.
+     *
+     * @param type type of the expected service provider
+     * @param <T>  service type or service contract
+     * @return the best service provider matching the lookup
+     */
+    default <T> Optional<Supplier<T>> find(Class<T> type) {
+        return find(Lookup.builder()
+                            .addContract(type)
+                            .build());
+    }
+
+    /**
+     * Get all service suppliers matching the lookup with the expectation that there may not be a match available.
+     *
+     * @param type type of the expected service provider
+     * @param <T>  type of the expected service suppliers
+     * @return list of service suppliers ordered, may be empty if there is no match
+     */
+    default <T> List<Supplier<T>> all(Class<T> type) {
+        return all(Lookup.builder()
+                           .addContract(type)
+                           .build());
+    }
+
+    /**
+     * Get all service suppliers matching the lookup with the expectation that there may not be a match available.
+     *
+     * @param lookup lookup to use
+     * @param <T>    type of the expected service suppliers, use {@code Object} if not known, or may contain a mix of types
+     * @return list of service suppliers ordered, may be empty if there is no match, cast to the expected type; please use a
+     *         {@code Object} as the type if the result may contain unknown provider types (or a mixture of them)
+     */
+    <T> List<Supplier<T>> all(Lookup lookup);
+
+    /**
+     * Find the first service provider matching the lookup with the expectation that there may not be a match available.
+     *
+     * @param lookup lookup to use
+     * @param <T>    type of the expected service providers, use {@code Object} if not known
+     * @return the best service provider matching the lookup, cast to the expected type; please use a {@code Object} as the type
+     *         if the result may contain an unknown provider type
+     */
+    default <T> Optional<ServiceProvider<T>> findServiceProvider(Lookup lookup) {
+        return this.<T>serviceProviders(lookup)
+                .stream()
+                .findFirst();
+    }
+
+    /**
+     * Find the first service provider matching the lookup with the expectation that there must be a match available.
+     *
+     * @param lookup lookup to use
+     * @param <T>    type of the expected service providers, use {@code Object} if not known
+     * @return the best service provider matching the lookup, cast to the expected type; please use a {@code Object} as the type
+     *         if the result may contain an unknown provider type
+     */
+    default <T> ServiceProvider<T> firstServiceProvider(Lookup lookup) {
+        return this.<T>findServiceProvider(lookup)
+                .orElseThrow(() -> new InjectionException("There are no services matching " + lookup));
+    }
+
+    /**
+     * Get all service providers matching the lookup. This is an advanced use case method, use
+     * {@link #all(Lookup)} to lookup services in registry.
+     *
+     * @param lookup lookup to use
+     * @param <T>    type of the expected service providers, use {@code Object} if not known, or may contain a mix of types
+     * @return list of service providers
+     */
+    <T> List<ServiceProvider<T>> serviceProviders(Lookup lookup);
+
+    /**
+     * Get a service provider for a descriptor.
+     *
+     * @param serviceInfo service information (metadata of the service)
+     * @param <T>         type of the expected service providers, use {@code Object} if not known, or may contain a mix of types
+     * @return service provider created for the descriptor
+     * @throws java.util.NoSuchElementException in case the descriptor is not part of this registry
+     */
+    <T> ServiceProvider<T> serviceProvider(ServiceInfo serviceInfo);
+
+    /**
+     * Injection services this instance is managed by.
+     *
+     * @return injection services
+     */
+    InjectionServices injectionServices();
+
+    /**
+     * Provides a binder for this service registry.
+     * Note that by default you can only bind services from {@link io.helidon.inject.service.ModuleComponent} instances that
+     * are code generated at build time.
+     * <p>
+     * This binder is only allowed if you enable dynamic binding. Although this may be tempting, you are breaking the
+     * deterministic behavior of the service registry, and may encounter runtime errors that are otherwise impossible.
+     *
+     * @return service binder that allows binding into this service registry
+     */
+    ServiceBinder binder();
+
+    /**
+     * Limit runtime phase.
+     *
+     * @return phase to activate to
+     * @see io.helidon.inject.InjectionConfig#limitRuntimePhase()
+     */
+    default Phase limitRuntimePhase() {
+        return injectionServices().config().limitRuntimePhase();
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/Services.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Services.java
@@ -69,8 +69,8 @@ public interface Services {
      *         if the result may contain an unknown provider type
      * @throws io.helidon.inject.InjectionException if resolution fails to resolve a match
      */
-    default <T> Supplier<T> first(Lookup lookup) {
-        return this.<T>find(lookup)
+    default <T> Supplier<T> get(Lookup lookup) {
+        return this.<T>first(lookup)
                 .orElseThrow(() -> new InjectionException("There are no services matching " + lookup));
     }
 
@@ -82,8 +82,8 @@ public interface Services {
      * @return the best service provider matching the lookup
      * @throws io.helidon.inject.InjectionException if resolution fails to resolve a match
      */
-    default <T> Supplier<T> first(Class<T> type) {
-        return this.find(type)
+    default <T> Supplier<T> get(Class<T> type) {
+        return this.first(type)
                 .orElseThrow(() -> new InjectionException("There are no services with type (or contract) of " + type.getName()));
     }
 
@@ -95,7 +95,7 @@ public interface Services {
      * @return the best service provider matching the lookup, cast to the expected type; please use a {@code Object} as the type
      *         if the result may contain an unknown provider type
      */
-    <T> Optional<Supplier<T>> find(Lookup lookup);
+    <T> Optional<Supplier<T>> first(Lookup lookup);
 
     /**
      * Find the first service provider matching the provided type with the expectation that there may not be a match available.
@@ -104,8 +104,8 @@ public interface Services {
      * @param <T>  service type or service contract
      * @return the best service provider matching the lookup
      */
-    default <T> Optional<Supplier<T>> find(Class<T> type) {
-        return find(Lookup.builder()
+    default <T> Optional<Supplier<T>> first(Class<T> type) {
+        return first(Lookup.builder()
                             .addContract(type)
                             .build());
     }
@@ -141,8 +141,8 @@ public interface Services {
      * @return the best service provider matching the lookup, cast to the expected type; please use a {@code Object} as the type
      *         if the result may contain an unknown provider type
      */
-    default <T> Optional<ServiceProvider<T>> findServiceProvider(Lookup lookup) {
-        return this.<T>serviceProviders(lookup)
+    default <T> Optional<ServiceProvider<T>> firstProvider(Lookup lookup) {
+        return this.<T>allProviders(lookup)
                 .stream()
                 .findFirst();
     }
@@ -155,8 +155,8 @@ public interface Services {
      * @return the best service provider matching the lookup, cast to the expected type; please use a {@code Object} as the type
      *         if the result may contain an unknown provider type
      */
-    default <T> ServiceProvider<T> firstServiceProvider(Lookup lookup) {
-        return this.<T>findServiceProvider(lookup)
+    default <T> ServiceProvider<T> getProvider(Lookup lookup) {
+        return this.<T>firstProvider(lookup)
                 .orElseThrow(() -> new InjectionException("There are no services matching " + lookup));
     }
 
@@ -168,7 +168,7 @@ public interface Services {
      * @param <T>    type of the expected service providers, use {@code Object} if not known, or may contain a mix of types
      * @return list of service providers
      */
-    <T> List<ServiceProvider<T>> serviceProviders(Lookup lookup);
+    <T> List<ServiceProvider<T>> allProviders(Lookup lookup);
 
     /**
      * Get a service provider for a descriptor.

--- a/inject/inject/src/main/java/io/helidon/inject/ServicesActivator.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServicesActivator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+class ServicesActivator extends ServiceProviderBase<Services> {
+    private ServicesActivator(ServicesImpl services) {
+        super(services, Services__ServiceDescriptor.INSTANCE);
+    }
+
+    static ServicesActivator create(ServicesImpl services) {
+        ServicesActivator response = new ServicesActivator(services);
+        response.state(Phase.ACTIVE, services);
+        return response;
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServicesImpl.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServicesImpl.java
@@ -105,7 +105,7 @@ class ServicesImpl implements Services, ServiceBinder {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> Optional<Supplier<T>> find(Lookup criteria) {
+    public <T> Optional<Supplier<T>> first(Lookup criteria) {
         return this.<T>lookup(criteria, 1)
                 .stream()
                 .findFirst();
@@ -119,7 +119,7 @@ class ServicesImpl implements Services, ServiceBinder {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> List<ServiceProvider<T>> serviceProviders(Lookup criteria) {
+    public <T> List<ServiceProvider<T>> allProviders(Lookup criteria) {
         return this.lookup(criteria, Integer.MAX_VALUE);
     }
 
@@ -170,7 +170,7 @@ class ServicesImpl implements Services, ServiceBinder {
 
     List<ServiceProvider<Interception.Interceptor>> interceptors() {
         if (interceptors == null) {
-            interceptors = serviceProviders(Lookup.builder()
+            interceptors = allProviders(Lookup.builder()
                                                     .addContract(Interception.Interceptor.class)
                                                     .addQualifier(Qualifier.WILDCARD_NAMED)
                                                     .build());

--- a/inject/inject/src/main/java/io/helidon/inject/ServicesImpl.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServicesImpl.java
@@ -1,0 +1,508 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.lang.System.Logger.Level;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import io.helidon.common.HelidonServiceLoader;
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.Interception;
+import io.helidon.inject.service.Ip;
+import io.helidon.inject.service.ModuleComponent;
+import io.helidon.inject.service.Qualifier;
+import io.helidon.inject.service.ServiceBinder;
+import io.helidon.inject.service.ServiceDescriptor;
+import io.helidon.inject.service.ServiceInfo;
+import io.helidon.inject.spi.ActivatorProvider;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Meter;
+import io.helidon.metrics.api.Metrics;
+
+class ServicesImpl implements Services, ServiceBinder {
+    private static final System.Logger LOGGER = System.getLogger(Services.class.getName());
+    private static final Map<String, ActivatorProvider> ACTIVATOR_PROVIDERS;
+
+    static {
+        Map<String, ActivatorProvider> activators = new HashMap<>();
+
+        HelidonServiceLoader.builder(ServiceLoader.load(ActivatorProvider.class))
+                .addService(new InjectActivatorProvider())
+                .build()
+                .asList()
+                .forEach(it -> activators.putIfAbsent(it.id(), it));
+        ACTIVATOR_PROVIDERS = Map.copyOf(activators);
+    }
+
+    private final Map<Lookup, List<ServiceProvider<?>>> cache = new ConcurrentHashMap<>();
+    // a map of service provider instances to their activators, so we can correctly handle activation requests
+    private final Map<ServiceProvider<?>, Activator<?>> providersToActivators = new IdentityHashMap<>();
+    private final Counter lookupCounter;
+    private final InjectionConfig cfg;
+    private final Map<TypeName, ServiceProvider<?>> servicesByTypeName;
+    private final Map<TypeName, Set<ServiceProvider<?>>> servicesByContract;
+    private final Counter cacheLookupCounter;
+    private final Counter cacheHitCounter;
+    private final InjectionServicesImpl injectionServices;
+    private final State state;
+
+    private volatile List<ServiceProvider<Interception.Interceptor>> interceptors;
+
+    ServicesImpl(InjectionServicesImpl injectionServices, State state) {
+        this.injectionServices = injectionServices;
+        this.state = state;
+        this.cfg = injectionServices.config();
+
+        this.lookupCounter = Metrics.globalRegistry()
+                .getOrCreate(Counter.builder("io.helidon.inject.lookups")
+                                     .description("Number of lookups in the service registry")
+                                     .scope(Meter.Scope.VENDOR));
+        if (cfg.serviceLookupCaching()) {
+            this.cacheLookupCounter = Metrics.globalRegistry()
+                    .getOrCreate(Counter.builder("io.helidon.inject.cacheLookups")
+                                         .description("Number of lookups in cache in the service registry")
+                                         .scope(Meter.Scope.VENDOR));
+            this.cacheHitCounter = Metrics.globalRegistry()
+                    .getOrCreate(Counter.builder("io.helidon.inject.cacheHits")
+                                         .description("Number of cache hits in the service registry")
+                                         .scope(Meter.Scope.VENDOR));
+        } else {
+            this.cacheLookupCounter = null;
+            this.cacheHitCounter = null;
+        }
+
+        this.servicesByTypeName = new ConcurrentHashMap<>();
+        this.servicesByContract = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Optional<Supplier<T>> find(Lookup criteria) {
+        return this.<T>lookup(criteria, 1)
+                .stream()
+                .findFirst();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> List<Supplier<T>> all(Lookup criteria) {
+        return this.lookup(criteria, Integer.MAX_VALUE);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> List<ServiceProvider<T>> serviceProviders(Lookup criteria) {
+        return this.lookup(criteria, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public void bind(ServiceDescriptor<?> serviceDescriptor) {
+        ActivatorProvider activatorProvider = ACTIVATOR_PROVIDERS.get(serviceDescriptor.runtimeId());
+        if (activatorProvider == null) {
+            throw new IllegalStateException("Expected an activator provider for runtime id: " + serviceDescriptor.runtimeId()
+                                                    + ", available activator providers: " + ACTIVATOR_PROVIDERS.keySet());
+        }
+        bind(activatorProvider.activator(this, serviceDescriptor));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> ServiceProvider<T> serviceProvider(ServiceInfo serviceInfo) {
+        ServiceProvider<?> serviceProvider = servicesByTypeName.get(serviceInfo.serviceType());
+        if (serviceProvider == null) {
+            throw new NoSuchElementException("Requested service is not managed by this registry: "
+                                                     + serviceInfo.serviceType().fqName());
+        }
+        return (ServiceProvider<T>) serviceProvider;
+    }
+
+    @Override
+    public InjectionServicesImpl injectionServices() {
+        return injectionServices;
+    }
+
+    @Override
+    public ServiceBinder binder() {
+        return this;
+    }
+
+    void bindSelf() {
+        bind(ServicesActivator.create(this));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void interceptors(ServiceInfo... serviceInfos) {
+        if (this.interceptors == null) {
+            List list = Stream.of(serviceInfos)
+                    .map(this::serviceProvider)
+                    .toList();
+            this.interceptors = List.copyOf(list);
+        }
+    }
+
+    List<ServiceProvider<Interception.Interceptor>> interceptors() {
+        if (interceptors == null) {
+            interceptors = serviceProviders(Lookup.builder()
+                                                    .addContract(Interception.Interceptor.class)
+                                                    .addQualifier(Qualifier.WILDCARD_NAMED)
+                                                    .build());
+        }
+        return interceptors;
+    }
+
+    void bind(ModuleComponent module) {
+        String moduleName = module.name();
+
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            LOGGER.log(Level.TRACE, "Starting module binding: " + moduleName);
+        }
+
+        ServiceBinder moduleBinder = new ServiceBinderImpl(moduleName);
+        module.configure(moduleBinder);
+        bind(InjectionModuleActivator.create(this, module, moduleName));
+
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            LOGGER.log(Level.TRACE, "Finished module binding: " + moduleName);
+
+        }
+    }
+
+    void bind(Application application) {
+        String appName = application.name();
+
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            LOGGER.log(Level.TRACE, "Starting application binding: " + appName);
+        }
+
+        ServiceInjectionPlanBinder appBinder = new AppBinderImpl(appName);
+        application.configure(appBinder);
+        bind(InjectionApplicationActivator.create(this, application, appName));
+
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            LOGGER.log(Level.TRACE, "Finished application binding: " + appName);
+
+        }
+    }
+
+    Optional<Activator<?>> activator(ServiceProvider<?> instance) {
+        return Optional.ofNullable(providersToActivators.get(instance));
+    }
+
+    List<ServiceProvider<?>> allProviders() {
+        Set<ServiceProvider<?>> result = new HashSet<>(servicesByTypeName.values());
+        servicesByContract.values()
+                .forEach(result::addAll);
+
+        return result.stream()
+                .toList();
+    }
+
+    private static boolean hasNamed(Set<Qualifier> qualifiers) {
+        return qualifiers.stream()
+                .anyMatch(it -> it.typeName().equals(InjectTypes.NAMED));
+    }
+
+    private void bind(Activator<?> activator) {
+        if (state.currentPhase().ordinal() > Phase.GATHERING_DEPENDENCIES.ordinal()) {
+            if (!cfg.permitsDynamic()) {
+                throw new IllegalStateException(
+                        "Attempting to bind to Services that do not support dynamic updates. Set option permitsDynamic, "
+                                + "or configuration option 'inject.permits-dynamic=true' to enable");
+            }
+        }
+
+        // make sure the activator has a chance to do something, such as create the initial service provider instance
+        activator.activate(ActivationRequest.builder()
+                                   .targetPhase(Phase.INIT)
+                                   .throwIfError(false)
+                                   .build());
+        ServiceProvider<?> serviceProvider = activator.serviceProvider();
+        this.providersToActivators.put(serviceProvider, activator);
+
+        TypeName serviceType = serviceProvider.serviceType();
+
+        // only put if absent, as this may be a lower weight provider for the same type
+        ServiceProvider<?> previousValue = servicesByTypeName.putIfAbsent(serviceType, serviceProvider);
+        if (previousValue != null) {
+            // a value was already registered for this service type, ignore this registration
+            if (LOGGER.isLoggable(Level.TRACE)) {
+                LOGGER.log(Level.TRACE, "Attempt to register another service provider for the same service type."
+                        + " Service type: " + serviceType.fqName()
+                        + ", existing provider: " + previousValue
+                        + ", new provider: " + serviceProvider);
+            }
+            return;
+        }
+        servicesByContract.computeIfAbsent(serviceType, it -> new TreeSet<>(ServiceProviderComparator.instance()))
+                .add(serviceProvider);
+
+        for (TypeName contract : serviceProvider.contracts()) {
+            servicesByContract.computeIfAbsent(contract, it -> new TreeSet<>(ServiceProviderComparator.instance()))
+                    .add(serviceProvider);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private <T> List lookup(Lookup criteria, int limit) {
+        lookupCounter.increment();
+
+        if (criteria.serviceType().isPresent()) {
+            // when a specific service type is requested, we go for it
+            ServiceProvider<?> exact = servicesByTypeName.get(criteria.serviceType().get());
+            if (exact != null) {
+                return explodeFilterAndSort(List.of(exact), criteria);
+            }
+        }
+
+        if (1 == criteria.contracts().size()) {
+            TypeName theOnlyContractRequested = criteria.contracts().iterator().next();
+            Set<ServiceProvider<?>> subsetOfMatches = servicesByContract.get(theOnlyContractRequested);
+            if (subsetOfMatches != null) {
+                List<ServiceProvider<?>> result = subsetOfMatches.stream()
+                        .parallel()
+                        .filter(criteria::matches)
+                        .limit(limit)
+                        .toList();
+                if (!result.isEmpty()) {
+                    return explodeFilterAndSort(result, criteria);
+                }
+            }
+            if (criteria.serviceType().isEmpty()) {
+                // we may have a request for service type and not a contract
+                ServiceProvider<?> exact = servicesByTypeName.get(theOnlyContractRequested);
+                if (exact != null) {
+                    return explodeFilterAndSort(List.of(exact), criteria);
+                }
+            }
+        }
+
+        if (cfg.serviceLookupCaching()) {
+            List result = cache.get(criteria);
+            cacheLookupCounter.increment();
+            if (result != null) {
+                cacheHitCounter.increment();
+                return result;
+            }
+        }
+
+        // table scan :-(
+        List result = servicesByTypeName.values()
+                .stream()
+                .parallel()
+                .filter(criteria::matches)
+                .limit(limit)
+                .toList();
+
+        if (!result.isEmpty()) {
+            result = explodeFilterAndSort(result, criteria);
+        }
+
+        if (cfg.serviceLookupCaching()) {
+            cache.put(criteria, result);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private <T> List<Supplier<T>> explodeFilterAndSort(List<ServiceProvider<?>> coll, Lookup criteria) {
+        List<ServiceProvider<?>> exploded;
+        if ((coll.size() > 1)
+                || coll.stream().anyMatch(sp -> sp instanceof ServiceProviderProvider)) {
+            exploded = new ArrayList<>();
+
+            coll.forEach(s -> {
+                if (s instanceof ServiceProviderProvider spp) {
+                    List<? extends ServiceProvider<?>> subList = spp.serviceProviders(criteria, true, true);
+                    if (subList != null && !subList.isEmpty()) {
+                        subList.stream().filter(Objects::nonNull).forEach(exploded::add);
+                    }
+                } else {
+                    exploded.add(s);
+                }
+            });
+        } else {
+            exploded = new ArrayList<>(coll);
+        }
+
+        if (exploded.size() > 1) {
+            exploded.sort(ServiceProviderComparator.instance());
+        }
+
+        // the providers are sorted by weight and other properties
+        // we need to have unnamed providers before named ones (if criteria does not contain a Named qualifier)
+        // in similar fashion, if criteria does not contain any qualifier, put unqualified instances first
+        if (criteria.qualifiers().isEmpty()) {
+            // unqualified first, unnamed before named, but keep the existing order otherwise
+            List unqualified = new ArrayList<>();
+            List<ServiceProvider<?>> qualified = new ArrayList<>();
+            for (ServiceProvider<?> serviceProvider : exploded) {
+                if (serviceProvider.qualifiers().isEmpty()) {
+                    unqualified.add(serviceProvider);
+                } else {
+                    qualified.add(serviceProvider);
+                }
+            }
+            unqualified.addAll(qualified);
+            return unqualified;
+        } else if (!hasNamed(criteria.qualifiers())) {
+            // unnamed first
+            List unnamed = new ArrayList<>();
+            List<ServiceProvider<?>> named = new ArrayList<>();
+            for (ServiceProvider serviceProvider : exploded) {
+                if (hasNamed(serviceProvider.qualifiers())) {
+                    named.add(serviceProvider);
+                } else {
+                    unnamed.add(serviceProvider);
+                }
+            }
+            unnamed.addAll(named);
+            return unnamed;
+        }
+
+        // need to coerce the compiler into the correct type here...
+        return (List) exploded;
+    }
+
+    private static class NoOpBinder implements ServiceInjectionPlanBinder.Binder {
+        private final ServiceProvider<?> serviceProvider;
+
+        NoOpBinder(ServiceProvider<?> serviceProvider) {
+            this.serviceProvider = serviceProvider;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder bind(Ip id, boolean useProvider, ServiceInfo serviceInfo) {
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder bindOptional(Ip id, boolean useProvider, ServiceInfo... serviceInfos) {
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder bindMany(Ip id, boolean useProvider, ServiceInfo... serviceInfos) {
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder bindNull(Ip id) {
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBind(Ip id, boolean useProvider, Class<?> serviceType) {
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBindOptional(Ip id, boolean useProvider, Class<?> serviceType) {
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBindMany(Ip id, boolean useProvider, Class<?> serviceType) {
+            return this;
+        }
+
+        @Override
+        public ServiceInjectionPlanBinder.Binder runtimeBindNullable(Ip id, boolean useProvider, Class<?> serviceType) {
+            return this;
+        }
+
+        @Override
+        public void commit() {
+        }
+
+        @Override
+        public String toString() {
+            return "No-op binder for " + serviceProvider.description();
+        }
+    }
+
+    private class ServiceBinderImpl implements ServiceBinder {
+        private final String moduleName;
+
+        ServiceBinderImpl(String moduleName) {
+            this.moduleName = moduleName;
+        }
+
+        @Override
+        public void bind(ServiceDescriptor<?> serviceDescriptor) {
+            ServicesImpl.this.bind(serviceDescriptor);
+        }
+
+        @Override
+        public String toString() {
+            return "Service binder for module: " + moduleName;
+        }
+    }
+
+    private class AppBinderImpl implements ServiceInjectionPlanBinder {
+        private final String appName;
+
+        AppBinderImpl(String appName) {
+            this.appName = appName;
+        }
+
+        @Override
+        public Binder bindTo(ServiceInfo serviceInfo) {
+            ServiceProvider<?> serviceProvider = ServicesImpl.this.serviceProvider(serviceInfo);
+
+            Optional<Binder> binder = serviceProvider.serviceProviderBindable()
+                    .flatMap(ServiceProviderBindable::injectionPlanBinder);
+
+            if (binder.isEmpty()) {
+                // basically this means this service will not support compile-time injection
+                LOGGER.log(Level.WARNING,
+                           "service provider is not capable of being bound to injection points: " + serviceProvider);
+                return new NoOpBinder(serviceProvider);
+            }
+
+            if (LOGGER.isLoggable(Level.DEBUG)) {
+                LOGGER.log(Level.DEBUG, "binding injection plan to " + binder.get());
+            }
+
+            return binder.get();
+        }
+
+        @Override
+        public void interceptors(ServiceInfo... serviceInfos) {
+            ServicesImpl.this.interceptors(serviceInfos);
+        }
+
+        @Override
+        public String toString() {
+            return "Service binder for application: " + appName;
+        }
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/ServicesImpl.java
+++ b/inject/inject/src/main/java/io/helidon/inject/ServicesImpl.java
@@ -221,8 +221,7 @@ class ServicesImpl implements Services, ServiceBinder {
         servicesByContract.values()
                 .forEach(result::addAll);
 
-        return result.stream()
-                .toList();
+        return List.copyOf(result);
     }
 
     private static boolean hasNamed(Set<Qualifier> qualifiers) {
@@ -286,8 +285,8 @@ class ServicesImpl implements Services, ServiceBinder {
             TypeName theOnlyContractRequested = criteria.contracts().iterator().next();
             Set<ServiceProvider<?>> subsetOfMatches = servicesByContract.get(theOnlyContractRequested);
             if (subsetOfMatches != null) {
+                // the subset is ordered, cannot use parallel
                 List<ServiceProvider<?>> result = subsetOfMatches.stream()
-                        .parallel()
                         .filter(criteria::matches)
                         .limit(limit)
                         .toList();

--- a/inject/inject/src/main/java/io/helidon/inject/Services__ServiceDescriptor.java
+++ b/inject/inject/src/main/java/io/helidon/inject/Services__ServiceDescriptor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Set;
+
+import io.helidon.common.types.TypeName;
+import io.helidon.inject.service.ServiceDescriptor;
+
+/**
+ * Service descriptor to enable injection of {@link io.helidon.inject.Services}.
+ * Injection of services enables a possibility to have multiple Services instances within a single JVM,
+ * as it allows a service to inject the instance it is managed by (for example to do programmatic lookups),
+ * rather than depending on the singleton static instance.
+ */
+@SuppressWarnings("checkstyle:TypeName") // matches pattern of generated descriptors
+public class Services__ServiceDescriptor implements ServiceDescriptor<Services> {
+    /**
+     * Singleton instance to be referenced when building applications.
+     */
+    public static final Services__ServiceDescriptor INSTANCE = new Services__ServiceDescriptor();
+
+    private static final TypeName SERVICES = TypeName.create(Services.class);
+    private static final TypeName INFO_TYPE = TypeName.create(Services__ServiceDescriptor.class);
+
+    private Services__ServiceDescriptor() {
+    }
+
+    @Override
+    public TypeName serviceType() {
+        return SERVICES;
+    }
+
+    @Override
+    public TypeName infoType() {
+        return INFO_TYPE;
+    }
+
+    @Override
+    public Set<TypeName> scopes() {
+        return Set.of(InjectTypes.SINGLETON);
+    }
+}

--- a/inject/inject/src/main/java/io/helidon/inject/State.java
+++ b/inject/inject/src/main/java/io/helidon/inject/State.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+class State implements Resettable, Cloneable {
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private Phase currentPhase;
+    private boolean isFinished;
+    private Throwable lastError;
+
+    private State() {
+    }
+
+    static State create(Phase phase) {
+        return new State().currentPhase(phase);
+    }
+
+    @Override
+    public State clone() {
+        ReentrantReadWriteLock.ReadLock rlock = lock.readLock();
+        rlock.lock();
+        try {
+            return create(currentPhase()).finished(finished()).lastError(lastError());
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    @Override
+    public String toString() {
+        ReentrantReadWriteLock.WriteLock rlock = lock.writeLock();
+        rlock.lock();
+        try {
+            return "currentPhase=" + currentPhase + ", isFinished=" + isFinished + ", lastError=" + lastError;
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    @Override
+    public void reset(boolean deep) {
+        ReentrantReadWriteLock.WriteLock wlock = lock.writeLock();
+        wlock.lock();
+        try {
+            currentPhase(Phase.INIT).finished(false).lastError(null);
+        } finally {
+            wlock.unlock();
+        }
+    }
+
+    State currentPhase(Phase phase) {
+        ReentrantReadWriteLock.WriteLock wlock = lock.writeLock();
+        wlock.lock();
+        try {
+            Phase lastPhase = this.currentPhase;
+            this.currentPhase = Objects.requireNonNull(phase);
+            if (lastPhase != this.currentPhase) {
+                this.isFinished = false;
+                this.lastError = null;
+            }
+            return this;
+        } finally {
+            wlock.unlock();
+        }
+    }
+
+    Phase currentPhase() {
+        ReentrantReadWriteLock.ReadLock rlock = lock.readLock();
+        rlock.lock();
+        try {
+            return currentPhase;
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    State finished(boolean finished) {
+        ReentrantReadWriteLock.WriteLock wlock = lock.writeLock();
+        wlock.lock();
+        try {
+            this.isFinished = finished;
+            return this;
+        } finally {
+            wlock.unlock();
+        }
+    }
+
+    boolean finished() {
+        ReentrantReadWriteLock.ReadLock rlock = lock.readLock();
+        rlock.lock();
+        try {
+            return isFinished;
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    State lastError(Throwable t) {
+        ReentrantReadWriteLock.WriteLock wlock = lock.writeLock();
+        wlock.lock();
+        try {
+            this.lastError = t;
+            return this;
+        } finally {
+            wlock.unlock();
+        }
+    }
+
+    Throwable lastError() {
+        ReentrantReadWriteLock.ReadLock rlock = lock.readLock();
+        rlock.lock();
+        try {
+            return lastError;
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+}

--- a/inject/inject/src/main/java/io/helidon/inject/package-info.java
+++ b/inject/inject/src/main/java/io/helidon/inject/package-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The Helidon Injection API provide these annotation types that are typically used at compile time
+ * to assign special meaning to the type. It is used in conjunction with Helidon tooling (see the {@code injection processor} and
+ * injection {@code maven-plugin} modules) to create and validate the DI module at compile time.
+ * <ul>
+ * <li>{@link io.helidon.inject.service.Injection.Contract} - signifies that the type can be used for lookup in the service
+ * registry.</li>
+ * <li>{@link io.helidon.inject.service.Injection.ExternalContracts} - same as Contract, but applied to the implementation
+ * class instead.</li>
+ * <li>{@link io.helidon.inject.service.Injection.RunLevel} - ascribes meaning for when the service should start.</li>
+ * </ul>
+ * <p>
+ * Other types from the API are less commonly used, but are still made available for situations where programmatic access
+ * is required or desirable in some way. The two most common types for entry into this part of the API are shown below.
+ * <ul>
+ * <li>{@link io.helidon.inject.Services} - the services registry, which is one such service from this suite.</li>
+ * </ul>
+ */
+package io.helidon.inject;

--- a/inject/inject/src/main/java/io/helidon/inject/spi/ActivatorProvider.java
+++ b/inject/inject/src/main/java/io/helidon/inject/spi/ActivatorProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject.spi;
+
+import io.helidon.inject.Activator;
+import io.helidon.inject.Services;
+import io.helidon.inject.service.ServiceDescriptor;
+
+/**
+ * A {@link java.util.ServiceLoader} provider interface that allows extensibility of the activator created based
+ * on the service descriptor.
+ * The {@link #id()} is matched with {@link io.helidon.inject.service.ServiceDescriptor#runtimeId()} and the provider with
+ * highest {@link io.helidon.common.Weight} for that id would be used to prepare an activator for the service descriptor.
+ */
+public interface ActivatorProvider {
+    /**
+     * Id to match with {@link io.helidon.inject.service.ServiceDescriptor#runtimeId()}.
+     *
+     * @return id this provider provides
+     */
+    String id();
+
+    /**
+     * Create a service activator for a service descriptor.
+     *
+     * @param services   service registry (the service registry is being initialized when activators are created!)
+     * @param descriptor descriptor to create activator for
+     * @param <T>        type of the provided service
+     * @return a new activator
+     */
+    <T> Activator<T> activator(Services services, ServiceDescriptor<T> descriptor);
+}

--- a/inject/inject/src/main/java/io/helidon/inject/spi/package-info.java
+++ b/inject/inject/src/main/java/io/helidon/inject/spi/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Injection SPI to support extensibility.
+ *
+ * @see io.helidon.inject.spi.ActivatorProvider
+ */
+package io.helidon.inject.spi;

--- a/inject/inject/src/main/java/module-info.java
+++ b/inject/inject/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon Inject.
+ * <p>
+ * This module provides service registry with injection support.
+ */
+module io.helidon.inject {
+    requires transitive io.helidon.inject.service;
+    requires transitive io.helidon.common.types;
+    requires transitive io.helidon.builder.api;
+
+    requires io.helidon.metrics.api;
+
+    exports io.helidon.inject;
+    exports io.helidon.inject.spi;
+
+    uses io.helidon.inject.service.ModuleComponent;
+    uses io.helidon.inject.Application;
+    uses io.helidon.inject.spi.ActivatorProvider;
+}

--- a/inject/inject/src/test/java/io/helidon/inject/ControlBlueprint.java
+++ b/inject/inject/src/test/java/io/helidon/inject/ControlBlueprint.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+interface ControlBlueprint {
+    Optional<RuntimeException> exceptionBeforeProceed();
+
+    Optional<RuntimeException> exceptionAfterProceed();
+
+    Optional<Object> shortCircuitValue();
+
+    @Option.DefaultInt(0)
+    int timesToCatchException();
+
+    @Option.DefaultInt(1)
+    int timesToCallProceed();
+}

--- a/inject/inject/src/test/java/io/helidon/inject/InvocationTest.java
+++ b/inject/inject/src/test/java/io/helidon/inject/InvocationTest.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypedElementInfo;
+import io.helidon.inject.service.Interception.Interceptor;
+import io.helidon.inject.service.InvocationContext;
+import io.helidon.inject.service.Invoker;
+import io.helidon.inject.service.ServiceInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InvocationTest {
+    TestInterceptor first;
+    TestInterceptor second;
+    InvocationContext dummyCtx;
+    ArrayList<Object[]> calls = new ArrayList<>();
+    List<ConcreteProvider<Interceptor>> interceptors;
+
+    @BeforeEach
+    void reset() {
+        first = new TestInterceptor("first");
+        second = new TestInterceptor("second");
+        interceptors = List.of(first.provider, second.provider);
+        dummyCtx = InvocationContext.builder()
+                .serviceInfo(new DummyServiceInfo())
+                .elementInfo(TypedElementInfo.builder()
+                                     .elementName("test")
+                                     .kind(ElementKind.METHOD)
+                                     .typeName(TypeName.create(InvocationTest.class)))
+                .build();
+        calls.clear();
+    }
+
+    @Test
+    void normalCaseWithInterceptors() throws Exception {
+        Object[] args = new Object[] {};
+        Boolean result = Invocation.createInvokeAndSupply(dummyCtx,
+                                                          interceptors,
+                                                          (arguments) -> calls.add(arguments),
+                                                          args,
+                                                          Set.of());
+        assertThat(result, is(true));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(1));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(second.callCount.get(), equalTo(1));
+        assertThat(second.proceedCount.get(), equalTo(1));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(1));
+    }
+
+    @Test
+    void normalCaseWithNoInterceptors() throws Exception {
+        InvocationContext dummyCtx = InvocationContext.builder()
+                .serviceInfo(new DummyServiceInfo())
+                .elementInfo(TypedElementInfo.builder()
+                                     .elementName("test")
+                                     .kind(ElementKind.METHOD)
+                                     .typeName(TypeName.create(InvocationTest.class))
+                                     .build())
+                .build();
+
+        Object[] args = new Object[] {};
+        Boolean result = Invocation.createInvokeAndSupply(dummyCtx,
+                                                          List.of(),
+                                                          (arguments) -> calls.add(arguments),
+                                                          args,
+                                                          Set.of());
+        assertThat(result, is(true));
+        assertThat(first.callCount.get(), equalTo(0));
+        assertThat(first.proceedCount.get(), equalTo(0));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(second.callCount.get(), equalTo(0));
+        assertThat(second.proceedCount.get(), equalTo(0));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(1));
+
+        calls.clear();
+        RuntimeException re = new RuntimeException("forced");
+        Invoker<Object> fnc = (arguments) -> {
+            throw re;
+        };
+        InvocationException e = assertThrows(InvocationException.class,
+                                             () -> Invocation.createInvokeAndSupply(dummyCtx, List.of(), fnc, args, Set.of()));
+        assertThat(e.getMessage(), equalTo("Error in interceptor chain processing"));
+        assertThat(e.targetWasCalled(), is(true));
+        assertThat(e.getCause(), is(re));
+        assertThat(calls.size(), equalTo(0));
+    }
+
+    @Test
+    void illegalCallToInterceptorProceedTwice() {
+        first.control.timesToCallProceed(2);
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = (arguments) -> calls.add(arguments);
+        InvocationException e = assertThrows(InvocationException.class,
+                                             () -> Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of()));
+        assertThat(e.getMessage(),
+                   equalTo("Duplicate invocation, or unknown call type: io.helidon.inject.InvocationTest test"));
+        assertThat(e.targetWasCalled(), is(true));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(2));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(1));
+        assertThat(second.callCount.get(), equalTo(1));
+        assertThat(second.proceedCount.get(), equalTo(1));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(1));
+    }
+
+    @Test
+    void illegalCallToTargetProceedTwice() {
+        second.control.timesToCallProceed(2);
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = arguments -> calls.add(arguments);
+        InvocationException e = assertThrows(InvocationException.class,
+                                             () -> Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of()));
+        assertThat(e.getMessage(),
+                   equalTo("Duplicate invocation, or unknown call type: io.helidon.inject.InvocationTest test"));
+        assertThat(e.targetWasCalled(), is(true));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(1));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(1));
+        assertThat(second.callCount.get(), equalTo(1));
+        assertThat(second.proceedCount.get(), equalTo(2));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(1));
+        assertThat(calls.size(), equalTo(1));
+    }
+
+    @Test
+    void illegalCallToProceedAfterSuccessfulCallToTargetButExceptionInInterceptor() {
+        first.control.timesToCallProceed(2).timesToCatchException(1);
+        second.control.exceptionAfterProceed(new RuntimeException("after"));
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = (arguments) -> calls.add(arguments);
+        InvocationException e = assertThrows(InvocationException.class,
+                                             () -> Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of()));
+        assertThat(e.targetWasCalled(), is(true));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(2));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(2));
+        assertThat(second.callCount.get(), equalTo(1));
+        assertThat(second.proceedCount.get(), equalTo(1));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(1));
+    }
+
+    @Test
+    @Disabled
+    void exceptionThrownInInterceptorPriorToReachingTarget() throws Exception {
+        first.control.timesToCatchException(1).timesToCallProceed(2);
+        second.control.exceptionBeforeProceed(new RuntimeException("before"));
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = (arguments) -> calls.add(arguments);
+        Boolean result = Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of());
+        assertThat(result, is(true));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(2));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(1));
+        assertThat(second.callCount.get(), equalTo(2));
+        assertThat(second.proceedCount.get(), equalTo(1));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(1));
+    }
+
+    @Test
+    void exceptionThrownInInterceptorAfterReachingTarget() {
+        first.control.timesToCatchException(1).timesToCallProceed(2);
+        second.control.exceptionAfterProceed(new RuntimeException("after"));
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = (arguments) -> calls.add(arguments);
+        InvocationException e = assertThrows(InvocationException.class,
+                                             () -> Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of()));
+        assertThat(e.getMessage(),
+                   equalTo("Duplicate invocation, or unknown call type: io.helidon.inject.InvocationTest test"));
+        assertThat(e.targetWasCalled(), is(true));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(2));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(2));
+        assertThat(second.callCount.get(), equalTo(1));
+        assertThat(second.proceedCount.get(), equalTo(1));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(1));
+    }
+
+    @Test
+    @Disabled
+    void exceptionThrownMultipleTimesInSecond() throws Exception {
+        first.control.timesToCatchException(3).timesToCallProceed(3);
+        second.control.exceptionBeforeProceed(new RuntimeException("before"));
+        second.control.exceptionAfterProceed(new RuntimeException("after"));
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = (arguments) -> calls.add(arguments);
+        Boolean result = Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of());
+        assertThat("because exception happened after we called proceed in second the value is lost", result, nullValue());
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(3));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(3));
+        assertThat(second.callCount.get(), equalTo(2));
+        assertThat(second.proceedCount.get(), equalTo(1));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(1));
+    }
+
+    @Test
+    void shortCircuitInFirst() throws Exception {
+        first.control.shortCircuitValue(false);
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = (arguments) -> calls.add(arguments);
+        Boolean result = Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of());
+        assertThat(result, is(false));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(0));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(second.callCount.get(), equalTo(0));
+        assertThat(second.proceedCount.get(), equalTo(0));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(0));
+    }
+
+    @Test
+    void shortCircuitInSecond() throws Exception {
+        second.control.shortCircuitValue(false);
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = (arguments) -> calls.add(arguments);
+        Boolean result = Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of());
+        assertThat(result, is(false));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(1));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(second.callCount.get(), equalTo(1));
+        assertThat(second.proceedCount.get(), equalTo(0));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(0));
+    }
+
+    @Test
+    void firstDoingAllOfTheProceedCalls() throws Exception {
+        first.control.timesToCallProceed(2);
+        second.control.timesToCallProceed(0);
+        Object[] args = new Object[] {};
+        Invoker<Boolean> fnc = (arguments) -> calls.add(arguments);
+        Boolean result = Invocation.createInvokeAndSupply(dummyCtx, interceptors, fnc, args, Set.of());
+        assertThat(result, is(true));
+        assertThat(first.callCount.get(), equalTo(1));
+        assertThat(first.proceedCount.get(), equalTo(2));
+        assertThat(first.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(second.callCount.get(), equalTo(1));
+        assertThat(second.proceedCount.get(), equalTo(0));
+        assertThat(second.downstreamExceptionCount.get(), equalTo(0));
+        assertThat(calls.size(), equalTo(1));
+    }
+
+    static class ConcreteProvider<T> implements Supplier<T> {
+        private final T delegate;
+
+        ConcreteProvider(T delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public T get() {
+            return delegate;
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+    }
+
+    static class TestInterceptor {
+        final String name;
+        AtomicInteger callCount = new AtomicInteger();
+        AtomicInteger proceedCount = new AtomicInteger();
+        AtomicInteger downstreamExceptionCount = new AtomicInteger();
+        Control.Builder control = Control.builder();
+        ConcreteProvider<Interceptor> provider = new ConcreteProvider<>(new Interceptor() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <V> V proceed(InvocationContext ctx, Chain<V> chain, Object... args) {
+                callCount.incrementAndGet();
+
+                RuntimeException re = control.exceptionBeforeProceed().orElse(null);
+                if (re != null) {
+                    control.exceptionBeforeProceed(Optional.empty());
+                    throw re;
+                }
+
+                if (control.shortCircuitValue().isPresent()) {
+                    return (V) control.shortCircuitValue().get();
+                }
+
+                V v = null;
+                int countDown = control.timesToCallProceed();
+                while (countDown-- > 0) {
+                    proceedCount.incrementAndGet();
+
+                    try {
+                        try {
+                            v = chain.proceed(args);
+                        } catch (RuntimeException e) {
+                            throw e;
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    } catch (RuntimeException e) {
+                        downstreamExceptionCount.incrementAndGet();
+                        if (control.timesToCatchException() <= 0) {
+                            throw e;
+                        }
+                        control.timesToCatchException(control.timesToCatchException() - 1);
+                    }
+
+                    re = control.exceptionAfterProceed().orElse(null);
+                    if (re != null) {
+                        control.exceptionAfterProceed(Optional.empty());
+                        throw re;
+                    }
+                }
+
+                return v;
+            }
+        });
+
+        TestInterceptor(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    private static class DummyServiceInfo implements ServiceInfo {
+        @Override
+        public TypeName serviceType() {
+            return TypeName.create(DummyServiceInfo.class);
+        }
+
+        @Override
+        public Set<TypeName> scopes() {
+            return Set.of(InjectTypes.SINGLETON);
+        }
+    }
+}

--- a/inject/pom.xml
+++ b/inject/pom.xml
@@ -41,6 +41,7 @@
     <!-- this will show the progression of what has come over, and what is left to come over -->
     <modules>
         <module>service</module>
+        <module>inject</module>
         <module>codegen</module>
         <module>codegen-jakarta</module>
         <module>codegen-javax</module>

--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -121,10 +121,24 @@
                             <artifactId>helidon-codegen-helidon-copyright</artifactId>
                             <version>${helidon.version}</version>
                         </path>
-
                     </annotationProcessorPaths>
                 </configuration>
                 <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.common.features</groupId>
+                        <artifactId>helidon-common-features-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.config</groupId>
+                        <artifactId>helidon-config-metadata-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.inject.configdriven</groupId>
+                        <artifactId>helidon-inject-configdriven-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
                         <artifactId>helidon-codegen-apt</artifactId>


### PR DESCRIPTION
This PR introduces
- `helidon-inject` - to replace `helidon-inject-api` and `helidon-inject-runtime`
- `helidon-inject-configdriven-services` - to replace `helidon-inject-configdriven-api` - to align with `helidon-inject-services`
- `helidon-inject-configdriven` - to replace `helidon-inject-configdriven-runtime` - to align with `helidon-inject`

### Description
There are no removed modules, that will be done in a follow up PR.
This is to enable comparison of the types as they are.

Similar to #8149 the modules are not yet used anywhwere, all changes in usage will be done as a follow up PR

This change drastically simplifies the API and SPI, removes a couple of features (debug flag, activation log) to make it as simple as possible, without extensibility (except for what we need in Helidon).

As we now have a single implementation, we can use a configuration objec to initialize the service registry (and the list of options on that object was reduced).

One of the bigger changes is refactoring of `lookup` methods to something we already use in Helidon (`first`, `find` and `all`)