### PR TITLE
Fix  for #8344 - Incorrect SQL Type for null Parameters in JDBC Parameter Binding

### DIFF
--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
@@ -15,14 +15,6 @@
  */
 package io.helidon.dbclient.jdbc;
 
-import io.helidon.dbclient.DbClientException;
-import io.helidon.dbclient.DbClientServiceContext;
-import io.helidon.dbclient.DbIndexedStatementParameters;
-import io.helidon.dbclient.DbNamedStatementParameters;
-import io.helidon.dbclient.DbStatement;
-import io.helidon.dbclient.DbStatementBase;
-import io.helidon.dbclient.DbStatementParameters;
-
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayReader;
 import java.lang.System.Logger.Level;
@@ -38,6 +30,14 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import io.helidon.dbclient.DbClientException;
+import io.helidon.dbclient.DbClientServiceContext;
+import io.helidon.dbclient.DbIndexedStatementParameters;
+import io.helidon.dbclient.DbNamedStatementParameters;
+import io.helidon.dbclient.DbStatement;
+import io.helidon.dbclient.DbStatementBase;
+import io.helidon.dbclient.DbStatementParameters;
 
 /**
  * JDBC statement base implementation.

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
@@ -15,6 +15,14 @@
  */
 package io.helidon.dbclient.jdbc;
 
+import io.helidon.dbclient.DbClientException;
+import io.helidon.dbclient.DbClientServiceContext;
+import io.helidon.dbclient.DbIndexedStatementParameters;
+import io.helidon.dbclient.DbNamedStatementParameters;
+import io.helidon.dbclient.DbStatement;
+import io.helidon.dbclient.DbStatementBase;
+import io.helidon.dbclient.DbStatementParameters;
+
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayReader;
 import java.lang.System.Logger.Level;
@@ -30,14 +38,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import io.helidon.dbclient.DbClientException;
-import io.helidon.dbclient.DbClientServiceContext;
-import io.helidon.dbclient.DbIndexedStatementParameters;
-import io.helidon.dbclient.DbNamedStatementParameters;
-import io.helidon.dbclient.DbStatement;
-import io.helidon.dbclient.DbStatementBase;
-import io.helidon.dbclient.DbStatementParameters;
 
 /**
  * JDBC statement base implementation.
@@ -299,7 +299,7 @@ public abstract class JdbcStatement<S extends DbStatement<S>> extends DbStatemen
             statement.setBoolean(index, b);
         } else if (parameter == null) {
             // Normally null is passed as a DatabaseField so the type is included, but in some case may be passed directly.
-            statement.setNull(index, Types.VARCHAR);
+            statement.setNull(index, Types.NULL);
         } else if (parameter instanceof byte[] b) {
             if (jdbcContext().parametersConfig().useByteArrayBinding()) {
                 ByteArrayInputStream inputStream = new ByteArrayInputStream(b);

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Summary:
This PR addresses an issue in the JDBC parameter binding logic where `null` values were incorrectly being set with `Types.VARCHAR` SQL type. This behavior lead to SQL exceptions when inserting `null` into non-`VARCHAR` columns in a database. The proposed change ensures that `null` values are set with `Types.NULL`, allowing the JDBC driver to correctly interpret the intended type based on the column definition.

### Problem Description:
When attempting to insert `null` values into a database using the Helidon JDBC client, the fixed SQL type of `Types.VARCHAR` for `null` parameters leads to type mismatch errors for columns of types other than `VARCHAR`. For example, inserting `null` into a `NUMERIC` column results in a `PSQLException` with a message indicating a type mismatch.

### Proposed Solution:
The fix involves changing the SQL type for `null` parameters from `Types.VARCHAR` to `Types.NULL` in the `setParameter` method of the JDBC parameter handling logic. This change allows the JDBC driver to determine the correct type for the `null` value based on the context of the column it is being inserted into, thus preventing type mismatch errors.
