### PR TITLE
4.x Include scheme and port of origin and host in deciding whether to classify a request as CORS or not

### DIFF
--- a/cors/src/main/java/io/helidon/cors/CorsRequestAdapter.java
+++ b/cors/src/main/java/io/helidon/cors/CorsRequestAdapter.java
@@ -75,6 +75,13 @@ public interface CorsRequestAdapter<T> {
     String method();
 
     /**
+     * Reports whether the request arrived securely (i.e., over https).
+     *
+     * @return true if secure
+     */
+    boolean isSecure();
+
+    /**
      * Processes the next handler/filter/request processor in the chain.
      */
     void next();

--- a/cors/src/main/java/io/helidon/cors/CorsRequestAdapter.java
+++ b/cors/src/main/java/io/helidon/cors/CorsRequestAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,13 +73,6 @@ public interface CorsRequestAdapter<T> {
      * @return the method name
      */
     String method();
-
-    /**
-     * Reports whether the request arrived securely (i.e., over https).
-     *
-     * @return true if secure
-     */
-    boolean isSecure();
 
     /**
      * Processes the next handler/filter/request processor in the chain.

--- a/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
+++ b/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
@@ -371,7 +371,7 @@ public class CorsSupportHelper<Q, R> {
     }
 
     // For testing
-    static RequestTypeInfo isRequestTypeNormal(String originHeader, UriInfo requestedHostUri) {
+    static RequestTypeInfo requestType(String originHeader, UriInfo requestedHostUri) {
         return RequestTypeInfo.create(originHeader, requestedHostUri);
     }
 
@@ -406,7 +406,7 @@ public class CorsSupportHelper<Q, R> {
             return true;
         }
 
-        RequestTypeInfo result = isRequestTypeNormal(originOpt.get(), requestAdapter.requestedUri());
+        RequestTypeInfo result = requestType(originOpt.get(), requestAdapter.requestedUri());
         LogHelper.logIsRequestTypeNormal(result.isNormal,
                                          silent,
                                          requestAdapter,

--- a/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
+++ b/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,8 +371,8 @@ public class CorsSupportHelper<Q, R> {
     }
 
     // For testing
-    static RequestTypeInfo isRequestTypeNormal(String originHeader, UriInfo requestedHostUri, boolean isRequestSecure) {
-        return RequestTypeInfo.create(originHeader, requestedHostUri, isRequestSecure);
+    static RequestTypeInfo isRequestTypeNormal(String originHeader, UriInfo requestedHostUri) {
+        return RequestTypeInfo.create(originHeader, requestedHostUri);
     }
 
     /**
@@ -380,18 +380,18 @@ public class CorsSupportHelper<Q, R> {
      * <p>
      *     We want to use the intermediate results for clearer logging if that's turned on without having to recompute it.
      * </p>
-     * @param originLocation full origin (including port)
+     * @param originLocation full origin (including scheme and port)
      * @param hostLocation   full host (including scheme and port)
      * @param isNormal       whether the origin and host information represent a normal (non-CORS) request
      */
     record RequestTypeInfo(String originLocation, String hostLocation, boolean isNormal) {
 
-        static RequestTypeInfo create(String originHeader, UriInfo requestedHostUri, boolean isRequestSecure) {
+        static RequestTypeInfo create(String originHeader, UriInfo requestedHostUri) {
             String originLocation = CorsSupportHelper.originLocation(originHeader);
             String hostLocation = CorsSupportHelper.hostLocation(requestedHostUri);
 
-            return new RequestTypeInfo(CorsSupportHelper.originLocation(originHeader),
-                                       CorsSupportHelper.hostLocation(requestedHostUri),
+            return new RequestTypeInfo(originLocation,
+                                       hostLocation,
                                        originLocation.equals(hostLocation));
         }
     }
@@ -406,7 +406,7 @@ public class CorsSupportHelper<Q, R> {
             return true;
         }
 
-        RequestTypeInfo result = isRequestTypeNormal(originOpt.get(), requestAdapter.requestedUri(), requestAdapter.isSecure());
+        RequestTypeInfo result = isRequestTypeNormal(originOpt.get(), requestAdapter.requestedUri());
         LogHelper.logIsRequestTypeNormal(result.isNormal,
                                          silent,
                                          requestAdapter,

--- a/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
+++ b/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 import io.helidon.common.config.Config;
+import io.helidon.common.uri.UriInfo;
 import io.helidon.cors.LogHelper.Headers;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -369,14 +370,68 @@ public class CorsSupportHelper<Q, R> {
         return aggregator;
     }
 
-    private boolean isRequestTypeNormal(CorsRequestAdapter<Q> requestAdapter, boolean silent) {
+    // For testing
+    static RequestTypeInfo isRequestTypeNormal(String originHeader, UriInfo requestedHostUri, boolean isRequestSecure) {
+        return RequestTypeInfo.create(originHeader, requestedHostUri, isRequestSecure);
+    }
+
+    /**
+     * Captures intermediate data and the final result in deciding whether a request is a normal (non-CORS) request or not.
+     * <p>
+     *     We want to use the intermediate results for clearer logging if that's turned on without having to recompute it.
+     * </p>
+     * @param originLocation full origin (including port)
+     * @param hostLocation   full host (including scheme and port)
+     * @param isNormal       whether the origin and host information represent a normal (non-CORS) request
+     */
+    record RequestTypeInfo(String originLocation, String hostLocation, boolean isNormal) {
+
+        static RequestTypeInfo create(String originHeader, UriInfo requestedHostUri, boolean isRequestSecure) {
+            String originLocation = CorsSupportHelper.originLocation(originHeader);
+            String hostLocation = CorsSupportHelper.hostLocation(requestedHostUri);
+
+            return new RequestTypeInfo(CorsSupportHelper.originLocation(originHeader),
+                                       CorsSupportHelper.hostLocation(requestedHostUri),
+                                       originLocation.equals(hostLocation));
+        }
+    }
+
+    private static boolean isRequestTypeNormal(CorsRequestAdapter<?> requestAdapter, boolean silent) {
+
         // If no origin header or same as host, then just normal
         Optional<String> originOpt = requestAdapter.firstHeader(HeaderNames.ORIGIN);
-        String host = requestAdapter.requestedUri().host();
+        // Fast decision if there is no Origin header.
+        if (originOpt.isEmpty()) {
+            LogHelper.logIsRequestTypeNormalNoOrigin(silent, requestAdapter);
+            return true;
+        }
 
-        boolean result = originOpt.isEmpty() || originOpt.get().contains("://" + host);
-        LogHelper.logIsRequestTypeNormal(result, silent, requestAdapter, originOpt, host);
-        return result;
+        RequestTypeInfo result = isRequestTypeNormal(originOpt.get(), requestAdapter.requestedUri(), requestAdapter.isSecure());
+        LogHelper.logIsRequestTypeNormal(result.isNormal,
+                                         silent,
+                                         requestAdapter,
+                                         originOpt,
+                                         result.originLocation,
+                                         result.hostLocation);
+        return result.isNormal;
+    }
+
+    private static String originLocation(String origin) {
+        int originEndOfScheme = origin.indexOf(':');
+        int originLastColon = origin.lastIndexOf(':');
+
+        return origin + (
+                (originEndOfScheme == originLastColon)
+                        ? ":" + portForScheme(origin.substring(0, originEndOfScheme))
+                        : "");
+    }
+
+    private static String hostLocation(UriInfo requestedUri) {
+        return requestedUri.scheme() + "://" + requestedUri.host() + ":" + requestedUri.port();
+    }
+
+    private static String portForScheme(String origin) {
+        return origin.startsWith("https") ? "443" : "80";
     }
 
     private RequestType inferCORSRequestType(CorsRequestAdapter<Q> requestAdapter, boolean silent) {

--- a/cors/src/main/java/io/helidon/cors/LogHelper.java
+++ b/cors/src/main/java/io/helidon/cors/LogHelper.java
@@ -68,8 +68,21 @@ class LogHelper {
         }
     }
 
+
+    static <T> void logIsRequestTypeNormalNoOrigin(boolean silent, CorsRequestAdapter<T> requestAdapter) {
+        if (silent || !CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {
+            return;
+        }
+        if (CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {
+            CorsSupportHelper.LOGGER.log(DECISION_LEVEL,
+                                         String.format("Request %s is not cross-host: %s",
+                                                       requestAdapter,
+                                                       List.of("header " + HeaderNames.ORIGIN + " is absent")));
+        }
+    }
+
     static <T> void logIsRequestTypeNormal(boolean result, boolean silent, CorsRequestAdapter<T> requestAdapter,
-            Optional<String> originOpt, String host) {
+            Optional<String> originOpt, String effectiveOrigin, String host) {
         if (silent || !CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {
             return;
         }
@@ -81,7 +94,7 @@ class LogHelper {
         if (originOpt.isEmpty()) {
             reasonsWhyNormal.add("header " + HeaderNames.ORIGIN + " is absent");
         } else {
-            factorsWhyCrossHost.add(String.format("header %s is present (%s)", HeaderNames.ORIGIN, originOpt.get()));
+            factorsWhyCrossHost.add(String.format("header %s is present (%s)", HeaderNames.ORIGIN, effectiveOrigin));
         }
 
         if (host.isEmpty()) {
@@ -95,10 +108,10 @@ class LogHelper {
             if (originOpt.get()
                     .contains(partOfOriginMatchingHost)) {
                 reasonsWhyNormal.add(String.format("header %s '%s' matches header %s '%s'", HeaderNames.ORIGIN,
-                                                   originOpt.get(), HeaderNames.HOST, host));
+                                                   effectiveOrigin, HeaderNames.HOST, host));
             } else {
                 factorsWhyCrossHost.add(String.format("header %s '%s' does not match header %s '%s'", HeaderNames.ORIGIN,
-                                                      originOpt.get(), HeaderNames.HOST, host));
+                                                      effectiveOrigin, HeaderNames.HOST, host));
             }
         }
 

--- a/cors/src/main/java/io/helidon/cors/LogHelper.java
+++ b/cors/src/main/java/io/helidon/cors/LogHelper.java
@@ -73,12 +73,10 @@ class LogHelper {
         if (silent || !CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {
             return;
         }
-        if (CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {
-            CorsSupportHelper.LOGGER.log(DECISION_LEVEL,
-                                         String.format("Request %s is not cross-host: %s",
-                                                       requestAdapter,
-                                                       List.of("header " + HeaderNames.ORIGIN + " is absent")));
-        }
+        CorsSupportHelper.LOGGER.log(DECISION_LEVEL,
+                                     String.format("Request %s is not cross-host: %s",
+                                                   requestAdapter,
+                                                   List.of("header " + HeaderNames.ORIGIN + " is absent")));
     }
 
     static <T> void logIsRequestTypeNormal(boolean result, boolean silent, CorsRequestAdapter<T> requestAdapter,

--- a/cors/src/main/java/io/helidon/cors/LogHelper.java
+++ b/cors/src/main/java/io/helidon/cors/LogHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
+++ b/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
+++ b/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
@@ -66,24 +66,24 @@ class CorsSupportHelperTest {
     @Test
     void sameNodeDifferentPorts() {
         assertThat("Default different origin port",
-                   CorsSupportHelper.isRequestTypeNormal("http://ok.com",
-                                                         uriInfo("ok.com", 8010, false)).isNormal(),
+                   CorsSupportHelper.requestType("http://ok.com",
+                                                 uriInfo("ok.com", 8010, false)).isNormal(),
                    is(false));
         assertThat("Explicit different origin port",
-                   CorsSupportHelper.isRequestTypeNormal("http://ok.com:8080",
-                                                         uriInfo("ok.com", false)).isNormal(),
+                   CorsSupportHelper.requestType("http://ok.com:8080",
+                                                 uriInfo("ok.com", false)).isNormal(),
                    is(false));
     }
 
     @Test
     void sameNodeSamePort() {
         assertThat("Default origin port",
-                   CorsSupportHelper.isRequestTypeNormal("http://ok.com",
-                                                         uriInfo("ok.com", false)).isNormal(),
+                   CorsSupportHelper.requestType("http://ok.com",
+                                                 uriInfo("ok.com", false)).isNormal(),
                    is(true));
         assertThat("Explicit origin port",
-                   CorsSupportHelper.isRequestTypeNormal("http://ok.com:80",
-                                                         UriInfo.builder()
+                   CorsSupportHelper.requestType("http://ok.com:80",
+                                                 UriInfo.builder()
                                                                  .host("ok.com")
                                                                  .build()).isNormal(),
                    is(true));
@@ -92,40 +92,40 @@ class CorsSupportHelperTest {
     @Test
     void differentNode() {
         assertThat("Different node, same (default) port",
-                   CorsSupportHelper.isRequestTypeNormal("http://bad.com",
-                                                         uriInfo("ok.com", false)).isNormal(),
+                   CorsSupportHelper.requestType("http://bad.com",
+                                                 uriInfo("ok.com", false)).isNormal(),
                    is(false));
         assertThat("Different node, same explicit port",
-                   CorsSupportHelper.isRequestTypeNormal("http://bad.com:80",
-                                                         uriInfo("ok.com", false)).isNormal(),
+                   CorsSupportHelper.requestType("http://bad.com:80",
+                                                 uriInfo("ok.com", false)).isNormal(),
                    is(false));
 
         assertThat("Different node, different explicit port",
-                   CorsSupportHelper.isRequestTypeNormal("http://bad.com:8080",
-                                                         uriInfo("ok.com", false)).isNormal(),
+                   CorsSupportHelper.requestType("http://bad.com:8080",
+                                                 uriInfo("ok.com", false)).isNormal(),
                    is(false));
     }
 
     @Test
     void differentScheme() {
         assertThat("Same node, insecure origin, secure host",
-                   CorsSupportHelper.isRequestTypeNormal("http://foo.com",
-                                                         uriInfo("foo.com", true)).isNormal(),
+                   CorsSupportHelper.requestType("http://foo.com",
+                                                 uriInfo("foo.com", true)).isNormal(),
                    is(false));
 
         assertThat("Same node, secure origin, insecure host",
-                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("foo.com", false)).isNormal(),
+                   CorsSupportHelper.requestType("https://foo.com",
+                                                 uriInfo("foo.com", false)).isNormal(),
                    is(false));
 
         assertThat("Different nodes, insecure origin, secure host",
-                   CorsSupportHelper.isRequestTypeNormal("http://foo.com",
-                                                         uriInfo("other.com", true)).isNormal(),
+                   CorsSupportHelper.requestType("http://foo.com",
+                                                 uriInfo("other.com", true)).isNormal(),
                    is(false));
 
         assertThat("Different nodes, secure origin, insecure host",
-                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("other.com", false)).isNormal(),
+                   CorsSupportHelper.requestType("https://foo.com",
+                                                 uriInfo("other.com", false)).isNormal(),
                    is(false));
     }
 
@@ -134,28 +134,28 @@ class CorsSupportHelperTest {
         // Note that the real UriInfo instances from real requests will set the port according to whether the request is
         // secure or not.
         assertThat("Same node, secure origin, secure host",
-                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("foo.com", true)).isNormal(),
+                   CorsSupportHelper.requestType("https://foo.com",
+                                                 uriInfo("foo.com", true)).isNormal(),
                    is(true));
 
         assertThat("Different node, secure origin, secure host",
-                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("other.com", true)).isNormal(),
+                   CorsSupportHelper.requestType("https://foo.com",
+                                                 uriInfo("other.com", true)).isNormal(),
                    is(false));
 
         assertThat("Same nodes, different ports, secure origin, secure host",
-                   CorsSupportHelper.isRequestTypeNormal("https://foo.com:1234",
-                                                        uriInfo("foo.com",5678, true)).isNormal(),
+                   CorsSupportHelper.requestType("https://foo.com:1234",
+                                                 uriInfo("foo.com",5678, true)).isNormal(),
                    is(false));
 
         assertThat("Same nodes, explicit origin port, secure origin, secure host",
-                   CorsSupportHelper.isRequestTypeNormal("https://foo.com:443",
-                                                         uriInfo("foo.com", true)).isNormal(),
+                   CorsSupportHelper.requestType("https://foo.com:443",
+                                                 uriInfo("foo.com", true)).isNormal(),
                    is(true));
 
         assertThat("Same nodes, explicit host port, secure origin, secure host",
-                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("foo.com", 443, true)).isNormal(),
+                   CorsSupportHelper.requestType("https://foo.com",
+                                                 uriInfo("foo.com", 443, true)).isNormal(),
                    is(true));
     }
 

--- a/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
+++ b/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
@@ -15,21 +15,295 @@
  */
 package io.helidon.cors;
 
-import org.hamcrest.MatcherAssert;
+import java.util.Optional;
+
+import io.helidon.common.testing.junit5.OptionalMatcher;
+import io.helidon.common.uri.UriInfo;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 
 class CorsSupportHelperTest {
 
+    private final static String YAML_PATH = "/configMapperTest.yaml";
+
+    private static Config testConfig;
+    private static CorsSupportHelper<TestCorsServerRequestAdapter, TestCorsServerResponseAdapter> secureCheckHelper;
+
+    @BeforeAll
+    public static void loadTestConfig() {
+        testConfig = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .addSource(ConfigSources.classpath(YAML_PATH))
+                .build();
+        secureCheckHelper =
+                CorsSupportHelper.<TestCorsServerRequestAdapter, TestCorsServerResponseAdapter>builder()
+                        .mappedConfig(testConfig.get("secure-check"))
+                        .build();
+
+    }
+
     @Test
     void testNormalize() {
-        MatcherAssert.assertThat(CorsSupportHelper.normalize("something"), is("something"));
-        MatcherAssert.assertThat(CorsSupportHelper.normalize("/something"), is("something"));
-        MatcherAssert.assertThat(CorsSupportHelper.normalize("something/"), is("something"));
-        MatcherAssert.assertThat(CorsSupportHelper.normalize("/something/"), is("something"));
-        MatcherAssert.assertThat(CorsSupportHelper.normalize("/"), isEmptyString());
-        MatcherAssert.assertThat(CorsSupportHelper.normalize(""), isEmptyString());
+        assertThat(CorsSupportHelper.normalize("something"), is("something"));
+        assertThat(CorsSupportHelper.normalize("/something"), is("something"));
+        assertThat(CorsSupportHelper.normalize("something/"), is("something"));
+        assertThat(CorsSupportHelper.normalize("/something/"), is("something"));
+        assertThat(CorsSupportHelper.normalize("/"), isEmptyString());
+        assertThat(CorsSupportHelper.normalize(""), isEmptyString());
+    }
+
+    @Test
+    void sameNodeDifferentPorts() {
+        assertThat("Default different origin port",
+                   CorsSupportHelper.isRequestTypeNormal("http://ok.com",
+                                                         uriInfo("ok.com", 8010, false),
+                                                         false).isNormal(),
+                   is(false));
+        assertThat("Explicit different origin port",
+                   CorsSupportHelper.isRequestTypeNormal("http://ok.com:8080",
+                                                         uriInfo("ok.com", false),
+                                                         false).isNormal(),
+                   is(false));
+    }
+
+    @Test
+    void sameNodeSamePort() {
+        assertThat("Default origin port",
+                   CorsSupportHelper.isRequestTypeNormal("http://ok.com",
+                                                         uriInfo("ok.com", false),
+                                                         false).isNormal(),
+                   is(true));
+        assertThat("Explicit origin port",
+                   CorsSupportHelper.isRequestTypeNormal("http://ok.com:80",
+                                                         UriInfo.builder()
+                                                                 .host("ok.com")
+                                                                 .build(),
+                                                         false).isNormal(),
+                   is(true));
+    }
+
+    @Test
+    void differentNode() {
+        assertThat("Different node, same (default) port",
+                   CorsSupportHelper.isRequestTypeNormal("http://bad.com",
+                                                         uriInfo("ok.com", false),
+                                                         false).isNormal(),
+                   is(false));
+        assertThat("Different node, same explicit port",
+                   CorsSupportHelper.isRequestTypeNormal("http://bad.com:80",
+                                                         uriInfo("ok.com", false),
+                                                         false).isNormal(),
+                   is(false));
+
+        assertThat("Different node, different explicit port",
+                   CorsSupportHelper.isRequestTypeNormal("http://bad.com:8080",
+                                                         uriInfo("ok.com", false),
+                                                         false).isNormal(),
+                   is(false));
+    }
+
+    @Test
+    void differentScheme() {
+        assertThat("Same node, insecure origin, secure host",
+                   CorsSupportHelper.isRequestTypeNormal("http://foo.com",
+                                                         uriInfo("foo.com", true),
+                                                         true).isNormal(),
+                   is(false));
+
+        assertThat("Same node, secure origin, insecure host",
+                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
+                                                         uriInfo("foo.com", false),
+                                                         false).isNormal(),
+                   is(false));
+
+        assertThat("Different nodes, insecure origin, secure host",
+                   CorsSupportHelper.isRequestTypeNormal("http://foo.com",
+                                                         uriInfo("other.com", true),
+                                                         true).isNormal(),
+                   is(false));
+
+        assertThat("Different nodes, secure origin, insecure host",
+                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
+                                                         uriInfo("other.com", false),
+                                                         false).isNormal(),
+                   is(false));
+    }
+
+    @Test
+    void sameSecureScheme() {
+        // Note that the real UriInfo instances from real requests will set the port according to whether the request is
+        // secure or not.
+        assertThat("Same node, secure origin, secure host",
+                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
+                                                         uriInfo("foo.com", true),
+                                                         true).isNormal(),
+                   is(true));
+
+        assertThat("Different node, secure origin, secure host",
+                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
+                                                         uriInfo("other.com", true),
+                                                         true).isNormal(),
+                   is(false));
+
+        assertThat("Same nodes, different ports, secure origin, secure host",
+                   CorsSupportHelper.isRequestTypeNormal("https://foo.com:1234",
+                                                        uriInfo("foo.com",5678, true),
+                                                         true).isNormal(),
+                   is(false));
+
+        assertThat("Same nodes, explicit origin port, secure origin, secure host",
+                   CorsSupportHelper.isRequestTypeNormal("https://foo.com:443",
+                                                         uriInfo("foo.com", true),
+                                                         true).isNormal(),
+                   is(true));
+
+        assertThat("Same nodes, explicit host port, secure origin, secure host",
+                   CorsSupportHelper.isRequestTypeNormal("https://foo.com",
+                                                         uriInfo("foo.com", 443, true),
+                                                         true).isNormal(),
+                   is(true));
+    }
+
+    /*
+    The CORS processing uses the "requested URI" which is trusted information that accounts for intermediary nodes between the
+    original client and the server. The host for the requested URI is the actual server running the code (server.com in these
+    tests). The Host header reflects the presence of a load balancer or other intermediary proxy immediately before the request
+    reaches the server.
+     */
+
+    @Test
+    void checkPlainRequestToPlainPath() {
+        // Access the insecure path with an insecure host in the CORS config using an insecure request.
+        // UriInfo contains the trusted information about the host.
+        UriInfo uriInfo = UriInfo.builder()
+                .scheme("http")
+                .host("server.com")
+                .path("/greet")
+                .port(80)
+                .build();
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.ORIGIN, "http://here.com")
+                .add(HeaderNames.HOST, "someProxy.com")
+                .add(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+        CorsRequestAdapter<TestCorsServerRequestAdapter> req = new TestCorsServerRequestAdapter("/greet",
+                                                                                                uriInfo,
+                                                                                                "OPTIONS",
+                                                                                                false,
+                                                                                                headers);
+        CorsResponseAdapter<TestCorsServerResponseAdapter> resp = new TestCorsServerResponseAdapter();
+
+        Optional<TestCorsServerResponseAdapter> immediateResponse = secureCheckHelper.processRequest(req, resp);
+
+        assertThat("Immediate response from insecure PUT", immediateResponse, OptionalMatcher.optionalPresent());
+        assertThat("Immediate response status", immediateResponse.get().status(), is(Status.OK_200.code()));
+    }
+
+    @Test
+    void checkSecureAccessToPlainPath() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.ORIGIN, "https://secure.com:443")
+                .add(HeaderNames.HOST, "someProxy.com:443")
+                .add(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+        UriInfo uriInfo = UriInfo.builder()
+                .scheme("https")
+                .host("server.com")
+                .path("/greet")
+                .port(443)
+                .build();
+        CorsRequestAdapter<TestCorsServerRequestAdapter> secureReq = new TestCorsServerRequestAdapter("/greet",
+                                                                                                      uriInfo,
+                                                                                                      "OPTIONS",
+                                                                                                      true,
+                                                                                                      headers);
+        CorsResponseAdapter<TestCorsServerResponseAdapter> secureResp = new TestCorsServerResponseAdapter();
+
+        Optional<TestCorsServerResponseAdapter> secureImmediateResponse = secureCheckHelper.processRequest(secureReq, secureResp);
+        assertThat("Immediate response from secure PUT to unsecured path",
+                   secureImmediateResponse,
+                   OptionalMatcher.optionalPresent());
+        assertThat("Immediate response status from secure PUT to unsecured path",
+                   secureImmediateResponse.get().status(),
+                   is(Status.FORBIDDEN_403.code()));
+    }
+
+    @Test
+    void checkPlainAccessToSecurePath() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.ORIGIN, "http://here.com")
+                .add(HeaderNames.HOST, "someProxy.com")
+                .add(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+        UriInfo uriInfo = UriInfo.builder()
+                .scheme("http")
+                .host("server.com")
+                .path("/secure-greet")
+                .port(80)
+                .build();
+        CorsRequestAdapter<TestCorsServerRequestAdapter> secureReq = new TestCorsServerRequestAdapter("/secure-greet",
+                                                                                                      uriInfo,
+                                                                                                      "OPTIONS",
+                                                                                                      false,
+                                                                                                      headers);
+        CorsResponseAdapter<TestCorsServerResponseAdapter> secureResp = new TestCorsServerResponseAdapter();
+
+        Optional<TestCorsServerResponseAdapter> secureImmediateResponse = secureCheckHelper.processRequest(secureReq, secureResp);
+        assertThat("Immediate response from secure PUT to unsecured path",
+                   secureImmediateResponse,
+                   OptionalMatcher.optionalPresent());
+        assertThat("Immediate response status from secure PUT to unsecured path",
+                   secureImmediateResponse.get().status(),
+                   is(Status.FORBIDDEN_403.code()));
+    }
+
+    @Test
+    void checkSecureAccessToSecurePath() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.ORIGIN, "https://secure.com:443")
+                .add(HeaderNames.HOST, "someProxy.com:443")
+                .add(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+        UriInfo uriInfo = UriInfo.builder()
+                .scheme("https")
+                .host("server.com")
+                .path("/secure-greet")
+                .port(443)
+                .build();
+        CorsRequestAdapter<TestCorsServerRequestAdapter> secureReq = new TestCorsServerRequestAdapter("/secure-greet",
+                                                                                                      uriInfo,
+                                                                                                      "OPTIONS",
+                                                                                                      true,
+                                                                                                      headers);
+        CorsResponseAdapter<TestCorsServerResponseAdapter> secureResp = new TestCorsServerResponseAdapter();
+
+        Optional<TestCorsServerResponseAdapter> secureImmediateResponse = secureCheckHelper.processRequest(secureReq, secureResp);
+        assertThat("Immediate response from secure PUT to secured path",
+                   secureImmediateResponse,
+                   OptionalMatcher.optionalPresent());
+        assertThat("Immediate response status from secure PUT to secured path",
+                   secureImmediateResponse.get().status(),
+                   is(Status.OK_200.code()));
+    }
+
+    private static UriInfo uriInfo(String host, boolean isSecure) {
+        return UriInfo.builder()
+                .host(host)
+                .scheme(isSecure ? "https" : "http")
+                .build();
+    }
+    private static UriInfo uriInfo(String host, int port, boolean isSecure) {
+        return UriInfo.builder()
+                .host(host)
+                .port(port)
+                .scheme(isSecure ? "https" : "http")
+                .build();
     }
 }

--- a/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
+++ b/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,13 +67,11 @@ class CorsSupportHelperTest {
     void sameNodeDifferentPorts() {
         assertThat("Default different origin port",
                    CorsSupportHelper.isRequestTypeNormal("http://ok.com",
-                                                         uriInfo("ok.com", 8010, false),
-                                                         false).isNormal(),
+                                                         uriInfo("ok.com", 8010, false)).isNormal(),
                    is(false));
         assertThat("Explicit different origin port",
                    CorsSupportHelper.isRequestTypeNormal("http://ok.com:8080",
-                                                         uriInfo("ok.com", false),
-                                                         false).isNormal(),
+                                                         uriInfo("ok.com", false)).isNormal(),
                    is(false));
     }
 
@@ -81,15 +79,13 @@ class CorsSupportHelperTest {
     void sameNodeSamePort() {
         assertThat("Default origin port",
                    CorsSupportHelper.isRequestTypeNormal("http://ok.com",
-                                                         uriInfo("ok.com", false),
-                                                         false).isNormal(),
+                                                         uriInfo("ok.com", false)).isNormal(),
                    is(true));
         assertThat("Explicit origin port",
                    CorsSupportHelper.isRequestTypeNormal("http://ok.com:80",
                                                          UriInfo.builder()
                                                                  .host("ok.com")
-                                                                 .build(),
-                                                         false).isNormal(),
+                                                                 .build()).isNormal(),
                    is(true));
     }
 
@@ -97,19 +93,16 @@ class CorsSupportHelperTest {
     void differentNode() {
         assertThat("Different node, same (default) port",
                    CorsSupportHelper.isRequestTypeNormal("http://bad.com",
-                                                         uriInfo("ok.com", false),
-                                                         false).isNormal(),
+                                                         uriInfo("ok.com", false)).isNormal(),
                    is(false));
         assertThat("Different node, same explicit port",
                    CorsSupportHelper.isRequestTypeNormal("http://bad.com:80",
-                                                         uriInfo("ok.com", false),
-                                                         false).isNormal(),
+                                                         uriInfo("ok.com", false)).isNormal(),
                    is(false));
 
         assertThat("Different node, different explicit port",
                    CorsSupportHelper.isRequestTypeNormal("http://bad.com:8080",
-                                                         uriInfo("ok.com", false),
-                                                         false).isNormal(),
+                                                         uriInfo("ok.com", false)).isNormal(),
                    is(false));
     }
 
