### PR TITLE
4.x: fix broken documentation links Part 2

### DIFF
--- a/docs/src/main/asciidoc/includes/attributes.adoc
+++ b/docs/src/main/asciidoc/includes/attributes.adoc
@@ -201,6 +201,7 @@ endif::[]
 :faulttolerance-javadoc-base-url: {javadoc-base-url}/io.helidon.faulttolerance
 :grpc-server-javadoc-base-url: {javadoc-base-url}/io.helidon.webserver.grpc
 :health-javadoc-base-url: {javadoc-base-url}/io.helidon.health.checks
+:http-javadoc-base-url: {javadoc-base-url}/io.helidon.http
 :integration-oci-sdk-cdi-javadoc-base-url: {javadoc-base-url}/io.helidon.integrations.oci.sdk.cdi
 :media-jsonp-javadoc-base-url: {javadoc-base-url}/io.helidon.http.media.jsonp
 :media-jsonb-javadoc-base-url: {javadoc-base-url}/io.helidon.http.media.jsonb
@@ -218,7 +219,7 @@ endif::[]
 :reactive-base-url: {javadoc-base-url}/io.helidon.common.reactive
 :scheduling-javadoc-base-url: {javadoc-base-url}/io.helidon.microprofile.scheduling
 :security-integration-jersey-base-url: {javadoc-base-url}/io.helidon.security.integration.jersey
-:security-integration-webserver-base-url: {javadoc-base-url}/io.helidon.security.integration.webserver
+:security-integration-webserver-base-url: {javadoc-base-url}/io.helidon.webserver.security
 :webclient-javadoc-base-url: {javadoc-base-url}/io.helidon.webclient
 :webserver-javadoc-base-url: {javadoc-base-url}/io.helidon.webserver
 :webserver-staticcontent-javadoc-base-url: {webserver-javadoc-base-url}.staticcontent

--- a/docs/src/main/asciidoc/includes/cors.adoc
+++ b/docs/src/main/asciidoc/includes/cors.adoc
@@ -27,6 +27,9 @@ ifndef::h1-prefix[:h1-prefix: SE]
 :config-table-methods-column-header: builder method
 :cors-config-key-explanation:
 
+:ws-cors-javadoc: {webserver-cors-javadoc-base-url}/io/helidon/webserver/cors
+:cors-javadoc: {cors-javadoc-base-url}/io/helidon/cors
+
 = CORS Shared content
 
 // tag::cors-intro[]
@@ -74,9 +77,9 @@ the following dependency in your project:
 Support in Helidon for CORS configuration uses two closely-related cross-origin configuration formats: basic and mapped.
 Each format corresponds to a class
 in the Helidon CORS library.
-The basic format corresponds to the link:{ws-cors-javadoc}/CrossOriginConfig.html[`CrossOriginConfig`]
+The basic format corresponds to the link:{cors-javadoc}/CrossOriginConfig.html[`CrossOriginConfig`]
 class, and the mapped format corresponds to the
-link:{ws-cors-javadoc}/MappedCrossOriginConfig.html[`MappedCrossOriginConfig`] class.
+link:{cors-javadoc}/MappedCrossOriginConfig.html[`MappedCrossOriginConfig`] class.
 //end::cors-configuration-formats-intro[]
 
 //tag::basic-cross-origin-config[]

--- a/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ class Example {
 }
 ----
 --
-* Get a Helidon link:{metrics-mp-javadoc-base-url}/RegistryFactory.html[`RegistryFactory`] instance and invoke its `getRegistry` method.
+* Get a Helidon link:{metrics-mp-javadoc-base-url}/io/helidon/microprofile/metrics/RegistryFactory.html[`RegistryFactory`] instance and invoke its `getRegistry` method.
 +
 --
 Obtain the `RegistryFactory` using either of the following techniques:

--- a/docs/src/main/asciidoc/mp/cors/cors.adoc
+++ b/docs/src/main/asciidoc/mp/cors/cors.adoc
@@ -77,7 +77,7 @@ For each resource class in your application:
 . Identify the resources and subresources--in other words, the paths--declared in the resource class which you want to support CORS.
 . For each of those resources and subresources which should support CORS:
 .. Find or create a Java method annotated with `@OPTIONS` and with the correct `@Path`.
