### PR TITLE
Replace deprecated  Awaitable.await(long, TimeUnit) on Awaitable.await(Duration)

### DIFF
--- a/common/reactive/src/test/java/io/helidon/common/reactive/AwaitTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/AwaitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -59,7 +60,7 @@ public class AwaitTest {
 
         future.thenAccept(whenCompleteFuture::complete);
 
-        future.await(100, TimeUnit.MILLISECONDS);
+        future.await(ofMillis(100));
 
         assertThat("Peek needs to be invoked at await!", peekFuture.isDone(), is(true));
         assertThat(peekFuture.get(), is(equalTo("1")));
@@ -79,7 +80,7 @@ public class AwaitTest {
 
         single.whenComplete((s, throwable) -> whenCompleteFuture.complete(s));
 
-        single.await(100, TimeUnit.MILLISECONDS);
+        single.await(ofMillis(100));
 
         assertThat("Peek needs to be invoked at await!", peekFuture.isDone(), is(true));
         assertThat(peekFuture.get(), is(equalTo("1")));
@@ -115,7 +116,7 @@ public class AwaitTest {
                 })
                 .whenComplete((s, throwable) -> result.add(7));
 
-        awaitable.await(SAFE_WAIT_MILLIS, TimeUnit.MILLISECONDS);
+        awaitable.await(ofMillis(SAFE_WAIT_MILLIS));
         assertThat(result, equalTo(IntStream.rangeClosed(1, 7).boxed().collect(Collectors.toList())));
     }
 
@@ -148,7 +149,7 @@ public class AwaitTest {
                 })
                 .whenComplete((s, throwable) -> result.add(8));
 
-        awaitable.await(SAFE_WAIT_MILLIS, TimeUnit.MILLISECONDS);
+        awaitable.await(ofMillis(SAFE_WAIT_MILLIS));
         assertThat(result, equalTo(IntStream.rangeClosed(1, 8).boxed().collect(Collectors.toList())));
     }
 
@@ -195,7 +196,7 @@ public class AwaitTest {
         AtomicLong sum = new AtomicLong();
         testMulti()
                 .forEach(sum::addAndGet)
-                .await(SAFE_WAIT_MILLIS, TimeUnit.MILLISECONDS);
+                .await(ofMillis(SAFE_WAIT_MILLIS));
         assertThat(sum.get(), equalTo(EXPECTED_SUM));
     }
 
@@ -218,7 +219,7 @@ public class AwaitTest {
     void forEachAwaitTimeoutNegative() {
         assertThrows(CompletionException.class, () -> testMulti()
                 .forEach(TestConsumer.noop())
-                .await(10, TimeUnit.MILLISECONDS));
+                .await(ofMillis(10)));
     }
 
     @Test
