### PR TITLE
Fix unwrap methods to return cast delegates rather than cast 'this'

### DIFF
--- a/tracing/providers/opentelemetry/pom.xml
+++ b/tracing/providers/opentelemetry/pom.xml
@@ -89,4 +89,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <configurationParameters>
+                            junit.jupiter.extensions.autodetection.enabled = true
+                        </configurationParameters>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
@@ -113,7 +113,11 @@ class OpenTelemetrySpan implements Span {
 
     @Override
     public <T> T unwrap(Class<T> spanClass) {
-        return spanClass.cast(delegate);
+        if (spanClass.isInstance(delegate)) {
+            return spanClass.cast(delegate);
+        }
+        throw new IllegalArgumentException("Cannot provide an instance of " + spanClass.getName()
+                                                   + ", telemetry span is: " + delegate.getClass().getName());
     }
 
     // Check if OTEL Context is already available in Global Helidon Context.

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
@@ -111,6 +111,11 @@ class OpenTelemetrySpan implements Span {
         return Optional.ofNullable(baggage.getEntryValue(key));
     }
 
+    @Override
+    public <T> T unwrap(Class<T> spanClass) {
+        return spanClass.cast(delegate);
+    }
+
     // Check if OTEL Context is already available in Global Helidon Context.
     // If not – use Current context.
     private static Context getContext() {

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
@@ -116,6 +116,9 @@ class OpenTelemetrySpan implements Span {
         if (spanClass.isInstance(delegate)) {
             return spanClass.cast(delegate);
         }
+        if (spanClass.isInstance(this)) {
+            return spanClass.cast(this);
+        }
         throw new IllegalArgumentException("Cannot provide an instance of " + spanClass.getName()
                                                    + ", telemetry span is: " + delegate.getClass().getName());
     }

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
@@ -97,6 +97,11 @@ class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder>
         return result;
     }
 
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        return type.cast(spanBuilder);
+    }
+
     // used to set open telemetry context as parent, to be equivalent in function to
     // #parent(SpanContext)
     void parent(Context context) {

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
@@ -102,6 +102,9 @@ class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder>
         if (type.isInstance(spanBuilder)) {
             return type.cast(spanBuilder);
         }
+        if (type.isInstance(this)) {
+            return type.cast(this);
+        }
         throw new IllegalArgumentException("Cannot provide an instance of " + type.getName()
                                                    + ", span builder is: " + spanBuilder.getClass().getName());
     }

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
@@ -99,7 +99,11 @@ class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder>
 
     @Override
     public <T> T unwrap(Class<T> type) {
-        return type.cast(spanBuilder);
+        if (type.isInstance(spanBuilder)) {
+            return type.cast(spanBuilder);
+        }
+        throw new IllegalArgumentException("Cannot provide an instance of " + type.getName()
+                                                   + ", span builder is: " + spanBuilder.getClass().getName());
     }
 
     // used to set open telemetry context as parent, to be equivalent in function to

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanContext.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanContext.java
@@ -39,7 +39,8 @@ class OpenTelemetrySpanContext implements SpanContext {
 
     @Override
     public void asParent(io.helidon.tracing.Span.Builder<?> spanBuilder) {
-        ((OpenTelemetrySpanBuilder) spanBuilder).parent(context);
+        spanBuilder.unwrap(OpenTelemetrySpanBuilder.class)
+                .parent(context);
     }
 
     Context openTelemetry() {

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanContext.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,7 @@ class OpenTelemetrySpanContext implements SpanContext {
 
     @Override
     public void asParent(io.helidon.tracing.Span.Builder<?> spanBuilder) {
-        spanBuilder.unwrap(OpenTelemetrySpanBuilder.class)
-                .parent(context);
+        ((OpenTelemetrySpanBuilder) spanBuilder).parent(context);
     }
 
     Context openTelemetry() {

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/OtelTestsJunitExtension.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/OtelTestsJunitExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.opentelemetry;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class OtelTestsJunitExtension implements Extension, BeforeAllCallback, AfterAllCallback {
+
+    private static final String OTEL_AUTO_CONFIGURE_PROP = "otel.java.global-autoconfigure.enabled";
+    private static final String OTEL_SDK_DISABLED_PROP = "otel.sdk.disabled";
+    private String originalOtelSdkAutoConfiguredSetting;
+    private String originalOtelSdkDisabledSetting;
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        if (originalOtelSdkAutoConfiguredSetting != null) {
+            System.setProperty(OTEL_AUTO_CONFIGURE_PROP, originalOtelSdkAutoConfiguredSetting);
+        }
+        if (originalOtelSdkDisabledSetting != null) {
+            System.setProperty(OTEL_SDK_DISABLED_PROP, originalOtelSdkDisabledSetting);
+        }
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        originalOtelSdkAutoConfiguredSetting = System.setProperty(OTEL_AUTO_CONFIGURE_PROP, "true");
+        originalOtelSdkDisabledSetting = System.setProperty(OTEL_SDK_DISABLED_PROP, "false");
+    }
+}

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestSpanAndBaggage.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestSpanAndBaggage.java
@@ -26,8 +26,6 @@ import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.Tracer;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,27 +34,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 class TestSpanAndBaggage {
-
-    private static final String OTEL_AUTO_CONFIGURE_PROP = "otel.java.global-autoconfigure.enabled";
-    private static final String OTEL_SDK_DISABLED_PROP = "otel.sdk.disabled";
-    private static String originalOtelSdkAutoConfiguredSetting;
-    private static String originalOtelSdkDisabledSetting;
-
-    @BeforeAll
-    static void init() {
-        originalOtelSdkAutoConfiguredSetting = System.setProperty(OTEL_AUTO_CONFIGURE_PROP, "true");
-        originalOtelSdkDisabledSetting = System.setProperty(OTEL_SDK_DISABLED_PROP, "false");
-    }
-
-    @AfterAll
-    static void wrapup() {
-        if (originalOtelSdkAutoConfiguredSetting != null) {
-            System.setProperty(OTEL_AUTO_CONFIGURE_PROP, originalOtelSdkAutoConfiguredSetting);
-        }
-        if (originalOtelSdkDisabledSetting != null) {
-            System.setProperty(OTEL_SDK_DISABLED_PROP, originalOtelSdkDisabledSetting);
-        }
-    }
 
     @Test
     void testActiveSpanScopeWithoutBaggage() {

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestUnwrap.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestUnwrap.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.opentelemetry;
+
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+class TestUnwrap {
+
+    @Test
+    void testTracer() {
+        var tracer = io.helidon.tracing.Tracer.global();
+        assertThat("Tracer unwrapped",
+                   tracer.unwrap(Tracer.class),
+                   instanceOf(Tracer.class));
+    }
+
+    @Test
+    void testSpanAndSpanBuilder() {
+        var tracer = io.helidon.tracing.Tracer.global();
+        var spanBuilder = tracer.spanBuilder("test1");
+        assertThat("Span builder unwrapped",
+                   spanBuilder.unwrap(SpanBuilder.class),
+                   instanceOf(SpanBuilder.class));
+
+        var span = spanBuilder.start();
+        assertThat("Span unwrapped",
+                   span.unwrap(Span.class),
+                   instanceOf(Span.class));
+
+    }
+}

--- a/tracing/providers/opentelemetry/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/tracing/providers/opentelemetry/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+io.helidon.tracing.providers.opentelemetry.OtelTestsJunitExtension

--- a/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingContext.java
+++ b/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingContext.java
@@ -38,7 +38,8 @@ class OpenTracingContext implements io.helidon.tracing.SpanContext {
 
     @Override
     public void asParent(Span.Builder<?> spanBuilder) {
-        ((OpenTracingSpanBuilder) spanBuilder).parent(this);
+        spanBuilder.unwrap(OpenTracingSpanBuilder.class)
+                .parent(this);
     }
 
     SpanContext openTracing() {

--- a/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingContext.java
+++ b/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,7 @@ class OpenTracingContext implements io.helidon.tracing.SpanContext {
 
     @Override
     public void asParent(Span.Builder<?> spanBuilder) {
-        spanBuilder.unwrap(OpenTracingSpanBuilder.class)
-                .parent(this);
+        ((OpenTracingSpanBuilder) spanBuilder).parent(this);
     }
 
     SpanContext openTracing() {

--- a/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpan.java
+++ b/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,8 +114,11 @@ class OpenTracingSpan implements Span {
 
     @Override
     public <T> T unwrap(Class<T> spanClass) {
-        if (spanClass.isAssignableFrom(delegate.getClass())) {
+        if (spanClass.isInstance(delegate)) {
             return spanClass.cast(delegate);
+        }
+        if (spanClass.isInstance(this)) {
+            return spanClass.cast(this);
         }
         throw new IllegalArgumentException("Cannot provide an instance of " + spanClass.getName()
                                                    + ", open tracing span is: " + delegate.getClass().getName());

--- a/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpanBuilder.java
+++ b/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpanBuilder.java
@@ -102,6 +102,10 @@ class OpenTracingSpanBuilder implements Span.Builder<OpenTracingSpanBuilder> {
 
     @Override
     public <T> T unwrap(Class<T> type) {
-        return type.cast(delegate);
+        if (type.isInstance(delegate)) {
+            return type.cast(delegate);
+        }
+        throw new IllegalArgumentException("Cannot provide an instance of " + type.getName()
+                                                   + ", span builder is: " + delegate.getClass().getName());
     }
 }

--- a/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpanBuilder.java
+++ b/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpanBuilder.java
@@ -99,4 +99,9 @@ class OpenTracingSpanBuilder implements Span.Builder<OpenTracingSpanBuilder> {
         }
         return result;
     }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        return type.cast(delegate);
+    }
 }

--- a/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpanBuilder.java
+++ b/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpanBuilder.java
@@ -105,6 +105,9 @@ class OpenTracingSpanBuilder implements Span.Builder<OpenTracingSpanBuilder> {
         if (type.isInstance(delegate)) {
             return type.cast(delegate);
         }
+        if (type.isInstance(this)) {
+            return type.cast(this);
+        }
         throw new IllegalArgumentException("Cannot provide an instance of " + type.getName()
                                                    + ", span builder is: " + delegate.getClass().getName());
     }

--- a/tracing/providers/opentracing/src/test/java/io/helidon/tracing/providers/opentracing/TestUnwrap.java
+++ b/tracing/providers/opentracing/src/test/java/io/helidon/tracing/providers/opentracing/TestUnwrap.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.opentracing;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+class TestUnwrap {
+
+    @Test
+    void testTracer() {
+        var tracer = io.helidon.tracing.Tracer.global();
+        assertThat("Tracer unwrapped",
+                   tracer.unwrap(Tracer.class),
+                   instanceOf(Tracer.class));
+    }
+
+    @Test
+    void testSpanAndSpanBuilder() {
+        var tracer = io.helidon.tracing.Tracer.global();
+        var spanBuilder = tracer.spanBuilder("test1");
+        assertThat("Span builder unwrapped",
+                   spanBuilder.unwrap(Tracer.SpanBuilder.class),
+                   instanceOf(Tracer.SpanBuilder.class));
+
+        var span = spanBuilder.start();
+        assertThat("Span unwrapped",
+                   span.unwrap(Span.class),
+                   instanceOf(Span.class));
+
+    }
+}

--- a/tracing/tracing/src/main/java/io/helidon/tracing/NoOpTracer.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/NoOpTracer.java
@@ -58,7 +58,11 @@ class NoOpTracer implements Tracer {
 
     @Override
     public <T> T unwrap(Class<T> tracerClass) {
-        return tracerClass.cast(this);
+        if (tracerClass.isInstance(this)) {
+            return tracerClass.cast(this);
+        }
+        throw new IllegalArgumentException("Cannot provide an instance of " + tracerClass.getName()
+                                                   + ",  tracer is: " + getClass().getName());
     }
 
     private static class Builder implements Span.Builder<Builder> {

--- a/tracing/tracing/src/main/java/io/helidon/tracing/NoOpTracer.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/NoOpTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,11 @@ class NoOpTracer implements Tracer {
 
     }
 
+    @Override
+    public <T> T unwrap(Class<T> tracerClass) {
+        return tracerClass.cast(this);
+    }
+
     private static class Builder implements Span.Builder<Builder> {
         @Override
         public Span build() {
@@ -90,6 +95,11 @@ class NoOpTracer implements Tracer {
         @Override
         public Span start(Instant instant) {
             return SPAN;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> type) {
+            return type.cast(this);
         }
     }
 
@@ -145,6 +155,11 @@ class NoOpTracer implements Tracer {
         @Override
         public Optional<String> baggage(String key) {
             return Optional.empty();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> spanClass) {
+            return spanClass.cast(this);
         }
     }
 

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
@@ -157,13 +157,7 @@ public interface Span {
      * @return instance of the span
      * @throws java.lang.IllegalArgumentException in case the span cannot provide the expected type
      */
-    default <T> T unwrap(Class<T> spanClass) {
-        try {
-            return spanClass.cast(this);
-        } catch (ClassCastException e) {
-            throw new IllegalArgumentException("This span is not compatible with " + spanClass.getName());
-        }
-    }
+    <T> T unwrap(Class<T> spanClass);
 
     /**
      * Span kind.
@@ -297,12 +291,6 @@ public interface Span {
          * @throws java.lang.IllegalArgumentException when the expected type is not the actual type, or the builder cannot be
          *                                            coerced into that type
          */
-        default <T> T unwrap(Class<T> type) {
-            if (type.isAssignableFrom(getClass())) {
-                return type.cast(this);
-            }
-            throw new IllegalArgumentException("This instance cannot be unwrapped to " + type.getName()
-                                                       + ", this builder: " + getClass().getName());
-        }
+        <T> T unwrap(Class<T> type);
     }
 }

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
@@ -157,7 +157,13 @@ public interface Span {
      * @return instance of the span
      * @throws java.lang.IllegalArgumentException in case the span cannot provide the expected type
      */
-    <T> T unwrap(Class<T> spanClass);
+    default <T> T unwrap(Class<T> spanClass) {
+        try {
+            return spanClass.cast(this);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("This span is not compatible with " + spanClass.getName());
+        }
+    }
 
     /**
      * Span kind.
@@ -291,6 +297,12 @@ public interface Span {
          * @throws java.lang.IllegalArgumentException when the expected type is not the actual type, or the builder cannot be
          *                                            coerced into that type
          */
-        <T> T unwrap(Class<T> type);
+        default <T> T unwrap(Class<T> type) {
+            if (type.isAssignableFrom(getClass())) {
+                return type.cast(this);
+            }
+            throw new IllegalArgumentException("This instance cannot be unwrapped to " + type.getName()
+                                                       + ", this builder: " + getClass().getName());
+        }
     }
 }

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Tracer.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Tracer.java
@@ -94,5 +94,11 @@ public interface Tracer {
      * @param <T> type of the tracer
      * @throws java.lang.IllegalArgumentException in case the tracer cannot provide the expected type
      */
-    <T> T unwrap(Class<T> tracerClass);
+    default <T> T unwrap(Class<T> tracerClass) {
+        try {
+            return tracerClass.cast(this);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("This tracer is not compatible with " + tracerClass.getName());
+        }
+    }
 }

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Tracer.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Tracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,11 +94,5 @@ public interface Tracer {
      * @param <T> type of the tracer
      * @throws java.lang.IllegalArgumentException in case the tracer cannot provide the expected type
      */
-    default <T> T unwrap(Class<T> tracerClass) {
-        try {
-            return tracerClass.cast(this);
-        } catch (ClassCastException e) {
-            throw new IllegalArgumentException("This tracer is not compatible with " + tracerClass.getName());
-        }
-    }
+    <T> T unwrap(Class<T> tracerClass);
 }


### PR DESCRIPTION
### Description
Resolves #8200 

This PR basically does these things:
1. Remove the default interface implementation of `unwrap` from `Tracer`, `Span`, and `Span.Builder`. The code would cast `this` but the classes were package-private and inaccessible to developers.
2. Implement proper logic to cast and return the delegate rather than `this` in the various implementations.
3. Slightly revise the `asParent` implementations which used `unwrap` and now just simply cast.
4. Add tests.

### Documentation
Bug fix; no doc impact