### PR TITLE
Set incoming baggage from parent on Span

### DIFF
--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.time.Instant;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
@@ -27,6 +28,7 @@ import io.opentelemetry.context.Context;
 class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder> {
     private final SpanBuilder spanBuilder;
     private boolean parentSet;
+    private Baggage parentBaggage;
 
     OpenTelemetrySpanBuilder(SpanBuilder spanBuilder) {
         this.spanBuilder = spanBuilder;
@@ -41,6 +43,7 @@ class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder>
     public OpenTelemetrySpanBuilder parent(SpanContext spanContext) {
         this.parentSet = true;
         spanContext.asParent(this);
+        parentBaggage = Baggage.fromContext(((OpenTelemetrySpanContext) spanContext).openTelemetry());
         return this;
     }
 
@@ -87,7 +90,11 @@ class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder>
         }
         spanBuilder.setStartTimestamp(instant);
         io.opentelemetry.api.trace.Span span = spanBuilder.startSpan();
-        return new OpenTelemetrySpan(span);
+        Span result = new OpenTelemetrySpan(span);
+        if (parentBaggage != null) {
+            parentBaggage.forEach((key, baggageEntry) -> result.baggage(key, baggageEntry.getValue()));
+        }
+        return result;
     }
 
     // used to set open telemetry context as parent, to be equivalent in function to

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/MapHeaderProvider.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/MapHeaderProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.opentelemetry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.helidon.tracing.HeaderProvider;
+
+record MapHeaderProvider(Map<String, List<String>> values) implements HeaderProvider {
+
+    @Override
+    public Iterable<String> keys() {
+        return values.keySet();
+    }
+
+    @Override
+    public Optional<String> get(String key) {
+        if (!values.containsKey(key)) {
+            return Optional.empty();
+        }
+        List<String> matches = values.get(key);
+        return matches.isEmpty() ? Optional.empty() : Optional.of(matches.get(0));
+    }
+
+    @Override
+    public Iterable<String> getAll(String key) {
+        return values.get(key);
+    }
+
+    @Override
+    public boolean contains(String key) {
+        return values.containsKey(key);
+    }
+}


### PR DESCRIPTION
### Description
Resolves #8299 
Resolves #8265 

The Helidon code correctly set up the implementation-specific span context when a parent was assigned to a new span, but the code did not map any baggage in that implementation-specific context to the `Span` object.

### Documentation
Bug fix; no doc impact