-.. To that `@OPTIONS` Java method add a Helidon link:{mp-cors-javadoc-base-url}/io/helidon/microprofile/cors/CrossOrigin.html}[`@CrossOrigin`] annotation that describes the cross-origin sharing you want for that resource.
+.. To that `@OPTIONS` Java method add a Helidon link:{mp-cors-javadoc-base-url}/io/helidon/microprofile/cors/CrossOrigin.html[`@CrossOrigin`] annotation that describes the cross-origin sharing you want for that resource.
 
 [NOTE]
 .Using @CrossOrigin Correctly
@@ -122,7 +122,8 @@ The index `_i_` is an integer (0, 1, 2, etc.).
 
 The system uses the index `_i_`, not the position in the config file, to identify the settings for a particular resource.
 
-Path patterns can be any expression accepted by the link:{webserver-javadoc-base-url}/io/helidon/webserver/PathMatcher.html[`PathMatcher`] class.
+Path patterns can be any expression accepted by the
+link:{http-javadoc-base-url}/io/helidon/http/PathMatcher.html[`PathMatcher`] class.
 
 NOTE: Helidon scans the cross-origin entries in index order (0, 1, 2, etc.) until it finds an entry that
 matches an incoming request's path and HTTP method, so be sure to assign index values to the entries so Helidon will check them in the order you want. In particular, use lower index values for entries with more specific path patterns.

--- a/docs/src/main/asciidoc/mp/fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/mp/fault-tolerance.adoc
@@ -171,8 +171,8 @@ NOTE: There is currently _no support_ to configure these executor properties via
 `microprofile-config.properties` file.
 
 For a complete set of properties available to configure these executors, see
-link:{configurable-javadoc-base-url}/io.helidon.common.configurable/ThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)[ServerThreadPoolSupplier] and
-link:{configurable-javadoc-base-url}/io.helidon.common.configurable/ScheduledThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)[ScheduledThreadPoolSupplier].
+link:{configurable-javadoc-base-url}/io/helidon/common/configurable/ThreadPoolConfig.html[ThreadPoolConfig].
+link:{configurable-javadoc-base-url}/io/helidon/common/configurable/ScheduledThreadPoolConfig.html[ScheduledThreadPoolConfig].
 
 == Examples
 

--- a/docs/src/main/asciidoc/se/config/advanced-configuration.adoc
+++ b/docs/src/main/asciidoc/se/config/advanced-configuration.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -693,8 +693,8 @@ the override source above.
 === Retry Policy Custom Executor
 You can control which executor a retry policy should use for its work.
 The `RetryPolicies.repeat(int retries)` method returns
-a link:{config-javadoc-base-url}/io/helidon/config/RetryPolicies.Builder.html[RetryPolicies.Builder].
-Your application can invoke the retry policy builder's `executor` method to
+a link:{config-javadoc-base-url}/io/helidon/config/SimpleRetryPolicy.Builder.html[SimpleRetryPolicy.Builder].
+Your application can invoke the retry policy builder's `executorService` method to
 specify which `ScheduledExecutorService` instance it should use to schedule and
 execute delayed retries. By default, the config system uses a separate thread
 pool executor for each retry policy instance.

--- a/docs/src/main/asciidoc/se/config/config-profiles.adoc
+++ b/docs/src/main/asciidoc/se/config/config-profiles.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -147,7 +147,7 @@ Except for the `system-properties` and `environment-variables` types, the profil
 `properties` section for a source can also specify any optional settings for the
 corresponding config source type. The JavaDoc for the related config source
 type builders lists the supported properties for each type. (For example,
-link:{config-javadoc-base-url}/io/helidon/config/internal/FileConfigSource.FileBuilder.html[`FileConfigSource.FileBuilder`].)
+link:{config-javadoc-base-url}/io/helidon/config/FileConfigSource.Builder.html[`FileConfigSource.Builder`].)
 
 Here is an example profile in YAML format. Note how the `properties` sections
 are at the same level as the `type` or `class` within a `sources` array entry.
@@ -291,7 +291,7 @@ accompanying `properties`.
 |Policy Type |Usage |Properties
 
 |`repeat`
-|Regularly-scheduled - see link:{config-javadoc-base-url}/io/helidon/configRetryPolicies.html#repeat-int-[`RetryPolicies.repeat`].
+|Regularly-scheduled - see link:{config-javadoc-base-url}/io/helidon/config/RetryPolicies.html#repeat-int-[`RetryPolicies.repeat`].
 a|`retries` (`int`) - number of retries to perform +
 
 Optional:

