### PR TITLE
Change backport action to accept target versions for porting via checkboxes and select current issue's version from a list

### DIFF
--- a/.github/workflows/create-backport-issues.yml
+++ b/.github/workflows/create-backport-issues.yml
@@ -38,4 +38,4 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - run: etc/scripts/actions/create-backport-issues.sh $GITHUB_REPOSITORY ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }} ${{ github.event.inputs.target-2 }} ${{ github.event.inputs.target-3 }} ${{ github.event.inputs.target-4 }}
+      - run: etc/scripts/actions/create-backport-issues.sh helidon-io/helidon ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }} ${{ github.event.inputs.target-2 }} ${{ github.event.inputs.target-3 }} ${{ github.event.inputs.target-4 }}

--- a/.github/workflows/create-backport-issues.yml
+++ b/.github/workflows/create-backport-issues.yml
@@ -10,6 +10,19 @@ on:
         description: 'Helidon version this issue was reported for'
         required: true
         default: '2.x'
+      target-2:
+        type: boolean
+        description: 'Port to 2.x?'
+        default:  false
+      target-3:
+        type: boolean
+        description: 'Port to 3.x?'
+        default: true
+      target-4:
+        type: boolean
+        description: 'Port to 4.x?'
+        default: true
+
 env:
   GITHUB_API_KEY: ${{ secrets.GITHUB_TOKEN }}
 
@@ -20,4 +33,4 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - run: etc/scripts/actions/create-backport-issues.sh $GITHUB_REPOSITORY ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }}
+      - run: etc/scripts/actions/create-backport-issues.sh $GITHUB_REPOSITORY ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }} ${{ github.event.inputs.target-2 }} ${{ github.event.inputs.target-3 }} ${{ github.event.inputs.target-4 }}

--- a/.github/workflows/create-backport-issues.yml
+++ b/.github/workflows/create-backport-issues.yml
@@ -38,4 +38,4 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - run: etc/scripts/actions/create-backport-issues.sh helidon-io/helidon ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }} ${{ github.event.inputs.target-2 }} ${{ github.event.inputs.target-3 }} ${{ github.event.inputs.target-4 }}
+      - run: etc/scripts/actions/create-backport-issues.sh $GITHUB_REPOSITORY ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }} ${{ github.event.inputs.target-2 }} ${{ github.event.inputs.target-3 }} ${{ github.event.inputs.target-4 }}

--- a/.github/workflows/create-backport-issues.yml
+++ b/.github/workflows/create-backport-issues.yml
@@ -9,6 +9,11 @@ on:
       version:
         description: 'Helidon version this issue was reported for'
         required: true
+        type: choice
+        options:
+          - 2.x
+          - 3.x
+          - 4.x
         default: '2.x'
       target-2:
         type: boolean

--- a/etc/scripts/actions/create-backport-issues.sh
+++ b/etc/scripts/actions/create-backport-issues.sh
@@ -38,8 +38,6 @@ readonly REPOSITORY_FULL_NAME="$1"
 readonly ISSUE_NUMBER="$2"
 readonly HELIDON_VERSION="$3"
 
