### PR TITLE
Replace deprecated java.util.Locale constructors on factory methods

### DIFF
--- a/config/tests/module-mappers-1-base/src/main/java/io/helidon/config/tests/module/mappers1/LocaleConfigMapper.java
+++ b/config/tests/module-mappers-1-base/src/main/java/io/helidon/config/tests/module/mappers1/LocaleConfigMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class LocaleConfigMapper implements Function<Config, Locale> {
         String country = config.get("country").asString().orElse("");
         String variant = config.get("variant").asString().orElse("");
 
-        return new Locale(language, country, variant);
+        return Locale.of(language, country, variant);
     }
 
 }

--- a/config/tests/module-mappers-2-override/src/main/java/io/helidon/config/tests/module/mappers2/LocaleConfigMapper.java
+++ b/config/tests/module-mappers-2-override/src/main/java/io/helidon/config/tests/module/mappers2/LocaleConfigMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class LocaleConfigMapper implements Function<Config, Locale> {
         String country = config.get("country").asString().orElse("");
         String variant = config.get("variant").asString().orElse("");
 
-        return new Locale("m2:" + language, "m2:" + country, "m2:" + variant);
+        return Locale.of("m2:" + language, "m2:" + country, "m2:" + variant);
     }
 
 }

--- a/config/tests/test-mappers-1-common/src/test/java/io/helidon/config/tests/mappers1/MapperServicesEnabledOverrideTest.java
+++ b/config/tests/test-mappers-1-common/src/test/java/io/helidon/config/tests/mappers1/MapperServicesEnabledOverrideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class MapperServicesEnabledOverrideTest extends AbstractMapperServicesTes
 
     @Test
     public void testLocale() {
-        assertThat(getLocale(), is(new Locale("TEST:cs", "TEST:CZ", "TEST:Praha")));
+        assertThat(getLocale(), is(Locale.of("TEST:cs", "TEST:CZ", "TEST:Praha")));
     }
 
 }

--- a/config/tests/test-mappers-1-common/src/test/java/io/helidon/config/tests/mappers1/MapperServicesEnabledTest.java
+++ b/config/tests/test-mappers-1-common/src/test/java/io/helidon/config/tests/mappers1/MapperServicesEnabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class MapperServicesEnabledTest extends AbstractMapperServicesTest {
 
     @Test
     public void testLocale() {
-        assertThat(getLocale(), is(new Locale("cs", "CZ", "Praha")));
+        assertThat(getLocale(), is(Locale.of("cs", "CZ", "Praha")));
     }
 
 }

--- a/config/tests/test-mappers-1-common/src/test/java/io/helidon/config/tests/mappers1/MyLocaleConfigMapper.java
+++ b/config/tests/test-mappers-1-common/src/test/java/io/helidon/config/tests/mappers1/MyLocaleConfigMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class MyLocaleConfigMapper implements Function<Config, Locale> {
         String country = config.get("country").asString().orElse("");
         String variant = config.get("variant").asString().orElse("");
 
-        return new Locale("TEST:" + language, "TEST:" + country, "TEST:" + variant);
+        return Locale.of("TEST:" + language, "TEST:" + country, "TEST:" + variant);
     }
 
 }

--- a/config/tests/test-mappers-2-complex/src/test/java/io/helidon/config/tests/mappers2/MapperServicesEnabledTest.java
+++ b/config/tests/test-mappers-2-complex/src/test/java/io/helidon/config/tests/mappers2/MapperServicesEnabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class MapperServicesEnabledTest extends AbstractMapperServicesTest {
      */
     @Test
     public void testLocale() {
-        assertThat(getLocale(), is(new Locale("m2:cs", "m2:CZ", "m2:Praha")));
+        assertThat(getLocale(), is(Locale.of("m2:cs", "m2:CZ", "m2:Praha")));
     }
 
 }

--- a/config/tests/test-mappers-2-complex/src/test/java/io/helidon/config/tests/mappers2/MyLocaleConfigMapper.java
+++ b/config/tests/test-mappers-2-complex/src/test/java/io/helidon/config/tests/mappers2/MyLocaleConfigMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class MyLocaleConfigMapper implements Function<Config, Locale> {
         String country = config.get("country").asString().get();
         String variant = config.get("variant").asString().get();
 
-        return new Locale("TEST:" + language, "TEST:" + country, "TEST:" + variant);
+        return Locale.of("TEST:" + language, "TEST:" + country, "TEST:" + variant);
     }
 
 }

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -297,7 +297,7 @@ public final class JwtUtil {
         Matcher matcher = LOCALE_PATTERN.matcher(locale);
         Locale result;
         if (matcher.matches()) {
-            result = new Locale(matcher.group(1), matcher.group(2));
+            result = Locale.of(matcher.group(1), matcher.group(2));
         } else {
             result = Locale.forLanguageTag(locale);
         }


### PR DESCRIPTION
### Description
Since java 19 constructors `java.util.Locale` were deprecated.  [There are several ways to obtain Locale object](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/util/Locale.html#ObtainingLocale). I used factory methods.