### PR TITLE
Ensures that the enabled flag is honored in JpaExtension's observer methods

### DIFF
--- a/archetypes/helidon/src/main/archetype/common/observability.xml
+++ b/archetypes/helidon/src/main/archetype/common/observability.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -103,14 +103,14 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
                                         <value>io.helidon.metrics.api.MetricsFactory</value>
                                     </list>
                                     <list key="MainTest-other-imports">
-                                        <value>org.junit.jupiter.api.BeforeAll</value>
+                                        <value>org.junit.jupiter.api.AfterAll</value>
                                     </list>
                                     <list key="MainTest-static-imports">
                                         <value>static org.junit.jupiter.api.Assertions.assertEquals</value>
                                     </list>
                                     <list key="MainTest-methods" order="999">
                                         <value><![CDATA[
-    @BeforeAll
+    @AfterAll
     static void clear() {
         MetricsFactory.closeAll();
     }
@@ -199,7 +199,7 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
                                         <value>io.helidon.metrics.api.MetricsFactory</value>
                                     </list>
                                     <list key="MainTest-other-imports">
-                                        <value>org.junit.jupiter.api.BeforeAll</value>
+                                        <value>org.junit.jupiter.api.AfterAll</value>
                                     </list>
                                     <list key="MainTest-static-fields">
                                         <value><![CDATA[
@@ -208,7 +208,7 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
                                     </list>
                                     <list key="MainTest-methods" order="999">
                                         <value><![CDATA[
-    @BeforeAll
+    @AfterAll
     static void clear() {
         MetricsFactory.closeAll();
     }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2049,7 +2049,7 @@ public class JpaExtension implements Extension {
                            Object event,
                            @ContainerManaged
                            Instance<EntityManagerFactory> emfs) {
-        if (!emfs.isUnsatisfied()) {
+        if (this.enabled && !emfs.isUnsatisfied()) {
             for (EntityManagerFactory emfProxy : emfs) {
                 // Container-managed EntityManagerFactory instances are client proxies, so we call a business method to
                 // force "inflation" of the proxied instance.  This, in turn, may run DDL and persistence provider

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAnnotationRewriting.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAnnotationRewriting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,6 @@ class TestAnnotationRewriting {
     
     @BeforeEach
     void startCdiContainer() {
-        System.setProperty("jpaAnnotationRewritingEnabled", "true");
         final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
             .addBeanClasses(this.getClass());
         assertThat(initializer, notNullValue());


### PR DESCRIPTION
This PR ensures that the observer method at the bottom of the `JpaExtension` class honors the `enabled` flag like other container-invoked methods in the class. Small oversight; shouldn't have any real-world effects either way.

Documentation impact: none.