@@ -228,12 +229,12 @@ public class AwaitTest {
 
     @Test
     void singleAwaitTimeout() {
-        assertThat(testSingle().await(SAFE_WAIT_MILLIS, TimeUnit.MILLISECONDS), equalTo(EXPECTED_SUM));
+        assertThat(testSingle().await(ofMillis(SAFE_WAIT_MILLIS)), equalTo(EXPECTED_SUM));
     }
 
     @Test
     void singleAwaitTimeoutNegative() {
-        assertThrows(CompletionException.class, () -> testSingle().await(10, TimeUnit.MILLISECONDS));
+        assertThrows(CompletionException.class, () -> testSingle().await(ofMillis(10)));
     }
 
     @Test

--- a/common/reactive/src/test/java/io/helidon/common/reactive/BufferedEmittingPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/BufferedEmittingPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofSeconds;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -280,7 +281,7 @@ public class BufferedEmittingPublisherTest {
                 .forEach(unused -> cnt.incrementAndGet());
 
         try {
-            promise.await(10, TimeUnit.SECONDS);
+            promise.await(ofSeconds(10));
             assertThat(cnt.get(), is(equalTo(STREAM_SIZE)));
         } finally {
             exec.shutdown();

--- a/common/reactive/src/test/java/io/helidon/common/reactive/IgnoreElementsTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/IgnoreElementsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -58,7 +59,7 @@ public class IgnoreElementsTest {
         Multi.just(1, 2, 3)
                 .peek(result::add)
                 .ignoreElements()
-                .await(200, TimeUnit.MILLISECONDS);
+                .await(ofMillis(200));
 
         assertThat(result, Matchers.contains(1, 2, 3));
     }
@@ -69,7 +70,7 @@ public class IgnoreElementsTest {
         Single.just(3)
                 .peek(result::set)
                 .ignoreElement()
-                .await(200, TimeUnit.MILLISECONDS);
+                .await(ofMillis(200));
 
         assertThat(result.get(), Matchers.is(3));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapCompletionStageTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapCompletionStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultiFlatMapCompletionStageTest {
@@ -50,7 +52,7 @@ public class MultiFlatMapCompletionStageTest {
         List<Integer> result = Multi.just(1, 2, 3, 4)
                 .flatMapCompletionStage(CompletableFuture::completedFuture)
                 .collectList()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, Matchers.contains(1, 2, 3, 4));
     }
@@ -62,7 +64,7 @@ public class MultiFlatMapCompletionStageTest {
                 .map(Throwable.class::cast)
                 .onErrorResume(Function.identity())
                 .first()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, Matchers.instanceOf(NullPointerException.class));
     }
@@ -95,7 +97,7 @@ public class MultiFlatMapCompletionStageTest {
                     }
                 }, exec))
                 .collectList()
-                .await(2, TimeUnit.SECONDS);
+                .await(ofSeconds(2));
 
         assertThat(result, Matchers.contains(10, 0, 8, 1));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 package io.helidon.common.reactive;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -31,6 +29,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
