### PR TITLE
Remove unnecessary GreetingProvider from example custom liveness health check

### DIFF
--- a/docs/src/main/asciidoc/mp/guides/health.adoc
+++ b/docs/src/main/asciidoc/mp/guides/health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -133,7 +133,6 @@ import org.eclipse.microprofile.health.Liveness;
 @Liveness // <1>
 @ApplicationScoped // <2>
 public class GreetLivenessCheck implements HealthCheck {
-  private GreetingProvider provider;
 
   @Override
   public HealthCheckResponse call() {


### PR DESCRIPTION
### Description
This `GreetingProvider` in the example looks unnecessary and can be deleted. Similar example in `docs/src/main/asciidoc/mp/health.adoc` doesn't contain it.

