### PR TITLE
4.x Add support for `@SpanAttribute` annotation, use entire path for REST resource span name

### DIFF
--- a/common/testing/junit5/src/main/java/io/helidon/common/testing/junit5/MatcherWithRetry.java
+++ b/common/testing/junit5/src/main/java/io/helidon/common/testing/junit5/MatcherWithRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,15 +44,34 @@ public class MatcherWithRetry {
      * @param <T> type of the supplied value
      */
     public static <T> T assertThatWithRetry(String reason, Supplier<T> actualSupplier, Matcher<? super T> matcher) {
+        return assertThatWithRetry(reason, actualSupplier, matcher, RETRY_COUNT, RETRY_DELAY_MS);
+    }
+
+    /**
+     * Checks the matcher, possibly multiple times after configured delays, invoking the supplier of the matched value each time,
+     * until either the matcher passes or the maximum retry expires.
+     * @param reason explanation of the assertion
+     * @param actualSupplier {@code Supplier} that furnishes the value to submit to the matcher
+     * @param matcher Hamcrest matcher which evaluates the supplied value
+     * @param retryCount number of times to retry the supplier while it does not give an answer satisfying the matcher
+     * @param retryDelayMs delay in milliseconds between retries
+     * @return the supplied value
+     * @param <T> type of the supplied value
+     */
+    public static <T> T assertThatWithRetry(String reason,
+                                            Supplier<T> actualSupplier,
+                                            Matcher<? super T> matcher,
+                                            int retryCount,
+                                            int retryDelayMs) {
 
         T actual = null;
-        for (int i = 0; i < RETRY_COUNT; i++) {
+        for (int i = 0; i < retryCount; i++) {
             actual = actualSupplier.get();
             if (matcher.matches(actual)) {
                 return actual;
             }
             try {
-                Thread.sleep(RETRY_DELAY_MS);
+                Thread.sleep(retryDelayMs);
             } catch (InterruptedException e) {
                 fail("Error sleeping during assertThatWithRetry", e);
             }

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -134,6 +134,32 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/WithSpanWithExplicitAppTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>run-separately</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/WithSpanTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
 </project>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -100,6 +100,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -134,32 +134,32 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-test</id>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/WithSpanWithExplicitAppTest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>run-separately</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/WithSpanTest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>pipeline</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <configuration>
+                                    <!-- The test times out in the pipeline, even with very long retry delays. -->
+                                    <excludes>
+                                        <exclude>**/WithSpanWithExplicitAppTest.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -88,6 +88,16 @@
         </dependency>
         <!-- testing -->
         <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
@@ -166,20 +168,20 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         ExtendedUriInfo extendedUriInfo = (ExtendedUriInfo) requestContext.getUriInfo();
 
         // Derive the original path (including path parameters) of the matched resource from the bottom up.
-        StringBuilder derivedPath = new StringBuilder();
+        Deque<String> derivedPath = new LinkedList<>();
 
         Resource resource = extendedUriInfo.getMatchedModelResource();
         while (resource != null) {
-            derivedPath.insert(0, resource.getPath());
+            derivedPath.push(resource.getPath());
             if (!resource.getPath().startsWith("/")) {
-                derivedPath.insert(0, "/");
+                derivedPath.push("/");
             }
             resource = resource.getParent();
         }
 
-        derivedPath.insert(0, applicationPath())
-                .insert(0, requestContext.getMethod() + " ");
-        return derivedPath.toString();
+        derivedPath.push(applicationPath());
+        derivedPath.push(requestContext.getMethod() + " ");
+        return String.join("", derivedPath);
     }
 
     private String applicationPath() {

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -156,14 +156,16 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
     }
 
     private String spanName(ContainerRequestContext requestContext) {
-        // According to OpenTelemetry semantic conventions for spans, the span name for a REST endpoint should be
+        // According to recent OpenTelemetry semantic conventions for spans, the span name for a REST endpoint should be
         //
         // http-method-name low-cardinality-path
         //
         // where a low-cardinality path would be, for example /greet/{name} rather than /greet/Joe, /greet/Dmitry, etc.
+        // But the version of semantic conventions in force when the MP Telemetry spec was published did not include the
+        // http-method-name. So our code omits that for now to pass the MP Telemetry TCK.
 
         if (spanNameFullUrl) {
-            return requestContext.getMethod() + " " + requestContext.getUriInfo().getAbsolutePath().toString();
+            return requestContext.getUriInfo().getAbsolutePath().toString();
         }
         ExtendedUriInfo extendedUriInfo = (ExtendedUriInfo) requestContext.getUriInfo();
 

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -172,15 +172,17 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
 
         Resource resource = extendedUriInfo.getMatchedModelResource();
         while (resource != null) {
-            derivedPath.push(resource.getPath());
-            if (!resource.getPath().startsWith("/")) {
-                derivedPath.push("/");
+            String resourcePath = resource.getPath();
+            if (!resourcePath.equals("/") && !resourcePath.isBlank()) {
+                derivedPath.push(resourcePath);
+                if (!resourcePath.startsWith("/")) {
+                    derivedPath.push("/");
+                }
             }
             resource = resource.getParent();
         }
 
         derivedPath.push(applicationPath());
-        derivedPath.push(requestContext.getMethod() + " ");
         return String.join("", derivedPath);
     }
 
@@ -193,7 +195,7 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
             return "";
         }
         ApplicationPath applicationPath = getRealClass(app.getClass()).getAnnotation(ApplicationPath.class);
-        return (applicationPath == null) ? "" : applicationPath.value();
+        return (applicationPath == null || applicationPath.value().equals("/")) ? "" : applicationPath.value();
     }
 
     // Resolve target string.

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.helidon.microprofile.telemetry;
 import java.util.List;
 import java.util.Objects;
 
+import io.helidon.common.context.Contexts;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
@@ -27,13 +29,16 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.Path;
+import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.ext.Provider;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.model.Resource;
 
 import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_METHOD;
 import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_SCHEME;
@@ -96,29 +101,14 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
             LOGGER.log(System.Logger.Level.TRACE, "Starting Span in a Container Request");
         }
 
-        Context parentContext = Context.current();
-
         // Extract Parent Context from request headers to be used from previous filters
         Context extractedContext = openTelemetry.getPropagators().getTextMapPropagator()
                 .extract(Context.current(), requestContext, CONTEXT_HEADER_INJECTOR);
 
-        if (extractedContext != null) {
-            parentContext = extractedContext;
-        }
-
-        String annotatedPath;
-        if (spanNameFullUrl) {
-            annotatedPath = requestContext.getUriInfo().getAbsolutePath().toString();
-        } else {
-            annotatedPath = requestContext.getUriInfo().getPath();
-            Path pathAnnotation = resourceInfo.getResourceMethod().getAnnotation(Path.class);
-            if (pathAnnotation != null) {
-                annotatedPath = pathAnnotation.value();
-            }
-        }
+        Context parentContext = Objects.requireNonNullElseGet(extractedContext, Context::current);
 
         //Start new span for container request.
-        Span span = tracer.spanBuilder(annotatedPath)
+        Span span = tracer.spanBuilder(spanName(requestContext))
                 .setParent(parentContext)
                 .setSpanKind(SpanKind.SERVER)
                 .setAttribute(HTTP_METHOD, requestContext.getMethod())
@@ -163,6 +153,47 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         }
     }
 
