### PR TITLE
4.x: fix broken documentation links Part 1

### DIFF
--- a/docs/src/main/asciidoc/guides/jib.adoc
+++ b/docs/src/main/asciidoc/guides/jib.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ Add the following plugin declaration to your pom.xml:
 
 NOTE: By default, Jib uses link:https://github.com/GoogleContainerTools/distroless/tree/master/java[distroless/java] as
  the base image. You can override the default with configuration see the
- link:{jib-base-url}/jib-maven-plugin/README.md#extended-usage[documentation]
+ link:{jib-base-url}/README.md#extended-usage[documentation]
 
 [source,bash]
 .Package the updated application
@@ -128,6 +128,6 @@ REPOSITORY          TAG           IMAGE ID      CREATED        SIZE
 jib-quickstart-se   latest        384aebda5594  48 years ago   124MB <1>
 ----
 <1> Ignore the fact that it says the image was created 48 years ago. Refer to
- the  link:{jib-base-url}/docs/faq.md#why-is-my-image-created-48-years-ago[Jib FAQ] for explanations.
+ the  link:{jib-base-url}/../docs/faq.md#why-is-my-image-created-48-years-ago[Jib FAQ] for explanations.
 
 NOTE: the Jib image is smaller because of the use of a distroless base image.

--- a/docs/src/main/asciidoc/includes/attributes.adoc
+++ b/docs/src/main/asciidoc/includes/attributes.adoc
@@ -57,23 +57,23 @@ endif::[]
 
 // jakarta specifications
 :version-lib-jakarta-core: 10
-:version-lib-jakarta-cdi: 4.0.1
-:version-lib-jakarta-websockets-api: 2.1.0
+:version-lib-jakarta-cdi: 4.0
+:version-lib-jakarta-websockets-api: 2.1
 :version-lib-jakarta-bean-validation: 3.0
-:version-lib-jakarta-jsonp-api: 2.1.1
+:version-lib-jakarta-jsonp-api: 2.1
 :version-lib-jakarta-jsonb-api: 3.0
-:version-lib-jakarta-jsonp-api: 2.1.1
+:version-lib-jakarta-jsonp-api: 2.1
 :version-lib-jakarta-annotations-api: 2.1.1
 :version-lib-jakarta-transaction-api: 2.0
-:version-lib-jakarta-persistence-api: 3.1.0
-:version-lib-jakarta-jaxrs-api: 3.1.0
-:version-lib-jakarta-inject: 2.0.1
+:version-lib-jakarta-persistence-api: 3.1
+:version-lib-jakarta-jaxrs-api: 3.1
+:version-lib-jakarta-inject: 2.0
 
 // 3rd party
 :version-lib-jaeger: 1.22
 :version-lib-hikaricp: 5.0.1
 :version-lib-eclipselink: 4.0.2
-:version-lib-hibernate: 6.1.7.Final
+:version-lib-hibernate: 6.1
 :version-lib-oracle-jdbc: 21
 :version-lib-oracle-ucp: {version-lib-oracle-jdbc}
 :version-plugin-jib: 0.10.1
@@ -141,7 +141,7 @@ endif::[]
 
 :microprofile-graphql-base-url: {microprofile-base-url}/microprofile-graphql-{version-lib-microprofile-graphql}
 :microprofile-graphql-spec-url: {microprofile-graphql-base-url}/microprofile-graphql-spec-{version-lib-microprofile-graphql}.html
-:microprofile-graphql-javadoc-url: {microprofile-rest-graphql-url}/apidocs
+:microprofile-graphql-javadoc-url: {microprofile-graphql-base-url}/apidocs
 
 // Jakarta versioned URLs
 
@@ -152,11 +152,11 @@ endif::[]
 :jakarta-cdi-javadoc-url: {jakarta-cdi-base-url}/apidocs/
 
 :jakarta-websocket-base-url: {jakarta-base-url}/websocket/{version-lib-jakarta-websockets-api}
