### PR TITLE
Upgrades Oracle database libraries to version 21.9.0.0. Adds tests under datasource-ucp CDI integration.

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -127,7 +127,8 @@
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.100.Final</version.lib.netty>
         <version.lib.oci>3.34.0</version.lib.oci>
-        <version.lib.ojdbc8>21.4.0.0</version.lib.ojdbc8>
+        <version.lib.ojdbc>21.9.0.0</version.lib.ojdbc>
+        <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
         <version.lib.okio>3.4.0</version.lib.okio>
         <!-- Force upgrade okhttp3 for CVE-2023-0833 -->

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -127,7 +127,7 @@
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.100.Final</version.lib.netty>
         <version.lib.oci>3.34.0</version.lib.oci>
-        <version.lib.ojdbc>21.9.0.0</version.lib.ojdbc>
+        <version.lib.ojdbc>21.11.0.0</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
         <version.lib.okio>3.4.0</version.lib.okio>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1380,7 +1380,7 @@
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc-bom</artifactId>
-                <version>${version.lib.ojdbc8}</version>
+                <version>${version.lib.ojdbc}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -127,7 +127,11 @@
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.100.Final</version.lib.netty>
         <version.lib.oci>3.34.0</version.lib.oci>
-        <version.lib.ojdbc>21.11.0.0</version.lib.ojdbc>
+        <!--
+            UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.
+            Until this bug is fixed do not upgrade past version 21.9.0.0.
+        -->
+        <version.lib.ojdbc>21.9.0.0</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
         <version.lib.okio>3.4.0</version.lib.okio>

--- a/examples/employee-app/pom.xml
+++ b/examples/employee-app/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8-production</artifactId>
+            <artifactId>ojdbc11-production</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/examples/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp/pom.xml
@@ -52,7 +52,7 @@
         <!-- Runtime-scoped dependencies. -->
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8-production</artifactId>
+            <artifactId>ojdbc11-production</artifactId>
             <type>pom</type>
             <scope>runtime</scope>
         </dependency>

--- a/examples/integrations/oci/atp-cdi/pom.xml
+++ b/examples/integrations/oci/atp-cdi/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8-production</artifactId>
+            <artifactId>ojdbc11-production</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/examples/integrations/oci/atp/pom.xml
+++ b/examples/integrations/oci/atp/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8-production</artifactId>
+            <artifactId>ojdbc11-production</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8-production</artifactId>
+            <artifactId>ojdbc11-production</artifactId>
             <type>pom</type>
             <scope>compile</scope>
         </dependency>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -47,11 +47,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <scope>compile</scope>

