### PR TITLE
3.x: upgrade dependency check. Suppress fp

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -92,7 +92,7 @@
    <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
 </suppress>
 
-<!-- False Positive. This does not apply to server Java deployment and certainly not to our use of graalvm SDK.
+<!-- False Positive. These do not apply to server Java deployment and certainly not to our use of graalvm SDK.
     This vulnerability applies to Java deployments, typically in clients running sandboxed
     Java Web Start applications or sandboxed Java applets, that load and run untrusted code
     (e.g., code that comes from the internet) and rely on the Java sandbox for security. This
@@ -104,6 +104,13 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.graalvm\.sdk/graal\-sdk@.*$</packageUrl>
    <vulnerabilityName>CVE-2023-22006</vulnerabilityName>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: graal-sdk-22.3.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.sdk/graal\-sdk@.*$</packageUrl>
+   <vulnerabilityName>CVE-2024-20932</vulnerabilityName>
 </suppress>
 
 <!-- 

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.plugin.source>3.3.0</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>9.0.4</version.plugin.dependency-check>
+        <version.plugin.dependency-check>9.0.9</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2016, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Upgrades owasp dependency check to 9.0.9

Suppresses a graalvm CVE that is not applicable to us.

### Documentation

No impact