### PR TITLE
Add back span name test containing an explicit Application bean

### DIFF
--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -134,32 +134,33 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/WithSpanWithExplicitAppTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Run in a separate execution so other tests don't have the Application bean in play. -->
+                        <id>test-with-explicit-app</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/WithSpanWithExplicitAppTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>pipeline</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <configuration>
-                                    <!-- The test times out in the pipeline, even with very long retry delays. -->
-                                    <excludes>
-                                        <exclude>**/WithSpanWithExplicitAppTest.java</exclude>
-                                    </excludes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTestBase.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTestBase.java
@@ -17,7 +17,6 @@ package io.helidon.microprofile.telemetry;
 
 import java.util.List;
 
-import io.helidon.microprofile.server.JaxRsApplication;
 import io.helidon.microprofile.server.JaxRsCdiExtension;
 import io.helidon.microprofile.testing.junit5.AddBean;
 import io.helidon.microprofile.testing.junit5.AddConfig;
@@ -58,7 +57,6 @@ class WithSpanTestBase {
 
     void testSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
         JaxRsCdiExtension jaxRsCdiExtension = CDI.current().getBeanManager().getExtension(JaxRsCdiExtension.class);
-        List<JaxRsApplication> apps = jaxRsCdiExtension.applicationsToRun();
         Response response = webTarget.path(spanPathTestInfo.requestPath)
                 .request(MediaType.TEXT_PLAIN)
                 .get();

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppTest.java
@@ -15,14 +15,10 @@
  */
 package io.helidon.microprofile.telemetry;
 
-import java.util.List;
 import java.util.stream.Stream;
 
-import io.helidon.microprofile.server.JaxRsApplication;
-import io.helidon.microprofile.server.JaxRsCdiExtension;
 import io.helidon.microprofile.testing.junit5.AddBean;
 
-import jakarta.enterprise.inject.spi.CDI;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -33,7 +29,6 @@ class WithSpanWithExplicitAppTest extends WithSpanTestBase {
     @ParameterizedTest()
     @MethodSource()
     void testExplicitAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
-        List<JaxRsApplication> apps = CDI.current().getBeanManager().getExtension(JaxRsCdiExtension.class).applicationsToRun();
         testSpanNameFromPath(spanPathTestInfo);
     }
 


### PR DESCRIPTION
### Description

The original PR #8216 which addressed #8162 added a test but disabled it in the pipeline because the test did not run correctly there. This PR resolves that.

### Documentation
No impact.
