### PR TITLE
Introduces Dependabot configuration file to help manage OCI updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/dependencies/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "com.oracle.oci.sdk:oci-java-sdk-bom"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,11 @@
 version: 2
 updates:
   - package-ecosystem: "maven"
-    directory: "/dependencies/"
+    directory: "/dependencies"
     schedule:
       interval: "weekly"
     allow:
       - dependency-name: "com.oracle.oci.sdk:oci-java-sdk-bom"
+    labels:
+      - "build"
+      - "dependencies"


### PR DESCRIPTION
This PR introduces the `.github/dependabot.yml` file with an initial configuration to hopefully support OCI updates.

I have placed the PR in draft state to begin since I do not see an easy way to test its effects before merging it. Please review carefully.

My further understanding is that merging this PR will enable Dependabot as configured and in no other way, and that there are no additional steps to take.