### PR TITLE
Support for Map<String, String> in configured builders.

### DIFF
--- a/builder/processor/src/main/java/io/helidon/builder/processor/TypeHandlerMap.java
+++ b/builder/processor/src/main/java/io/helidon/builder/processor/TypeHandlerMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import io.helidon.common.processor.classmodel.Javadoc;
 import io.helidon.common.processor.classmodel.Method;
 import io.helidon.common.processor.classmodel.TypeArgument;
 import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
 
 import static io.helidon.builder.processor.Types.STRING_TYPE;
 import static io.helidon.common.types.TypeNames.LIST;
@@ -98,12 +99,18 @@ class TypeHandlerMap extends TypeHandler {
     void generateFromConfig(Method.Builder method,
                             AnnotationDataOption configured,
                             FactoryMethods factoryMethods) {
-        method.addLine(configGet(configured)
-                               + ".asNodeList().ifPresent(nodes -> nodes.forEach"
-                               + "(node -> "
-                               + name() + ".put(node.get(\"name\").asString().orElse(node.name()), node"
-                               + generateFromConfig(factoryMethods)
-                               + ".get())));");
+        List<TypeName> typeArguments = declaredType().typeArguments();
+        if (TypeNames.STRING.equals(typeArguments.get(0)) && TypeNames.STRING.equals(typeArguments.get(1))) {
+            // the special case of Map<String, String>
+            method.addLine(configGet(configured) + ".detach().asMap().ifPresent(this::" + name() + ");");
+        } else {
+            method.addLine(configGet(configured)
+                                   + ".asNodeList().ifPresent(nodes -> nodes.forEach"
+                                   + "(node -> "
+                                   + name() + ".put(node.get(\"name\").asString().orElse(node.name()), node"
+                                   + generateFromConfig(factoryMethods)
+                                   + ".get())));");
+        }
     }
 
     @Override

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ConfigMapBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ConfigMapBlueprint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.Map;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Configured
+@Prototype.Blueprint
+interface ConfigMapBlueprint {
+    @Option.Configured
+    @Option.Singular
+    Map<String, String> properties();
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ConfigMapTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ConfigMapTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test;
+
+import java.util.Map;
+
+import io.helidon.builder.test.testsubjects.ConfigMap;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+
+public class ConfigMapTest {
+    private static Config config;
+
+    @BeforeAll
+    static void beforeAll() {
+        config = Config.just(ConfigSources.classpath("config-map-test.yaml"));
+    }
+
+    @Test
+    void testMap() {
+        ConfigMap configMap = ConfigMap.create(config);
+        Map<String, String> properties = configMap.properties();
+
+        assertThat(properties, hasEntry("my.first.key", "firstValue"));
+        assertThat(properties, hasEntry("my.second.key", "secondValue"));
+    }
+}

--- a/builder/tests/builder/src/test/resources/config-map-test.yaml
+++ b/builder/tests/builder/src/test/resources/config-map-test.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Used in ConfigMapTest
+properties:
+  my.first.key: "firstValue"
+  my.second.key: "secondValue"
+


### PR DESCRIPTION
### Description
Resovles #8217 

Adds explicit support for type `Map<String, String>`, and instead of doing the "complicated" get from config, it uses `config.detach().asMap()` to get the child values