-:jakarta-websocket-spec-url: {jakarta-websocket-base-url}/websocket-spec-{version-lib-jakarta-websockets-api}.html
+:jakarta-websocket-spec-url: {jakarta-websocket-base-url}/jakarta-websocket-spec-{version-lib-jakarta-websockets-api}.html
 :jakarta-websocket-javadoc-url: {jakarta-websocket-base-url}/apidocs/
 
 :jakarta-bean-validation-base-url: {jakarta-base-url}/bean-validation/{version-lib-jakarta-bean-validation}
-:jakarta-bean-validation-spec-url: {jakarta-bean-validation-base-url}/bean-validation_{version-lib-jakarta-bean-validation}.html
+:jakarta-bean-validation-spec-url: {jakarta-bean-validation-base-url}/jakarta-bean-validation-spec-{version-lib-jakarta-bean-validation}.html
 :jakarta-bean-validation-javadoc-url: {jakarta-bean-validation-base-url}/apidocs
 
 :jakarta-jsonp-base-url: {jakarta-base-url}/jsonp/{version-lib-jakarta-jsonp-api}
@@ -267,7 +267,7 @@ endif::[]
 :oracle-ucp-javadoc-base-url: https://docs.oracle.com/en/database/oracle/oracle-database/{version-lib-oracle-ucp}/jjuar
 
 :micrometer-url: https://micrometer.io
-:micrometer-api-url: https://micrometer.io/docs/concepts
+:micrometer-api-url: https://docs.micrometer.io/micrometer/reference/concepts.html
 :micrometer-javadoc-base-url: https://javadoc.io/doc/io.micrometer
 :micrometer-javadoc-registry-prometheus-base-url: {micrometer-javadoc-base-url}/micrometer-registry-prometheus/{version-lib-micrometer}/io/micrometer/prometheus
 

--- a/docs/src/main/asciidoc/includes/attributes.adoc
+++ b/docs/src/main/asciidoc/includes/attributes.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ endif::[]
 :version-lib-microprofile-metrics-api: 5.0.1
 :version-lib-microprofile-openapi-api: 3.1
 :version-lib-microprofile-reactive-messaging-api: 3.0
-:version-lib-microprofile-rs-operators-api: 3.1.1
+:version-lib-microprofile-rs-operators-api: 3.0
 :version-lib-microprofile-rest-client: 3.0
 :version.lib.microprofile-telemetry-tck: 1.0
 :version-lib-microprofile-telemetry: 1.0

--- a/docs/src/main/asciidoc/includes/openapi/openapi.adoc
+++ b/docs/src/main/asciidoc/includes/openapi/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -184,7 +184,7 @@ A Jandex index stores information about the classes and methods in your app and
 what annotations they have. It allows CDI to process annotations faster during your
 application's start-up.
 
-Add the link:https://github.com/smallrye/jandex/maven-plugin[Jandex maven plug-in] to the `<build><plugins>`
+Add the link:https://github.com/smallrye/jandex/tree/main/maven-plugin[Jandex maven plug-in] to the `<build><plugins>`
 section of your `pom.xml`:
 
 [source,xml,subs="attributes+"]

--- a/docs/src/main/asciidoc/mp/beanvalidation.adoc
+++ b/docs/src/main/asciidoc/mp/beanvalidation.adoc
@@ -396,7 +396,7 @@ public class GreetingProvider {
 +
 NOTE: `beans.xml` is required to identify beans and for bean validation to work properly.
 
-Examples are available in link:{helidon-github-tree-url}}/examples/microprofile/bean-validation[our official GitHub repository].
+Examples are available in link:{helidon-github-tree-url}/examples/microprofile/bean-validation[our official GitHub repository].
 
 == Additional Information
 
@@ -404,4 +404,4 @@ Helidon uses link:https://hibernate.org/validator/[Hibernate Bean Validator] for
 
 == Reference
 
-* link:{jakarta-bean-validation-spec-url}}[Bean Validation Specification]
+* link:{jakarta-bean-validation-spec-url}[Bean Validation Specification]

--- a/docs/src/main/asciidoc/mp/beanvalidation.adoc
+++ b/docs/src/main/asciidoc/mp/beanvalidation.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/mp/config/introduction.adoc
+++ b/docs/src/main/asciidoc/mp/config/introduction.adoc
@@ -243,5 +243,5 @@ Step-by-step guide about using {spec-name} in your Helidon MP application.
 
 == Reference
 
