### PR TITLE
Fix copyrights from an earlier merge

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/inject/tests/resources-inject/src/test/java/io/helidon/inject/tests/inject/interceptor/InterceptorRuntimeTest.java
+++ b/inject/tests/resources-inject/src/test/java/io/helidon/inject/tests/inject/interceptor/InterceptorRuntimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,8 +103,10 @@ class InterceptorRuntimeTest {
         File file = new File("./target/generated-sources/annotations", path);
         assertThat(file.exists(), is(true));
         String java = Files.readString(file.toPath());
-        assertEquals(loadStringFromResource("expected/yimpl-interceptor._java_"),
-                     java);
+        String expected = loadStringFromResource("expected/yimpl-interceptor._java_");
+        assertEquals(
+                expected.replaceFirst("#DATE#", Integer.toString(Calendar.getInstance().get(Calendar.YEAR))),
+                java);
     }
 
     @Test

--- a/inject/tests/resources-inject/src/test/resources/expected/yimpl-interceptor._java_
+++ b/inject/tests/resources-inject/src/test/resources/expected/yimpl-interceptor._java_
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) #DATE# Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
  * you may not use this file except in compliance with the License.

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
Fix copyrights from the earlier merge of #8174

There was also an error in an injection interceptor test because the expected data contained a hard-coded 2023 date instead of a placeholder which the test should have substituted for. This PR now also repairs that.

### Documentation
None