### PR TITLE
4.x: TLS default config values

### DIFF
--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/ConfiguredTlsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,6 @@ public class ConfiguredTlsManager implements TlsManager {
     // secure random cannot be stored in native image, it must
     // be initialized at runtime
     private static final LazyValue<SecureRandom> RANDOM = LazyValue.create(SecureRandom::new);
-
     private final String name;
     private final String type;
 
@@ -163,7 +162,11 @@ public class ConfiguredTlsManager implements TlsManager {
 
             SSLSessionContext serverSessionContext = sslContext.getServerSessionContext();
             if (serverSessionContext != null) {
-                serverSessionContext.setSessionCacheSize(tlsConfig.sessionCacheSize());
+                if (tlsConfig.sessionCacheSize() != TlsConfig.DEFAULT_SESSION_CACHE_SIZE) {
+                    // To allow javax.net.ssl.sessionCacheSize system property usage
+                    // see javax.net.ssl.SSLSessionContext.getSessionCacheSize doc
+                    serverSessionContext.setSessionCacheSize(tlsConfig.sessionCacheSize());
+                }
                 // seconds
                 serverSessionContext.setSessionTimeout((int) tlsConfig.sessionTimeout().toSeconds());
             }

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/TlsConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,14 @@ interface TlsConfigBlueprint extends Prototype.Factory<Tls> {
      * The default protocol is set to {@value}.
      */
     String DEFAULT_PROTOCOL = "TLS";
+    /**
+     * The default session cache size as defined for unset value in {@link javax.net.ssl.SSLSessionContext#getSessionCacheSize()}.
+     */
+    int DEFAULT_SESSION_CACHE_SIZE = 20480;
+    /**
+     * The default session timeout as defined for unset value in {@link javax.net.ssl.SSLSessionContext#getSessionTimeout()}.
+     */
+    String DEFAULT_SESSION_TIMEOUT = "PT24H";
 
     @Prototype.FactoryMethod
     static Optional<PrivateKey> createPrivateKey(Keys config) {
@@ -248,17 +256,17 @@ interface TlsConfigBlueprint extends Prototype.Factory<Tls> {
     /**
      * SSL session cache size.
      *
-     * @return session cache size, defaults to 1024
+     * @return session cache size, defaults to {@value DEFAULT_SESSION_CACHE_SIZE}.
      */
-    @ConfiguredOption("1024")
+    @Option.DefaultInt(DEFAULT_SESSION_CACHE_SIZE)
     int sessionCacheSize();
 
     /**
      * SSL session timeout.
      *
-     * @return session timeout, defaults to 30 minutes
+     * @return session timeout, defaults to {@value DEFAULT_SESSION_TIMEOUT}.
      */
-    @ConfiguredOption("PT30M")
+    @Option.Default(DEFAULT_SESSION_TIMEOUT)
     Duration sessionTimeout();
 
     /**


### PR DESCRIPTION
Fixes #8127

### Helidon 2, 3
While in Helidon 2 and 3 following logic was used for `sessionCacheSize` and `sessionTimeoutSeconds`:
```java
private long sessionCacheSize; // def 0
private long sessionTimeoutSeconds; //def 0
...
int sessionCacheSize = tlsConfig.sessionCacheSize();
if (sessionCacheSize > 0) {
  serverSessionContext.setSessionCacheSize(sessionCacheSize);
}
int sessionTimeoutSecs = tlsConfig.sessionTimeoutSeconds();
if (sessionTimeoutSecs > 0) {
  serverSessionContext.setSessionTimeout(sessionTimeoutSecs);
}
```

Resulting in an actual defaults being the unset defaults of [SSLSessionContext](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/javax/net/ssl/SSLSessionContext.html#getSessionCacheSize()):

- void setSessionTimeout(int seconds);  ----> `86400`
 seconds – the new session timeout limit in seconds; zero means there is no limit.
The JDK implementation returns the session timeout as set by the setSessionTimeout method, or if not set, a default value of `86400` seconds (24 hours).

 - void setSessionCacheSize(int size); ----> `20480`
 size – the new session cache size limit; zero means there is no limit.
 The JDK implementation returns the cache size as set by the setSessionCacheSize method, or if not set, the value of the javax.net.ssl.sessionCacheSize system property. If neither is set, it returns a default value of `20480`.  

### Helidon 4
In Helidon 4 we are currently using:
```java
@ConfiguredOption("1024")
int sessionCacheSize();
@ConfiguredOption("PT30M")
Duration sessionTimeout();
...
SSLSessionContext serverSessionContext = sslContext.getServerSessionContext();
if (serverSessionContext != null) {
  serverSessionContext.setSessionCacheSize(tlsConfig.sessionCacheSize());
  serverSessionContext.setSessionTimeout((int) tlsConfig.sessionTimeout().toSeconds());
}
```

This PR alignes the defaults with previous versions of Helidon.

 
