### PR TITLE
4.x Make `RegistryFactory` and its `getInstance` and `getRegistry` methods public

### DIFF
--- a/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
@@ -153,24 +153,70 @@ In addition to your application {metrics}, the reports contain other
 To register or look up {metrics} programmatically, your service code uses the link:{microprofile-metrics-javadoc-url}/org/eclipse/microprofile/metrics/MetricRegistry.html[`MetricRegistry`] instance for the scope of interest: `base`, `vendor`, `application`, or a custom scope.
 
 ifdef::mp-flavor[]
-To get a `MetricRegistry` reference
+Either of the following techniques gets a `MetricRegistry` reference.
+Remember that injection works only if the class is a bean so CDI can inject into it.
 
-* `@Inject` the metric registry you want, perhaps also using the link:{microprofile-metrics-javadoc-annotation-url}/RegistryScope.html[`@RegistryScope`] annotation to select the registry type, or
-* Get a Helidon link:{metrics-mp-javadoc-base-url}/RegistryFactory.html[`RegistryFactory`]; either
+* `@Inject MetricRegistry`, optionally using link:{microprofile-metrics-javadoc-annotation-url}/RegistryScope.html[`@RegistryScope`] to indicate the registry scope.
 +
 --
-** `@Inject` `RegistryFactory` or
-** Invoke one of the static `getInstance` methods on `RegistryFactory`
+[source,java]
+.Injecting the default `MetricRegistry` (for the application scope)
+----
+class Example {
+
+    @Inject
+    private MetricRegistry applicationRegistry;
+}
+----
+
+[source,java]
+.Injecting a non-default `MetricRegistry`
+----
+class Example {
+
+    @RegistryScope("myCustomScope")
+    @Inject
+    private MetricRegistry myCustomRegistry;
+}
+----
 --
+* Get a Helidon link:{metrics-mp-javadoc-base-url}/RegistryFactory.html[`RegistryFactory`] instance and invoke its `getRegistry` method.
 +
-Then invoke `getRegistry` on the `RegistryFactory` instance.
-endif::[]
-ifdef::se-flavor[]
-To get a `MetricRegistry` reference, first get a Helidon link:{metrics-javadoc-base-url}/RegistryFactory.html[`RegistryFactory`].
-Then invoke `getRegistry` on the `RegistryFactory` instance.
+--
+Obtain the `RegistryFactory` using either of the following techniques:
+
+** `@Inject RegistryFactory`.
++
+[source,java]
+.Getting the `RegistryFactory` using injection
+----
+class InjectExample {
+
+    @Inject
+    private RegistryFactory registryFactory;
+
+    private MetricRegistry findRegistry(String scope) {
+        return registryFactory.getRegistry(scope);
+    }
+}
+----
++
+** Invoke the static `getInstance()` method on the `RegistryFactory` class.
++
+[source,java]
+.Getting the `RegistryFactory` programmatically
+----
+class Example {
+
+    private MetricRegistry findRegistry(String scope) {
+        return RegistryFactory.getInstance().getRegistry(scope);
+    }
+}
+----
+--
 endif::[]
 
-The `MetricRegistry` allows your code to register new metrics, look up previously-registered metrics, and remove metrics.
+Once it has a reference to a `MetricRegistry` your code can use the reference to register new metrics, look up previously-registered metrics, and remove metrics.
 // end::metric-registry-api[]
 
 // tag::example-apps[]

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -206,7 +206,7 @@ class MetricProducer {
             final Metric metricAnno = ip.getAnnotated().getAnnotation(Metric.class);
             final Tag[] tags = tags(metricAnno);
             final String scope = metricAnno == null ? MetricRegistry.APPLICATION_SCOPE : metricAnno.scope();
-            Registry registry = RegistryFactory.getInstance().getRegistry(scope);
+            Registry registry = RegistryFactory.getInstance().registry(scope);
             final MetricID metricID = new MetricID(getName(metricAnno, ip), tags);
             return new MetricLocator(metricAnno, registry, metricID);
         }

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryFactory.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 
 /**
@@ -52,7 +53,7 @@ import org.eclipse.microprofile.metrics.Timer;
  * method creates a new instance but does not record it internally.
  * </p>
  */