-* link:{microprofile-config-spec-url}}[{spec-name} Specifications]
+* link:{microprofile-config-spec-url}[{spec-name} Specifications]
 * link:{microprofile-fault-tolerance-javadoc-url}[{spec-name} Javadocs]

--- a/docs/src/main/asciidoc/mp/config/introduction.adoc
+++ b/docs/src/main/asciidoc/mp/config/introduction.adoc
@@ -1,7 +1,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/mp/fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/mp/fault-tolerance.adoc
@@ -227,4 +227,4 @@ link:{microprofile-fault-tolerance-javadoc-url}[MicroProfile Fault Tolerance Jav
 
 == Reference
 
-* link:{microprofile-fault-tolerance-spec-url}}[MicroProfile Fault Tolerance]
+* link:{microprofile-fault-tolerance-spec-url}[MicroProfile Fault Tolerance]

--- a/docs/src/main/asciidoc/mp/fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/mp/fault-tolerance.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/mp/guides/mp-tutorial.adoc
+++ b/docs/src/main/asciidoc/mp/guides/mp-tutorial.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -722,8 +722,7 @@ Helidon also support custom metrics.  To add a new metric, annotate the
  below:
 
 TIP:  You can find details of the available annotations in the
- https://microprofile.io/project/eclipse/microprofile-metrics[MicroProfile Metrics
- Specification].
+link:{microprofile-metrics-spec-url}[MicroProfile Metrics Specification]
 
 [source,java]
 .Updated GreetResource.java with custom metrics
@@ -1154,7 +1153,7 @@ There were several links to more detailed information included in the
 * link:{jakarta-cdi-spec-url}[Contexts and Dependency Injection Specification]
 * xref:../server.adoc[Server Configuration]
 * xref:../config/introduction.adoc[Config]
-* https://microprofile.io/project/eclipse/microprofile-metrics[MicroProfile Metrics Specification]
+* link:{microprofile-metrics-spec-url}[MicroProfile Metrics Specification]
 * xref:metrics.adoc[Metrics Guide]
 * link:{microprofile-health-spec-url}##_protocol_and_wireformat[MicroProfile Health Protocol and Wireformat]
 * xref:../../about/kubernetes.adoc[Install Kubernetes on your desktop]

--- a/docs/src/main/asciidoc/mp/guides/upgrade_4x.adoc
+++ b/docs/src/main/asciidoc/mp/guides/upgrade_4x.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ Incompatible changes described in link:https://download.eclipse.org/microprofile
 
 * *MicroProfile Metrics {version-lib-microprofile-metrics-api}*:
 +
-Incompatible changes described in link:https://download.eclipse.org/microprofile/microprofile-metrics-5.0/microprofile-metrics-spec-5.0.html#_incompatible_changes[MicroProfile Metrics {version-lib-microprofile-metrics-api} Specification]
+Incompatible changes described in link:https://download.eclipse.org/microprofile/microprofile-metrics-5.0.0/microprofile-metrics-spec-5.0.0.html#_incompatible_changes[MicroProfile Metrics {version-lib-microprofile-metrics-api} Specification]
 
 * *MicroProfile OpenAPI {version-lib-microprofile-openapi-api}*:
 +

--- a/docs/src/main/asciidoc/mp/metrics/metrics.adoc
+++ b/docs/src/main/asciidoc/mp/metrics/metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -584,4 +584,4 @@ include::{rootdir}/includes/guides/metrics.adoc[tag=k8s-and-prometheus-integrati
 === References
 link:{microprofile-metrics-spec-url}[MicroProfile Metrics specification]
 
-link:{microprofile-metrics-javadoc-url}/org/eclipse/microprofile/metrics/package-info.html[MicroProfile Metrics API]
+link:{microprofile-metrics-javadoc-url}/org/eclipse/microprofile/metrics/package-summary.html[MicroProfile Metrics API]

--- a/docs/src/main/asciidoc/mp/openapi/openapi.adoc
+++ b/docs/src/main/asciidoc/mp/openapi/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/mp/openapi/openapi.adoc
+++ b/docs/src/main/asciidoc/mp/openapi/openapi.adoc
@@ -257,7 +257,7 @@ curl -X GET http://localhost:8080/openapi
 The output describes not only then endpoints from `GreetResource` but
 also one contributed by the `SimpleAPIModelReader`.
 
-Full example is available link:{helidon-github-tree-url}}/examples/microprofile/openapi[in our official repository]
+Full example is available link:{helidon-github-tree-url}/examples/microprofile/openapi[in our official repository]
 
 
 == Additional Information