@@ -311,7 +310,7 @@ public class MultiFlatMapPublisherTest {
                 .flatMap(MultiFlatMapPublisherTest::asyncFlowPublisher, MAX_CONCURRENCY, false, PREFETCH)
                 .distinct()
                 .collectList()
-                .await(800, TimeUnit.MILLISECONDS), hasSize(EXPECTED_EMISSION_COUNT));
+                .await(ofMillis(800)), hasSize(EXPECTED_EMISSION_COUNT));
     }
 
     private static Flow.Publisher<? extends String> asyncFlowPublisher(Integer i) {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromByteChannelTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromByteChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofSeconds;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -70,7 +71,7 @@ public class MultiFromByteChannelTest {
         // assert
         byte[] bytes = Multi.create(publisher)
                 .collect(new BufferCollector())
-                .await(5, TimeUnit.SECONDS);
+                .await(ofSeconds(5));
 
         assertThat(bytes.length, is(TEST_DATA_SIZE));
         assertByteSequence(bytes);
@@ -92,7 +93,7 @@ public class MultiFromByteChannelTest {
         // assert
         byte[] bytes = Multi.create(publisher)
                 .collect(new BufferCollector())
-                .await(5, TimeUnit.SECONDS);
+                .await(ofSeconds(5));
 
         assertThat(bytes.length, is(TEST_DATA_SIZE));
         assertByteSequence(bytes);
@@ -119,7 +120,7 @@ public class MultiFromByteChannelTest {
         // assert
         byte[] bytes = Multi.create(publisher)
                 .collect(new BufferCollector())
-                .await(5, TimeUnit.SECONDS);
+                .await(ofSeconds(5));
 
         assertThat(bytes.length, is(TEST_DATA_SIZE));
         assertByteSequence(bytes);
@@ -148,7 +149,7 @@ public class MultiFromByteChannelTest {
         // assert
         byte[] bytes = Multi.create(publisher)
                 .collect(new BufferCollector())
-                .await(5, TimeUnit.SECONDS);
+                .await(ofSeconds(5));
 
         assertThat(bytes.length, is(TEST_DATA_SIZE));
         assertByteSequence(bytes);
@@ -170,7 +171,7 @@ public class MultiFromByteChannelTest {
         try {
             Multi.create(publisher)
                     .collect(new BufferCollector())
-                    .await(5, TimeUnit.SECONDS);
+                    .await(ofSeconds(5));
             fail("Did not throw expected CompletionException!");
         } catch (CompletionException e) {
             assertThat(e.getCause(), instanceOf(ClosedChannelException.class));
@@ -201,7 +202,7 @@ public class MultiFromByteChannelTest {
         // immediately close the channel, so we fail reading
         pc.close();
 
-        CompletionException c = assertThrows(CompletionException.class, () -> data.await(5, TimeUnit.SECONDS));
+        CompletionException c = assertThrows(CompletionException.class, () -> data.await(ofSeconds(5)));
         assertThat(c.getCause(), instanceOf(ClosedChannelException.class));
 
         MultiFromByteChannel multi = (MultiFromByteChannel) publisher;
@@ -272,7 +273,7 @@ public class MultiFromByteChannelTest {
         try {
             Multi.create(publisher)
                     .collect(new BufferCollector())
-                    .await(5, TimeUnit.SECONDS);
+                    .await(ofSeconds(5));
 
             fail("Did not throw expected CompletionException!");
         } catch (CompletionException e) {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromInputStreamTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -36,6 +35,8 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -68,7 +69,7 @@ public class MultiFromInputStreamTest {
                     return list;
                 })
                 .collectList()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
         assertThat(result, equalTo(toList(initialArray)));
     }
 
@@ -111,7 +112,7 @@ public class MultiFromInputStreamTest {
                 .map(CharBuffer::toString)
                 .map(CharSequence.class::cast)
                 .collectStream(Collectors.joining())
-                .await(100, TimeUnit.SECONDS);
+                .await(ofSeconds(100));
 
         assertThat(result, equalTo(expected));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiLogTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -133,7 +133,7 @@ public class MultiLogTest {
 
 
         assertThat(
-                assertThrows(CompletionException.class, () -> single.await(300, TimeUnit.MILLISECONDS))
+                assertThrows(CompletionException.class, () -> single.await(ofMillis(300)))
                         .getCause()
                         .getMessage(),
                 equalTo("BOOM!"));

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -405,7 +406,7 @@ public class MultiTest {
         List<Integer> result = Multi.just(1, 2, 3)
                 .onCompleteResume(4)
                 .collectList()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, is(equalTo(List.of(1, 2, 3, 4))));
     }
@@ -415,7 +416,7 @@ public class MultiTest {
         List<Integer> result = Multi.just(1, 2, 3)
                 .onCompleteResumeWith(Multi.just(4, 5, 6))
                 .collectList()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, is(equalTo(List.of(1, 2, 3, 4, 5, 6))));
     }
@@ -425,7 +426,7 @@ public class MultiTest {
         Integer result = Multi.<Integer>empty()
                 .onCompleteResume(1)
                 .first()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, is(equalTo(1)));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleFlatMapCompletionStageTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleFlatMapCompletionStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ package io.helidon.common.reactive;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SingleFlatMapCompletionStageTest {
@@ -46,7 +47,7 @@ public class SingleFlatMapCompletionStageTest {
     void singleThread() {
         Integer result = Single.just(1)
                 .flatMapCompletionStage(CompletableFuture::completedFuture)
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, Matchers.equalTo(1));
     }
@@ -75,7 +76,7 @@ public class SingleFlatMapCompletionStageTest {
                         throw new IllegalStateException(e);
                     }
                 }, exec))
-                .await(2, TimeUnit.SECONDS);
+                .await(ofSeconds(2));
 
         assertThat(result, Matchers.equalTo(10));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleLogTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -118,7 +118,7 @@ public class SingleLogTest {
 
 
         assertThat(
-                assertThrows(CompletionException.class, () -> single.await(300, TimeUnit.MILLISECONDS))
+                assertThrows(CompletionException.class, () -> single.await(ofMillis(300)))
                         .getCause()
                         .getMessage(),
                 equalTo("BOOM!"));

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -517,7 +518,7 @@ public class SingleTest {
         List<Integer> result = Single.just(1)
                 .onCompleteResume(4)
                 .collectList()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, is(equalTo(List.of(1, 4))));
     }
@@ -527,7 +528,7 @@ public class SingleTest {
         List<Integer> result = Single.just(1)
                 .onCompleteResumeWith(Multi.just(4, 5, 6))
                 .collectList()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, is(equalTo(List.of(1, 4, 5, 6))));
     }
@@ -537,7 +538,7 @@ public class SingleTest {
         Integer result = Single.<Integer>empty()
                 .onCompleteResume(1)
                 .first()
-                .await(100, TimeUnit.MILLISECONDS);
+                .await(ofMillis(100));
 
         assertThat(result, is(equalTo(1)));
     }
@@ -548,7 +549,7 @@ public class SingleTest {
 
         assertThat(Single.just(TEST_PAYLOAD)
                 .onComplete(() -> onCompleteFuture.complete(null))
-                .await(100, TimeUnit.MILLISECONDS), is(equalTo(TEST_PAYLOAD)));
+                .await(ofMillis(100)), is(equalTo(TEST_PAYLOAD)));
         onCompleteFuture.get(100, TimeUnit.MILLISECONDS);
     }
 
@@ -597,7 +598,7 @@ public class SingleTest {
                 .onError(t -> onErrorCnt.incrementAndGet())
                 .forSingle(result::complete);
 
-        assertThat(Single.create(result).await(300, TimeUnit.MILLISECONDS), is(TEST_PAYLOAD));
+        assertThat(Single.create(result).await(ofMillis(300)), is(TEST_PAYLOAD));
         assertThat(onCancelCnt.get(), is(0));
         assertThat(onErrorCnt.get(), is(0));
         assertThat(onCompleteCnt.get(), is(1));
@@ -618,7 +619,7 @@ public class SingleTest {
                         .onComplete(onCompleteCnt::incrementAndGet)
                         .onError(t -> onErrorCnt.countDown())
                         .forSingle(result::complete)
-                        .await(300, TimeUnit.MILLISECONDS));
+                        .await(ofMillis(300)));
 
         assertThat(onErrorCnt.await(300, TimeUnit.MILLISECONDS), is(true));
         assertThat(actualException.getCause(), is(testException));
@@ -666,7 +667,7 @@ public class SingleTest {
                 })
                 .exceptionallyAccept(result::complete);
 
-        assertThat(Single.create(result).await(300, TimeUnit.MILLISECONDS).getCause(), is(testException));
+        assertThat(Single.create(result).await(ofMillis(300)).getCause(), is(testException));
         assertThat(onCancelCnt.get(), is(0));
         assertThat(onErrorCnt.get(), is(0));
         assertThat(onCompleteCnt.get(), is(1));
@@ -682,9 +683,9 @@ public class SingleTest {
                     exceptionallyFuture.complete(value);
                     return null;
                 })
-                .await(300, TimeUnit.MILLISECONDS);
+                .await(ofMillis(300));
 
-        assertThat(Single.create(exceptionallyFuture).await(300, TimeUnit.MILLISECONDS), is(testException));
+        assertThat(Single.create(exceptionallyFuture).await(ofMillis(300)), is(testException));
     }
 
     @Test
@@ -694,9 +695,9 @@ public class SingleTest {
         RuntimeException testException = new RuntimeException("BOOM!!!");
         Single.error(testException)
                 .exceptionallyAccept(exceptionallyFuture::complete)
-                .await(300, TimeUnit.MILLISECONDS);
+                .await(ofMillis(300));
 
-        assertThat(Single.create(exceptionallyFuture).await(300, TimeUnit.MILLISECONDS), is(testException));
+        assertThat(Single.create(exceptionallyFuture).await(ofMillis(300)), is(testException));
     }
 
     @Test
@@ -705,7 +706,7 @@ public class SingleTest {
 
         String result = Single.just(TEST_PAYLOAD)
                 .exceptionallyAccept(exceptionallyFuture::complete)
-                .await(300, TimeUnit.MILLISECONDS);
+                .await(ofMillis(300));
 
         assertThat(result, is(TEST_PAYLOAD));
     }

--- a/microprofile/messaging/health/src/test/java/io/helidon/microprofile/messaging/health/MessagingHealthTest.java
+++ b/microprofile/messaging/health/src/test/java/io/helidon/microprofile/messaging/health/MessagingHealthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package io.helidon.microprofile.messaging.health;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import io.helidon.microprofile.config.ConfigCdiExtension;
 import io.helidon.microprofile.health.HealthCdiExtension;
@@ -45,6 +44,7 @@ import org.opentest4j.AssertionFailedError;
 
 import static io.helidon.microprofile.messaging.health.TestMessagingBean.CHANNEL_1;
 import static io.helidon.microprofile.messaging.health.TestMessagingBean.CHANNEL_2;
+import static java.time.Duration.ofMillis;
 import static org.eclipse.microprofile.health.HealthCheckResponse.Status.DOWN;
 import static org.eclipse.microprofile.health.HealthCheckResponse.Status.UP;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -104,7 +104,7 @@ public class MessagingHealthTest {
                 CHANNEL_1, DOWN,
                 CHANNEL_2, UP
         ));
