### PR TITLE
3.x: Upgrade OCI SDK to 3.34.0

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/oci/files/server/src/test/java/__pkg__/server/GreetResourceMockedTest.java.mustache
+++ b/archetypes/helidon/src/main/archetype/mp/oci/files/server/src/test/java/__pkg__/server/GreetResourceMockedTest.java.mustache
@@ -141,13 +141,33 @@ class GreetResourceMockedTest {
         public CreateAlarmResponse createAlarm(CreateAlarmRequest createAlarmRequest) {return null;}
 
         @Override
+        public CreateAlarmSuppressionResponse createAlarmSuppression(CreateAlarmSuppressionRequest createAlarmSuppressionRequest) {
+            return null;
+        }
+
+        @Override
         public DeleteAlarmResponse deleteAlarm(DeleteAlarmRequest deleteAlarmRequest) {return null;}
+
+        @Override
+        public DeleteAlarmSuppressionResponse deleteAlarmSuppression(DeleteAlarmSuppressionRequest deleteAlarmSuppressionRequest) {
+            return null;
+        }
 
         @Override
         public GetAlarmResponse getAlarm(GetAlarmRequest getAlarmRequest) {return null;}
 
         @Override
         public GetAlarmHistoryResponse getAlarmHistory(GetAlarmHistoryRequest getAlarmHistoryRequest) {return null;}
+
+        @Override
+        public GetAlarmSuppressionResponse getAlarmSuppression(GetAlarmSuppressionRequest getAlarmSuppressionRequest) {
+            return null;
+        }
+
+        @Override
+        public ListAlarmSuppressionsResponse listAlarmSuppressions(ListAlarmSuppressionsRequest listAlarmSuppressionsRequest) {
+            return null;
+        }
 
         @Override
         public ListAlarmsResponse listAlarms(ListAlarmsRequest listAlarmsRequest) {return null;}
@@ -180,6 +200,11 @@ class GreetResourceMockedTest {
 
         @Override
         public RetrieveDimensionStatesResponse retrieveDimensionStates(RetrieveDimensionStatesRequest retrieveDimensionStatesRequest) {
+            return null;
+        }
+
+        @Override
+        public SummarizeAlarmSuppressionHistoryResponse summarizeAlarmSuppressionHistory(SummarizeAlarmSuppressionHistoryRequest summarizeAlarmSuppressionHistoryRequest) {
             return null;
         }
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -130,7 +130,7 @@
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.100.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
-        <version.lib.oci>3.29.0</version.lib.oci>
+        <version.lib.oci>3.34.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <!-- Manage okio version for dependency convergence -->

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,16 @@ package io.helidon.integrations.oci.metrics.cdi;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import com.oracle.bmc.monitoring.requests.CreateAlarmSuppressionRequest;
+import com.oracle.bmc.monitoring.requests.DeleteAlarmSuppressionRequest;
+import com.oracle.bmc.monitoring.requests.GetAlarmSuppressionRequest;
+import com.oracle.bmc.monitoring.requests.ListAlarmSuppressionsRequest;
+import com.oracle.bmc.monitoring.requests.SummarizeAlarmSuppressionHistoryRequest;
+import com.oracle.bmc.monitoring.responses.CreateAlarmSuppressionResponse;
+import com.oracle.bmc.monitoring.responses.DeleteAlarmSuppressionResponse;
+import com.oracle.bmc.monitoring.responses.GetAlarmSuppressionResponse;
+import com.oracle.bmc.monitoring.responses.ListAlarmSuppressionsResponse;
+import com.oracle.bmc.monitoring.responses.SummarizeAlarmSuppressionHistoryResponse;
 import io.helidon.config.Config;
 import io.helidon.integrations.oci.metrics.OciMetricsSupport;
 import io.helidon.metrics.api.RegistryFactory;
@@ -198,7 +208,17 @@ class OciMetricsCdiExtensionTest {
         }
 
         @Override
+        public CreateAlarmSuppressionResponse createAlarmSuppression(CreateAlarmSuppressionRequest createAlarmSuppressionRequest) {
+            return null;
+        }
+
+        @Override
         public DeleteAlarmResponse deleteAlarm(DeleteAlarmRequest deleteAlarmRequest) {
+            return null;
+        }
+
+        @Override
+        public DeleteAlarmSuppressionResponse deleteAlarmSuppression(DeleteAlarmSuppressionRequest deleteAlarmSuppressionRequest) {
             return null;
         }
 
@@ -209,6 +229,16 @@ class OciMetricsCdiExtensionTest {
 
         @Override
         public GetAlarmHistoryResponse getAlarmHistory(GetAlarmHistoryRequest getAlarmHistoryRequest) {
+            return null;
+        }
+
+        @Override
+        public GetAlarmSuppressionResponse getAlarmSuppression(GetAlarmSuppressionRequest getAlarmSuppressionRequest) {
+            return null;
+        }
+
+        @Override
+        public ListAlarmSuppressionsResponse listAlarmSuppressions(ListAlarmSuppressionsRequest listAlarmSuppressionsRequest) {
             return null;
         }
 
@@ -245,6 +275,11 @@ class OciMetricsCdiExtensionTest {
 
         @Override
         public RetrieveDimensionStatesResponse retrieveDimensionStates(RetrieveDimensionStatesRequest retrieveDimensionStatesRequest) {
+            return null;
+        }
+
+        @Override
+        public SummarizeAlarmSuppressionHistoryResponse summarizeAlarmSuppressionHistory(SummarizeAlarmSuppressionHistoryRequest summarizeAlarmSuppressionHistoryRequest) {
             return null;
         }
 


### PR DESCRIPTION
### Description

Upgrade OCI SDK to 3.34.0. This required adding some methods to a mock test class.

### Documentation

No impact