### PR TITLE
Cleans up and simplifies logic to determine which type of IP addresses to consider

### DIFF
--- a/webclient/api/pom.xml
+++ b/webclient/api/pom.xml
@@ -161,6 +161,14 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultAddressLookupFinder.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultAddressLookupFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,9 @@
 
 package io.helidon.webclient.api;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Enumeration;
-
 import io.helidon.common.LazyValue;
+
+import static java.lang.System.Logger.Level;
 
 /**
  * Heavily inspired by Netty.
@@ -34,27 +30,22 @@ final class DefaultAddressLookupFinder {
     /**
      * {@code true} if IPv4 should be used even if the system supports both IPv4 and IPv6.
      */
-    private static final LazyValue<Boolean> IPV4_PREFERRED = LazyValue.create(() -> {
-        return Boolean.getBoolean("java.net.preferIPv4Stack");
-    });
+    private static final LazyValue<Boolean> IPV4_PREFERRED = LazyValue.create(() ->
+            Boolean.getBoolean("java.net.preferIPv4Stack"));
 
     /**
      * {@code true} if an IPv6 address should be preferred when a host has both an IPv4 address and an IPv6 address.
      */
-    private static final LazyValue<Boolean> IPV6_PREFERRED = LazyValue.create(() -> {
-        return Boolean.getBoolean("java.net.preferIPv6Addresses");
-    });
+    private static final LazyValue<Boolean> IPV6_PREFERRED = LazyValue.create(() ->
+            Boolean.getBoolean("java.net.preferIPv6Addresses"));
 
     private static final LazyValue<DnsAddressLookup> DEFAULT_IP_VERSION = LazyValue.create(() -> {
-        if (IPV4_PREFERRED.get() || !anyInterfaceSupportsIpV6()) {
-            return DnsAddressLookup.IPV4;
-        } else {
-            if (IPV6_PREFERRED.get()) {
-                return DnsAddressLookup.IPV6_PREFERRED;
-            } else {
-                return DnsAddressLookup.IPV4_PREFERRED;
-            }
+        if (IPV4_PREFERRED.get() || !IPV6_PREFERRED.get()) {
+            LOGGER.log(Level.DEBUG, "Preferring IPv4 over IPv6 address resolution");
+            return DnsAddressLookup.IPV4_PREFERRED;
         }
+        LOGGER.log(Level.DEBUG, "Preferring IPv6 over IPv4 address resolution");
+        return DnsAddressLookup.IPV6_PREFERRED;
     });
 
     private DefaultAddressLookupFinder() {
@@ -64,34 +55,4 @@ final class DefaultAddressLookupFinder {
     static DnsAddressLookup defaultDnsAddressLookup() {
         return DEFAULT_IP_VERSION.get();
     }
-
-    /**
-     * Returns {@code true} if any {@link NetworkInterface} supports {@code IPv6}, {@code false} otherwise.
-     */
-    private static boolean anyInterfaceSupportsIpV6() {
-        try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            while (interfaces.hasMoreElements()) {
-                NetworkInterface networkInterface = interfaces.nextElement();
-                Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
-                while (addresses.hasMoreElements()) {
-                    InetAddress inetAddress = addresses.nextElement();
-                    if (inetAddress instanceof Inet6Address
-                            && !inetAddress.isAnyLocalAddress()
-                            && !inetAddress.isLoopbackAddress()
-                            && !inetAddress.isLinkLocalAddress()) {
-                        return true;
-                    }
-                }
-            }
-        } catch (SocketException ignore) {
-            if (LOGGER.isLoggable(System.Logger.Level.INFO)) {
-                LOGGER.log(System.Logger.Level.INFO,
-                           "Unable to detect if any interface supports IPv6, assuming IPv4-only",
-                           ignore);
-            }
-        }
-        return false;
-    }
-
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultAddressLookupFinder.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultAddressLookupFinder.java
@@ -41,10 +41,14 @@ final class DefaultAddressLookupFinder {
 
     private static final LazyValue<DnsAddressLookup> DEFAULT_IP_VERSION = LazyValue.create(() -> {
         if (IPV4_PREFERRED.get() || !IPV6_PREFERRED.get()) {
-            LOGGER.log(Level.DEBUG, "Preferring IPv4 over IPv6 address resolution");
+            if (LOGGER.isLoggable(Level.DEBUG)) {
+                LOGGER.log(Level.DEBUG, "Preferring IPv4 over IPv6 address resolution");
+            }
             return DnsAddressLookup.IPV4_PREFERRED;
         }
-        LOGGER.log(Level.DEBUG, "Preferring IPv6 over IPv4 address resolution");
+        if (LOGGER.isLoggable(Level.DEBUG)) {
+            LOGGER.log(Level.DEBUG, "Preferring IPv6 over IPv4 address resolution");
+        }
         return DnsAddressLookup.IPV6_PREFERRED;
     });
 

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultDnsResolver.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultDnsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.webclient.api;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import io.helidon.webclient.spi.DnsResolver;
 
@@ -46,7 +47,15 @@ public final class DefaultDnsResolver implements DnsResolver {
 
     @Override
     public InetAddress resolveAddress(String hostname, DnsAddressLookup dnsAddressLookup) {
-        throw new IllegalStateException("This DNS resolver is not meant to be used.");
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(hostname);
+            addresses = dnsAddressLookup.filter(addresses);
+            if (addresses.length > 0) {
+                return addresses[0];
+            }
+        } catch (UnknownHostException e) {
+            // falls through
+        }
+        throw new IllegalArgumentException("Failed to get address for host " + hostname);
     }
-
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -22,7 +22,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
-import java.net.UnknownHostException;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
@@ -246,21 +245,8 @@ public class TcpClientConnection implements ClientConnection {
 
     private InetSocketAddress inetSocketAddress() {
         DnsResolver dnsResolver = connectionKey.dnsResolver();
-        if (dnsResolver.useDefaultJavaResolver()) {
-            try {
-                InetAddress[] addresses = InetAddress.getAllByName(connectionKey.host());
-                addresses = connectionKey.dnsAddressLookup().filter(addresses);
-                if (addresses.length > 0) {
-                    return new InetSocketAddress(addresses[0], connectionKey.port());
-                }
-            } catch (UnknownHostException e) {
-                // falls through
-            }
-            throw new IllegalArgumentException("Failed to get address from host: " + connectionKey.host());
-        } else {
-            InetAddress address = dnsResolver.resolveAddress(connectionKey.host(), connectionKey.dnsAddressLookup());
-            return new InetSocketAddress(address, connectionKey.port());
-        }
+        InetAddress address = dnsResolver.resolveAddress(connectionKey.host(), connectionKey.dnsAddressLookup());
+        return new InetSocketAddress(address, connectionKey.port());
     }
 
     private void debugTls(SSLSocket sslSocket) {

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/DnsResolver.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/DnsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,13 @@ public interface DnsResolver {
 
     /**
      * Whether to use standard Java DNS resolver.
-     * If this method returns true, {@link #resolveAddress(String, io.helidon.webclient.api.DnsAddressLookup)} method is not invoked and
-     * no {@link DnsAddressLookup} preferences will be applied.
+     * If this method returns true, {@link #resolveAddress(String, io.helidon.webclient.api.DnsAddressLookup)}
+     * method is not invoked and no {@link DnsAddressLookup} preferences will be applied.
      *
      * @return use standard Java resolver
+     * @deprecated this method is no longer invoked and may be removed in the future
      */
+    @Deprecated(forRemoval = true, since = "4.0.4")
     default boolean useDefaultJavaResolver() {
         return false;
     }

--- a/webclient/api/src/test/java/io/helidon/webclient/api/DefaultDnsResolverTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/DefaultDnsResolverTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.api;
+
+import java.net.InetAddress;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+class DefaultDnsResolverTest {
+
+    @Test
+    void testIpv4Resolution() {
+        DefaultDnsResolver resolver = DefaultDnsResolver.create();
+        InetAddress inetAddress = resolver.resolveAddress("localhost", DnsAddressLookup.IPV4_PREFERRED);
+        assertThat(inetAddress.getHostAddress(), is("127.0.0.1"));
+    }
+
+    @Test
+    void testIpv6Resolution() {
+        DefaultDnsResolver resolver = DefaultDnsResolver.create();
+        InetAddress inetAddress = resolver.resolveAddress("localhost", DnsAddressLookup.IPV6_PREFERRED);
+        assertThat(inetAddress.getHostAddress(), is("0:0:0:0:0:0:0:1"));
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/Ipv4LookupFinderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/Ipv4LookupFinderTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class Ipv4LookupFinderTest {
+
+    /**
+     * Default is to prefer IPv4 addresses.
+     */
+    @Test
+    void testIpv4Preference() {
+        DnsAddressLookup dnsAddressLookup = DefaultAddressLookupFinder.defaultDnsAddressLookup();
+        assertThat(dnsAddressLookup, is(DnsAddressLookup.IPV4_PREFERRED));
+    }
+}

--- a/webclient/api/src/test/java/io/helidon/webclient/api/Ipv6LookupFinderTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/Ipv6LookupFinderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+
+class Ipv6LookupFinderTest {
+
+    /**
+     * If {@code java.net.preferIPv6Addresses} is set, use IPv6.
+     */
+    @Test
+    void testIpv6Preference() {
+        assertThat(System.getProperty("java.net.preferIPv6Addresses"), is(nullValue()));
+        System.setProperty("java.net.preferIPv6Addresses", "true");
+        DnsAddressLookup dnsAddressLookup = DefaultAddressLookupFinder.defaultDnsAddressLookup();
+        assertThat(dnsAddressLookup, is(DnsAddressLookup.IPV6_PREFERRED));
+    }
+}

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/EmptyFrameCntTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/EmptyFrameCntTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import io.helidon.http.http2.Http2Util;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.ConnectionKey;
 import io.helidon.webclient.api.DefaultDnsResolver;
+import io.helidon.webclient.api.DnsAddressLookup;
 import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.WebClient;
@@ -95,7 +96,7 @@ class EmptyFrameCntTest {
                                                         Duration.ZERO,
                                                         Tls.builder().enabled(false).build(),
                                                         DefaultDnsResolver.create(),
-                                                        null,
+                                                        DnsAddressLookup.defaultLookup(),
                                                         Proxy.noProxy());
 
         TcpClientConnection conn = TcpClientConnection.create(WebClient.builder()


### PR DESCRIPTION
### Description

Cleans up and simplifies logic to determine which type of IP addresses (v4 or v6) to consider during name resolution. No longer inspect hosts interfaces to determine priority. Honors JVM properties defined for this purpose. Also updates TcpClientConnection to use whatever strategy specified by a user as part of a WebClient's configuration.

### Documentation

Needs doc update
