### PR TITLE
4.x: Return 500 when 204 with entity is sent from routing.

### DIFF
--- a/archetypes/archetypes/src/main/archetype/se/database/files/src/main/java/__pkg__/PokemonService.java.mustache
+++ b/archetypes/archetypes/src/main/archetype/se/database/files/src/main/java/__pkg__/PokemonService.java.mustache
@@ -270,10 +270,10 @@ public class PokemonService implements HttpService {
                 .pathParameters()
                 .first("id").map(Integer::parseInt)
                 .orElseThrow(() -> new BadRequestException("No pokemon id"));
-        long count = dbClient.execute().createNamedDelete("delete-pokemon-by-id")
+        dbClient.execute().createNamedDelete("delete-pokemon-by-id")
                 .addParam("id", id)
                 .execute();
         response.status(Status.NO_CONTENT_204)
-                .send("Deleted: " + count + " values\n");
+                .send();
     }
 }

--- a/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonService.java
+++ b/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,10 +286,10 @@ public class PokemonService implements HttpService {
                 .pathParameters()
                 .first("id").map(Integer::parseInt)
                 .orElseThrow(() -> new BadRequestException("No pokemon id"));
-        long count = dbClient.execute().createNamedDelete("delete-pokemon-by-id")
+        dbClient.execute().createNamedDelete("delete-pokemon-by-id")
                 .addParam("id", id)
                 .execute();
         response.status(Status.NO_CONTENT_204)
-                .send("Deleted: " + count + " values\n");
+                .send();
     }
 }

--- a/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusService.java
+++ b/examples/metrics/http-status-count-se/src/test/java/io/helidon/examples/se/httpstatuscount/StatusService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.examples.se.httpstatuscount;
 
 import io.helidon.http.Status;
@@ -43,6 +44,12 @@ public class StatusService implements HttpService {
             status = Status.INTERNAL_SERVER_ERROR_500.code();
             msg = "Unsuccessful conversion";
         }
-        response.status(status).send(msg);
+        Status httpStatus = Status.create(status);
+        response.status(status);
+        if (httpStatus != Status.NO_CONTENT_204) {
+            response.send(msg);
+        } else {
+            response.send();
+        }
     }
 }

--- a/microprofile/tests/server/pom.xml
+++ b/microprofile/tests/server/pom.xml
@@ -61,5 +61,10 @@
             <artifactId>helidon-microprofile-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/microprofile/tests/server/src/test/java/io/helidon/microprofile/tests/server/NoContentWithEntityTest.java
+++ b/microprofile/tests/server/src/test/java/io/helidon/microprofile/tests/server/NoContentWithEntityTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.server;
+
+import io.helidon.http.Status;
+import io.helidon.microprofile.server.JaxRsCdiExtension;
+import io.helidon.microprofile.server.ServerCdiExtension;
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddExtension;
+import io.helidon.microprofile.testing.junit5.DisableDiscovery;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@DisableDiscovery
+@AddBean(NoContentWithEntityTest.TestResource.class)
+@AddExtension(ServerCdiExtension.class)
+@AddExtension(JaxRsCdiExtension.class)
+@AddExtension(CdiComponentProvider.class)
+class NoContentWithEntityTest {
+    @Inject
+    WebTarget target;
+
+    @Test
+    void streamingOutput() {
+        Response response = target.path("/noContent")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(Status.INTERNAL_SERVER_ERROR_500.code()));
+
+        response = target.path("/ok")
+                .request()
+                .get();
+        assertThat(response.getStatus(), is(Status.OK_200.code()));
+        assertThat(response.readEntity(String.class), is("hello"));
+    }
+
+    @Path("/")
+    public static class TestResource {
+
+        @GET
+        @Path("/noContent")
+        public Response noContent() {
+            return Response.noContent()
+                    .entity("hello")
+                    .build();
+        }
+
+        @GET
+        @Path("/ok")
+        public Response ok() {
+            return Response
+                    .ok("hello")
+                    .build();
+        }
+    }
+}

--- a/microprofile/tests/server/src/test/resources/logging-test.properties
+++ b/microprofile/tests/server/src/test/resources/logging-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/webserver/tests/webserver/pom.xml
+++ b/webserver/tests/webserver/pom.xml
@@ -53,5 +53,10 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/NoContentWithEntityTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/NoContentWithEntityTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.http.Status;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class NoContentWithEntityTest {
+    private final Http1Client client;
+
+    NoContentWithEntityTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.post("/noContent", NoContentWithEntityTest::noContent)
+                .post("/noContentStream", NoContentWithEntityTest::noContentStream)
+                .post("/ok", NoContentWithEntityTest::ok);
+
+        LogConfig.configureRuntime();
+    }
+
+    @Test
+    void testNoContentWorksFollowedByOk() {
+        try (Http1ClientResponse response = client.post("/noContent")
+                .submit("text")) {
+
+            assertThat(response.status(), is(Status.INTERNAL_SERVER_ERROR_500));
+        }
+
+        ClientResponseTyped<String> okResponse = client.post("/ok")
+                .submit("text", String.class);
+
+        assertThat(okResponse.status(), is(Status.OK_200));
+        assertThat(okResponse.entity(), is("text"));
+    }
+
+    @Test
+    void testNoContentWorksFollowedByOkStreaming() {
+        try (Http1ClientResponse response = client.post("/noContentStream")
+                .submit("text")) {
+
+            assertThat(response.status(), is(Status.INTERNAL_SERVER_ERROR_500));
+        }
+
+        ClientResponseTyped<String> okResponse = client.post("/ok")
+                .submit("text", String.class);
+
+        assertThat(okResponse.status(), is(Status.OK_200));
+        assertThat(okResponse.entity(), is("text"));
+    }
+
+    private static void ok(ServerRequest req, ServerResponse res) {
+        res.status(Status.OK_200).send("text");
+    }
+
+    private static void noContentStream(ServerRequest req, ServerResponse res) throws IOException {
+        res.status(Status.NO_CONTENT_204);
+        try (OutputStream out = res.outputStream()) {
+            out.write("text".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private static void noContent(ServerRequest req, ServerResponse res) {
+        res.status(Status.NO_CONTENT_204).send("text");
+    }
+
+}
+

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -109,7 +109,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         if (status != null && status.code() == Status.NO_CONTENT_204.code()) {
             // https://www.rfc-editor.org/rfc/rfc9110#status.204
             // A 204 response is terminated by the end of the header section; it cannot contain content or trailers
-            if (headers.contains(HeaderNames.CONTENT_LENGTH) || headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+            if ((headers.contains(HeaderNames.CONTENT_LENGTH) && !headers.contains(HeaderValues.CONTENT_LENGTH_ZERO))
+                         || headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
                 status = Status.INTERNAL_SERVER_ERROR_500;
                 LOGGER.log(System.Logger.Level.ERROR, "Attempt to send status 204 No-Content with entity. Server responded"
                         + " with Internal Server Error. Please fix your routing, this is not allowed by HTTP specification.");


### PR DESCRIPTION
### Description
Fixed a problem when user returned `204` with an entity in JAX-RS. 
With the default connector, the next (!) request would fail with Status code `-1` (caused by the client ignoring the entity according to the specification, but then the connection was broken, and the next response started reading the previous entity).

The client could handle this more gracefully (i.e. close the connection, report the problem), but it is the default one in Java...

Updated solution:
- if an attempt is done to write entity with `204` status, the status is changed to `500`, and everything else carries out as usual (as entity is allowed with 500). The server logs an error explaining the problem.