### PR TITLE
Add null check for resource path in filter

### DIFF
--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -175,7 +175,7 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         Resource resource = extendedUriInfo.getMatchedModelResource();
         while (resource != null) {
             String resourcePath = resource.getPath();
-            if (!resourcePath.equals("/") && !resourcePath.isBlank()) {
+            if (resourcePath != null && !resourcePath.equals("/") && !resourcePath.isBlank()) {
                 derivedPath.push(resourcePath);
                 if (!resourcePath.startsWith("/")) {
                     derivedPath.push("/");


### PR DESCRIPTION
### Description
Resolves #8311 

It turns out that the `path` returned from the Jersey `Resource` can be null in some cases. So add a null check before trying to use it.

A user found this but we do not have a small reproducer so the PR does not include a verifying test. 

As noted in the issue, the Jersey code anticipates the path being null sometimes so we should have checked for null ourselves too. With this PR, we now do.

### Documentation
No impact