-        assertThat(bean.getSubscriber1().error().await(200, TimeUnit.MILLISECONDS).getMessage(),
+        assertThat(bean.getSubscriber1().error().await(ofMillis(200)).getMessage(),
                 equalTo(ERROR_MESSAGE));
 
         bean.getEmitter2().fail(new RuntimeException(ERROR_MESSAGE));
@@ -112,7 +112,7 @@ public class MessagingHealthTest {
                 CHANNEL_1, DOWN,
                 CHANNEL_2, DOWN
         ));
-        assertThat(bean.getSubscriber1().error().await(200, TimeUnit.MILLISECONDS).getMessage(),
+        assertThat(bean.getSubscriber1().error().await(ofMillis(200)).getMessage(),
                 equalTo(ERROR_MESSAGE));
     }
 

--- a/microprofile/tests/tck/tck-lra/src/test/java/io/helidon/microprofile/lra/tck/CoordinatorAppService.java
+++ b/microprofile/tests/tck/tck-lra/src/test/java/io/helidon/microprofile/lra/tck/CoordinatorAppService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package io.helidon.microprofile.lra.tck;
 
 import java.lang.System.Logger.Level;
 import java.net.URI;
-import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.LazyValue;
 import io.helidon.config.Config;
@@ -36,6 +35,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
 import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+import static java.time.Duration.ofSeconds;
 
 @ApplicationScoped
 public class CoordinatorAppService {
@@ -49,7 +49,7 @@ public class CoordinatorAppService {
     ServerCdiExtension serverCdiExtension;
 
     LazyValue<URI> coordinatorUri = LazyValue.create(() -> {
-        CoordinatorDeployer.started().await(30, TimeUnit.SECONDS);
+        CoordinatorDeployer.started().await(ofSeconds(30));
         // Check if external coordinator is set or use internal with random port
         int randomPort = serverCdiExtension.port(CoordinatorDeployer.COORDINATOR_ROUTING_NAME);
         String port = System.getProperty("lra.coordinator.port", String.valueOf(randomPort));


### PR DESCRIPTION
### Description
There are many usages deprecated method `Awaitable.await(long, TimeUnit)`. It can be replaced on `Awaitable.await(Duration)`