### PR TITLE
4.x: Upgrading to latest Tyrus 2.1.5

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -149,7 +149,7 @@
         <version.lib.snakeyaml>2.0</version.lib.snakeyaml>
         <version.lib.testcontainers>1.19.3</version.lib.testcontainers>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>
-        <version.lib.tyrus>2.1.4</version.lib.tyrus>
+        <version.lib.tyrus>2.1.5</version.lib.tyrus>
         <version.lib.weld-api>5.0.SP3</version.lib.weld-api>
         <version.lib.weld>5.1.1.SP2</version.lib.weld>
         <version.lib.yasson>3.0.3</version.lib.yasson>


### PR DESCRIPTION
### Description

Upgrading to latest Tyrus 2.1.5

### Documentation

None