-echo "Repo: $REPOSITORY_FULL_NAME"
-exit 1
 if [ -z "${REPOSITORY_FULL_NAME}" -o -z "${ISSUE_NUMBER}" -o -z "${HELIDON_VERSION}" -o $# -le 3 ]; then
   echo "usage: $0 <repository-name> <issue-number> <helidon-version> <helidon-versions-to-port-to...>"
   exit 1

--- a/etc/scripts/actions/create-backport-issues.sh
+++ b/etc/scripts/actions/create-backport-issues.sh
@@ -118,6 +118,7 @@ version_targets=()
 next_version_to_check=2
 for is_version_selected in "${@:4}"; do
   version=${next_version_to_check}.x
+  next_version_to_check=$((next_version_to_check+1))
   if [ "$version" != "$HELIDON_VERSION" -a "$is_version_selected" = "true" ]; then
     # Create issue for other indicated versions and add the same labels and assignee
     new_issue_title="[$version] ${issue_title}"

--- a/etc/scripts/actions/create-backport-issues.sh
+++ b/etc/scripts/actions/create-backport-issues.sh
@@ -37,6 +37,9 @@ function join_by {
 readonly REPOSITORY_FULL_NAME="$1"
 readonly ISSUE_NUMBER="$2"
 readonly HELIDON_VERSION="$3"
+readonly TARGET_2="$4"
+readonly TARGET_3="$5"
+readonly TARGET_4="$6"
 
 if [ -z "${REPOSITORY_FULL_NAME}" -o -z "${ISSUE_NUMBER}" -o -z "${HELIDON_VERSION}" ]; then
   echo "usage: $0 <repository-name> <issue-number> <helidon-version>"

--- a/etc/scripts/actions/create-backport-issues.sh
+++ b/etc/scripts/actions/create-backport-issues.sh
@@ -114,9 +114,12 @@ issue_title=$(sed "s/\"/'/g" <<< "$issue_title")
 ############################################################
 # For each version the caller specified add a porting issue.
 ############################################################
-for version in "${@:4}"; do
-  if [ "$version" != "$HELIDON_VERSION" ]; then
-    # Create issue for all other versions and add the same labels and assignee
+version_targets=()
+next_version_to_check=2
+for is_version_selected in "${@:4}"; do
+  version=${next_version_to_check}.x
+  if [ "$version" != "$HELIDON_VERSION" -a "$is_version_selected" = "true" ]; then
+    # Create issue for other indicated versions and add the same labels and assignee
     new_issue_title="[$version] ${issue_title}"
     new_issue_text="Backport of #${ISSUE_NUMBER} for Helidon ${version}"
 

--- a/etc/scripts/actions/create-backport-issues.sh
+++ b/etc/scripts/actions/create-backport-issues.sh
@@ -37,12 +37,9 @@ function join_by {
 readonly REPOSITORY_FULL_NAME="$1"
 readonly ISSUE_NUMBER="$2"
 readonly HELIDON_VERSION="$3"
-readonly TARGET_2="$4"
-readonly TARGET_3="$5"
-readonly TARGET_4="$6"
 
-if [ -z "${REPOSITORY_FULL_NAME}" -o -z "${ISSUE_NUMBER}" -o -z "${HELIDON_VERSION}" ]; then
-  echo "usage: $0 <repository-name> <issue-number> <helidon-version>"
+if [ -z "${REPOSITORY_FULL_NAME}" -o -z "${ISSUE_NUMBER}" -o -z "${HELIDON_VERSION}" -o $# -le 3 ]; then
+  echo "usage: $0 <repository-name> <issue-number> <helidon-version> <helidon-versions-to-port-to...>"
   exit 1
 fi
 
@@ -115,9 +112,9 @@ fi
 issue_title=$(sed "s/\"/'/g" <<< "$issue_title")
 
 ############################################################
-# For each version that is not the issue's version, add backport
+# For each version the caller specified add a porting issue.
 ############################################################
-for version in ${VERSIONS[@]}; do
+for version in "${@:4}"; do
   if [ "$version" != "$HELIDON_VERSION" ]; then
     # Create issue for all other versions and add the same labels and assignee
     new_issue_title="[$version] ${issue_title}"

--- a/etc/scripts/actions/create-backport-issues.sh
+++ b/etc/scripts/actions/create-backport-issues.sh
@@ -38,6 +38,8 @@ readonly REPOSITORY_FULL_NAME="$1"
 readonly ISSUE_NUMBER="$2"
 readonly HELIDON_VERSION="$3"
 
+echo "Repo: $REPOSITORY_FULL_NAME"
+exit 1
 if [ -z "${REPOSITORY_FULL_NAME}" -o -z "${ISSUE_NUMBER}" -o -z "${HELIDON_VERSION}" -o $# -le 3 ]; then
   echo "usage: $0 <repository-name> <issue-number> <helidon-version> <helidon-versions-to-port-to...>"
   exit 1

--- a/etc/scripts/actions/create-backport-issues.sh
+++ b/etc/scripts/actions/create-backport-issues.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 #
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
In the current backport GitHub action, the user enters the current version of the issue being ported and automatically ports to all other versions.

This change displays the current version as a choice list (from which the user chooses one) and present check boxes for the versions to port to with the _other_ releases defaulted for porting to.

There is no validity checking in the yaml but the changes to the bash script, as before, make sure to not create another issue targeted to the same version as the original script.

I kept the same defaults--existing issue version is 2.x and default targets are 3.x and 4.x--for compatibility with the original action but we could certainly change that. I think it's probably now a more frequent use case that we port from 4.x to 3 and/or 2.