--- a/docs/src/main/asciidoc/se/config/supported-formats.adoc
+++ b/docs/src/main/asciidoc/se/config/supported-formats.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ Config config = Config.create(classpath("my-config")                            
 cannot choose a parser automatically.
 <2> The config system will parse the resource `my-config` on the runtime classpath
 using the YAML parser instance created by the
-link:{config-javadoc-base-url}/io/helidon/config/yaml/YamlConfigParser.html[`YamlConfigParser`].
+link:{config-javadoc-base-url}.yaml/io/helidon/config/yaml/YamlConfigParser.html[`YamlConfigParser`].
 The `create()` method creates a config parser with default behavior.
 
 [source,java]
@@ -275,7 +275,7 @@ The config system will use the <<Config-ModuleYaml,YAML parser>> automatically i
 because the file type of the key is `.yaml`.
 
 The `EtcdConfigSourceBuilder` class extends
-link:{config-javadoc-base-url}/io/helidon/config/spi/AbstractConfigSourceBuilder.html[`AbstractConfigSourceBuilder`]
+link:{config-javadoc-base-url}/io/helidon/config/AbstractConfigSourceBuilder.html[`AbstractConfigSourceBuilder`]
 and so supports the usual settings on config sources.
 
 ==== Monitoring for Source Changes
@@ -420,8 +420,8 @@ meta-configuration from a git config source set the following properties for the
 
 The meta-configuration must set the `path` and one of `uri` or `directory`.
 Other optional `properties` are inherited from
- `AbstractParsableConfigSource.Builder` (see
- link:{config-javadoc-base-url}/io/helidon/config/spi/AbstractParsableConfigSource.Builder.html#init-io.helidon.config.Config-[javadoc])
+ `AbstractConfigSourceBuilder` (see
+ link:{config-javadoc-base-url}/io/helidon/config/AbstractConfigSourceBuilder.html[javadoc])
 
 [source,java]
 .Load Config from meta-configuration

--- a/docs/src/main/asciidoc/se/metrics/metrics.adoc
+++ b/docs/src/main/asciidoc/se/metrics/metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -146,7 +146,7 @@ WebServer server = WebServer.builder()
 == API
 To work with Helidon Metrics in your code, follow these steps:
 
-. Use the static `globalRegistry` method on the link:{metrics-javadoc-base-url}/Metrics.html[`Metrics`] interface to get a reference to the global  link:{metrics-javadoc-base-url}/MeterRegistry.html[`MeterRegistry`] instance.
+. Use the static `globalRegistry` method on the link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Metrics.html[`Metrics`] interface to get a reference to the global  link:{metrics-javadoc-base-url}/io/helidon/metrics/api/MeterRegistry.html[`MeterRegistry`] instance.
 . Use the `MeterRegistry` instance to register new {metrics} and look up previously-registered {metrics}.
 . Use the {metric} reference returned from the `MeterRegistry` to update the {metric} or get its value.
 
@@ -163,17 +163,17 @@ The following table summarizes the {metric} types.
 |====
 | {Metric_uc} Type | Usage
 
-| link:{metrics-javadoc-base-url}/Counter.html[`Counter`]
+| link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Counter.html[`Counter`]
 | Monotonically increasing count of events.
 
-| link:{metrics-javadoc-base-url}/Gauge.html[`Gauge`]
+| link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Gauge.html[`Gauge`]
 | Access to a value managed by other code in the service.
 
-|link:{metrics-javadoc-base-url}/DistributionSummary.html[`DistributionSummary`]
+|link:{metrics-javadoc-base-url}/io/helidon/metrics/api/DistributionSummary.html[`DistributionSummary`]
 |Calculates the distribution of a value.
 
 
-| link:{metrics-javadoc-base-url}/Timer.html[`Timer`]
+| link:{metrics-javadoc-base-url}/io/helidon/metrics/api/Timer.html[`Timer`]
 | Frequency of invocations and the distribution of how long the invocations take.
 
 |====
@@ -317,7 +317,7 @@ To expose those metrics to clients via a REST endpoint, your code uses the `Prom
 
 [#prom-api]
 ==== API
-Your code creates a link:{prometheus-javadoc-base-url}/PrometheusSupport.html[`PrometheusSupport`] object either using a static factory method (shown in the following example) or by using its link:{prometheus-javadoc-base-url}/PrometheusSupport.Builder.html[`Builder`].
+Your code creates a link:{prometheus-javadoc-base-url}/io/helidon/metrics/prometheus/PrometheusSupport.html[`PrometheusSupport`] object either using a static factory method (shown in the following example) or by using its link:{prometheus-javadoc-base-url}/io/helidon/metrics/prometheus/PrometheusSupport.Builder.html[`Builder`].
 
 [source,java]
 ----

--- a/docs/src/main/asciidoc/se/metrics/micrometer.adoc
+++ b/docs/src/main/asciidoc/se/metrics/micrometer.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -199,9 +199,9 @@ MicrometerSupport support = MicrometerSupport.builder()
                 .build();
 ----
 <1> Create the meter registry. This example uses a Prometheus registry but it can be any extension of `MeterRegistry`.
-<2> Provide the function that checks if the link:{webserver-javadoc-base-url}/io/helidon/webserver/ServerRequest.html[`ServerRequest`]
+<2> Provide the function that checks if the link:{webserver-javadoc-base-url}/io/helidon/webserver/http/ServerRequest.html[`ServerRequest`]
  accepts content that your meter registry can produce (e.g., either `text/plain` or unspecified is normally an indication for Prometheus-style output)
-and returns the appropriate `Optional<link:{webserver-javadoc-base-url}/io/helidon/webserver/Handler.html[``Handler``]>`.
+and returns the appropriate `Optional<link:{webserver-javadoc-base-url}/io/helidon/webserver/http/Handler.html[``Handler``]>`.
 <3> A very simple in-line `Handler` that sets the response entity from the Prometheus registry's `scrape()` method.
 
 include::{rootdir}/includes/metrics/micrometer-shared.adoc[tag=accessing-endpoint-intro]

--- a/docs/src/main/asciidoc/se/openapi/openapi-generator.adoc
+++ b/docs/src/main/asciidoc/se/openapi/openapi-generator.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -83,7 +83,9 @@ public void handleGetPetById(ServerRequest request, ServerResponse response, Lon
 include::{gen-inc}[tag=using-generated-code-client-intro]
 
 The generated Helidon SE client includes the class `ApiClient`. This class corresponds to
-the Helidon link:{webclient-javadoc-base-url}/io/helidon/webclient/WebClient.html[`WebClient`] and represents the connection between your code and the remote server. The generator also creates one or more `Api` interfaces and corresponding implementation classes. The examples below use the `PetApi` interface and the `PetApiImpl` class.
+the Helidon link:{webclient-javadoc-base-url}.api/io/helidon/webclient/api/WebClient.html[`WebClient`] and represents the
+connection between your code and the remote server. The generator also creates one or more `Api` interfaces and
+corresponding implementation classes. The examples below use the `PetApi` interface and the `PetApiImpl` class.
 
 To invoke the remote service your code must:
 
@@ -98,7 +100,8 @@ The Helidon SE client generator gives you as much flexibility as you need in con
 
 Internally, the `ApiClient` uses a Helidon `WebClient` object to contact the remote system.
 The `ApiClient.Builder` automatically prepares a Helidon
-link:{webclient-javadoc-base-url}/io/helidon/webclient/WebClient.Builder.html[`WebClient.Builder`] object using information from the OpenAPI document.
+link:{webclient-javadoc-base-url}.api/io/helidon/webclient/api/WebClientConfig.Builder.html[`WebClientConfig.Builder`]
+object using information from the OpenAPI document.
 
 The next sections describe, from simplest to most complicated, the ways your code can create an `ApiClient` instance, each involving increased involvement with the `WebClient.Builder` object.
 

--- a/docs/src/main/asciidoc/se/openapi/openapi-ui.adoc
+++ b/docs/src/main/asciidoc/se/openapi/openapi-ui.adoc
@@ -1,6 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -25,7 +24,7 @@
 include::{rootdir}/includes/se.adoc[]
 
 :javadoc-path: {openapi-ui-javadoc-base-url}/io/helidon/integrations/openapi/ui
-:openapi-javadoc-path: {openapi-javadoc-base-url}/io/helidon/openapi
+:openapi-javadoc-path: {openapi-javadoc-base-url}/io/helidon/integrations/openapi
 
 include::{ui-inc}[tag=preamble]
 
@@ -70,8 +69,8 @@ If your code invokes the `OpenApiFeature.Builder` `config` method, Helidon autom
 === Customizing the UI Behavior
 You can control some of the behavior of the UI programmatically in two steps:
 
-. Create an link:{javadoc-path}/OpenApiUi.Builder.html[`OpenApiUi.Builder`] and invoke methods on it to set the UI behavior, then invoke the builder's `build` method to create the `OpenApiUi` object.
-. Invoke the `addService` method on link:{openapi-javadoc-base-url}/io.helidon.openapi.OpenApiFeature.Builder.html[`OpenApiFeature.Builder`], passing the `OpenApiUi` object you prepared above.
+. Create an link:{javadoc-path}/OpenApiUiConfig.Builder.html[`OpenApiUiConfig.Builder`] and invoke methods on it to set the UI behavior, then invoke the builder's `build` method to create the `OpenApiUi` object.
+. Invoke the `addService` method on link:{openapi-javadoc-base-url}/io/helidon/openapi/OpenApiFeatureConfig.Builder.html[`OpenApiFeature.Builder`], passing the `OpenApiUi` object you prepared above.
 
 The following example illustrates these steps, combining configuration with explicit programmatic settings.
 

--- a/docs/src/main/asciidoc/se/openapi/openapi.adoc
+++ b/docs/src/main/asciidoc/se/openapi/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -61,8 +61,11 @@ To control the behavior of the OpenAPI feature programmatically, you can add and
 
 ==== Create and Register `OpenApiFeature` in your application
 
-Helidon SE provides the link:{openapi-javadoc-base-url}/OpenApiFeature.html[`OpenApiFeature`] class which your application uses to assemble the in-memory model and expose the `/openapi` endpoint to clients. You can create an instance either using a static `create` method or by instantiating its link:{openapi-javadoc-base-url}/OpenApiFeature.Builder.html[`Builder`]. The xref:#register_openapifeature[example below]  illustrates one way to do this.
-
+Helidon SE provides the link:{openapi-javadoc-base-url}/io/helidon/openapi/OpenApiFeature.html[`OpenApiFeature`] class
+which your application uses to assemble the in-memory model and expose the `/openapi` endpoint to clients. You can
+create an instance either using a static `create` method or by instantiating its
+link:{openapi-javadoc-base-url}/io/helidon/openapi/OpenApiFeatureConfig.Builder.html[`Builder`].
+The xref:#register_openapifeature[example below]  illustrates one way to do this.
 
 include::{incdir}/openapi.adoc[tag=furnish-openapi-info]
 
@@ -70,7 +73,7 @@ include::{incdir}/openapi.adoc[tag=usage-access-endpoint]
 
 == API
 
-Helidon {flavor-uc} provides an API for creating and setting up the REST endpoint which serves OpenAPI documents to clients at the `/openapi` path. Use either static methods on link:{openapi-javadoc-base-url}/OpenApiFeature.html[`OpenApiFeature`]  or use its link:{openapi-javadoc-base-url}/OpenApiFeature.Builder.html[`Builder`]. Then add that instance or builder to your application's routing. The <<#register_openapifeature,example>> below shows how to do this.
+Helidon {flavor-uc} provides an API for creating and setting up the REST endpoint which serves OpenAPI documents to clients at the `/openapi` path. Use either static methods on link:{openapi-javadoc-base-url}/io/helidon/openapi/OpenApiFeature.html[`OpenApiFeature`]  or use its link:{openapi-javadoc-base-url}/io/helidon/openapi/OpenApiFeatureConfig.Builder.html[`Builder`]. Then add that instance or builder to your application's routing. The <<#register_openapifeature,example>> below shows how to do this.
 
 [[config]]
 == Configuration

--- a/docs/src/main/asciidoc/se/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -337,7 +337,7 @@ While `Http1Route` for Http/1 is always available with Helidon webserver, other 
 include::{requested-uri-discovery-inc}[tag=intro]
 
 === Setting Up Requested URI Discovery Programmatically
-To set up requested URI discovery on the default socket for your server, use the link:{webserver-javadoc-base-url}/io/helidon/webserver/WebServer.Builder.html[`WebServer.Builder`]:
+To set up requested URI discovery on the default socket for your server, use the link:{webserver-javadoc-base-url}/io/helidon/webserver/WebServerConfig.Builder.html[`WebServerConfig.Builder`]:
 [source,java]
 .Requested URI set-up for the default server socket
 ----


### PR DESCRIPTION
### Description

Fix links to javadocs as reported in  #8181. This leaves about a half dozen broken links that are in the generated configuration files.

### Documentation

Fixes broken links in documentation.