### PR TITLE
2.x post 2.6.5 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ For Helidon 1.x releases please see [Helidon 1.x CHANGELOG.md](https://github.co
 
 For Helidon 3.x releases please see [Helidon 3.x CHANGELOG.md](https://github.com/oracle/helidon/blob/helidon-3.x/CHANGELOG.md)
 
+## [2.6.5]
+
+This is a bugfix release of Helidon. It is recommended for all users of Helidon 2.
+
+### CHANGES
+
+- OCI: Adds support for Provider-specializing injection points in OciExtension [8028](https://github.com/helidon-io/helidon/pull/8028)
+- Dependencies: Update gRPC version to 1.60.0 [8147](https://github.com/helidon-io/helidon/pull/8147)
+- Dependencies: Upgrade slf4j to 2.0.9 and logback to 1.4.14 [8121](https://github.com/helidon-io/helidon/pull/8121)
+- Dependencies: Upgrade to mysql-connector-j 8.2.0 [8017](https://github.com/helidon-io/helidon/pull/8017)
+- Docs: Correct errors in how OpenAPI generator config settings are set [7971](https://github.com/helidon-io/helidon/pull/7971)
+
 ## [2.6.4]
 
 This is a bugfix release of Helidon. It is recommended for all users of Helidon 2.
@@ -2191,6 +2203,7 @@ If there is no authorization provider configured, ABAC provider will be configur
       otherwise they are ignored
 
 
+[2.6.5]: https://github.com/oracle/helidon/compare/2.6.4...2.6.5
 [2.6.4]: https://github.com/oracle/helidon/compare/2.6.3...2.6.4
 [2.6.3]: https://github.com/oracle/helidon/compare/2.6.2...2.6.3
 [2.6.2]: https://github.com/oracle/helidon/compare/2.6.1...2.6.2

--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-applications</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-mp</artifactId>

--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-applications-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.applications</groupId>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-dependencies</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../dependencies/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.applications</groupId>

--- a/applications/se/pom.xml
+++ b/applications/se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-applications</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-se</artifactId>

--- a/archetypes/bare-mp/pom.xml
+++ b/archetypes/bare-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>helidon-archetype</packaging>
     <artifactId>helidon-bare-mp</artifactId>

--- a/archetypes/bare-se/pom.xml
+++ b/archetypes/bare-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>helidon-archetype</packaging>
     <artifactId>helidon-bare-se</artifactId>

--- a/archetypes/catalog/pom.xml
+++ b/archetypes/catalog/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>helidon-archetype-catalog</packaging>
     <artifactId>helidon-archetype-catalog</artifactId>

--- a/archetypes/database-mp/pom.xml
+++ b/archetypes/database-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>helidon-archetype</packaging>
     <artifactId>helidon-database-mp</artifactId>

--- a/archetypes/database-se/pom.xml
+++ b/archetypes/database-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>helidon-archetype</packaging>
     <artifactId>helidon-database-se</artifactId>

--- a/archetypes/oci-mp/pom.xml
+++ b/archetypes/oci-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>helidon-archetype</packaging>
     <artifactId>helidon-oci-mp</artifactId>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.archetypes</groupId>
     <artifactId>helidon-archetypes-project</artifactId>

--- a/archetypes/quickstart-mp/pom.xml
+++ b/archetypes/quickstart-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>helidon-archetype</packaging>
     <artifactId>helidon-quickstart-mp</artifactId>

--- a/archetypes/quickstart-se/pom.xml
+++ b/archetypes/quickstart-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.archetypes</groupId>
         <artifactId>helidon-archetypes-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>helidon-archetype</packaging>
     <artifactId>helidon-quickstart-se</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-parent</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon</groupId>
@@ -32,7 +32,7 @@
     <name>Helidon BOM POM</name>
 
     <properties>
-        <helidon.version>2.6.5-SNAPSHOT</helidon.version>
+        <helidon.version>2.6.6-SNAPSHOT</helidon.version>
     </properties>
 
     <dependencyManagement>

--- a/bundles/config/pom.xml
+++ b/bundles/config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-bundles-config</artifactId>

--- a/bundles/jersey/pom.xml
+++ b/bundles/jersey/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-bundles-jersey</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modules>
         <module>config</module>

--- a/bundles/security/pom.xml
+++ b/bundles/security/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-bundles-security</artifactId>

--- a/bundles/webserver/pom.xml
+++ b/bundles/webserver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-bundles-webserver</artifactId>

--- a/common/common/pom.xml
+++ b/common/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common</artifactId>
     <name>Helidon Common</name>

--- a/common/configurable/pom.xml
+++ b/common/configurable/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <name>Helidon Common Configurable</name>
     <artifactId>helidon-common-configurable</artifactId>

--- a/common/context/pom.xml
+++ b/common/context/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-context</artifactId>
     <name>Helidon Common Context</name>

--- a/common/crypto/pom.xml
+++ b/common/crypto/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/http/pom.xml
+++ b/common/http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-common-project</artifactId>
         <groupId>io.helidon.common</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-common-http</artifactId>

--- a/common/key-util/pom.xml
+++ b/common/key-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-key-util</artifactId>
     <name>Helidon Common Key Util</name>

--- a/common/mapper/pom.xml
+++ b/common/mapper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-common-project</artifactId>
         <groupId>io.helidon.common</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/media-type/pom.xml
+++ b/common/media-type/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-media-type</artifactId>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.common</groupId>
     <artifactId>helidon-common-project</artifactId>

--- a/common/reactive/pom.xml
+++ b/common/reactive/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-common-reactive</artifactId>
     <name>Helidon Common Reactive</name>

--- a/common/service-loader/pom.xml
+++ b/common/service-loader/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-common-project</artifactId>
         <groupId>io.helidon.common</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/testing/junit5/pom.xml
+++ b/common/testing/junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.common.testing</groupId>
         <artifactId>helidon-common-testing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-common-testing-junit5</artifactId>

--- a/common/testing/pom.xml
+++ b/common/testing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.common.testing</groupId>

--- a/config/config-mp/pom.xml
+++ b/config/config-mp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-config-mp</artifactId>

--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config</artifactId>
     <name>Helidon Config</name>

--- a/config/encryption/pom.xml
+++ b/config/encryption/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-config-encryption</artifactId>

--- a/config/etcd/pom.xml
+++ b/config/etcd/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-etcd</artifactId>
     <name>Helidon Config Etcd</name>

--- a/config/git/pom.xml
+++ b/config/git/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-git</artifactId>
     <name>Helidon Config Git</name>

--- a/config/hocon-mp/pom.xml
+++ b/config/hocon-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-hocon-mp</artifactId>
     <name>Helidon Config HOCON MP</name>

--- a/config/hocon/pom.xml
+++ b/config/hocon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-hocon</artifactId>
     <name>Helidon Config HOCON</name>

--- a/config/metadata-processor/pom.xml
+++ b/config/metadata-processor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-metadata-processor</artifactId>
     <name>Helidon Config Metadata Annotation Processor</name>

--- a/config/metadata/pom.xml
+++ b/config/metadata/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-metadata</artifactId>
     <name>Helidon Config Metadata</name>

--- a/config/object-mapping/pom.xml
+++ b/config/object-mapping/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-config-project</artifactId>
         <groupId>io.helidon.config</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.config</groupId>
     <artifactId>helidon-config-project</artifactId>

--- a/config/test-infrastructure/pom.xml
+++ b/config/test-infrastructure/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-test-infrastructure</artifactId>
     <name>Helidon Config Test Infrastructure</name>

--- a/config/testing/pom.xml
+++ b/config/testing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-testing</artifactId>
     <name>Helidon Config Testing</name>

--- a/config/tests/integration-tests/pom.xml
+++ b/config/tests/integration-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-integration-tests</artifactId>
     <name>Helidon Config Tests Integration</name>

--- a/config/tests/module-mappers-1-base/pom.xml
+++ b/config/tests/module-mappers-1-base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-mappers-1-base</artifactId>
     <name>Helidon Config Tests Mappers 1</name>

--- a/config/tests/module-mappers-2-override/pom.xml
+++ b/config/tests/module-mappers-2-override/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-mappers-2-override</artifactId>
     <name>Helidon Config Tests Parser 2</name>

--- a/config/tests/module-meta-source-1/pom.xml
+++ b/config/tests/module-meta-source-1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-meta-source-1</artifactId>
     <name>Helidon Config Tests Meta Source 1</name>

--- a/config/tests/module-meta-source-2/pom.xml
+++ b/config/tests/module-meta-source-2/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-meta-source-2</artifactId>
     <name>Helidon Config Tests Meta Source 2</name>

--- a/config/tests/module-parsers-1-override/pom.xml
+++ b/config/tests/module-parsers-1-override/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-module-parsers-1-override</artifactId>
     <name>Helidon Config Tests Parser 1</name>

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.config.tests</groupId>
     <artifactId>helidon-config-tests-project</artifactId>

--- a/config/tests/test-bundle/pom.xml
+++ b/config/tests/test-bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-bundle</artifactId>
     <name>Helidon Config Tests Bundle</name>

--- a/config/tests/test-default_config-1-properties/pom.xml
+++ b/config/tests/test-default_config-1-properties/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-1-properties</artifactId>
     <name>Helidon Config Tests Default Config 1</name>

--- a/config/tests/test-default_config-2-hocon-json/pom.xml
+++ b/config/tests/test-default_config-2-hocon-json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-2-hocon-json</artifactId>
     <name>Helidon Config Tests Default Config 2</name>

--- a/config/tests/test-default_config-3-hocon/pom.xml
+++ b/config/tests/test-default_config-3-hocon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-3-hocon</artifactId>
     <name>Helidon Config Tests Default Config 3</name>

--- a/config/tests/test-default_config-4-yaml/pom.xml
+++ b/config/tests/test-default_config-4-yaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-4-yaml</artifactId>
     <name>Helidon Config Tests Default Config 4</name>

--- a/config/tests/test-default_config-5-env_vars/pom.xml
+++ b/config/tests/test-default_config-5-env_vars/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-5-env_vars</artifactId>
     <name>Helidon Config Tests Default Config 5</name>

--- a/config/tests/test-default_config-6-meta-properties/pom.xml
+++ b/config/tests/test-default_config-6-meta-properties/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-6-meta-properties</artifactId>
     <name>Helidon Config Tests Default Config 6</name>

--- a/config/tests/test-default_config-7-meta-hocon-json/pom.xml
+++ b/config/tests/test-default_config-7-meta-hocon-json/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-7-meta-hocon-json</artifactId>
     <name>Helidon Config Tests Default Config 7</name>

--- a/config/tests/test-default_config-8-meta-hocon/pom.xml
+++ b/config/tests/test-default_config-8-meta-hocon/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-8-meta-hocon</artifactId>
     <name>Helidon Config Tests Default Config 8</name>

--- a/config/tests/test-default_config-9-meta-yaml/pom.xml
+++ b/config/tests/test-default_config-9-meta-yaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-default_config-9-meta-yaml</artifactId>
     <name>Helidon Config Tests Default Config 9</name>

--- a/config/tests/test-mappers-1-common/pom.xml
+++ b/config/tests/test-mappers-1-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-mappers-1-common</artifactId>
     <name>Helidon Config Tests Mappers Common 1</name>

--- a/config/tests/test-mappers-2-complex/pom.xml
+++ b/config/tests/test-mappers-2-complex/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-mappers-2-complex</artifactId>
     <name>Helidon Config Tests Parsers 2</name>

--- a/config/tests/test-meta-source/pom.xml
+++ b/config/tests/test-meta-source/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-meta-source</artifactId>
     <name>Helidon Config Tests Meta Source</name>

--- a/config/tests/test-parsers-1-complex/pom.xml
+++ b/config/tests/test-parsers-1-complex/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-tests-test-parsers-1-complex</artifactId>
     <name>Helidon Config Tests Parsers 1</name>

--- a/config/yaml-mp/pom.xml
+++ b/config/yaml-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-yaml-mp</artifactId>
     <name>Helidon Config YAML MP</name>

--- a/config/yaml/pom.xml
+++ b/config/yaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-yaml</artifactId>
     <name>Helidon Config YAML</name>

--- a/dbclient/common/pom.xml
+++ b/dbclient/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-dbclient-project</artifactId>
         <groupId>io.helidon.dbclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dbclient/dbclient/pom.xml
+++ b/dbclient/dbclient/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-dbclient-project</artifactId>
         <groupId>io.helidon.dbclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-dbclient</artifactId>

--- a/dbclient/health/pom.xml
+++ b/dbclient/health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-dbclient-health</artifactId>

--- a/dbclient/jdbc/pom.xml
+++ b/dbclient/jdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-dbclient-project</artifactId>
         <groupId>io.helidon.dbclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-dbclient-jdbc</artifactId>

--- a/dbclient/jsonp/pom.xml
+++ b/dbclient/jsonp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-dbclient-project</artifactId>
         <groupId>io.helidon.dbclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dbclient/metrics-jdbc/pom.xml
+++ b/dbclient/metrics-jdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-dbclient-metrics-jdbc</artifactId>

--- a/dbclient/metrics/pom.xml
+++ b/dbclient/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-dbclient-metrics</artifactId>

--- a/dbclient/mongodb/pom.xml
+++ b/dbclient/mongodb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-dbclient-project</artifactId>
         <groupId>io.helidon.dbclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dbclient/pom.xml
+++ b/dbclient/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-project</artifactId>
         <groupId>io.helidon</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/dbclient/tracing/pom.xml
+++ b/dbclient/tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-dbclient-tracing</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-bom</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../bom/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dependencies</artifactId>

--- a/examples/config/basics/pom.xml
+++ b/examples/config/basics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/changes/pom.xml
+++ b/examples/config/changes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/git/pom.xml
+++ b/examples/config/git/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/mapping/pom.xml
+++ b/examples/config/mapping/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/metadata/pom.xml
+++ b/examples/config/metadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/overrides/pom.xml
+++ b/examples/config/overrides/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/pom.xml
+++ b/examples/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.config</groupId>
     <artifactId>helidon-examples-config-project</artifactId>

--- a/examples/config/profiles/pom.xml
+++ b/examples/config/profiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/config/sources/pom.xml
+++ b/examples/config/sources/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.config</groupId>

--- a/examples/cors/pom.xml
+++ b/examples/cors/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/dbclient/common/pom.xml
+++ b/examples/dbclient/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples.dbclient</groupId>
         <artifactId>helidon-examples-dbclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-examples-dbclient-common</artifactId>

--- a/examples/dbclient/jdbc/pom.xml
+++ b/examples/dbclient/jdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/dbclient/mongodb/pom.xml
+++ b/examples/dbclient/mongodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/dbclient/pokemons/pom.xml
+++ b/examples/dbclient/pokemons/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/dbclient/pom.xml
+++ b/examples/dbclient/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/examples/employee-app/pom.xml
+++ b/examples/employee-app/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.employee</groupId>

--- a/examples/graphql/basics/pom.xml
+++ b/examples/graphql/basics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.graphql</groupId>

--- a/examples/graphql/pom.xml
+++ b/examples/graphql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-examples-project</artifactId>
         <groupId>io.helidon.examples</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.graphql</groupId>
     <artifactId>helidon-examples-graphql-project</artifactId>

--- a/examples/grpc/basics/pom.xml
+++ b/examples/grpc/basics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/client-standalone/pom.xml
+++ b/examples/grpc/client-standalone/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/common/pom.xml
+++ b/examples/grpc/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/metrics/pom.xml
+++ b/examples/grpc/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/microprofile/basic-client/pom.xml
+++ b/examples/grpc/microprofile/basic-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-examples-grpc-microprofile-client</artifactId>

--- a/examples/grpc/microprofile/basic-server-implicit/pom.xml
+++ b/examples/grpc/microprofile/basic-server-implicit/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-examples-grpc-microprofile-basic-implicit</artifactId>

--- a/examples/grpc/microprofile/metrics/pom.xml
+++ b/examples/grpc/microprofile/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-examples-grpc-microprofile-metrics</artifactId>

--- a/examples/grpc/microprofile/pom.xml
+++ b/examples/grpc/microprofile/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples.grpc</groupId>
         <artifactId>helidon-examples-grpc-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.examples.grpc.microprofile</groupId>

--- a/examples/grpc/opentracing/pom.xml
+++ b/examples/grpc/opentracing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/pom.xml
+++ b/examples/grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>
     <artifactId>helidon-examples-grpc-project</artifactId>

--- a/examples/grpc/security-abac/pom.xml
+++ b/examples/grpc/security-abac/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/security-outbound/pom.xml
+++ b/examples/grpc/security-outbound/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/grpc/security/pom.xml
+++ b/examples/grpc/security/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.grpc</groupId>

--- a/examples/health/basics/pom.xml
+++ b/examples/health/basics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.health</groupId>

--- a/examples/health/pom.xml
+++ b/examples/health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-examples-project</artifactId>
         <groupId>io.helidon.examples</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.health</groupId>
     <artifactId>helidon-examples-health-project</artifactId>

--- a/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/jedis/pom.xml
+++ b/examples/integrations/cdi/jedis/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/jpa/pom.xml
+++ b/examples/integrations/cdi/jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/oci-objectstorage/pom.xml
+++ b/examples/integrations/cdi/oci-objectstorage/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/pokemons/pom.xml
+++ b/examples/integrations/cdi/pokemons/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>

--- a/examples/integrations/cdi/pom.xml
+++ b/examples/integrations/cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples.integrations</groupId>
         <artifactId>helidon-examples-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.integrations.cdi</groupId>
     <artifactId>helidon-examples-integrations-cdi-project</artifactId>

--- a/examples/integrations/micrometer/mp/pom.xml
+++ b/examples/integrations/micrometer/mp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/integrations/micrometer/pom.xml
+++ b/examples/integrations/micrometer/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples.integrations</groupId>
         <artifactId>helidon-examples-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-examples-micrometer-project</artifactId>

--- a/examples/integrations/micrometer/se/pom.xml
+++ b/examples/integrations/micrometer/se/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/micronaut/data/pom.xml
+++ b/examples/integrations/micronaut/data/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-examples-integrations-micronaut-data</artifactId>

--- a/examples/integrations/micronaut/pom.xml
+++ b/examples/integrations/micronaut/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples.integrations</groupId>
         <artifactId>helidon-examples-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.integrations.micronaut</groupId>
     <artifactId>helidon-examples-integrations-micronaut-project</artifactId>

--- a/examples/integrations/microstream/greetings-mp/pom.xml
+++ b/examples/integrations/microstream/greetings-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/microstream/greetings-se/pom.xml
+++ b/examples/integrations/microstream/greetings-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/microstream/pom.xml
+++ b/examples/integrations/microstream/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples.integrations</groupId>
         <artifactId>helidon-examples-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.examples.integrations.microstream</groupId>

--- a/examples/integrations/neo4j/neo4j-mp/pom.xml
+++ b/examples/integrations/neo4j/neo4j-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.neo4j</groupId>

--- a/examples/integrations/neo4j/neo4j-se/pom.xml
+++ b/examples/integrations/neo4j/neo4j-se/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.integrations.neo4j</groupId>

--- a/examples/integrations/neo4j/pom.xml
+++ b/examples/integrations/neo4j/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples.integrations</groupId>
         <artifactId>helidon-examples-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.integrations.neo4j</groupId>
     <artifactId>helidon-examples-integrations-neo4j-project</artifactId>

--- a/examples/integrations/oci/atp-cdi/pom.xml
+++ b/examples/integrations/oci/atp-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/oci/atp-reactive/pom.xml
+++ b/examples/integrations/oci/atp-reactive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/oci/metrics-reactive/pom.xml
+++ b/examples/integrations/oci/metrics-reactive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/oci/objectstorage-cdi/pom.xml
+++ b/examples/integrations/oci/objectstorage-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/oci/objectstorage-reactive/pom.xml
+++ b/examples/integrations/oci/objectstorage-reactive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/oci/pom.xml
+++ b/examples/integrations/oci/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples.integrations</groupId>
         <artifactId>helidon-examples-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.integrations.oci</groupId>
     <artifactId>helidon-examples-integrations-oci-project</artifactId>

--- a/examples/integrations/oci/vault-cdi/pom.xml
+++ b/examples/integrations/oci/vault-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/oci/vault-reactive/pom.xml
+++ b/examples/integrations/oci/vault-reactive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/pom.xml
+++ b/examples/integrations/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.integrations</groupId>
     <artifactId>helidon-examples-integrations-project</artifactId>

--- a/examples/integrations/vault/hcp-cdi/pom.xml
+++ b/examples/integrations/vault/hcp-cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/vault/hcp-reactive/pom.xml
+++ b/examples/integrations/vault/hcp-reactive/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/integrations/vault/pom.xml
+++ b/examples/integrations/vault/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples.integrations</groupId>
         <artifactId>helidon-examples-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.integrations.vault</groupId>
     <artifactId>helidon-examples-integrations-vault-project</artifactId>

--- a/examples/istio/helidon-config/pom.xml
+++ b/examples/istio/helidon-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/istio/helidon-jpa/pom.xml
+++ b/examples/istio/helidon-jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/istio/pom.xml
+++ b/examples/istio/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.istio</groupId>
     <artifactId>helidon-examples-istio-project</artifactId>

--- a/examples/jbatch/pom.xml
+++ b/examples/jbatch/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.jbatch</groupId>

--- a/examples/logging/jul/pom.xml
+++ b/examples/logging/jul/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/log4j/pom.xml
+++ b/examples/logging/log4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/logback-aot/pom.xml
+++ b/examples/logging/logback-aot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/logging/pom.xml
+++ b/examples/logging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>
     <artifactId>helidon-examples-logging-project</artifactId>

--- a/examples/logging/slf4j/pom.xml
+++ b/examples/logging/slf4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.logging</groupId>

--- a/examples/media/multipart/pom.xml
+++ b/examples/media/multipart/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.media</groupId>

--- a/examples/media/pom.xml
+++ b/examples/media/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.media</groupId>
     <artifactId>helidon-examples-media-project</artifactId>

--- a/examples/messaging/jms-websocket-mp/pom.xml
+++ b/examples/messaging/jms-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.jms</groupId>

--- a/examples/messaging/jms-websocket-se/pom.xml
+++ b/examples/messaging/jms-websocket-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.jms</groupId>

--- a/examples/messaging/kafka-websocket-mp/pom.xml
+++ b/examples/messaging/kafka-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.messaging.mp</groupId>

--- a/examples/messaging/kafka-websocket-se/pom.xml
+++ b/examples/messaging/kafka-websocket-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.messaging.se</groupId>

--- a/examples/messaging/oracle-aq-websocket-mp/pom.xml
+++ b/examples/messaging/oracle-aq-websocket-mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.messaging.aq</groupId>

--- a/examples/messaging/pom.xml
+++ b/examples/messaging/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.messaging</groupId>
     <artifactId>helidon-examples-messaging-project</artifactId>

--- a/examples/metrics/exemplar/pom.xml
+++ b/examples/metrics/exemplar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/filtering/mp/pom.xml
+++ b/examples/metrics/filtering/mp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/filtering/pom.xml
+++ b/examples/metrics/filtering/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-examples-metrics-project</artifactId>
         <groupId>io.helidon.examples</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/examples/metrics/filtering/se/pom.xml
+++ b/examples/metrics/filtering/se/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/http-status-count-se/pom.xml
+++ b/examples/metrics/http-status-count-se/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/metrics/kpi/pom.xml
+++ b/examples/metrics/kpi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/pom.xml
+++ b/examples/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-examples-project</artifactId>
         <groupId>io.helidon.examples</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/examples/microprofile/bean-validation/pom.xml
+++ b/examples/microprofile/bean-validation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/cors/pom.xml
+++ b/examples/microprofile/cors/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/graphql/pom.xml
+++ b/examples/microprofile/graphql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-examples-microprofile-hello-world-explicit</artifactId>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/http-status-count-mp/pom.xml
+++ b/examples/microprofile/http-status-count-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>
@@ -34,7 +34,7 @@
     <name>Helidon Examples Metrics HTTP Status Counters</name>
 
     <properties>
-        <helidon.version>2.6.5-SNAPSHOT</helidon.version>
+        <helidon.version>2.6.6-SNAPSHOT</helidon.version>
     </properties>
 
     <dependencies>

--- a/examples/microprofile/idcs/pom.xml
+++ b/examples/microprofile/idcs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/lra/pom.xml
+++ b/examples/microprofile/lra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/messaging-sse/pom.xml
+++ b/examples/microprofile/messaging-sse/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/multipart/pom.xml
+++ b/examples/microprofile/multipart/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/multiport/pom.xml
+++ b/examples/microprofile/multiport/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/oidc/pom.xml
+++ b/examples/microprofile/oidc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/pom.xml
+++ b/examples/microprofile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/security/pom.xml
+++ b/examples/microprofile/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/static-content/pom.xml
+++ b/examples/microprofile/static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/microprofile/tls/pom.xml
+++ b/examples/microprofile/tls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
 

--- a/examples/microprofile/websocket/pom.xml
+++ b/examples/microprofile/websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.microprofile</groupId>

--- a/examples/openapi-tools/pom.xml
+++ b/examples/openapi-tools/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.examples.openapi.tools</groupId>

--- a/examples/openapi-tools/quickstart-mp/mp-client/pom.xml
+++ b/examples/openapi-tools/quickstart-mp/mp-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <artifactId>openapi-mp-client</artifactId>

--- a/examples/openapi-tools/quickstart-mp/mp-server/pom.xml
+++ b/examples/openapi-tools/quickstart-mp/mp-server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <artifactId>openapi-mp-server</artifactId>

--- a/examples/openapi-tools/quickstart-mp/pom.xml
+++ b/examples/openapi-tools/quickstart-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples.openapi.tools</groupId>
         <artifactId>helidon-examples-openapi-tools-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <artifactId>helidon-examples-openapi-tools-quickstart-mp</artifactId>

--- a/examples/openapi-tools/quickstart-se/pom.xml
+++ b/examples/openapi-tools/quickstart-se/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples.openapi.tools</groupId>
         <artifactId>helidon-examples-openapi-tools-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <artifactId>helidon-examples-openapi-tools-quickstart-se</artifactId>

--- a/examples/openapi-tools/quickstart-se/se-client/pom.xml
+++ b/examples/openapi-tools/quickstart-se/se-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <artifactId>openapi-se-client</artifactId>

--- a/examples/openapi-tools/quickstart-se/se-server/pom.xml
+++ b/examples/openapi-tools/quickstart-se/se-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>org.openapitools</groupId>

--- a/examples/openapi/pom.xml
+++ b/examples/openapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples</groupId>
     <artifactId>helidon-examples-project</artifactId>

--- a/examples/quickstarts/helidon-quickstart-mp/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/build.gradle
@@ -32,7 +32,7 @@ tasks.withType(JavaCompile) {
 }
 
 ext {
-    helidonversion = '2.6.5-SNAPSHOT'
+    helidonversion = '2.6.6-SNAPSHOT'
     mainClass='io.helidon.microprofile.cdi.Main'
 }
 

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>

--- a/examples/quickstarts/helidon-quickstart-se/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/build.gradle
@@ -31,7 +31,7 @@ tasks.withType(JavaCompile) {
 }
 
 ext {
-    helidonversion = '2.6.5-SNAPSHOT'
+    helidonversion = '2.6.6-SNAPSHOT'
     mainClass='io.helidon.examples.quickstart.se.Main'
 }
 

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples</groupId>
     <artifactId>helidon-quickstart-se</artifactId>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
     <name>Helidon Quickstart SE Example</name>
 
     <properties>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -22,11 +22,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon.examples.quickstarts</groupId>
     <artifactId>helidon-standalone-quickstart-mp</artifactId>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
     <name>Helidon Standalone Quickstart MP Example</name>
 
     <properties>
-        <helidon.version>2.6.5-SNAPSHOT</helidon.version>
+        <helidon.version>2.6.6-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.microprofile.cdi.Main</mainClass>
 
         <maven.compiler.source>11</maven.compiler.source>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -22,11 +22,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon.examples.quickstarts</groupId>
     <artifactId>helidon-standalone-quickstart-se</artifactId>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
     <name>Helidon Standalone Quickstart SE Example</name>
 
     <properties>
-        <helidon.version>2.6.5-SNAPSHOT</helidon.version>
+        <helidon.version>2.6.6-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.examples.quickstart.se.Main</mainClass>
 
         <maven.compiler.source>11</maven.compiler.source>

--- a/examples/quickstarts/pom.xml
+++ b/examples/quickstarts/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.quickstarts</groupId>
     <artifactId>examples-quickstarts-project</artifactId>

--- a/examples/security/attribute-based-access-control/pom.xml
+++ b/examples/security/attribute-based-access-control/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/basic-auth-with-static-content/pom.xml
+++ b/examples/security/basic-auth-with-static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/google-login/pom.xml
+++ b/examples/security/google-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/idcs-login/pom.xml
+++ b/examples/security/idcs-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/jersey/pom.xml
+++ b/examples/security/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/nohttp-programmatic/pom.xml
+++ b/examples/security/nohttp-programmatic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/outbound-override/pom.xml
+++ b/examples/security/outbound-override/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/pom.xml
+++ b/examples/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.security</groupId>
     <artifactId>helidon-examples-security-project</artifactId>

--- a/examples/security/spi-examples/pom.xml
+++ b/examples/security/spi-examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/vaults/pom.xml
+++ b/examples/security/vaults/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/webserver-digest-auth/pom.xml
+++ b/examples/security/webserver-digest-auth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/security/webserver-signatures/pom.xml
+++ b/examples/security/webserver-signatures/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.security</groupId>

--- a/examples/todo-app/backend/pom.xml
+++ b/examples/todo-app/backend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.todos</groupId>

--- a/examples/todo-app/frontend/pom.xml
+++ b/examples/todo-app/frontend/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.todo</groupId>

--- a/examples/todo-app/pom.xml
+++ b/examples/todo-app/pom.xml
@@ -24,13 +24,13 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.examples.todos</groupId>
     <artifactId>example-todo-app-project</artifactId>
     <packaging>pom</packaging>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
     <name>Helidon Examples TODO Demo</name>
 
     <description>

--- a/examples/translator-app/backend/pom.xml
+++ b/examples/translator-app/backend/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>
     <artifactId>helidon-examples-translator-backend</artifactId>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
     <name>Helidon Examples Translator Backend</name>
 
     <description>

--- a/examples/translator-app/frontend/pom.xml
+++ b/examples/translator-app/frontend/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>
     <artifactId>helidon-examples-translator-frontend</artifactId>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
     <name>Helidon Examples Translator Frontend</name>
 
     <description>

--- a/examples/translator-app/pom.xml
+++ b/examples/translator-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.translator</groupId>
     <artifactId>helidon-examples-translator-project</artifactId>

--- a/examples/webclient/pom.xml
+++ b/examples/webclient/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.examples.webclient</groupId>

--- a/examples/webclient/standalone/pom.xml
+++ b/examples/webclient/standalone/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/webserver/basics/pom.xml
+++ b/examples/webserver/basics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/comment-aas/pom.xml
+++ b/examples/webserver/comment-aas/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/fault-tolerance/pom.xml
+++ b/examples/webserver/fault-tolerance/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/webserver/jersey/pom.xml
+++ b/examples/webserver/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/multiport/pom.xml
+++ b/examples/webserver/multiport/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/mutual-tls/pom.xml
+++ b/examples/webserver/mutual-tls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/opentracing/pom.xml
+++ b/examples/webserver/opentracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/pom.xml
+++ b/examples/webserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.examples</groupId>
         <artifactId>helidon-examples-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>
     <artifactId>helidon-examples-webserver-project</artifactId>

--- a/examples/webserver/static-content/pom.xml
+++ b/examples/webserver/static-content/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/streaming/pom.xml
+++ b/examples/webserver/streaming/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/threadpool/pom.xml
+++ b/examples/webserver/threadpool/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/tls/pom.xml
+++ b/examples/webserver/tls/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/examples/webserver/tutorial/pom.xml
+++ b/examples/webserver/tutorial/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/examples/webserver/websocket/pom.xml
+++ b/examples/webserver/websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.examples.webserver</groupId>

--- a/fault-tolerance/pom.xml
+++ b/fault-tolerance/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.fault-tolerance</groupId>

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>helidon-project</artifactId>
         <groupId>io.helidon</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.graphql</groupId>

--- a/graphql/server/pom.xml
+++ b/graphql/server/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.graphql</groupId>
         <artifactId>helidon-graphql-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-graphql-server</artifactId>

--- a/grpc/client/pom.xml
+++ b/grpc/client/pom.xml
@@ -25,7 +25,7 @@
     <parent>
       <groupId>io.helidon.grpc</groupId>
       <artifactId>helidon-grpc-project</artifactId>
-      <version>2.6.5-SNAPSHOT</version>
+      <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-grpc-client</artifactId>

--- a/grpc/core/pom.xml
+++ b/grpc/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-grpc-core</artifactId>

--- a/grpc/io.grpc/pom.xml
+++ b/grpc/io.grpc/pom.xml
@@ -47,4 +47,30 @@
             <artifactId>grpc-core</artifactId>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>empty-javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.build.directory}/javadoc</classesDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/grpc/io.grpc/pom.xml
+++ b/grpc/io.grpc/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.grpc</artifactId>

--- a/grpc/metrics/pom.xml
+++ b/grpc/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-grpc-metrics</artifactId>

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>helidon-project</artifactId>
         <groupId>io.helidon</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.grpc</groupId>

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-grpc-server</artifactId>

--- a/health/common/pom.xml
+++ b/health/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-health-project</artifactId>
         <groupId>io.helidon.health</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/health/health-checks/pom.xml
+++ b/health/health-checks/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.health</groupId>
         <artifactId>helidon-health-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-health-checks</artifactId>

--- a/health/health/pom.xml
+++ b/health/health/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-health-project</artifactId>
         <groupId>io.helidon.health</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/integrations/cdi/common-cdi/delegates/pom.xml
+++ b/integrations/cdi/common-cdi/delegates/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-delegates</artifactId>
     <name>Helidon CDI Integrations Common Delegates</name>

--- a/integrations/cdi/common-cdi/pom.xml
+++ b/integrations/cdi/common-cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-common-project</artifactId>
     <packaging>pom</packaging>

--- a/integrations/cdi/common-cdi/reference-counted-context/pom.xml
+++ b/integrations/cdi/common-cdi/reference-counted-context/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-reference-counted-context</artifactId>
     <name>Helidon CDI Integrations Common Reference Counted Context</name>

--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
     <name>Helidon CDI Integrations HikariCP DataSource</name>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-datasource-ucp</artifactId>
     <name>Helidon CDI Integrations UCP DataSource</name>

--- a/integrations/cdi/datasource/pom.xml
+++ b/integrations/cdi/datasource/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-datasource</artifactId>
     <name>Helidon CDI Integrations DataSource</name>

--- a/integrations/cdi/eclipselink-cdi/pom.xml
+++ b/integrations/cdi/eclipselink-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-eclipselink</artifactId>
     <name>Helidon CDI Integrations Eclipselink</name>

--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-hibernate</artifactId>
     <name>Helidon CDI Integrations Hibernate</name>

--- a/integrations/cdi/jedis-cdi/pom.xml
+++ b/integrations/cdi/jedis-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jedis</artifactId>
     <name>Helidon CDI Integrations Jedis</name>

--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jpa</artifactId>
     <name>Helidon CDI Integrations JPA</name>

--- a/integrations/cdi/jta-cdi/pom.xml
+++ b/integrations/cdi/jta-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jta</artifactId>
     <name>Helidon CDI Integrations JTA</name>

--- a/integrations/cdi/jta-weld/pom.xml
+++ b/integrations/cdi/jta-weld/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-jta-weld</artifactId>
     <name>Helidon CDI Integrations JTA Weld</name>

--- a/integrations/cdi/oci-objectstorage-cdi/pom.xml
+++ b/integrations/cdi/oci-objectstorage-cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
         <artifactId>helidon-integrations-cdi-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-oci-objectstorage</artifactId>
     <name>Helidon CDI Integrations OCI Object Storage</name>

--- a/integrations/cdi/pom.xml
+++ b/integrations/cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.integrations.cdi</groupId>
     <artifactId>helidon-integrations-cdi-project</artifactId>

--- a/integrations/common/pom.xml
+++ b/integrations/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/integrations/common/rest/pom.xml
+++ b/integrations/common/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.common</groupId>
         <artifactId>helidon-integrations-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-common-rest</artifactId>

--- a/integrations/db/h2/pom.xml
+++ b/integrations/db/h2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.db</groupId>
         <artifactId>helidon-integrations-db-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>h2</artifactId>

--- a/integrations/db/mysql/pom.xml
+++ b/integrations/db/mysql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.db</groupId>
         <artifactId>helidon-integrations-db-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-db-mysql</artifactId>

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.db</groupId>
         <artifactId>helidon-integrations-db-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>ojdbc</artifactId>

--- a/integrations/db/pgsql/pom.xml
+++ b/integrations/db/pgsql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.db</groupId>
         <artifactId>helidon-integrations-db-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-db-pgsql</artifactId>

--- a/integrations/db/pom.xml
+++ b/integrations/db/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/integrations/graal/mp-native-image-extension/pom.xml
+++ b/integrations/graal/mp-native-image-extension/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.integrations.graal</groupId>
         <artifactId>helidon-integrations-graal-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/graal/native-image-extension/pom.xml
+++ b/integrations/graal/native-image-extension/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.integrations.graal</groupId>
         <artifactId>helidon-integrations-graal-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/graal/pom.xml
+++ b/integrations/graal/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/integrations/jdbc/jdbc/pom.xml
+++ b/integrations/jdbc/jdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-jdbc-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.jdbc</groupId>

--- a/integrations/jdbc/pom.xml
+++ b/integrations/jdbc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/integrations/jta/jdbc/pom.xml
+++ b/integrations/jta/jdbc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-jta-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.jta</groupId>

--- a/integrations/jta/pom.xml
+++ b/integrations/jta/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/integrations/micrometer/cdi/pom.xml
+++ b/integrations/micrometer/cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-micrometer-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.micrometer</groupId>

--- a/integrations/micrometer/micrometer/pom.xml
+++ b/integrations/micrometer/micrometer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-micrometer-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.micrometer</groupId>

--- a/integrations/micrometer/pom.xml
+++ b/integrations/micrometer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-micrometer-project</artifactId>
     <name>Helidon Integrations Micrometer Project</name>

--- a/integrations/micronaut/cdi-processor/pom.xml
+++ b/integrations/micronaut/cdi-processor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.micronaut</groupId>
         <artifactId>helidon-integrations-micronaut-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-micronaut-cdi-processor</artifactId>

--- a/integrations/micronaut/cdi/pom.xml
+++ b/integrations/micronaut/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.micronaut</groupId>
         <artifactId>helidon-integrations-micronaut-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-micronaut-cdi</artifactId>

--- a/integrations/micronaut/data/pom.xml
+++ b/integrations/micronaut/data/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.micronaut</groupId>
         <artifactId>helidon-integrations-micronaut-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-micronaut-data</artifactId>

--- a/integrations/micronaut/pom.xml
+++ b/integrations/micronaut/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.micronaut</groupId>

--- a/integrations/microstream/cache/pom.xml
+++ b/integrations/microstream/cache/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.microstream</groupId>
         <artifactId>helidon-integrations-microstream-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-microstream-cache</artifactId>

--- a/integrations/microstream/cdi/pom.xml
+++ b/integrations/microstream/cdi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.microstream</groupId>
         <artifactId>helidon-integrations-microstream-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-microstream-cdi</artifactId>

--- a/integrations/microstream/core/pom.xml
+++ b/integrations/microstream/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.microstream</groupId>
         <artifactId>helidon-integrations-microstream-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-microstream</artifactId>

--- a/integrations/microstream/health/pom.xml
+++ b/integrations/microstream/health/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.microstream</groupId>
         <artifactId>helidon-integrations-microstream-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-microstream-health</artifactId>

--- a/integrations/microstream/metrics/pom.xml
+++ b/integrations/microstream/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.microstream</groupId>
         <artifactId>helidon-integrations-microstream-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-microstream-metrics</artifactId>

--- a/integrations/microstream/pom.xml
+++ b/integrations/microstream/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.microstream</groupId>

--- a/integrations/neo4j/health/pom.xml
+++ b/integrations/neo4j/health/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.neo4j</groupId>
         <artifactId>helidon-integrations-neo4j-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-neo4j-health</artifactId>

--- a/integrations/neo4j/metrics/pom.xml
+++ b/integrations/neo4j/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.integrations.neo4j</groupId>
         <artifactId>helidon-integrations-neo4j-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-neo4j-metrics</artifactId>

--- a/integrations/neo4j/neo4j/pom.xml
+++ b/integrations/neo4j/neo4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.neo4j</groupId>
         <artifactId>helidon-integrations-neo4j-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-neo4j</artifactId>

--- a/integrations/neo4j/pom.xml
+++ b/integrations/neo4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.integrations.neo4j</groupId>
     <artifactId>helidon-integrations-neo4j-project</artifactId>

--- a/integrations/oci/atp/pom.xml
+++ b/integrations/oci/atp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-oci-atp</artifactId>

--- a/integrations/oci/cdi/pom.xml
+++ b/integrations/oci/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-oci-cdi</artifactId>

--- a/integrations/oci/connect/pom.xml
+++ b/integrations/oci/connect/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-oci-connect</artifactId>

--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci.metrics</groupId>
         <artifactId>helidon-integrations-oci-metrics-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-oci-metrics-cdi</artifactId>
     <name>Helidon Integrations OCI Metrics CDI</name>

--- a/integrations/oci/metrics/metrics/pom.xml
+++ b/integrations/oci/metrics/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci.metrics</groupId>
         <artifactId>helidon-integrations-oci-metrics-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-oci-metrics</artifactId>
     <name>Helidon Integrations OCI Metrics</name>

--- a/integrations/oci/metrics/pom.xml
+++ b/integrations/oci/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.integrations.oci.metrics</groupId>
     <artifactId>helidon-integrations-oci-metrics-project</artifactId>

--- a/integrations/oci/objectstorage-health/pom.xml
+++ b/integrations/oci/objectstorage-health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-oci-objectstorage-health</artifactId>

--- a/integrations/oci/objectstorage/pom.xml
+++ b/integrations/oci/objectstorage/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-oci-objectstorage</artifactId>

--- a/integrations/oci/pom.xml
+++ b/integrations/oci/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.oci</groupId>

--- a/integrations/oci/sdk/cdi/pom.xml
+++ b/integrations/oci/sdk/cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci.sdk</groupId>
         <artifactId>helidon-integrations-oci-sdk-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-oci-sdk-cdi</artifactId>
     <name>Helidon Integrations OCI SDK CDI</name>

--- a/integrations/oci/sdk/pom.xml
+++ b/integrations/oci/sdk/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.integrations.oci.sdk</groupId>

--- a/integrations/oci/telemetry/pom.xml
+++ b/integrations/oci/telemetry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-oci-telemetry</artifactId>

--- a/integrations/oci/vault-health/pom.xml
+++ b/integrations/oci/vault-health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-oci-vault-health</artifactId>

--- a/integrations/oci/vault/pom.xml
+++ b/integrations/oci/vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.oci</groupId>
         <artifactId>helidon-integrations-oci-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-oci-vault</artifactId>

--- a/integrations/openapi-ui/pom.xml
+++ b/integrations/openapi-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.openapi-ui</groupId>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.integrations</groupId>
     <artifactId>helidon-integrations-project</artifactId>

--- a/integrations/vault/auths/approle/pom.xml
+++ b/integrations/vault/auths/approle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.auths</groupId>
         <artifactId>helidon-integrations-vault-auths-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-auths-approle</artifactId>

--- a/integrations/vault/auths/common/pom.xml
+++ b/integrations/vault/auths/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.auths</groupId>
         <artifactId>helidon-integrations-vault-auths-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-auths-common</artifactId>

--- a/integrations/vault/auths/k8s/pom.xml
+++ b/integrations/vault/auths/k8s/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.auths</groupId>
         <artifactId>helidon-integrations-vault-auths-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-auths-k8s</artifactId>

--- a/integrations/vault/auths/pom.xml
+++ b/integrations/vault/auths/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault</groupId>
         <artifactId>helidon-integrations-vault-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/integrations/vault/auths/token/pom.xml
+++ b/integrations/vault/auths/token/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.auths</groupId>
         <artifactId>helidon-integrations-vault-auths-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-auths-token</artifactId>

--- a/integrations/vault/cdi/pom.xml
+++ b/integrations/vault/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault</groupId>
         <artifactId>helidon-integrations-vault-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-cdi</artifactId>

--- a/integrations/vault/pom.xml
+++ b/integrations/vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations</groupId>
         <artifactId>helidon-integrations-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.integrations.vault</groupId>

--- a/integrations/vault/secrets/cubbyhole/pom.xml
+++ b/integrations/vault/secrets/cubbyhole/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.secrets</groupId>
         <artifactId>helidon-integrations-vault-secrets-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-secrets-cubbyhole</artifactId>

--- a/integrations/vault/secrets/database/pom.xml
+++ b/integrations/vault/secrets/database/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.secrets</groupId>
         <artifactId>helidon-integrations-vault-secrets-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-secrets-database</artifactId>

--- a/integrations/vault/secrets/kv1/pom.xml
+++ b/integrations/vault/secrets/kv1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.secrets</groupId>
         <artifactId>helidon-integrations-vault-secrets-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-secrets-kv1</artifactId>

--- a/integrations/vault/secrets/kv2/pom.xml
+++ b/integrations/vault/secrets/kv2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.secrets</groupId>
         <artifactId>helidon-integrations-vault-secrets-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-secrets-kv2</artifactId>

--- a/integrations/vault/secrets/pki/pom.xml
+++ b/integrations/vault/secrets/pki/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.secrets</groupId>
         <artifactId>helidon-integrations-vault-secrets-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-secrets-pki</artifactId>

--- a/integrations/vault/secrets/pom.xml
+++ b/integrations/vault/secrets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault</groupId>
         <artifactId>helidon-integrations-vault-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/integrations/vault/secrets/transit/pom.xml
+++ b/integrations/vault/secrets/transit/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault.secrets</groupId>
         <artifactId>helidon-integrations-vault-secrets-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault-secrets-transit</artifactId>

--- a/integrations/vault/sys/pom.xml
+++ b/integrations/vault/sys/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault</groupId>
         <artifactId>helidon-integrations-vault-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/integrations/vault/sys/sys/pom.xml
+++ b/integrations/vault/sys/sys/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-integrations-vault-sys-project</artifactId>
         <groupId>io.helidon.integrations.vault.sys</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/vault/vault/pom.xml
+++ b/integrations/vault/vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.integrations.vault</groupId>
         <artifactId>helidon-integrations-vault-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-integrations-vault</artifactId>

--- a/jersey/client/pom.xml
+++ b/jersey/client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.jersey</groupId>
         <artifactId>helidon-jersey-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jersey/common/pom.xml
+++ b/jersey/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-jersey-project</artifactId>
         <groupId>io.helidon.jersey</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jersey/connector/pom.xml
+++ b/jersey/connector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-jersey-project</artifactId>
         <groupId>io.helidon.jersey</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jersey/jsonp/pom.xml
+++ b/jersey/jsonp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-jersey-project</artifactId>
         <groupId>io.helidon.jersey</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jersey/pom.xml
+++ b/jersey/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-project</artifactId>
         <groupId>io.helidon</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/jersey/server/pom.xml
+++ b/jersey/server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.jersey</groupId>
         <artifactId>helidon-jersey-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-jersey-server</artifactId>

--- a/licensing/pom.xml
+++ b/licensing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.licensing</groupId>
     <artifactId>helidon-licensing</artifactId>

--- a/logging/common/pom.xml
+++ b/logging/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-logging-project</artifactId>
         <groupId>io.helidon.logging</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-logging-common</artifactId>

--- a/logging/jul/pom.xml
+++ b/logging/jul/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>helidon-logging-project</artifactId>
         <groupId>io.helidon.logging</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/logging/log4j/pom.xml
+++ b/logging/log4j/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>helidon-logging-project</artifactId>
         <groupId>io.helidon.logging</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-project</artifactId>
         <groupId>io.helidon</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.logging</groupId>

--- a/logging/slf4j/pom.xml
+++ b/logging/slf4j/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-logging-project</artifactId>
         <groupId>io.helidon.logging</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-logging-slf4j</artifactId>

--- a/lra/coordinator/client/narayana-client/pom.xml
+++ b/lra/coordinator/client/narayana-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.lra</groupId>
         <artifactId>helidon-lra-coordinator-client-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-lra-coordinator-narayana-client</artifactId>

--- a/lra/coordinator/client/pom.xml
+++ b/lra/coordinator/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.lra</groupId>
         <artifactId>helidon-lra-coordinator-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.lra</groupId>
     <artifactId>helidon-lra-coordinator-client-project</artifactId>

--- a/lra/coordinator/client/spi/pom.xml
+++ b/lra/coordinator/client/spi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.lra</groupId>
         <artifactId>helidon-lra-coordinator-client-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-lra-coordinator-client-spi</artifactId>

--- a/lra/coordinator/pom.xml
+++ b/lra/coordinator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.lra</groupId>
         <artifactId>helidon-lra-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.lra</groupId>
     <artifactId>helidon-lra-coordinator-project</artifactId>

--- a/lra/coordinator/server/pom.xml
+++ b/lra/coordinator/server/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
 

--- a/lra/pom.xml
+++ b/lra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.lra</groupId>
     <artifactId>helidon-lra-project</artifactId>

--- a/media/common/pom.xml
+++ b/media/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/media/jackson/pom.xml
+++ b/media/jackson/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-media-jackson</artifactId>

--- a/media/jsonb/pom.xml
+++ b/media/jsonb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-media-jsonb</artifactId>

--- a/media/jsonp/pom.xml
+++ b/media/jsonp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-media-jsonp</artifactId>

--- a/media/multipart/pom.xml
+++ b/media/multipart/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.media</groupId>
         <artifactId>helidon-media-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-media-multipart</artifactId>
     <name>Helidon Media MultiPart</name>

--- a/media/pom.xml
+++ b/media/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.media</groupId>

--- a/messaging/connectors/aq/pom.xml
+++ b/messaging/connectors/aq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.messaging</groupId>
         <artifactId>helidon-messaging-connectors-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.messaging.aq</groupId>

--- a/messaging/connectors/jms/pom.xml
+++ b/messaging/connectors/jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.messaging</groupId>
         <artifactId>helidon-messaging-connectors-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.messaging.jms</groupId>

--- a/messaging/connectors/pom.xml
+++ b/messaging/connectors/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.messaging</groupId>
         <artifactId>helidon-messaging-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-messaging-connectors-project</artifactId>
     <name>Helidon Messaging Connectors Project</name>

--- a/messaging/kafka/pom.xml
+++ b/messaging/kafka/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.messaging</groupId>
         <artifactId>helidon-messaging-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.messaging.kafka</groupId>

--- a/messaging/messaging/pom.xml
+++ b/messaging/messaging/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.messaging</groupId>
         <artifactId>helidon-messaging-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-messaging</artifactId>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.messaging</groupId>
     <artifactId>helidon-messaging-project</artifactId>

--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/metrics/jaeger/pom.xml
+++ b/metrics/jaeger/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-metrics-jaeger</artifactId>

--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-metrics</artifactId>
     <name>Helidon Metrics</name>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.metrics</groupId>

--- a/metrics/prometheus/pom.xml
+++ b/metrics/prometheus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-metrics-prometheus</artifactId>
     <name>Helidon Metrics Prometheus</name>

--- a/metrics/service-api/pom.xml
+++ b/metrics/service-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-metrics-service-api</artifactId>
     <name>Helidon Metrics Web Support API</name>

--- a/metrics/trace-exemplar/pom.xml
+++ b/metrics/trace-exemplar/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-metrics-project</artifactId>
         <groupId>io.helidon.metrics</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/access-log/pom.xml
+++ b/microprofile/access-log/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-microprofile-project</artifactId>
         <groupId>io.helidon.microprofile</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/bean-validation/pom.xml
+++ b/microprofile/bean-validation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.bean-validation</groupId>
     <artifactId>helidon-microprofile-bean-validation</artifactId>

--- a/microprofile/bundles/helidon-microprofile-core/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-core</artifactId>
     <name>Helidon Microprofile Core Bundle</name>

--- a/microprofile/bundles/helidon-microprofile/pom.xml
+++ b/microprofile/bundles/helidon-microprofile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.bundles</groupId>
         <artifactId>bundles-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile</artifactId>
     <name>Helidon Microprofile Full Bundle</name>

--- a/microprofile/bundles/pom.xml
+++ b/microprofile/bundles/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.bundles</groupId>

--- a/microprofile/cdi/pom.xml
+++ b/microprofile/cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.cdi</groupId>

--- a/microprofile/config/pom.xml
+++ b/microprofile/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.config</groupId>
     <artifactId>helidon-microprofile-config</artifactId>

--- a/microprofile/cors/pom.xml
+++ b/microprofile/cors/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-cors</artifactId>

--- a/microprofile/fault-tolerance/pom.xml
+++ b/microprofile/fault-tolerance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-fault-tolerance</artifactId>
     <name>Helidon Microprofile Fault Tolerance</name>

--- a/microprofile/graphql/pom.xml
+++ b/microprofile/graphql/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/graphql/server/pom.xml
+++ b/microprofile/graphql/server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.microprofile.graphql</groupId>
         <artifactId>helidon-microprofile-graphql</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/grpc/client/pom.xml
+++ b/microprofile/grpc/client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.grpc</groupId>
         <artifactId>helidon-microprofile-grpc</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-grpc-client</artifactId>

--- a/microprofile/grpc/core/pom.xml
+++ b/microprofile/grpc/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.grpc</groupId>
         <artifactId>helidon-microprofile-grpc</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-grpc-core</artifactId>

--- a/microprofile/grpc/metrics/pom.xml
+++ b/microprofile/grpc/metrics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.grpc</groupId>
         <artifactId>helidon-microprofile-grpc</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-grpc-metrics</artifactId>

--- a/microprofile/grpc/pom.xml
+++ b/microprofile/grpc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.grpc</groupId>

--- a/microprofile/grpc/server/pom.xml
+++ b/microprofile/grpc/server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.grpc</groupId>
         <artifactId>helidon-microprofile-grpc</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-grpc-server</artifactId>

--- a/microprofile/health/pom.xml
+++ b/microprofile/health/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.health</groupId>
     <artifactId>helidon-microprofile-health</artifactId>

--- a/microprofile/jwt-auth/pom.xml
+++ b/microprofile/jwt-auth/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.jwt</groupId>

--- a/microprofile/lra/jax-rs/pom.xml
+++ b/microprofile/lra/jax-rs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.lra</groupId>
         <artifactId>helidon-microprofile-lra-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-lra</artifactId>

--- a/microprofile/lra/pom.xml
+++ b/microprofile/lra/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.lra</groupId>

--- a/microprofile/messaging/core/pom.xml
+++ b/microprofile/messaging/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.messaging</groupId>
         <artifactId>helidon-microprofile-messaging-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-messaging</artifactId>

--- a/microprofile/messaging/health/pom.xml
+++ b/microprofile/messaging/health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.messaging</groupId>
         <artifactId>helidon-microprofile-messaging-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-messaging-health</artifactId>

--- a/microprofile/messaging/pom.xml
+++ b/microprofile/messaging/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.messaging</groupId>

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.metrics</groupId>
     <artifactId>helidon-microprofile-metrics</artifactId>

--- a/microprofile/oidc/pom.xml
+++ b/microprofile/oidc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-oidc</artifactId>
     <name>Helidon Microprofile Security OIDC Integration</name>

--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.openapi</groupId>
     <artifactId>helidon-microprofile-openapi</artifactId>

--- a/microprofile/pom.xml
+++ b/microprofile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile</groupId>

--- a/microprofile/reactive-streams/pom.xml
+++ b/microprofile/reactive-streams/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.reactive-streams</groupId>

--- a/microprofile/rest-client/pom.xml
+++ b/microprofile/rest-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.rest-client</groupId>

--- a/microprofile/scheduling/pom.xml
+++ b/microprofile/scheduling/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.scheduling</groupId>

--- a/microprofile/security/pom.xml
+++ b/microprofile/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-security</artifactId>
     <name>Helidon Microprofile Security Integration</name>

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.server</groupId>
     <artifactId>helidon-microprofile-server</artifactId>

--- a/microprofile/tests/arquillian/pom.xml
+++ b/microprofile/tests/arquillian/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-arquillian</artifactId>
     <name>Helidon Microprofile Arquillian Integration</name>

--- a/microprofile/tests/junit5-tests/pom.xml
+++ b/microprofile/tests/junit5-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-microprofile-tests-junit5-tests</artifactId>

--- a/microprofile/tests/junit5/pom.xml
+++ b/microprofile/tests/junit5/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/microprofile/tests/pom.xml
+++ b/microprofile/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.tests</groupId>

--- a/microprofile/tests/tck/pom.xml
+++ b/microprofile/tests/tck/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/microprofile/tests/tck/tck-config/pom.xml
+++ b/microprofile/tests/tck/tck-config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>tck-config</artifactId>
     <name>Helidon Microprofile Tests TCK Config</name>

--- a/microprofile/tests/tck/tck-fault-tolerance/pom.xml
+++ b/microprofile/tests/tck/tck-fault-tolerance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>tck-fault-tolerance</artifactId>
     <name>Helidon Microprofile Tests TCK Fault Tolerance</name>

--- a/microprofile/tests/tck/tck-graphql/pom.xml
+++ b/microprofile/tests/tck/tck-graphql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>tck-graphql</artifactId>
     <name>Helidon Microprofile Tests TCK GraphQL</name>

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tests/tck/tck-jwt-auth/pom.xml
+++ b/microprofile/tests/tck/tck-jwt-auth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>tck-project</artifactId>
         <groupId>io.helidon.microprofile.tests</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>tck-jwt-auth</artifactId>
     <name>Helidon Microprofile Tests TCK JWT-Auth</name>

--- a/microprofile/tests/tck/tck-lra/pom.xml
+++ b/microprofile/tests/tck/tck-lra/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>tck-lra</artifactId>

--- a/microprofile/tests/tck/tck-messaging/pom.xml
+++ b/microprofile/tests/tck/tck-messaging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>tck-messaging</artifactId>
     <name>Helidon Microprofile Tests TCK Messaging</name>

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>tck-metrics</artifactId>
     <name>Helidon Microprofile Tests TCK Metrics</name>

--- a/microprofile/tests/tck/tck-openapi/pom.xml
+++ b/microprofile/tests/tck/tck-openapi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>tck-project</artifactId>
         <groupId>io.helidon.microprofile.tests</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>tck-opentracing</artifactId>
     <name>Helidon Microprofile Tests TCK Opentracing</name>

--- a/microprofile/tests/tck/tck-reactive-operators/pom.xml
+++ b/microprofile/tests/tck/tck-reactive-operators/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>tck-reactive-operators</artifactId>
     <name>Helidon Microprofile Tests TCK Reactive Streams Operators</name>

--- a/microprofile/tests/tck/tck-rest-client/pom.xml
+++ b/microprofile/tests/tck/tck-rest-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>tck-project</artifactId>
         <groupId>io.helidon.microprofile.tests</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tracing/pom.xml
+++ b/microprofile/tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-microprofile-project</artifactId>
         <groupId>io.helidon.microprofile</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.microprofile.tracing</groupId>
     <artifactId>helidon-microprofile-tracing</artifactId>

--- a/microprofile/websocket/pom.xml
+++ b/microprofile/websocket/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.microprofile.websocket</groupId>

--- a/microprofile/weld/pom.xml
+++ b/microprofile/weld/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/weld/weld-core-impl/pom.xml
+++ b/microprofile/weld/weld-core-impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.microprofile.weld</groupId>
         <artifactId>helidon-microprofile-weld-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/weld/weld-se-core/pom.xml
+++ b/microprofile/weld/weld-se-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.microprofile.weld</groupId>
         <artifactId>helidon-microprofile-weld-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.openapi</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.helidon</groupId>
     <artifactId>helidon-parent</artifactId>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Helidon Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-dependencies</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>./dependencies/pom.xml</relativePath>
     </parent>
     <artifactId>helidon-project</artifactId>

--- a/scheduling/pom.xml
+++ b/scheduling/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.scheduling</groupId>

--- a/security/abac/policy-el/pom.xml
+++ b/security/abac/policy-el/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-security-abac-policy-el</artifactId>

--- a/security/abac/policy/pom.xml
+++ b/security/abac/policy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-abac-policy</artifactId>
     <name>Helidon Security Validators Policy</name>

--- a/security/abac/pom.xml
+++ b/security/abac/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/security/abac/role/pom.xml
+++ b/security/abac/role/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-abac-role</artifactId>
     <name>Helidon Security Validators Role</name>

--- a/security/abac/scope/pom.xml
+++ b/security/abac/scope/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-abac-scope</artifactId>
     <name>Helidon Security Validators Scope</name>

--- a/security/abac/time/pom.xml
+++ b/security/abac/time/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.abac</groupId>
         <artifactId>helidon-security-abac-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-abac-time</artifactId>
     <name>Helidon Security Validators Time</name>

--- a/security/annotations/pom.xml
+++ b/security/annotations/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-annotations</artifactId>
     <name>Helidon Security Integration Annotations</name>

--- a/security/integration/common/pom.xml
+++ b/security/integration/common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-common</artifactId>
     <name>Helidon Security Integration Common</name>

--- a/security/integration/grpc/pom.xml
+++ b/security/integration/grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-grpc</artifactId>
     <name>Helidon Security Integration gRPC Server</name>

--- a/security/integration/jersey-client/pom.xml
+++ b/security/integration/jersey-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-jersey-client</artifactId>
     <name>Helidon Security Integration Jersey Client</name>

--- a/security/integration/jersey/pom.xml
+++ b/security/integration/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-jersey</artifactId>
     <name>Helidon Security Integration Jersey</name>

--- a/security/integration/pom.xml
+++ b/security/integration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/security/integration/webserver/pom.xml
+++ b/security/integration/webserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.integration</groupId>
         <artifactId>helidon-security-integration-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-integration-webserver</artifactId>
     <name>Helidon Security Integration Webserver</name>

--- a/security/jwt/pom.xml
+++ b/security/jwt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-jwt</artifactId>
     <name>Helidon Security JWT</name>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.security</groupId>

--- a/security/providers/abac/pom.xml
+++ b/security/providers/abac/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-abac</artifactId>
     <name>Helidon Security Providers ABAC</name>

--- a/security/providers/common/pom.xml
+++ b/security/providers/common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-common</artifactId>
     <name>Helidon Security Providers Common</name>

--- a/security/providers/config-vault/pom.xml
+++ b/security/providers/config-vault/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-config-vault</artifactId>
     <name>Helidon Security Providers Config Vault</name>

--- a/security/providers/google-login/pom.xml
+++ b/security/providers/google-login/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-google-login</artifactId>
     <name>Helidon Security Providers Google Login</name>

--- a/security/providers/header/pom.xml
+++ b/security/providers/header/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-header</artifactId>
     <name>Helidon Security Providers Header authentication</name>

--- a/security/providers/http-auth/pom.xml
+++ b/security/providers/http-auth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-http-auth</artifactId>
     <name>Helidon Security Providers HTTP Authentication</name>

--- a/security/providers/http-sign/pom.xml
+++ b/security/providers/http-sign/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-http-sign</artifactId>
     <name>Helidon Security Providers HTTP Signature</name>

--- a/security/providers/idcs-mapper/pom.xml
+++ b/security/providers/idcs-mapper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/security/providers/jwt/pom.xml
+++ b/security/providers/jwt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-providers-jwt</artifactId>
     <name>Helidon Security Providers JWT</name>

--- a/security/providers/oidc-common/pom.xml
+++ b/security/providers/oidc-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-security-providers-oidc-common</artifactId>

--- a/security/providers/oidc/pom.xml
+++ b/security/providers/oidc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.security.providers</groupId>
         <artifactId>helidon-security-providers-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-security-providers-oidc</artifactId>

--- a/security/providers/pom.xml
+++ b/security/providers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.security.providers</groupId>
     <artifactId>helidon-security-providers-project</artifactId>

--- a/security/security/pom.xml
+++ b/security/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security</artifactId>
     <name>Helidon Security</name>

--- a/security/util/pom.xml
+++ b/security/util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.security</groupId>
         <artifactId>helidon-security-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-util</artifactId>
     <name>Helidon Security Utilities</name>

--- a/service-common/pom.xml
+++ b/service-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.service-common</groupId>

--- a/service-common/rest-cdi/pom.xml
+++ b/service-common/rest-cdi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.service-common</groupId>
         <artifactId>helidon-service-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-common/rest/pom.xml
+++ b/service-common/rest/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.service-common</groupId>
         <artifactId>helidon-service-common-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.apps.bookstore.bookstore-mp</groupId>

--- a/tests/apps/bookstore/bookstore-se/pom.xml
+++ b/tests/apps/bookstore/bookstore-se/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.apps.bookstore.bookstore-se</groupId>

--- a/tests/apps/bookstore/common/pom.xml
+++ b/tests/apps/bookstore/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.apps.bookstore.common</groupId>

--- a/tests/apps/bookstore/pom.xml
+++ b/tests/apps/bookstore/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests.apps</groupId>
         <artifactId>helidon-tests-apps-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.apps.bookstore</groupId>

--- a/tests/apps/pom.xml
+++ b/tests/apps/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.apps</groupId>

--- a/tests/functional/bookstore/pom.xml
+++ b/tests/functional/bookstore/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tests.functional</groupId>
         <artifactId>helidon-tests-functional-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.tests.functional.bookstore</groupId>
     <artifactId>helidon-tests-functional-bookstore</artifactId>

--- a/tests/functional/config-profiles/pom.xml
+++ b/tests/functional/config-profiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.functional</groupId>
         <artifactId>helidon-tests-functional-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.tests.functional.configprofile</groupId>
     <artifactId>helidon-tests-functional-configprofile</artifactId>

--- a/tests/functional/context-propagation/pom.xml
+++ b/tests/functional/context-propagation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-functional-context-propagation</artifactId>

--- a/tests/functional/jax-rs-multiple-apps/pom.xml
+++ b/tests/functional/jax-rs-multiple-apps/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-functional-jax-rs-multiple-apps</artifactId>

--- a/tests/functional/jax-rs-subresource/pom.xml
+++ b/tests/functional/jax-rs-subresource/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-tests-functional-jax-rs-subresource</artifactId>
     <name>Helidon Functional Test: JAX-RS Subresources</name>

--- a/tests/functional/mp-compression/pom.xml
+++ b/tests/functional/mp-compression/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-tests-functional-mp-compression</artifactId>
     <name>Helidon Functional Test: HTTP compression</name>

--- a/tests/functional/mp-synthetic-app/pom.xml
+++ b/tests/functional/mp-synthetic-app/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-tests-functional-mp-synthetic-app</artifactId>
     <name>Helidon Functional Test: MP Synthetic Application</name>

--- a/tests/functional/multiport/pom.xml
+++ b/tests/functional/multiport/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-tests-functional-multiport</artifactId>
     <name>Helidon Functional Test: Multiport with MP</name>

--- a/tests/functional/param-converter-provider/pom.xml
+++ b/tests/functional/param-converter-provider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-param-converter-provider</artifactId>

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.functional</groupId>

--- a/tests/functional/request-scope-cdi/pom.xml
+++ b/tests/functional/request-scope-cdi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-functional-request-scope-cdi</artifactId>

--- a/tests/functional/request-scope/pom.xml
+++ b/tests/functional/request-scope/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-functional-project</artifactId>
         <groupId>io.helidon.tests.functional</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-functional-request-scope</artifactId>

--- a/tests/integration/config/gh-2171-yml/pom.xml
+++ b/tests/integration/config/gh-2171-yml/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration-config</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/config/gh-2171/pom.xml
+++ b/tests/integration/config/gh-2171/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration-config</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/config/hocon-mp/pom.xml
+++ b/tests/integration/config/hocon-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration-config</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-config-hocon-mp</artifactId>

--- a/tests/integration/config/pom.xml
+++ b/tests/integration/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/integration/dbclient/appl/pom.xml
+++ b/tests/integration/dbclient/appl/pom.xml
@@ -31,13 +31,13 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
 
     <groupId>io.helidon.tests.integration.dbclient</groupId>
     <artifactId>helidon-tests-integration-dbclient-appl</artifactId>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
     <name>Integration Tests: DB Client Application</name>
 
     <properties>

--- a/tests/integration/dbclient/common/pom.xml
+++ b/tests/integration/dbclient/common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.dbclient</groupId>
         <artifactId>helidon-tests-integration-dbclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/dbclient/jdbc/pom.xml
+++ b/tests/integration/dbclient/jdbc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.dbclient</groupId>
         <artifactId>helidon-tests-integration-dbclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/dbclient/mongodb/pom.xml
+++ b/tests/integration/dbclient/mongodb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.dbclient</groupId>
         <artifactId>helidon-tests-integration-dbclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/dbclient/pom.xml
+++ b/tests/integration/dbclient/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/gh-5792/pom.xml
+++ b/tests/integration/gh-5792/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>
     <artifactId>helidon-tests-integration-yaml-parsing</artifactId>
-    <version>2.6.5-SNAPSHOT</version>
+    <version>2.6.6-SNAPSHOT</version>
 
     <properties>
         <mainClass>io.helidon.tests.integration.yamlparsing.Main</mainClass>

--- a/tests/integration/health/mp-disabled/pom.xml
+++ b/tests/integration/health/mp-disabled/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration.health</groupId>

--- a/tests/integration/health/pom.xml
+++ b/tests/integration/health/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.tests.integration.health</groupId>
     <artifactId>helidon-tests-integration-health-project</artifactId>

--- a/tests/integration/jep290/check_f_f_ok/pom.xml
+++ b/tests/integration/jep290/check_f_f_ok/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-check_f_f_ok</artifactId>

--- a/tests/integration/jep290/check_f_f_w/pom.xml
+++ b/tests/integration/jep290/check_f_f_w/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-check_f_f_w</artifactId>

--- a/tests/integration/jep290/check_f_p_ok/pom.xml
+++ b/tests/integration/jep290/check_f_p_ok/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-check_f_p_ok</artifactId>

--- a/tests/integration/jep290/check_f_p_w/pom.xml
+++ b/tests/integration/jep290/check_f_p_w/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-check_f_p_w</artifactId>

--- a/tests/integration/jep290/pom.xml
+++ b/tests/integration/jep290/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.tests.integration.jep290</groupId>
     <artifactId>helidon-tests-integration-jep290-project</artifactId>

--- a/tests/integration/jep290/server_and_custom/pom.xml
+++ b/tests/integration/jep290/server_and_custom/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-server-and-custom</artifactId>

--- a/tests/integration/jep290/set_c_f_c/pom.xml
+++ b/tests/integration/jep290/set_c_f_c/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-set_c_f_c</artifactId>

--- a/tests/integration/jep290/set_c_f_d/pom.xml
+++ b/tests/integration/jep290/set_c_f_d/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-set_c_f_d</artifactId>

--- a/tests/integration/jep290/set_c_t_d/pom.xml
+++ b/tests/integration/jep290/set_c_t_d/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-set_c_t_d</artifactId>

--- a/tests/integration/jep290/set_f/pom.xml
+++ b/tests/integration/jep290/set_f/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-set_f</artifactId>

--- a/tests/integration/jep290/set_o/pom.xml
+++ b/tests/integration/jep290/set_o/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jep290</groupId>
         <artifactId>helidon-tests-integration-jep290-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-jep290-set_o</artifactId>

--- a/tests/integration/jms/pom.xml
+++ b/tests/integration/jms/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.integration.jms</groupId>

--- a/tests/integration/jpa/appl/pom.xml
+++ b/tests/integration/jpa/appl/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/jpa/model/pom.xml
+++ b/tests/integration/jpa/model/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jpa</groupId>
         <artifactId>helidon-tests-integration-jpa-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/jpa/pom.xml
+++ b/tests/integration/jpa/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/jpa/simple/pom.xml
+++ b/tests/integration/jpa/simple/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.jpa</groupId>
         <artifactId>helidon-tests-integration-jpa-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/kafka/pom.xml
+++ b/tests/integration/kafka/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.integration.kafka</groupId>

--- a/tests/integration/mp-bean-validation/pom.xml
+++ b/tests/integration/mp-bean-validation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/mp-gh-1538/pom.xml
+++ b/tests/integration/mp-gh-1538/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-gh-2421/pom.xml
+++ b/tests/integration/mp-gh-2421/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-gh-2461/pom.xml
+++ b/tests/integration/mp-gh-2461/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-gh-3246/pom.xml
+++ b/tests/integration/mp-gh-3246/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-gh-3974/pom.xml
+++ b/tests/integration/mp-gh-3974/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-gh-4123/pom.xml
+++ b/tests/integration/mp-gh-4123/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-gh-4654/pom.xml
+++ b/tests/integration/mp-gh-4654/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-graphql/pom.xml
+++ b/tests/integration/mp-graphql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/mp-grpc/pom.xml
+++ b/tests/integration/mp-grpc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/integration/mp-security-client/pom.xml
+++ b/tests/integration/mp-security-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/mp-ws-services/pom.xml
+++ b/tests/integration/mp-ws-services/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/native-image/mp-1/pom.xml
+++ b/tests/integration/native-image/mp-1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/native-image/mp-2/pom.xml
+++ b/tests/integration/native-image/mp-2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/native-image/mp-3/pom.xml
+++ b/tests/integration/native-image/mp-3/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/native-image/pom.xml
+++ b/tests/integration/native-image/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/tests/integration/native-image/se-1/pom.xml
+++ b/tests/integration/native-image/se-1/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/native-image/static-content/pom.xml
+++ b/tests/integration/native-image/static-content/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/oidc/pom.xml
+++ b/tests/integration/oidc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/restclient/pom.xml
+++ b/tests/integration/restclient/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/se-gh-6845/pom.xml
+++ b/tests/integration/se-gh-6845/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/integration/security/gh1487/pom.xml
+++ b/tests/integration/security/gh1487/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/security/gh2297/pom.xml
+++ b/tests/integration/security/gh2297/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/security/gh2455/pom.xml
+++ b/tests/integration/security/gh2455/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/security/path-params/pom.xml
+++ b/tests/integration/security/path-params/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/security/pom.xml
+++ b/tests/integration/security/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/integration/security/security-context-not-overridden/pom.xml
+++ b/tests/integration/security/security-context-not-overridden/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-security-context-not-overridden</artifactId>

--- a/tests/integration/security/security-response-mapper/pom.xml
+++ b/tests/integration/security/security-response-mapper/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/tools/client/pom.xml
+++ b/tests/integration/tools/client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.tools</groupId>
         <artifactId>helidon-tests-integration-tools-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/tools/example/pom.xml
+++ b/tests/integration/tools/example/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../../applications/se/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/tools/pom.xml
+++ b/tests/integration/tools/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/tools/service/pom.xml
+++ b/tests/integration/tools/service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.tools</groupId>
         <artifactId>helidon-tests-integration-tools-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/vault/mp/pom.xml
+++ b/tests/integration/vault/mp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.vault</groupId>
         <artifactId>helidon-tests-integration-vault-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-vault-mp</artifactId>

--- a/tests/integration/vault/pom.xml
+++ b/tests/integration/vault/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/tests/integration/vault/se/pom.xml
+++ b/tests/integration/vault/se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration.vault</groupId>
         <artifactId>helidon-tests-integration-vault-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-vault-se</artifactId>

--- a/tests/integration/webclient/pom.xml
+++ b/tests/integration/webclient/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/webserver/context-propagation/pom.xml
+++ b/tests/integration/webserver/context-propagation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-tests-integration-webserver</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/webserver/gh2631/pom.xml
+++ b/tests/integration/webserver/gh2631/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>helidon-tests-integration-webserver</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/webserver/pom.xml
+++ b/tests/integration/webserver/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/integration/zipkin-mp-2.2/pom.xml
+++ b/tests/integration/zipkin-mp-2.2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
         <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.tests</groupId>

--- a/tests/tck/pom.xml
+++ b/tests/tck/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/tests/tck/tck-reactive-streams/pom.xml
+++ b/tests/tck/tck-reactive-streams/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>tck-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tck-reactive-streams</artifactId>

--- a/tracing/config/pom.xml
+++ b/tracing/config/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-config</artifactId>

--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-jaeger</artifactId>

--- a/tracing/jersey-client/pom.xml
+++ b/tracing/jersey-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-jersey-client</artifactId>

--- a/tracing/jersey/pom.xml
+++ b/tracing/jersey/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-jersey</artifactId>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.tracing</groupId>

--- a/tracing/tests/it-tracing-client-zipkin/pom.xml
+++ b/tracing/tests/it-tracing-client-zipkin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-tests</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-tests-it1</artifactId>

--- a/tracing/tests/pom.xml
+++ b/tracing/tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tracing/tracer-resolver/pom.xml
+++ b/tracing/tracer-resolver/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-tracer-resolver</artifactId>

--- a/tracing/tracing/pom.xml
+++ b/tracing/tracing/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing</artifactId>

--- a/tracing/zipkin/pom.xml
+++ b/tracing/zipkin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.tracing</groupId>
         <artifactId>helidon-tracing-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tracing-zipkin</artifactId>

--- a/webclient/context-propagation/pom.xml
+++ b/webclient/context-propagation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-webclient-project</artifactId>
         <groupId>io.helidon.webclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webclient/jaxrs/pom.xml
+++ b/webclient/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-webclient-project</artifactId>
         <groupId>io.helidon.webclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webclient/metrics/pom.xml
+++ b/webclient/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-webclient-project</artifactId>
         <groupId>io.helidon.webclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webclient/pom.xml
+++ b/webclient/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <groupId>io.helidon.webclient</groupId>

--- a/webclient/security/pom.xml
+++ b/webclient/security/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-webclient-project</artifactId>
         <groupId>io.helidon.webclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webclient/tracing/pom.xml
+++ b/webclient/tracing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>helidon-webclient-project</artifactId>
         <groupId>io.helidon.webclient</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webclient/webclient/pom.xml
+++ b/webclient/webclient/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webclient</groupId>
         <artifactId>helidon-webclient-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-webclient</artifactId>

--- a/webserver/access-log/pom.xml
+++ b/webserver/access-log/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-webserver-project</artifactId>
         <groupId>io.helidon.webserver</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webserver/context-propagation/pom.xml
+++ b/webserver/context-propagation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-webserver-context-propagation</artifactId>

--- a/webserver/cors/pom.xml
+++ b/webserver/cors/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-webserver-cors</artifactId>

--- a/webserver/jersey/pom.xml
+++ b/webserver/jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-webserver-jersey</artifactId>
     <name>Helidon WebServer Jersey</name>

--- a/webserver/pom.xml
+++ b/webserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.webserver</groupId>
     <artifactId>helidon-webserver-project</artifactId>

--- a/webserver/static-content/pom.xml
+++ b/webserver/static-content/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-webserver-project</artifactId>
         <groupId>io.helidon.webserver</groupId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webserver/test-support/pom.xml
+++ b/webserver/test-support/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-webserver-test-support</artifactId>
     <name>Helidon WebServer Test Support</name>

--- a/webserver/transport/netty/epoll/pom.xml
+++ b/webserver/transport/netty/epoll/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver.transport.netty</groupId>
         <artifactId>helidon-webserver-transport-netty-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-webserver-transport-netty-epoll</artifactId>
     <name>Helidon WebServer Transport Netty Epoll</name>

--- a/webserver/transport/netty/iouring/pom.xml
+++ b/webserver/transport/netty/iouring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver.transport.netty</groupId>
         <artifactId>helidon-webserver-transport-netty-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-webserver-transport-netty-iouring</artifactId>
     <name>Helidon WebServer Transport Netty io_uring</name>

--- a/webserver/transport/netty/pom.xml
+++ b/webserver/transport/netty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver.transport</groupId>
         <artifactId>helidon-webserver-transport-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.webserver.transport.netty</groupId>
     <artifactId>helidon-webserver-transport-netty-project</artifactId>

--- a/webserver/transport/pom.xml
+++ b/webserver/transport/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.webserver.transport</groupId>
     <artifactId>helidon-webserver-transport-project</artifactId>

--- a/webserver/tyrus/pom.xml
+++ b/webserver/tyrus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-webserver-tyrus</artifactId>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>2.6.5-SNAPSHOT</version>
+        <version>2.6.6-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-webserver</artifactId>
     <name>Helidon WebServer</name>


### PR DESCRIPTION
### Description

* Update CHANGELOG for 2.6.5
* Add empty javadoc.jar to `io.helidon.grpc:io.grpc` required for deployment
* Update version to 2.6.6-SNAPSHOT

### Documentation

No doc impact