+    private String spanName(ContainerRequestContext requestContext) {
+        // According to OpenTelemetry semantic conventions for spans, the span name for a REST endpoint should be
+        //
+        // http-method-name low-cardinality-path
+        //
+        // where a low-cardinality path would be, for example /greet/{name} rather than /greet/Joe, /greet/Dmitry, etc.
+
+        if (spanNameFullUrl) {
+            return requestContext.getMethod() + " " + requestContext.getUriInfo().getAbsolutePath().toString();
+        }
+        ExtendedUriInfo extendedUriInfo = (ExtendedUriInfo) requestContext.getUriInfo();
+
+        // Derive the original path (including path parameters) of the matched resource from the bottom up.
+        StringBuilder derivedPath = new StringBuilder();
+
+        Resource resource = extendedUriInfo.getMatchedModelResource();
+        while (resource != null) {
+            derivedPath.insert(0, resource.getPath());
+            if (!resource.getPath().startsWith("/")) {
+                derivedPath.insert(0, "/");
+            }
+            resource = resource.getParent();
+        }
+
+        derivedPath.insert(0, applicationPath())
+                .insert(0, requestContext.getMethod() + " ");
+        return derivedPath.toString();
+    }
+
+    private String applicationPath() {
+        Application app = Contexts.context()
+                .flatMap(it -> it.get(Application.class))
+                .orElseThrow(() -> new IllegalStateException("Application missing from context"));
+
+        if (app == null) {
+            return "";
+        }
+        ApplicationPath applicationPath = getRealClass(app.getClass()).getAnnotation(ApplicationPath.class);
+        return (applicationPath == null) ? "" : applicationPath.value();
+    }
+
     // Resolve target string.
     private String resolveTarget(ContainerRequestContext requestContext) {
         String path = requestContext.getUriInfo().getRequestUri().getPath();
@@ -190,4 +221,11 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         }
     }
 