--- a/docs/src/main/asciidoc/mp/persistence.adoc
+++ b/docs/src/main/asciidoc/mp/persistence.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ pools:
 
 1. https://github.com/brettwooldridge/HikariCP[HikariCP]
 
-2. link:{oracle-ucp-doc-base-url}index.html[Oracle Universal
+2. link:{oracle-ucp-doc-base-url}/index.html[Oracle Universal
    Connection Pool]
 
 You can choose to use either, but not both.
@@ -146,7 +146,7 @@ managed]
 
 ====== Maven Coordinates (Oracle Universal Connection Pool) [[DS-UCP-Maven-Coordinates]]
 
-To include the link:{oracle-ucp-doc-base-url}index.html[Oracle
+To include the link:{oracle-ucp-doc-base-url}/index.html[Oracle
 Universal Connection Pool] in your Helidon MP application:
 
 * xref:../about/managing-dependencies.adoc[Ensure your dependencies are
@@ -1428,7 +1428,7 @@ relational database tables, and how to perform other related tasks.
 * link:{jakarta-persistence-javadoc-url}/[Jakarta Persistence
   {persistence-lib-jakarta-persistence-api} API Reference]
 
-* link:{hibernate-doc-jboss-url}userguide/html_single/Hibernate_User_Guide.html[Hibernate
+* link:{hibernate-doc-jboss-url}/userguide/html_single/Hibernate_User_Guide.html[Hibernate
   ORM User Guide]
 
 * https://www.eclipse.org/eclipselink/documentation/[Eclipselink documentation]

--- a/docs/src/main/asciidoc/mp/testing-ng.adoc
+++ b/docs/src/main/asciidoc/mp/testing-ng.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -193,4 +193,4 @@ public class TestReqScopeDisabledDiscovery {
 
 == Reference
 
-* https://testng.org/doc/documentation-main.html[TestNG User Guide]
+* https://testng.org[TestNG Documentation]

--- a/docs/src/main/asciidoc/se/guides/tracing.adoc
+++ b/docs/src/main/asciidoc/se/guides/tracing.adoc
@@ -332,7 +332,8 @@ server:
   host: 0.0.0.0
 ----
 
-NOTE: The settings above are for development and experimental purposes only. For a production environment please see the xref:../tracing.adoc[Tracing documentation].
+NOTE: The settings above are for development and experimental purposes only. For production environment, please see the
+xref:{rootdir}/se/tracing.adoc[Tracing documentation].
 
 [source,java]
 .Update the `GreetService` class. Replace the `getDefaultMessageHandler` method:

--- a/docs/src/main/asciidoc/se/security/providers.adoc
+++ b/docs/src/main/asciidoc/se/security/providers.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/se/security/providers.adoc
+++ b/docs/src/main/asciidoc/se/security/providers.adoc
@@ -104,7 +104,7 @@ include::{rootdir}/includes/security/providers/jwt.adoc[]
 
 == Reference
 
-* link:{https://github.com/oracle/helidon/tree/master/examples/security[Helidon Security Examples]
+* link:{helidon-github-tree-url}examples/security[Helidon Security Examples]
 * link:{security-provider-oidc-base-url}/module-summary.html[Helidon OIDC JavaDoc]
 * link:{security-provider-httpauth-base-url}/module-summary.html[Helidon HTTP Authentication JavaDoc]
 * link:{security-provider-header-base-url}/module-summary.html[Helidon Header Authentication JavaDoc]


### PR DESCRIPTION
### Description

This fixes the non-javadoc broken links reported in #8181. This leaves the following broken links which will be fixed in Part 2:
```
404 /apidocs/io.helidon.common.configurable/io.helidon.common.configurable/ScheduledThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
404 /apidocs/io.helidon.common.configurable/io.helidon.common.configurable/ThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
404 /apidocs/io.helidon.config/io/helidon/config/RetryPolicies.Builder.html
404 /apidocs/io.helidon.config/io/helidon/config/internal/FileConfigSource.FileBuilder.html
404 /apidocs/io.helidon.config/io/helidon/config/spi/AbstractConfigSourceBuilder.html
404 /apidocs/io.helidon.config/io/helidon/config/spi/AbstractParsableConfigSource.Builder.html#init-io.helidon.config.Config-
404 /apidocs/io.helidon.config/io/helidon/config/yaml/YamlConfigParser.html
404 /apidocs/io.helidon.config/io/helidon/configRetryPolicies.html#repeat-int-
404 /apidocs/io.helidon.integrations.openapi.ui/io/helidon/integrations/openapi/ui/OpenApiUi.Builder.html
404 /apidocs/io.helidon.metrics.api/Counter.html
404 /apidocs/io.helidon.metrics.api/DistributionSummary.html
404 /apidocs/io.helidon.metrics.api/Gauge.html
404 /apidocs/io.helidon.metrics.api/MeterRegistry.html
404 /apidocs/io.helidon.metrics.api/Timer.html
404 /apidocs/io.helidon.metrics.prometheus/PrometheusSupport.Builder.html
 /apidocs/io.helidon.microprofile.cors/io/helidon/microprofile/cors/CrossOrigin.html}
404 /apidocs/io.helidon.microprofile.metrics/RegistryFactory.html
404 /apidocs/io.helidon.openapi/OpenApiFeature.Builder.html
404 /apidocs/io.helidon.openapi/io.helidon.openapi.OpenApiFeature.Builder.html
404 /apidocs/io.helidon.security.integration.webserver/module-summary.html
404 /apidocs/io.helidon.security.providers.httpauth.ConfigUserStore/io/helidon/security/providers/httpauth/ConfigUserStore/ConfigUser.html
404 /apidocs/io.helidon.security.providers.httpsign.SignedHeadersConfig/io/helidon/security/providers/httpsign/SignedHeadersConfig/HeadersConfig.html
404 /apidocs/io.helidon.security.providers.idcs.mapper.IdcsRoleMapperProviderBase/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase/Builder.html
404 /apidocs/io.helidon.security.providers.oidc.common/io/helidon/security/providers/oidc/common/BaseBuilder.html
404 /apidocs/io.helidon.webclient..api/io/helidon/webclient/api/ClientRequest.html
404 /apidocs/io.helidon.webclient/io/helidon/webclient/WebClient.Builder.html
404 /apidocs/io.helidon.webclient/io/helidon/webclient/WebClient.html
404 /apidocs/io.helidon.webserver.cors/io/helidon/cors/CrossOriginConfig.html
404 /apidocs/io.helidon.webserver.cors/io/helidon/cors/MappedCrossOriginConfig.html
404 /apidocs/io.helidon.webserver.cors/io/helidon/webserver/cors/CrossOriginConfig.html
404 /apidocs/io.helidon.webserver.http1/io/helidon/webserver/http1/Http1Config.html
404 /apidocs/io.helidon.webserver.servicecommon.HelidonFeatureSupport/io/helidon/webserver/servicecommon/HelidonFeatureSupport/Builder.html
404 /apidocs/io.helidon.webserver.servicecommon/io/helidon/webserver/servicecommon/RestServiceSettings.html
404 /apidocs/io.helidon.webserver/io/helidon/webserver/Handler.html
404 /apidocs/io.helidon.webserver/io/helidon/webserver/PathMatcher.html
404 /apidocs/io.helidon.webserver/io/helidon/webserver/ServerRequest.html
404 /apidocs/io.helidon.webserver/io/helidon/webserver/WebServer.Builder.html
```

### Documentation

Fixes documentation