### PR TITLE
4.x Several fixes to tracing config

### DIFF
--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/PathTracingConfig.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/PathTracingConfig.java
@@ -19,8 +19,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
+import io.helidon.common.config.Config;
 import io.helidon.common.uri.UriPath;
-import io.helidon.config.Config;
 import io.helidon.http.Method;
 import io.helidon.http.MethodPredicate;
 import io.helidon.http.PathMatcher;
@@ -32,7 +32,7 @@ import io.helidon.tracing.config.TracingConfig;
  */
 public interface PathTracingConfig {
     /**
-     * Create a new traced path configuration from {@link io.helidon.config.Config}.
+     * Create a new traced path configuration from {@link io.helidon.common.config.Config}.
      *
      * @param config config of a path
      * @return traced path configuration
@@ -107,7 +107,7 @@ public interface PathTracingConfig {
         }
 
         /**
-         * Update this builder from provided {@link io.helidon.config.Config}.
+         * Update this builder from provided {@link io.helidon.common.config.Config}.
          *
          * @param config config to update this builder from
          * @return updated builder instance

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
@@ -604,7 +604,7 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
         public void setup(HttpRouting.Builder routing) {
             routing.addFilter(new TracingFilter(config.tracer(),
                                                 config.envConfig(),
-                                                config.paths(),
+                                                config.pathConfigs(),
                                                 socketTag));
         }
     }

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
@@ -604,7 +604,7 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
         public void setup(HttpRouting.Builder routing) {
             routing.addFilter(new TracingFilter(config.tracer(),
                                                 config.envConfig(),
-                                                config.pathConfigs(),
+                                                config.paths(),
                                                 socketTag));
         }
     }

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserverConfigBlueprint.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserverConfigBlueprint.java
@@ -58,14 +58,14 @@ interface TracingObserverConfigBlueprint extends ObserverConfigBase, Prototype.F
      * health could be enabled by setting {@code tracing.paths.0.path=/observe/health} and
      * {@code tracing.paths.0.enabled=true}.
      *
-     * We disable both the SE-style paths ({@code /observe/health}) and the MP-style paths ({@code /health}).
+     * By default we disable both the SE-style paths ({@code /observe/health}) and the MP-style paths ({@code /health}).
      */
     /**
      * Path specific configuration of tracing.
      *
      * @return configuration of tracing for specific paths
      */
-    @Option.Configured
+    @Option.Configured("paths")
     @Option.Singular
     @Option.DefaultCode("new @java.util.ArrayList@(@java.util.List@.of(PathTracingConfig.builder()\n"
             + "                                  .path(\"/metrics/*\")\n"
@@ -91,7 +91,7 @@ interface TracingObserverConfigBlueprint extends ObserverConfigBase, Prototype.F
             + "                                  .path(\"/observe/openapi/*\")\n"
             + "                                  .tracingConfig(TracingConfig.DISABLED)\n"
             + "                                  .build()))")
-    List<PathTracingConfig> paths();
+    List<PathTracingConfig> pathConfigs();
 
     /**
      * Tracer to use to extract inbound span context.

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserverConfigBlueprint.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserverConfigBlueprint.java
@@ -55,8 +55,10 @@ interface TracingObserverConfigBlueprint extends ObserverConfigBase, Prototype.F
      * web-context's, then they would need to provide these exclusions manually.
      *
      * The default path configs below are overridable via configuration. For example,
-     * health could be enabled by setting {@code tracing.paths.0.path=/health} and
+     * health could be enabled by setting {@code tracing.paths.0.path=/observe/health} and
      * {@code tracing.paths.0.enabled=true}.
+     *
+     * We disable both the SE-style paths ({@code /observe/health}) and the MP-style paths ({@code /health}).
      */
     /**
      * Path specific configuration of tracing.
@@ -68,16 +70,28 @@ interface TracingObserverConfigBlueprint extends ObserverConfigBase, Prototype.F
     @Option.DefaultCode("new @java.util.ArrayList@(@java.util.List@.of(PathTracingConfig.builder()\n"
             + "                                  .path(\"/metrics/*\")\n"
             + "                                  .tracingConfig(TracingConfig.DISABLED)\n"
-            + "                                  .build(), "
+            + "                                  .build(), \n"
+            + "                                  PathTracingConfig.builder()\n"
+            + "                                  .path(\"/observe/metrics/*\")\n"
+            + "                                  .tracingConfig(TracingConfig.DISABLED)\n"
+            + "                                  .build(), \n"
             + "                                  PathTracingConfig.builder()\n"
             + "                                  .path(\"/health/*\")\n"
             + "                                  .tracingConfig(TracingConfig.DISABLED)\n"
-            + "                                  .build(),"
+            + "                                  .build(), \n"
+            + "                                  PathTracingConfig.builder()\n"
+            + "                                  .path(\"/observe/health/*\")\n"
+            + "                                  .tracingConfig(TracingConfig.DISABLED)\n"
+            + "                                  .build(), \n"
             + "                                  PathTracingConfig.builder()\n"
             + "                                  .path(\"/openapi/*\")\n"
             + "                                  .tracingConfig(TracingConfig.DISABLED)\n"
+            + "                                  .build(), \n"
+            + "                                  PathTracingConfig.builder()\n"
+            + "                                  .path(\"/observe/openapi/*\")\n"
+            + "                                  .tracingConfig(TracingConfig.DISABLED)\n"
             + "                                  .build()))")
-    List<PathTracingConfig> pathConfigs();
+    List<PathTracingConfig> paths();
 
     /**
      * Tracer to use to extract inbound span context.


### PR DESCRIPTION
### Description
Resolves #8148 

Fixes included: 
1. Change `path-configs` to `paths` for config key within tracing to conform to the doc and to be more user-friendly.
2. Add observe-style paths for built-in services to disabled-by-default tracing paths.
3. Change the factory method and builder config method for `PathTracingConfig` to accept common `Config` as parameter instead of the impl `Config` type. This change is backward compatible with recompiling.

### Documentation
Bug fix. No doc change.