+    private static Class<?> getRealClass(Class<?> object) {
+        Class<?> result = object;
+        while (result.isSynthetic()) {
+            result = result.getSuperclass();
+        }
+        return result;
+    }
 }

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryCdiExtension.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WithSpanInterceptor.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WithSpanInterceptor.java
@@ -17,7 +17,6 @@ package io.helidon.microprofile.telemetry;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WithSpanInterceptor.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WithSpanInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,15 @@
 package io.helidon.microprofile.telemetry;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
@@ -75,19 +79,42 @@ class WithSpanInterceptor {
             spanName = className + "." + method.getName();
         }
 
-        // Start new Span
-        Span span = tracer.spanBuilder(spanName)
+        SpanBuilder spanBuilder = tracer.spanBuilder(spanName)
                 .setSpanKind(annotation.kind())
-                .setParent(Context.current())
-                .startSpan();
+                .setParent(Context.current());
+
+        for (int i = 0; i < method.getParameters().length; i++) {
+            Parameter p = method.getParameters()[i];
+            if (p.isAnnotationPresent(SpanAttribute.class)) {
+                SpanAttribute spanAttribute = p.getAnnotation(SpanAttribute.class);
+                var attrName = spanAttribute.value().isBlank() ? p.getName() : spanAttribute.value();
+                Class<?> paramType = p.getType();
+                Object pValue = context.getParameters()[i];
+
+                if (paramType.isAssignableFrom(String.class)) {
+                    spanBuilder.setAttribute(attrName, (String) pValue);
+                } else if (paramType.isAssignableFrom(long.class) || paramType.isAssignableFrom(Long.class)) {
+                    spanBuilder.setAttribute(attrName, (long) pValue);
+                } else if (paramType.isAssignableFrom(double.class) || paramType.isAssignableFrom(Double.class)) {
+                    spanBuilder.setAttribute(attrName, (double) pValue);
+                } else if (paramType.isAssignableFrom(boolean.class) || paramType.isAssignableFrom(Boolean.class)) {
+                    spanBuilder.setAttribute(attrName, (boolean) pValue);
+                } else {
+                    spanBuilder.setAttribute(attrName, pValue.toString());
+                }
+            }
+        }
+
+        // Start new Span
+        Span span = spanBuilder.startSpan();
 
         try (Scope scope = span.makeCurrent()) {
-            return context.proceed();
+            Object result = context.proceed();
+            span.end();
+            return result;
         } catch (Exception e) {
             span.recordException(e);
             throw e;
-        } finally {
-            span.end();
         }
     }
 

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WithSpanInterceptor.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WithSpanInterceptor.java
@@ -90,14 +90,14 @@ class WithSpanInterceptor {
                 Class<?> paramType = p.getType();
                 Object pValue = context.getParameters()[i];
 
-                if (paramType.isAssignableFrom(String.class)) {
+                if (String.class.isAssignableFrom(paramType)) {
                     spanBuilder.setAttribute(attrName, (String) pValue);
-                } else if (paramType.isAssignableFrom(long.class) || paramType.isAssignableFrom(Long.class)) {
-                    spanBuilder.setAttribute(attrName, (long) pValue);
-                } else if (paramType.isAssignableFrom(double.class) || paramType.isAssignableFrom(Double.class)) {
-                    spanBuilder.setAttribute(attrName, (double) pValue);
-                } else if (paramType.isAssignableFrom(boolean.class) || paramType.isAssignableFrom(Boolean.class)) {
-                    spanBuilder.setAttribute(attrName, (boolean) pValue);
+                } else if (Long.class.isAssignableFrom(paramType) || long.class.isAssignableFrom(paramType)) {
+                    spanBuilder.setAttribute(attrName, (Long) pValue);
+                } else if (Double.class.isAssignableFrom(paramType) || double.class.isAssignableFrom(paramType)) {
+                    spanBuilder.setAttribute(attrName, (Double) pValue);
+                } else if (Boolean.class.isAssignableFrom(paramType) || boolean.class.isAssignableFrom(paramType)) {
+                    spanBuilder.setAttribute(attrName, (Boolean) pValue);
                 } else {
                     spanBuilder.setAttribute(attrName, pValue.toString());
                 }

--- a/microprofile/telemetry/src/main/java/module-info.java
+++ b/microprofile/telemetry/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ module io.helidon.microprofile.telemetry {
     requires io.helidon.common.context;
     requires io.helidon.config.mp;
     requires io.helidon.config;
+    requires io.helidon.microprofile.server;
     requires io.helidon.tracing.providers.opentelemetry;
     requires io.opentelemetry.api;
     requires io.opentelemetry.context;

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/App.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/App.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/topapp")
+public class App extends Application {
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AppTracedResource.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AppTracedResource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/apptraced")
+public class AppTracedResource {
+    @GET
+    @Path("/sub/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sub(@PathParam("name") String name) {
+        return "traced/sub result";
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String nosub() {
+        return "traced result";
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.testing.junit5.MatcherWithRetry;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.iterableWithSize;
+
+// Partially inspired by the MP Telemetry TCK InMemorySpanExporter.
+@ApplicationScoped
+public class TestSpanExporter implements SpanExporter {
+
+    private final List<SpanData> spanData = new CopyOnWriteArrayList<>();
+
+    private enum State {READY, STOPPED}
+
+    private State state = State.READY;
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> collection) {
+        if (state == State.STOPPED) {
+            return CompletableResultCode.ofFailure();
+        }
+        spanData.addAll(collection);
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        state = State.STOPPED;
+        spanData.clear();
+        return CompletableResultCode.ofSuccess();
+    }
+
+    List<SpanData> spanData(int expectedCount) {
+        return MatcherWithRetry.assertThatWithRetry("Expected span count",
+                                             () -> new ArrayList<>(spanData),
+                                             iterableWithSize(expectedCount),
+                                             15,
+                                             1000);
+    }
+
+    void clear() {
+        spanData.clear();
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
@@ -39,7 +39,7 @@ public class TestSpanExporter implements SpanExporter {
     private final List<SpanData> spanData = new CopyOnWriteArrayList<>();
     private final System.Logger LOGGER = System.getLogger(TestSpanExporter.class.getName());
 
-    private final int RETRY_COUNT = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryCount", 50);
+    private final int RETRY_COUNT = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryCount", 120);
     private final int RETRY_DELAY_MS = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryDelayMs", 500);
 
 

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporter.java
@@ -39,7 +39,7 @@ public class TestSpanExporter implements SpanExporter {
     private final List<SpanData> spanData = new CopyOnWriteArrayList<>();
     private final System.Logger LOGGER = System.getLogger(TestSpanExporter.class.getName());
 
-    private final int RETRY_COUNT = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryCount", 15);
+    private final int RETRY_COUNT = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryCount", 50);
     private final int RETRY_DELAY_MS = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryDelayMs", 500);
 
 

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporterProvider.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanExporterProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jakarta.enterprise.inject.spi.CDI;
+
+public class TestSpanExporterProvider implements ConfigurableSpanExporterProvider {
+
+    public TestSpanExporterProvider() {
+        System.err.println("provider ctor");
+    }
+
+    @Override
+    public SpanExporter createExporter(ConfigProperties configProperties) {
+        return CDI.current().select(TestSpanExporter.class).get();
+    }
+
+    @Override
+    public String getName() {
+        return "in-memory";
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TracedResource.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TracedResource.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/traced")
+public class TracedResource {
+
+    @GET
+    @Path("/sub/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sub(@PathParam("name") String name) {
+        return "traced/sub result";
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String nosub() {
+        return "traced result";
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanBean.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanBean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.opentelemetry.instrumentation.annotations.SpanAttribute;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+class WithSpanBean {
+
+    static final String TEST_SPAN_NAME_SCALAR = "withAttrsScalar";
+    static final String TEST_SPAN_NAME_OBJECT = "withAttrsObject";
+    static final String STRING_ATTR_NAME = "arg0";
+    static final String LONG_ATTR_NAME = "myLong";
+
+    @WithSpan(TEST_SPAN_NAME_SCALAR)
+    void runWithAttrsScalar(@SpanAttribute String aString,
+                            @SpanAttribute(LONG_ATTR_NAME) long aLong) {
+
+    }
+
+    @WithSpan(TEST_SPAN_NAME_OBJECT)
+    void runWithAttrsObject(@SpanAttribute String bString,
+                            @SpanAttribute(LONG_ATTR_NAME) Long bLong) {
+
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
@@ -16,38 +16,19 @@
 package io.helidon.microprofile.telemetry;
 
 import java.util.List;
-
-import io.helidon.microprofile.testing.junit5.AddBean;
-import io.helidon.microprofile.testing.junit5.AddConfig;
-import io.helidon.microprofile.testing.junit5.HelidonTest;
+import java.util.stream.Stream;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import jakarta.inject.Inject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@HelidonTest
-@AddBean(WithSpanBean.class)
-@AddBean(TestSpanExporter.class)
-@AddConfig(key = "otel.sdk.disabled", value = "false")
-@AddConfig(key = "otel.traces.exporter", value = "in-memory")
-class WithSpanTest {
-
-    @Inject
-    private WithSpanBean withSpanBean;
-
-    @Inject
-    private TestSpanExporter testSpanExporter;
-
-    @BeforeEach
-    void clear() {
-        testSpanExporter.clear();
-    }
+class WithSpanTest extends WithSpanTestBase {
 
     @Test
     void testSpanName() {
@@ -73,5 +54,16 @@ class WithSpanTest {
         attrs = spanData.get(1).getAttributes();
         assertThat("String attribute", attrs.get(stringKey), is("attrTestObject"));
         assertThat("Long attribute", attrs.get(longKey), is(5L));
+    }
+
+    @ParameterizedTest()
+    @MethodSource()
+    void testDefaultAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
+        testSpanNameFromPath(spanPathTestInfo);
+    }
+
+    static Stream<SpanPathTestInfo> testDefaultAppSpanNameFromPath() {
+        return Stream.of(new SpanPathTestInfo("traced", "GET /traced"),
+                         new SpanPathTestInfo("traced/sub/data", "GET /traced/sub/{name}"));
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.List;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddBean(WithSpanBean.class)
+@AddBean(TestSpanExporter.class)
+@AddConfig(key = "otel.sdk.disabled", value = "false")
+@AddConfig(key = "otel.traces.exporter", value = "in-memory")
+class WithSpanTest {
+
+    @Inject
+    private WithSpanBean withSpanBean;
+
+    @Inject
+    private TestSpanExporter testSpanExporter;
+
+    @BeforeEach
+    void clear() {
+        testSpanExporter.clear();
+    }
+
+    @Test
+    void testSpanName() {
+        withSpanBean.runWithAttrsScalar("nameTest", 3L);
+
+        List<SpanData> spanData = testSpanExporter.spanData(1);
+        assertThat("Test span name", spanData.get(0).getName(), is(WithSpanBean.TEST_SPAN_NAME_SCALAR));
+    }
+
+    @Test
+    void testSpanAttributes() {
+        withSpanBean.runWithAttrsScalar("attrTestScalar", 4L);
+        withSpanBean.runWithAttrsObject("attrTestObject", 5L);
+        List<SpanData> spanData = testSpanExporter.spanData(2);
+        AttributeKey<String> stringKey = AttributeKey.stringKey(WithSpanBean.STRING_ATTR_NAME);
+        AttributeKey<Long> longKey = AttributeKey.longKey(WithSpanBean.LONG_ATTR_NAME);
+
+        Attributes attrs = spanData.get(0).getAttributes();
+
+        assertThat("String attribute", attrs.get(stringKey), is("attrTestScalar"));
+        assertThat("Long attribute", attrs.get(longKey), is(4L));
+
+        attrs = spanData.get(1).getAttributes();
+        assertThat("String attribute", attrs.get(stringKey), is("attrTestObject"));
+        assertThat("Long attribute", attrs.get(longKey), is(5L));
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
@@ -63,7 +63,7 @@ class WithSpanTest extends WithSpanTestBase {
     }
 
     static Stream<SpanPathTestInfo> testDefaultAppSpanNameFromPath() {
-        return Stream.of(new SpanPathTestInfo("traced", "GET /traced"),
-                         new SpanPathTestInfo("traced/sub/data", "GET /traced/sub/{name}"));
+        return Stream.of(new SpanPathTestInfo("traced", "/traced"),
+                         new SpanPathTestInfo("traced/sub/data", "/traced/sub/{name}"));
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTestBase.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTestBase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.List;
+
+import io.helidon.microprofile.server.JaxRsApplication;
+import io.helidon.microprofile.server.JaxRsCdiExtension;
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddBean(WithSpanBean.class)
+@AddBean(TestSpanExporter.class)
+@AddBean(TracedResource.class)
+@AddConfig(key = "otel.sdk.disabled", value = "false")
+@AddConfig(key = "otel.traces.exporter", value = "in-memory")
+class WithSpanTestBase {
+
+    @Inject
+    WithSpanBean withSpanBean;
+
+    @Inject
+    TestSpanExporter testSpanExporter;
+
+    @Inject
+    WebTarget webTarget;
+
+    @BeforeEach
+    void clear() {
+        testSpanExporter.clear();
+    }
+
+    void testSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
+        JaxRsCdiExtension jaxRsCdiExtension = CDI.current().getBeanManager().getExtension(JaxRsCdiExtension.class);
+        List<JaxRsApplication> apps = jaxRsCdiExtension.applicationsToRun();
+        Response response = webTarget.path(spanPathTestInfo.requestPath)
+                .request(MediaType.TEXT_PLAIN)
+                .get();
+        assertThat("Status accessing " + spanPathTestInfo.requestPath, response.getStatus(), is(200));
+
+        List<SpanData> spanData = testSpanExporter.spanData(2); // Automatic GET span and then the resource method span
+        assertThat("Span name", spanData.get(0).getName(), is(spanPathTestInfo.expectedSpanName));
+    }
+
+    record SpanPathTestInfo(String requestPath, String expectedSpanName) {}
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import io.helidon.microprofile.server.JaxRsApplication;
+import io.helidon.microprofile.server.JaxRsCdiExtension;
+import io.helidon.microprofile.testing.junit5.AddBean;
+
+import jakarta.enterprise.inject.spi.CDI;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@AddBean(App.class)
+@AddBean(AppTracedResource.class)
+class WithSpanWithExplicitAppTest extends WithSpanTestBase {
+
+    @ParameterizedTest()
+    @MethodSource()
+    void testExplicitAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
+        List<JaxRsApplication> apps = CDI.current().getBeanManager().getExtension(JaxRsCdiExtension.class).applicationsToRun();
+        testSpanNameFromPath(spanPathTestInfo);
+    }
+
+    static Stream<SpanPathTestInfo> testExplicitAppSpanNameFromPath() {
+        return Stream.of(new SpanPathTestInfo("topapp/apptraced", "GET /topapp/apptraced"),
+                         new SpanPathTestInfo("topapp/apptraced/sub/data", "GET /topapp/apptraced/sub/{name}"));
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppTest.java
@@ -38,7 +38,7 @@ class WithSpanWithExplicitAppTest extends WithSpanTestBase {
     }
 
     static Stream<SpanPathTestInfo> testExplicitAppSpanNameFromPath() {
-        return Stream.of(new SpanPathTestInfo("topapp/apptraced", "GET /topapp/apptraced"),
-                         new SpanPathTestInfo("topapp/apptraced/sub/data", "GET /topapp/apptraced/sub/{name}"));
+        return Stream.of(new SpanPathTestInfo("topapp/apptraced", "/topapp/apptraced"),
+                         new SpanPathTestInfo("topapp/apptraced/sub/data", "/topapp/apptraced/sub/{name}"));
     }
 }

--- a/microprofile/telemetry/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/microprofile/telemetry/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.microprofile.telemetry.TestSpanExporterProvider

--- a/microprofile/tests/telemetry/src/test/java/io/helidon/microprofile/telemetry/RestSpanHierarchyTest.java
+++ b/microprofile/tests/telemetry/src/test/java/io/helidon/microprofile/telemetry/RestSpanHierarchyTest.java
@@ -88,7 +88,7 @@ public class RestSpanHierarchyTest {
 
 
         assertThat(spanItems.get(2).getKind(), is(SERVER));
-        assertThat(spanItems.get(2).getName(), is("mixed"));
+        assertThat(spanItems.get(2).getName(), is("/mixed"));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class RestSpanHierarchyTest {
 
 
         assertThat(spanItems.get(2).getKind(), is(SERVER));
-        assertThat(spanItems.get(2).getName(), is("mixed_injected"));
+        assertThat(spanItems.get(2).getName(), is("/mixed_injected"));
     }
 
 

--- a/microprofile/tests/telemetry/src/test/java/io/helidon/microprofile/telemetry/RestSpanHierarchyTest.java
+++ b/microprofile/tests/telemetry/src/test/java/io/helidon/microprofile/telemetry/RestSpanHierarchyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
Resolves #8157 
Resolves #8162 

Highlights:
* Enhance `WithSpanInterceptor` so it also processes `@SpanAttribute` annotations.
* Add tests to check span name and attributes.
* Fix derivation of OTel span name for REST endpoints to reflect OpenTelemetry span naming semantic conventions.
* Add tests for REST endpoint span naming.

### Documentation
Bug fix; no doc impact.
