### PR TITLE
4.x: Jersey 3.1.5

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -90,7 +90,7 @@
         <version.lib.jboss.classfilewriter>1.3.0.Final</version.lib.jboss.classfilewriter>
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
         <version.lib.jaxb-runtime>4.0.3</version.lib.jaxb-runtime>
-        <version.lib.jersey>3.1.4</version.lib.jersey>
+        <version.lib.jersey>3.1.5</version.lib.jersey>
         <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>
         <version.lib.kafka>3.6.0</version.lib.kafka>

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
@@ -128,8 +128,6 @@
                         <include>*IT.java</include>
                     </includes>
                     <excludes>
-                        <!-- Requires this in Jersey https://github.com/eclipse-ee4j/jersey/pull/5490 -->
-                        <exclude>ee/jakarta/tck/ws/rs/jaxrs21/ee/sse/sseeventsource/JAXRSClientIT.java</exclude>
                         <!-- TCK Challenge: https://github.com/jakartaee/rest/issues/1199 -->
                         <exclude>ee/jakarta/tck/ws/rs/ee/rs/container/responsecontext/JAXRSClientIT.java</exclude>
                     </excludes>


### PR DESCRIPTION
### Description

Upgrade Jersey version to 3.1.5 and enable one TCK test.

### Documentation

N/A