### PR TITLE
4.x: Docs: change WebServer.Builder to WebServerConfig.Builder.

### DIFF
--- a/docs/src/main/asciidoc/se/guides/health.adoc
+++ b/docs/src/main/asciidoc/se/guides/health.adoc
@@ -176,7 +176,7 @@ You can add your own custom health checks. These typically assess the conditions
 The following trivial but illustrative example adds a custom start-up check that reports `DOWN` until the server has been running for eight seconds and reports `UP` thereafter. Note the two main steps in the example code:
 
 1. Create an explicit instance of `ObserveFeature` which contains a custom `HealthObserver` with the custom check.
-2. Add that `ObserveFeature` instance to the `WebServer.Builder` as a feature.
+2. Add that `ObserveFeature` instance to the `WebServerConfig.Builder` as a feature.
 
 
 [source,java]

--- a/docs/src/main/asciidoc/se/guides/health.adoc
+++ b/docs/src/main/asciidoc/se/guides/health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/se/testing.adoc
+++ b/docs/src/main/asciidoc/se/testing.adoc
@@ -24,6 +24,8 @@
 :feature-name: Helidon Testing Framework
 :rootdir: {docdir}/..
 
+include::{rootdir}/includes/se.adoc[]
+
 == Contents
 
 - <<Overview, Overview>>
@@ -98,7 +100,7 @@ and may have any name. The `@SetUpRoute` annotation has `value` with socket name
 
 |===
 
-In addition, a static method annotated with `@SetUpServer` can be defined for `@ServerTest`, which has a single parameter of `WebServer.Builder`.
+In addition, a static method annotated with `@SetUpServer` can be defined for `@ServerTest`, which has a single parameter of link:{javadoc-base-url}/io.helidon.webserver/io/helidon/webserver/WebServerConfig.Builder.html[`WebServerConfig.Builder`].
 
 The following table lists the injectable types (through constructor or method injection).
 

--- a/docs/src/main/asciidoc/se/testing.adoc
+++ b/docs/src/main/asciidoc/se/testing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Change occurrences of `WebServer.Builder ` to `WebServerConfig.Builder`

Fixes #8168

### Documentation

Fixes a doc bug