-class RegistryFactory {
+public class RegistryFactory {
 
     static final Collection<Class<? extends Metric>> METRIC_TYPES = Set.of(Counter.class,
                                                                            Gauge.class,
@@ -86,7 +87,7 @@ class RegistryFactory {
      *
      * @return registry factory singleton
      */
-    static RegistryFactory getInstance() {
+    public static RegistryFactory getInstance() {
         RegistryFactory result = REGISTRY_FACTORY.get();
         if (result == null) {
             LOGGER.log(Level.WARNING, "Attempt to retrieve current " + RegistryFactory.class.getName()
@@ -115,7 +116,11 @@ class RegistryFactory {
      * @param scope scope of registry
      * @return Registry for the scope requested
      */
-    Registry getRegistry(String scope) {
+    public MetricRegistry getRegistry(String scope) {
+        return registry(scope);
+    }
+
+    Registry registry(String scope) {
         return accessMetricsSettings(() -> registries.computeIfAbsent(scope, s ->
                 Registry.create(s, meterRegistry)));
     }
@@ -150,7 +155,7 @@ class RegistryFactory {
         if (scope == null) {
             LOGGER.log(Level.WARNING, "Attempt to register an existing meter with no scope: " + delegate);
         }
-        getRegistry(scope).onMeterAdded(delegate);
+        registry(scope).onMeterAdded(delegate);
     }
 
     private void removeMetricForMeter(Meter meter) {
@@ -158,7 +163,7 @@ class RegistryFactory {
         if (scope == null) {
             LOGGER.log(Level.WARNING, "Attempt to register an existing meter with no scope: " + meter);
         }
-        getRegistry(scope).onMeterRemoved(meter);
+        registry(scope).onMeterRemoved(meter);
     }
 
 }

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
@@ -71,6 +71,11 @@ final class RegistryProducer {
         return RegistryFactory.getInstance().getRegistry(MetricRegistry.VENDOR_SCOPE);
     }
 
+    @Produces
+    public static RegistryFactory getRegistryFactory() {
+        return RegistryFactory.getInstance();
+    }
+
     /**
      * Clears Application registry. This is required for the Metric TCKs as they
      * all run on the same VM and must not interfere with each other.

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/ProducerTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/ProducerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -45,6 +46,9 @@ public class ProducerTest extends MetricsBaseTest {
 
     @Inject
     private MetricRegistry appRegistry;
+
+    @Inject
+    private RegistryFactory registryFactory;
 
     private final MetricID counter1 = new MetricID("counter1");
     private final MetricID counter2 = new MetricID("counter2");
@@ -78,5 +82,11 @@ public class ProducerTest extends MetricsBaseTest {
         assertThat("Counters are different", appCounter, is(not(sameInstance(specialCounter))));
         assertThat("App registry counter", appCounter.getCount(), is(appCounterIncr));
         assertThat("Special registry counter", specialCounter.getCount(), is(specialCounterIncr));
+    }
+
+    @Test
+    void testRegistryFactoryProducer() {
+        MetricRegistry customRegistry = registryFactory.getRegistry("myCustomScope");
+        assertThat("Custom scoped MetricRegistry", customRegistry, notNullValue());
     }
 }


### PR DESCRIPTION
### Description
Resolves #8161 

In 3.x, the `RegistryFactory` class was public in the metrics API module and usable from both SE and MP. It had public methods `getInstance()` and `getRegistry()` and was injectable.

In 4.x, we moved it to MP because it no longer applied in SE with the new neutral metrics API. At that time, I also made the class package-private because `RegistryFactory` only had a role in MP metrics now, and I anticipated that users would `@Inject MetricRegistry` rather than work with the `RegistryFactory`.

The 4.x doc still referred to `RegistryFactory` and, in fact, it is still a valid use case to either `@Inject` the `RegistryFactory` or retrieve it programmatically using a static method so as to invoke its `getRegistry` method to locate a `MetricRegistry` programmatically. As we found out in our internal Slack channel, users had used these approaches in 3.x and we broke their code by removing this capability.

Restoring these features, essentially to how they worked in 3.x, enlarges our surface area only very slightly as compared to 4.0.1 and allows existing user code to continue to work with only a change in `import` statements (because `RegistryFactory` is in a different package in 4.x).

This PR does the following:
1. Make `RegistryFactory` and its `getInstance()` and `getRegistry(String)` methods public.
   1. Change the return type of `getRegistry` from `Registry` (a package-private class) to `MetricRegistry` (an MP metrics  interface which `Registry` implements).
   2. Add a package-private method `registry(String)` to `RegistryFactory` which returns a `Registry` for use by our own methods in the package.
2. Update the MP metrics doc to clarify and show how to get and use a `RegistryFactory` instance.


### Documentation
Changes included in the PR.