### PR TITLE
Slight clean-up of recent baggage and span scope fix

### DIFF
--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryScope.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryScope.java
@@ -21,21 +21,16 @@ import io.helidon.tracing.Scope;
 
 class OpenTelemetryScope implements Scope {
     private final io.opentelemetry.context.Scope delegate;
-    private final io.opentelemetry.context.Scope baggageScope;
     private final AtomicBoolean closed = new AtomicBoolean();
 
-    OpenTelemetryScope(io.opentelemetry.context.Scope scope, io.opentelemetry.context.Scope baggageScope) {
+    OpenTelemetryScope(io.opentelemetry.context.Scope scope) {
         delegate = scope;
-        this.baggageScope = baggageScope;
     }
 
     @Override
     public void close() {
         if (closed.compareAndSet(false, true) && delegate != null) {
             delegate.close();
-            if (baggageScope != null) {
-                baggageScope.close();
-            }
         }
     }
 


### PR DESCRIPTION
### Description
Further fine-tuning to earlier fix for #8187 

The earlier fix properly make sure that, when activating a span, the scope resulting from making an Otel context current correctly reflected both the span information and the baggage.

Because of the way Otel contexts work, we have to create two new contexts, one with the span information, and then another that adds the baggage information. The earlier fix made each of these two contexts "current" on the Otel context stack. That worked, because the context corresponding to the second "active" scope reflected the span and baggage info. Then, when the Helidon `Scope` was closed the earlier fix closed both scopes internally.

But there is no need to create two scopes and make both of them current and then close both of them later when the Helidon `Scope` is closed.

This fine-tuning still creates two contexts (necessarily, as noted above) but only uses the second one (that knows about both span and baggage info). It creates only one scope by making that "all-knowing" context current. Then, when the Helidon `Scope` is closed, there's only the one Otel `Scope` to close. 

This PR also fixes a small bug in the earlier fix which failed to create an "all-knowing" Otel context when creating a context for the Helidon `SpanContext`

### Documentation
No doc impact.