### PR TITLE
[4.x] Set weight for `WebClientTracing` provider greater than that for `WebClientSecurity` provider

### DIFF
--- a/webclient/security/pom.xml
+++ b/webclient/security/pom.xml
@@ -45,6 +45,21 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-tracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webclient/security/src/test/java/io/helidon/webclient/security/ServiceProviderWeightTest.java
+++ b/webclient/security/src/test/java/io/helidon/webclient/security/ServiceProviderWeightTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.security;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.webclient.spi.WebClientServiceProvider;
+import io.helidon.webclient.tracing.WebClientTracingProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+
+class ServiceProviderWeightTest {
+
+    @Test
+    void verifyTracingVsSecurity() {
+        assertThat("Security and tracing service providers",
+                   weight(WebClientSecurityProvider.class),
+                   lessThan(weight(WebClientTracingProvider.class)));
+    }
+
+    private static double weight(Class<? extends WebClientServiceProvider> c) {
+        Weight weightAnno = c.getAnnotation(Weight.class);
+        return weightAnno == null ? Weighted.DEFAULT_WEIGHT : weightAnno.value();
+    }
+}

--- a/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
+++ b/webclient/tracing/src/main/java/io/helidon/webclient/tracing/WebClientTracingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.webclient.tracing;
 
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
 import io.helidon.common.config.Config;
 import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webclient.spi.WebClientServiceProvider;
@@ -23,10 +25,14 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
 /**
  * Client tracing SPI provider implementation.
  *
+ * Weight must exceed that of WebClientSecurityProvider because WebClientSecurity depends on span information having already
+ * been added to the request context by WebClientTracing.
+ *
  * @deprecated This class should only be used via {@link java.util.ServiceLoader}.
  *  Use {@link WebClientTracing} instead
  */
 @Deprecated
+@Weight(Weighted.DEFAULT_WEIGHT + 100)
 public class WebClientTracingProvider implements WebClientServiceProvider {
     /**
      * Required public constructor.


### PR DESCRIPTION
### Description
Likely/possibly resolves #8192

Assign an explicit weight to `WebClientTracingProvider` that is greater than the weight for `WebClientSecurityProvider` (which is the default). This makes sure that Helidon invokes `WebClientTracing#handle` before `WebClientSecurity#handle`. The latter depends on the request context containing span information which is set by `WebClientTracing#handle`.

With no explicit weight set, the order of execution is indeterminate and _could_ create the kind of failure noted in the issue.

(I tried creating a simple test but, because without explicit weighting the order is indeterminate, the test passed even without the fix because the order just happened to be the order that works: tracing, then security. So the PR contains no test.)

### Documentation
bug fix; no doc impact