### PR TITLE
Http client protocol creation not honoring disabled service discovery

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientSpiProvider.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientSpiProvider.java
@@ -52,6 +52,7 @@ public class Http1ClientSpiProvider implements HttpClientSpiProvider<Http1Client
                                    Http1ClientConfig.builder()
                                            .from(client.prototype())
                                            .protocolConfig(config)
+                                           .servicesDiscoverServices(false)
                                            .buildPrototype());
     }
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientSpiProvider.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientSpiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientSpiProvider.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientSpiProvider.java
@@ -51,6 +51,7 @@ public class Http2ClientSpiProvider implements HttpClientSpiProvider<Http2Client
                                    Http2ClientConfig.builder()
                                            .from(client.prototype())
                                            .protocolConfig(config)
+                                           .servicesDiscoverServices(false)
                                            .buildPrototype());
     }
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientSpiProvider.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientSpiProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Http client protocol creation was not honoring disabled service discovery. 

### Description

Fixes https://github.com/helidon-io/helidon/issues/8282

Follow-up issue: https://github.com/helidon-io/helidon/issues/8285

### Documentation

None
