### PR TITLE
Post 4.0.2 release changes 

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -82,7 +82,7 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>default</id>
+                                <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -95,7 +95,7 @@
                         <artifactId>helidon-javadoc-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <phase>package</phase>
+                                <phase>generate-resources</phase>
                                 <goals>
                                     <goal>javadoc</goal>
                                 </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1293,6 +1293,7 @@
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
                             <execution>
+                                <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>


### PR DESCRIPTION
### Description

Backport changes made in the 4.0.2 release branch to work with the site changes made in #8171
- Update release.sh
- Update javadoc profile to set the execution id to "attach-javadoc" (single execution with -Prelease,javadoc)
- Update aggregated javadoc phase to "generate-resources" to include them in helidon-docs.jar

### Documentation

None