### PR TITLE
4.x Allow programmatic look-up of MetricRegistry via CDI without NPE

### DIFF
--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
@@ -41,8 +41,8 @@ final class RegistryProducer {
     @Produces
     @Default
     public static org.eclipse.microprofile.metrics.MetricRegistry getScopedRegistry(InjectionPoint injectionPoint) {
-        Annotated annotated = injectionPoint == null ? null : injectionPoint.getAnnotated();
-        RegistryScope scope = annotated == null ? null : annotated.getAnnotation(RegistryScope.class);
+        Annotated annotated = (injectionPoint == null) ? null : injectionPoint.getAnnotated();
+        RegistryScope scope = (annotated == null) ? null : annotated.getAnnotation(RegistryScope.class);
         return scope == null
                 ? getApplicationRegistry()
                 : RegistryFactory.getInstance().getRegistry(scope.scope());

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.microprofile.metrics;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.Annotated;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricRegistry.Type;
@@ -40,7 +41,8 @@ final class RegistryProducer {
     @Produces
     @Default
     public static org.eclipse.microprofile.metrics.MetricRegistry getScopedRegistry(InjectionPoint injectionPoint) {
-        RegistryScope scope = injectionPoint.getAnnotated().getAnnotation(RegistryScope.class);
+        Annotated annotated = injectionPoint == null ? null : injectionPoint.getAnnotated();
+        RegistryScope scope = annotated == null ? null : annotated.getAnnotation(RegistryScope.class);
         return scope == null
                 ? getApplicationRegistry()
                 : RegistryFactory.getInstance().getRegistry(scope.scope());

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/ProducerTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/ProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.microprofile.metrics;
 
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricID;
@@ -88,5 +89,13 @@ public class ProducerTest extends MetricsBaseTest {
     void testRegistryFactoryProducer() {
         MetricRegistry customRegistry = registryFactory.getRegistry("myCustomScope");
         assertThat("Custom scoped MetricRegistry", customRegistry, notNullValue());
+    }
+
+    @Test
+    void testDirectMetricRegistryLookup() {
+        MetricRegistry appRegistry = CDI.current().select(MetricRegistry.class).get();
+        assertThat("Directly-looked-up app registry", appRegistry, notNullValue());
+
+        
     }
 }

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/ProducerTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/ProducerTest.java
@@ -95,7 +95,5 @@ public class ProducerTest extends MetricsBaseTest {
     void testDirectMetricRegistryLookup() {
         MetricRegistry appRegistry = CDI.current().select(MetricRegistry.class).get();
         assertThat("Directly-looked-up app registry", appRegistry, notNullValue());
-
-        
     }
 }


### PR DESCRIPTION
### Description
Resolves #8209 

The producer method failed to check that the injection point and its `getAnnotated()` return value were non-null before using them.  Thus `CDI.current().select(MetricRegistry.class).get()` triggered an NPE.

(It turned out that the `InjectionPoint` passed is non-null but its `getAnnotated()` return value _was_ null in this case.)


### Documentation
Bug fix - no doc impact