@@ -117,26 +110,22 @@ class CorsSupportHelperTest {
     void differentScheme() {
         assertThat("Same node, insecure origin, secure host",
                    CorsSupportHelper.isRequestTypeNormal("http://foo.com",
-                                                         uriInfo("foo.com", true),
-                                                         true).isNormal(),
+                                                         uriInfo("foo.com", true)).isNormal(),
                    is(false));
 
         assertThat("Same node, secure origin, insecure host",
                    CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("foo.com", false),
-                                                         false).isNormal(),
+                                                         uriInfo("foo.com", false)).isNormal(),
                    is(false));
 
         assertThat("Different nodes, insecure origin, secure host",
                    CorsSupportHelper.isRequestTypeNormal("http://foo.com",
-                                                         uriInfo("other.com", true),
-                                                         true).isNormal(),
+                                                         uriInfo("other.com", true)).isNormal(),
                    is(false));
 
         assertThat("Different nodes, secure origin, insecure host",
                    CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("other.com", false),
-                                                         false).isNormal(),
+                                                         uriInfo("other.com", false)).isNormal(),
                    is(false));
     }
 
@@ -146,32 +135,27 @@ class CorsSupportHelperTest {
         // secure or not.
         assertThat("Same node, secure origin, secure host",
                    CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("foo.com", true),
-                                                         true).isNormal(),
+                                                         uriInfo("foo.com", true)).isNormal(),
                    is(true));
 
         assertThat("Different node, secure origin, secure host",
                    CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("other.com", true),
-                                                         true).isNormal(),
+                                                         uriInfo("other.com", true)).isNormal(),
                    is(false));
 
         assertThat("Same nodes, different ports, secure origin, secure host",
                    CorsSupportHelper.isRequestTypeNormal("https://foo.com:1234",
-                                                        uriInfo("foo.com",5678, true),
-                                                         true).isNormal(),
+                                                        uriInfo("foo.com",5678, true)).isNormal(),
                    is(false));
 
         assertThat("Same nodes, explicit origin port, secure origin, secure host",
                    CorsSupportHelper.isRequestTypeNormal("https://foo.com:443",
-                                                         uriInfo("foo.com", true),
-                                                         true).isNormal(),
+                                                         uriInfo("foo.com", true)).isNormal(),
                    is(true));
 
         assertThat("Same nodes, explicit host port, secure origin, secure host",
                    CorsSupportHelper.isRequestTypeNormal("https://foo.com",
-                                                         uriInfo("foo.com", 443, true),
-                                                         true).isNormal(),
+                                                         uriInfo("foo.com", 443, true)).isNormal(),
                    is(true));
     }
 
