### PR TITLE
`OidcEncryption#generateMasterPassword` check file system support posix before setting permission

### DIFF
--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,9 @@ final class OidcEncryption {
             String password = UUID.randomUUID().toString();
             try {
                 Files.writeString(path, password, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
-                Files.setPosixFilePermissions(path, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+                if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                    Files.setPosixFilePermissions(path, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+                }
             } catch (IOException e) {
                 throw new SecurityException("Failed to create OIDC secret " + path.toAbsolutePath(), e);
             }

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
@@ -88,9 +88,9 @@ final class OidcEncryption {
                 } else {
                     File file = path.toFile();
                     boolean readable = file.setReadable(true, true);
-                    boolean executable = file.setExecutable(true, true);
-                    if (!readable || !executable) {
-                        LOGGER.log(Level.DEBUG, "Could not set file permission to " + file.toPath());
+                    boolean executable = file.setWritable(true, true);
+                    if ((!readable || !executable) && LOGGER.isLoggable(Level.DEBUG)) {
+                        LOGGER.log(Level.DEBUG, "Could not set file permission to " + path);
                     }
                 }
             } catch (IOException e) {

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
@@ -16,7 +16,6 @@
 
 package io.helidon.security.providers.oidc.common;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
@@ -85,13 +84,6 @@ final class OidcEncryption {
                 Files.writeString(path, password, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
                 if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
                     Files.setPosixFilePermissions(path, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
-                } else {
-                    File file = path.toFile();
-                    boolean readable = file.setReadable(true, true);
-                    boolean executable = file.setWritable(true, true);
-                    if ((!readable || !executable) && LOGGER.isLoggable(Level.DEBUG)) {
-                        LOGGER.log(Level.DEBUG, "Could not set file permission to " + path);
-                    }
                 }
             } catch (IOException e) {
                 throw new SecurityException("Failed to create OIDC secret " + path.toAbsolutePath(), e);

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
@@ -16,6 +16,7 @@
 
 package io.helidon.security.providers.oidc.common;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
@@ -84,6 +85,13 @@ final class OidcEncryption {
                 Files.writeString(path, password, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
                 if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
                     Files.setPosixFilePermissions(path, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+                } else {
+                    File file = path.toFile();
+                    boolean readable = file.setReadable(true, true);
+                    boolean executable = file.setExecutable(true, true);
+                    if (!readable || !executable) {
+                        LOGGER.log(Level.DEBUG, "Could not set file permission to " + file.toPath());
+                    }
                 }
             } catch (IOException e) {
                 throw new SecurityException("Failed to create OIDC secret " + path.toAbsolutePath(), e);


### PR DESCRIPTION
### Description

fix #8288

### Documentation

No impact
