### PR TITLE
4.x: Fix for buffer data when created with an offset.

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/FixedBufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/FixedBufferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class FixedBufferData implements BufferData {
     FixedBufferData(byte[] bytes, int position, int length) {
         this.bytes = bytes;
         this.length = length;
-        this.writePosition = length;
+        this.writePosition = position + length;
         this.readPosition = position;
     }
 


### PR DESCRIPTION
### Description
Resolves #8250 

When buffer is created with an offset, we incorrectly set the position.

Discovered due to Java upgrade...
