### PR TITLE
Fix issue for checking if app is running in an OCI instance which causes Instance Principal auth to fail

### DIFF
--- a/integrations/oci/sdk/runtime/pom.xml
+++ b/integrations/oci/sdk/runtime/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -91,6 +91,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityDefault.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityDefault.java
@@ -37,7 +37,7 @@ import static com.oracle.bmc.auth.AbstractFederationClientAuthenticationDetailsP
 @Singleton
 @Weight(ServiceInfoBasics.DEFAULT_INJECT_WEIGHT)
 class OciAvailabilityDefault implements OciAvailability {
-    static String OPC_PATH = getOpcPath();
+    private static final String OPC_PATH = getOpcPath();
 
     @Override
     public boolean isRunningOnOci(OciConfig ociConfig) {
@@ -74,7 +74,7 @@ class OciAvailabilityDefault implements OciAvailability {
         }
     }
 
-    static String getOpcPath() {
+    private static String getOpcPath() {
         String input = METADATA_SERVICE_BASE_URL;
         int index = -1;
         for (int nth = 3; nth > 0; nth--) {

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityDefault.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityDefault.java
@@ -37,7 +37,7 @@ import static com.oracle.bmc.auth.AbstractFederationClientAuthenticationDetailsP
 @Singleton
 @Weight(ServiceInfoBasics.DEFAULT_INJECT_WEIGHT)
 class OciAvailabilityDefault implements OciAvailability {
-    private static final String OPC_PATH = getOpcPath();
+    private static final String OPC_PATH = getOpcPath(METADATA_SERVICE_BASE_URL);
 
     @Override
     public boolean isRunningOnOci(OciConfig ociConfig) {
@@ -74,15 +74,15 @@ class OciAvailabilityDefault implements OciAvailability {
         }
     }
 
-    private static String getOpcPath() {
-        String input = METADATA_SERVICE_BASE_URL;
+    static String getOpcPath(String metadataServiceBaseURL) {
+        String input = metadataServiceBaseURL;
         int index = -1;
         for (int nth = 3; nth > 0; nth--) {
             index = input.indexOf("/", index + 1);
             if (index == -1) {
-                return null;
+                throw new IllegalStateException("Unable to find opc path from '" + metadataServiceBaseURL + "'");
             }
         }
-        return METADATA_SERVICE_BASE_URL.substring(index);
+        return metadataServiceBaseURL.substring(index);
     }
 }

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityDefault.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityDefault.java
@@ -28,6 +28,8 @@ import io.helidon.inject.api.ServiceInfoBasics;
 import com.oracle.bmc.Region;
 import jakarta.inject.Singleton;
 
+import static com.oracle.bmc.auth.AbstractFederationClientAuthenticationDetailsProviderBuilder.METADATA_SERVICE_BASE_URL;
+
 /**
  * This (overridable) implementation will check the {@link OciConfig} for {@code IMDS} availability. And if it is found to be
  * available, will also perform a secondary check on {@link Region#getRegionFromImds()} to ensure it returns a non-null value.
@@ -35,6 +37,7 @@ import jakarta.inject.Singleton;
 @Singleton
 @Weight(ServiceInfoBasics.DEFAULT_INJECT_WEIGHT)
 class OciAvailabilityDefault implements OciAvailability {
+    static String OPC_PATH = getOpcPath();
 
     @Override
     public boolean isRunningOnOci(OciConfig ociConfig) {
@@ -46,7 +49,7 @@ class OciAvailabilityDefault implements OciAvailability {
             return false;
         }
 
-        return (Region.getRegionFromImds("http://" + ociConfig.imdsHostName() + "/opc/v2/") != null);
+        return (Region.getRegionFromImds("http://" + ociConfig.imdsHostName() + OPC_PATH) != null);
     }
 
     static boolean canReach(String address,
@@ -71,4 +74,15 @@ class OciAvailabilityDefault implements OciAvailability {
         }
     }
 
+    static String getOpcPath() {
+        String input = METADATA_SERVICE_BASE_URL;
+        int index = -1;
+        for (int nth = 3; nth > 0; nth--) {
+            index = input.indexOf("/", index + 1);
+            if (index == -1) {
+                return null;
+            }
+        }
+        return METADATA_SERVICE_BASE_URL.substring(index);
+    }
 }

--- a/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityDefault.java
+++ b/integrations/oci/sdk/runtime/src/main/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ class OciAvailabilityDefault implements OciAvailability {
             return false;
         }
 
-        return (Region.getRegionFromImds() != null);
+        return (Region.getRegionFromImds("http://" + ociConfig.imdsHostName() + "/opc/v2/") != null);
     }
 
     static boolean canReach(String address,

--- a/integrations/oci/sdk/runtime/src/test/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityTest.java
+++ b/integrations/oci/sdk/runtime/src/test/java/io/helidon/integrations/oci/sdk/runtime/OciAvailabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,12 @@ package io.helidon.integrations.oci.sdk.runtime;
 import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OciAvailabilityTest {
 
@@ -32,4 +35,22 @@ class OciAvailabilityTest {
                                  is(false));
     }
 
+    @Test
+    void getValidOpcPath() {
+        assertThat(OciAvailabilityDefault.getOpcPath("http://169.254.169.254/opc/v2/"),
+                   is("/opc/v2/"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http169.254.169.254opcv2",
+            "http://169.254.169.254",
+    })
+    void getInValidOpcPath(String metadataServiceBaseURL) {
+        Exception e = assertThrows(IllegalStateException.class, () -> {
+            OciAvailabilityDefault.getOpcPath(metadataServiceBaseURL);
+        });
+        String expectedMessage = "Unable to find opc path from '" + metadataServiceBaseURL + "'";
+        assertThat(e.getMessage(), is(expectedMessage));
+    }
 }


### PR DESCRIPTION
### Description

The call to `Region.getRegionFromImds()` in `OciAvailabilityDefault.runningOnOci(OciConfig ociConfig)` is returning null causing Instance Principal authentication to not work because the code thinks it is not running in an OCI instance. To resolve this issue, passing in the Metadata Service Url in `Region.getRegionFromImds()` helps return a valid value.

Tested and validated this change to be working in a helidon app that is running in an OCI instance.

### Documentation

If no doc impact: None
