### PR TITLE
4.x: Fix bad include in cors documentation

### DIFF
--- a/docs/src/main/asciidoc/includes/cors.adoc
+++ b/docs/src/main/asciidoc/includes/cors.adoc
@@ -87,7 +87,7 @@ one or more key/value pairs. Each key-value pair assigns one characteristic of C
 {basic-table-intro}
 
 [[config-key-table]]
-include::[tag=cors-config-table]
+include::{rootdir}/includes/cors.adoc[tag=cors-config-table]
 
 The following example of basic cross-origin
 ifdef::se-flavor[configuration, when loaded and used by the application,]

--- a/docs/src/main/asciidoc/includes/cors.adoc
+++ b/docs/src/main/asciidoc/includes/cors.adoc
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Fix  #8023: bad include in SE CORs docs

### Documentation

Fixes a documentation bug