### PR TITLE
Replace deprecated MediaType.fullType() on MediaType.text()

### DIFF
--- a/common/media-type/src/main/java/io/helidon/common/media/type/MediaTypeImpl.java
+++ b/common/media-type/src/main/java/io/helidon/common/media/type/MediaTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,6 @@ record MediaTypeImpl(String type, String subtype, String text) implements MediaT
 
     @Override
     public String toString() {
-        return fullType();
+        return text();
     }
 }

--- a/common/media-type/src/test/java/io/helidon/common/media/type/MediaTypesTest.java
+++ b/common/media-type/src/test/java/io/helidon/common/media/type/MediaTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ class MediaTypesTest {
 
             assertAll(
                     () -> assertThat(value, notNullValue()),
-                    () -> assertThat(value.fullType(), notNullValue()),
+                    () -> assertThat(value.text(), notNullValue()),
                     () -> assertThat(value.subtype(), notNullValue()),
                     () -> assertThat(value.type(), notNullValue())
             );

--- a/config/config/src/test/java/io/helidon/config/UrlConfigSourceServerMockTest.java
+++ b/config/config/src/test/java/io/helidon/config/UrlConfigSourceServerMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class UrlConfigSourceServerMockTest {
                 .match(method(GET), uri("/application.properties"))
                 .then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT"),
                         stringContent(TEST_CONFIG)
                 );
@@ -98,7 +98,7 @@ public class UrlConfigSourceServerMockTest {
                 match(method(HEAD), uri("/application.properties")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT"),
                         stringContent(TEST_CONFIG)
                 );
@@ -107,7 +107,7 @@ public class UrlConfigSourceServerMockTest {
                 match(get("/application.properties")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT"),
                         stringContent(TEST_CONFIG)
                 );
@@ -139,7 +139,7 @@ public class UrlConfigSourceServerMockTest {
                 match(method(HEAD), uri("/application.properties")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT"),
                         stringContent(TEST_CONFIG)
                 );
@@ -148,7 +148,7 @@ public class UrlConfigSourceServerMockTest {
                 match(get("/application.properties")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT"),
                         stringContent(TEST_CONFIG)
                 );
@@ -166,7 +166,7 @@ public class UrlConfigSourceServerMockTest {
                 match(method(HEAD), uri("/application.properties")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:03 GMT"),
                         stringContent(TEST_CONFIG)
                 );
@@ -192,7 +192,7 @@ public class UrlConfigSourceServerMockTest {
                 match(get("/application.properties")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(TEST_CONFIG)
                 );
 
@@ -218,7 +218,7 @@ public class UrlConfigSourceServerMockTest {
                 match(get("/application.properties")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(TEST_CONFIG)
                 );
 
@@ -243,7 +243,7 @@ public class UrlConfigSourceServerMockTest {
                 match(get("/application.properties")).
                 then(
                         status(OK_200),
-                        contentType(TEST_MEDIA_TYPE.fullType()),
+                        contentType(TEST_MEDIA_TYPE.text()),
                         stringContent(TEST_CONFIG)
                 );
 

--- a/config/config/src/test/java/io/helidon/config/UrlOverrideSourceServerMockTest.java
+++ b/config/config/src/test/java/io/helidon/config/UrlOverrideSourceServerMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,14 +85,14 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(HEAD), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT")
                 );
         whenHttp(server).
                 match(method(GET), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT"),
                         stringContent(WILDCARDS)
                 );
@@ -118,14 +118,14 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(HEAD), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT")
                 );
         whenHttp(server).
                 match(method(GET), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT"),
                         stringContent(MULTIPLE_WILDCARDS)
                 );
@@ -150,14 +150,14 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(HEAD), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT")
                 );
         whenHttp(server).
                 match(method(GET), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         header("Last-Modified", "Sat, 10 Jun 2017 10:14:02 GMT"),
                         stringContent(MULTIPLE_WILDCARDS_ANOTHER_ORDERING)
                 );
@@ -182,7 +182,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(WILDCARDS)
                 );
 
@@ -190,7 +190,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/config")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(CONFIG)
                 );
 
@@ -213,7 +213,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(NEW_WILDCARDS)
                 );
 
@@ -232,7 +232,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(WILDCARDS)
                 );
 
@@ -240,7 +240,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/config")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(CONFIG)
                 );
 
@@ -259,7 +259,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(custom(call -> call.getMethod().equals(GET) || call.getMethod().equals(HEAD)), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(NO_WILDCARDS)
                 );
 
@@ -274,7 +274,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(WILDCARDS)
                 );
 
@@ -282,7 +282,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/config")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(CONFIG)
                 );
 
@@ -303,7 +303,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/config")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(CONFIG2)
                 );
 
@@ -318,7 +318,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/override")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(WILDCARDS)
                 );
 
@@ -326,7 +326,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/config")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(CONFIG)
                 );
 
@@ -350,7 +350,7 @@ public class UrlOverrideSourceServerMockTest {
                 match(method(GET), uri("/config")).
                 then(
                         status(OK_200),
-                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.fullType()),
+                        contentType(MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text()),
                         stringContent(CONFIG2)
                 );
 

--- a/http/http/src/main/java/io/helidon/http/HttpMediaTypeImpl.java
+++ b/http/http/src/main/java/io/helidon/http/HttpMediaTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ final class HttpMediaTypeImpl implements HttpMediaType {
 
     @Override
     public String text() {
-        StringBuilder result = new StringBuilder(mediaType.fullType());
+        StringBuilder result = new StringBuilder(mediaType.text());
         for (Map.Entry<String, String> param : parameters.entrySet()) {
             result.append("; ")
                     .append(param.getKey())


### PR DESCRIPTION
### Description

There are many usages deprecated method `MediaType.fullType()`. It can be replaced on `MediaType.text()`