--- a/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestUcpAndH2.java
+++ b/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestUcpAndH2.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static oracle.ucp.jdbc.PoolDataSourceFactory.getPoolDataSource;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.not;
 
 class TestUcpAndH2 {
 

--- a/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestUcpAndH2.java
+++ b/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestUcpAndH2.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.datasource.ucp.cdi;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import oracle.ucp.UniversalConnectionPoolException;
+import oracle.ucp.admin.UniversalConnectionPoolManager;
+import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
+import oracle.ucp.jdbc.PoolDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static oracle.ucp.jdbc.PoolDataSourceFactory.getPoolDataSource;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.not;
+
+class TestUcpAndH2 {
+
+    TestUcpAndH2() {
+        super();
+    }
+
+    @AfterEach
+    void destroyPools() throws SQLException, UniversalConnectionPoolException {
+        UniversalConnectionPoolManager ucpManager = UniversalConnectionPoolManagerImpl.getUniversalConnectionPoolManager();
+        for (String n : ucpManager.getConnectionPoolNames()) {
+            ucpManager.destroyConnectionPool(n);
+        }
+    }
+
+    /**
+     * Ensures we don't accidentally upgrade to a version of the Universal Connection Pool that throws {@link
+     * NullPointerException}s when no {@code serviceName} is set on a {@link PoolDataSource}.
+     *
+     * <p>The only way to set a service name on a {@link PoolDataSource} is, when the {@link PoolDataSource} is actually
+     * a {@link PoolDataSourceImpl}, by invoking its {@code private void setServiceName(String)} method via
+     * reflection.</p>
+     *
+     * @exception SQLException if a database access error occurs
+     *
+     * @exception NullPointerException if the Universal Connection Pool version in effect cannot handle unset service
+     * names
+     */
+    @Test
+    void testUcpAndH2Canary() throws SQLException {
+        PoolDataSource pds = getPoolDataSource();
+        pds.setConnectionFactoryClassName("org.h2.jdbcx.JdbcDataSource");
+        pds.setURL("jdbc:h2:mem:test");
+        pds.setUser("sa");
+        pds.setPassword("");
+        try (Connection c = pds.getConnection()) { // Throws NullPointerException in versions 21.10.0.0 and 21.11.0.0 and possibly others
+            assertThat(c, not(nullValue()));
+        }
+    }
+
+}

--- a/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestUcpConnectionStateResetBehavior.java
+++ b/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestUcpConnectionStateResetBehavior.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.datasource.ucp.cdi;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import oracle.ucp.jdbc.ConnectionInitializationCallback;
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolDataSourceFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * A test class that shows that the Universal Connection Pool does not reset connection state when a borrowed connection
+ * is returned.
+ */
+class TestUcpConnectionStateResetBehavior {
+
+    private PoolDataSource pds;
+
+    private TestUcpConnectionStateResetBehavior() {
+        super();
+    }
+
+    @BeforeEach
+    void initializeDataSource() throws SQLException {
+        this.pds = PoolDataSourceFactory.getPoolDataSource();
+
+        // We register this callback, knowing that UCP will ignore it, despite documentation that does not say so. It
+        // ignores it because the connection factory (DataSource) we use is H2, not Oracle. In case UCP fixes this
+        // shortcoming we want to know about it.
+        this.pds.registerConnectionInitializationCallback(new FailingCallback());
+        assertThat(this.pds.getConnectionInitializationCallback(), is(instanceOf(FailingCallback.class)));
+
+        this.pds.setConnectionFactoryClassName("org.h2.jdbcx.JdbcDataSource");
+        this.pds.setURL("jdbc:h2:mem:" + this.getClass().getSimpleName());
+        this.pds.setUser("sa");
+        this.pds.setPassword("");
+
+        this.pds.setInitialPoolSize(2);
+        this.pds.setMinPoolSize(2);
+        this.pds.setMaxPoolSize(8); // actually the default but just being explicit
+    }
+
+    @AfterEach
+    void destroyDataSource() throws SQLException {
+        this.pds.unregisterConnectionInitializationCallback();
+    }
+
+    @Test
+    void testUCPErroneouslyDoesNotResetConnectionStateOnReturn() throws SQLException {
+
+        // The connection pool has two connections in it.
+
+        // Borrow connection zero.
+        Connection c0 = this.pds.getConnection();
+        assertThat(c0.getAutoCommit(), is(true)); // we never set it anywhere; default value is true
+
+        // Borrow connection one.
+        Connection c1 = this.pds.getConnection();
+        assertThat(c1.getAutoCommit(), is(true)); // we never set it anywhere; default value is true
+
+        // There are now no more connections available in the pool.
+        assertThat(this.pds.getAvailableConnectionsCount(), is(0));
+
+        // Change the state of connection one.
+        c1.setAutoCommit(false);
+
+        // Return it to the pool.
+        c1.close();
+
+        // There is now exactly one connection available in the pool (the one we just returned).
+        assertThat(this.pds.getAvailableConnectionsCount(), is(1));
+
+        // Borrow connection two. (It will be connection one.)
+        Connection c2 = this.pds.getConnection();
+
+        // There are now no more connections available in the pool.
+        assertThat(this.pds.getAvailableConnectionsCount(), is(0));
+
+        // Note that the state of connection two includes the state of connection one. Oops. The pool really should
+        // reset at least this portion of the connection state, but it does not.
+        assertThat(c2.getAutoCommit(), is(false));
+
+        // Return it.
+        c2.close();
+
+        // Return connection zero.
+        c0.close();
+
+        // No more borrowed connections are extant.
+        assertThat(this.pds.getAvailableConnectionsCount(), is(2));
+    }
+
+    private static class FailingCallback implements ConnectionInitializationCallback {
+
+        private FailingCallback() {
+            super();
+        }
+
+        @Override
+        public void initialize(Connection connection) throws SQLException {
+            // ConnectionInitializationCallbacks are ignored by the UCP unless you are using an Oracle JDBC driver.
+            fail();
+        }
+
+    }
+
+}

--- a/integrations/cdi/datasource-ucp/src/test/logging.properties
+++ b/integrations/cdi/datasource-ucp/src/test/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-.level=INFO
-handlers=io.helidon.logging.jul.HelidonConsoleHandler
-oracle.ucp.level=FINE
+.level = INFO
+# handlers = io.helidon.logging.jul.HelidonConsoleHandler
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = FINEST
+oracle.ucp.level = FINEST

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8-production</artifactId>
+            <artifactId>ojdbc11-production</artifactId>
             <type>pom</type>
             <exclusions>
                 <exclusion>
@@ -59,7 +59,7 @@
             <!-- Include version without JAXP impl -->
             <groupId>com.oracle.database.xml</groupId>
             <artifactId>xmlparserv2_sans_jaxp_services</artifactId>
-            <version>${version.lib.ojdbc8}</version>
+            <version>${version.lib.ojdbc}</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/messaging/connectors/aq/pom.xml
+++ b/messaging/connectors/aq/pom.xml
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8-production</artifactId>
+            <artifactId>ojdbc11-production</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR updates the Oracle database library versions to 21.9.0.0.

Versions of the Universal Connection Pool higher than this can throw `NullPointerException`s if a non-Oracle driver is used (such as H2's). One of the tests this PR adds checks for this problem explicitly to catch it early should an accidental upgrade beyond 21.9.0.0 occur in the future.

This PR also ensures that we are using the `ojdbc11` family of artifacts, at least in the `datasource-ucp` CDI integration, which are the ones that should be used with JDK 11+ (or 21, which is the base of Helidon 4). See https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html for more information.

It also adds a test resulting from a very lengthy internal discussion that shows that the Universal Connection Pool does not do anything to reset any underlying connection state when a borrowed connection is checked out, modified, and returned to the pool. This is useful information going forward and we want this test to fail/alert us if UCP addresses this shortcoming in any way.