### PR TITLE
3.x: Workaround for Java 21 support with older jandex

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -66,6 +66,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.plugin.compiler}</version>
+                    <configuration>
+                        <!-- Workaround https://github.com/helidon-io/helidon/issues/8085 -->
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Description

Add workaround for #8085 (Java 21 and jandex)

### Documentation

No impact