### PR TITLE
[4.x] Fix CachedHandlerTest.testFsFromInMemory on Windows

### DIFF
--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/FileSystemContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/FileSystemContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ class FileSystemContentHandler extends FileBasedContentHandler {
 
         String rawPath = req.prologue().uriPath().rawPath();
 
-        String relativePath = root.relativize(path).toString();
+        String relativePath = root.relativize(path).toString().replace("\\", "/");
         String requestedResource;
         if (mapped) {
             requestedResource = relativePath;


### PR DESCRIPTION
### Description

fix #8290

When resource is added to in memory cache, the path is normalized but it was not when queried. (See line 181 of the same file)  

### Documentation

no impact