@@ -199,7 +183,6 @@ class CorsSupportHelperTest {
         CorsRequestAdapter<TestCorsServerRequestAdapter> req = new TestCorsServerRequestAdapter("/greet",
                                                                                                 uriInfo,
                                                                                                 "OPTIONS",
-                                                                                                false,
                                                                                                 headers);
         CorsResponseAdapter<TestCorsServerResponseAdapter> resp = new TestCorsServerResponseAdapter();
 
@@ -224,7 +207,6 @@ class CorsSupportHelperTest {
         CorsRequestAdapter<TestCorsServerRequestAdapter> secureReq = new TestCorsServerRequestAdapter("/greet",
                                                                                                       uriInfo,
                                                                                                       "OPTIONS",
-                                                                                                      true,
                                                                                                       headers);
         CorsResponseAdapter<TestCorsServerResponseAdapter> secureResp = new TestCorsServerResponseAdapter();
 
@@ -252,7 +234,6 @@ class CorsSupportHelperTest {
         CorsRequestAdapter<TestCorsServerRequestAdapter> secureReq = new TestCorsServerRequestAdapter("/secure-greet",
                                                                                                       uriInfo,
                                                                                                       "OPTIONS",
-                                                                                                      false,
                                                                                                       headers);
         CorsResponseAdapter<TestCorsServerResponseAdapter> secureResp = new TestCorsServerResponseAdapter();
 
@@ -280,7 +261,6 @@ class CorsSupportHelperTest {
         CorsRequestAdapter<TestCorsServerRequestAdapter> secureReq = new TestCorsServerRequestAdapter("/secure-greet",
                                                                                                       uriInfo,
                                                                                                       "OPTIONS",
-                                                                                                      true,
                                                                                                       headers);
         CorsResponseAdapter<TestCorsServerResponseAdapter> secureResp = new TestCorsServerResponseAdapter();
 

--- a/cors/src/test/java/io/helidon/cors/TestCorsServerRequestAdapter.java
+++ b/cors/src/test/java/io/helidon/cors/TestCorsServerRequestAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.helidon.common.uri.UriInfo;
 import io.helidon.http.HeaderName;
 import io.helidon.http.Headers;
 
-record TestCorsServerRequestAdapter(String path, UriInfo requestedUri, String method, boolean isSecure, Headers headers) implements CorsRequestAdapter<TestCorsServerRequestAdapter> {
+record TestCorsServerRequestAdapter(String path, UriInfo requestedUri, String method, Headers headers) implements CorsRequestAdapter<TestCorsServerRequestAdapter> {
 
     @Override
     public Optional<String> firstHeader(HeaderName key) {

--- a/cors/src/test/java/io/helidon/cors/TestCorsServerRequestAdapter.java
+++ b/cors/src/test/java/io/helidon/cors/TestCorsServerRequestAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.cors;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.uri.UriInfo;
+import io.helidon.http.HeaderName;
+import io.helidon.http.Headers;
+
+record TestCorsServerRequestAdapter(String path, UriInfo requestedUri, String method, boolean isSecure, Headers headers) implements CorsRequestAdapter<TestCorsServerRequestAdapter> {
+
+    @Override
+    public Optional<String> firstHeader(HeaderName key) {
+        return headers.first(key);
+    }
+
+    @Override
+    public boolean headerContainsKey(HeaderName key) {
+        return headers.contains(key);
+    }
+
+    @Override
+    public List<String> allHeaders(HeaderName key) {
+        return headers.values(key);
+    }
+
+    @Override
+    public void next() {
+    }
+
+    @Override
+    public TestCorsServerRequestAdapter request() {
+        return null;
+    }
+}

--- a/cors/src/test/java/io/helidon/cors/TestCorsServerResponseAdapter.java
+++ b/cors/src/test/java/io/helidon/cors/TestCorsServerResponseAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cors/src/test/java/io/helidon/cors/TestCorsServerResponseAdapter.java
+++ b/cors/src/test/java/io/helidon/cors/TestCorsServerResponseAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.cors;
+
+import io.helidon.http.HeaderName;
+import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.Status;
+
+class TestCorsServerResponseAdapter implements CorsResponseAdapter<TestCorsServerResponseAdapter> {
+
+    private final ServerResponseHeaders headers = ServerResponseHeaders.create();
+    private int status;
+
+    @Override
+    public CorsResponseAdapter<TestCorsServerResponseAdapter> header(HeaderName key, String value) {
+        headers.add(key, value);
+        return this;
+    }
+
+    @Override
+    public CorsResponseAdapter<TestCorsServerResponseAdapter> header(HeaderName key, Object value) {
+        headers.add(key, value.toString());
+        return this;
+    }
+
+    @Override
+    public TestCorsServerResponseAdapter forbidden(String message) {
+        status = Status.FORBIDDEN_403.code();
+        return this;
+    }
+
+    @Override
+    public TestCorsServerResponseAdapter ok() {
+        status = Status.OK_200.code();
+        return this;
+    }
+
+    @Override
+    public int status() {
+        return status;
+    }
+}

--- a/cors/src/test/resources/configMapperTest.yaml
+++ b/cors/src/test/resources/configMapperTest.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cors/src/test/resources/configMapperTest.yaml
+++ b/cors/src/test/resources/configMapperTest.yaml
@@ -56,3 +56,20 @@ order-check:
       allow-origins: [ "http://backend-base-uri}", "http://frontend-base-uri}", "http://test-origin}", "null" ]
       allow-methods: [ "DELETE", "PATCH", "HEAD" ]
       allow-credentials: true
+
+secure-check:
+  paths:
+    - path-pattern: "/greet"
+      allow-origins: [ "http://here.com" ]
+      allow-methods: [ "PUT", "POST"]
+      allow-credentials: true
+    - path-pattern: "/secure-greet"
+      allow-origins: [ "https://secure.com" ]
+      allow-methods: [ "PUT", "POST"]
+
+same-host-diff-ports:
+  paths:
+    - path-pattern: "/greet-8080"
+      allow-origins: [ "http://here.com:8080"]
+    - path-pattern: "/greet"
+      allow-origins: [ "http://here.com"]

--- a/cors/src/test/resources/configMapperTest.yaml
+++ b/cors/src/test/resources/configMapperTest.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,11 +146,6 @@ class CorsSupportMp extends CorsSupportBase<ContainerRequestContext, Response, C
         @Override
         public ContainerRequestContext request() {
             return requestContext;
-        }
-
-        @Override
-        public boolean isSecure() {
-            return requestContext.getSecurityContext().isSecure();
         }
 
         @Override

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
@@ -149,6 +149,11 @@ class CorsSupportMp extends CorsSupportBase<ContainerRequestContext, Response, C
         }
 
         @Override
+        public boolean isSecure() {
+            return requestContext.getSecurityContext().isSecure();
+        }
+
+        @Override
         public void next() {
         }
 

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsServerRequestAdapter.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsServerRequestAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,11 +71,6 @@ class CorsServerRequestAdapter implements CorsRequestAdapter<ServerRequest> {
     @Override
     public String method() {
         return request.prologue().method().text();
-    }
-
-    @Override
-    public boolean isSecure() {
-        return request.isSecure();
     }
 
     @Override

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsServerRequestAdapter.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsServerRequestAdapter.java
@@ -74,6 +74,11 @@ class CorsServerRequestAdapter implements CorsRequestAdapter<ServerRequest> {
     }
 
     @Override
+    public boolean isSecure() {
+        return request.isSecure();
+    }
+
+    @Override
     public void next() {
         response.next();
     }


### PR DESCRIPTION
### Description
Resolves #8088 
Resolves #8093 

Proper implementation of the CORS algorithm requires considering the scheme, node, and port of the origin (conveyed by the `Origin` header) and the host that was requested by the client (conveyed by the `Host` header or the `Forwarded` header or the `X-Forwarded-*` family of headers). A normal request in the CORS context is one that is _not_ cross-origin--that is, for which the origin and the host share the same scheme, node, and port.

The 4.x logic regressed from 3.x in not considering the scheme and port properly.

This PR does several things:
1. Adds an `isSecure` method to an adapter interface for requests. 
   
   The adapter insulates the CORS logic from differences in and dependence on the SE and MP request implementations. The PR also includes the enhancements to the SE and MP adapters to implement this new method.
3. Corrects the CORS logic which checks to see if the incoming request is a normal request (that is, non-CORS). 
   
   The CORS code first checks for whether the request is normal and, if so, skips the CORS processing. This normal check  failed to account properly for the scheme and port of the origin and host and therefore _incorrectly_ identified requests that needed CORS processing as normal (non-CORS) requests.
4. Adds numerous tests.

The CORS code does considerable logging (when turned on) to help users understand the decisions the code makes. This PR also introduces a new private record which represents the result of the "is the request normal" check, containing not only the true/false result but also the effective origin and host locations (full scheme, node, and port) that the is-normal check computed to decide the true/false result. The logging code now uses these intermediate results rather than having to recompute them for logging.

### Documentation
This is a bug fix. No doc impact.
