### PR TITLE
Suppress Helidon handling of OpenTelemetry annotations if OTel Java agent is present

### DIFF
--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -140,6 +140,8 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <!-- The default for the following is 5000 ms. Reducing it significantly speeds up tests. -->
+                    <argLine>-Dotel.bsp.schedule.delay=100</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -99,6 +99,10 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
     @Override
     public void filter(ContainerRequestContext requestContext) {
 
+        if (Boolean.getBoolean(TelemetryCdiExtension.OTEL_AGENT_PRESENT)) {
+            return;
+        }
+
         if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
             LOGGER.log(System.Logger.Level.TRACE, "Starting Span in a Container Request");
         }
@@ -131,6 +135,10 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
 
     @Override
     public void filter(final ContainerRequestContext request, final ContainerResponseContext response) {
+
+        if (Boolean.getBoolean(TelemetryCdiExtension.OTEL_AGENT_PRESENT)) {
+            return;
+        }
 
         if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
             LOGGER.log(System.Logger.Level.TRACE, "Closing Span in a Container Request");

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AgentDetectorTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AgentDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,11 +36,10 @@ import static org.hamcrest.Matchers.is;
 @AddExtension(ServerCdiExtension.class)
 class AgentDetectorTest {
 
-    public static final String OTEL_AGENT_PRESENT = "otel.agent.present";
     public static final String IO_OPENTELEMETRY_JAVAAGENT = "io.opentelemetry.javaagent";
 
     @Test
-    @AddConfig(key = OTEL_AGENT_PRESENT, value = "true")
+    @AddConfig(key = TelemetryCdiExtension.OTEL_AGENT_PRESENT, value = "true")
     void shouldBeNoOpTelemetry(){
         Config config = CDI.current().select(Config.class).get();
         boolean present = HelidonOpenTelemetry.AgentDetector.isAgentPresent(config);
@@ -48,7 +47,7 @@ class AgentDetectorTest {
     }
 
     @Test
-    @AddConfig(key = OTEL_AGENT_PRESENT, value = "false")
+    @AddConfig(key = TelemetryCdiExtension.OTEL_AGENT_PRESENT, value = "false")
     void shouldNotBeNoOpTelemetry(){
         Config config = CDI.current().select(Config.class).get();
         boolean present = HelidonOpenTelemetry.AgentDetector.isAgentPresent(config);


### PR DESCRIPTION
### Description
Resolves #8341 

OTel provides a Java agent which automatically traces JAX-RS endpoints and methods with the OTel `@WithSpan` annotation. 

Helidon's MP Telemetry support also automatically traces JAX-RS endpoints (via a filter) and `@WithSpan` methods (via an interceptor). 

If both are present the service creates double spans. Yet users still want to keep `helidon-microprofile-telemetry` so they can `@Inject` tracers.

This PR does several things:
1. If the OTel agent is present, the telemetry CDI portable extension bypasses binding our interceptor to `@WithSpan` methods.
2. If the OTel agent is present, the telemetry JAX-RS filter bypasses Helidon's automatic JAX-RS endpoint handling.

(Testing this automatically would be quite involved. Because of the unique behavior and requirements of a Java agent in general and the OTel agent specifically, automating a test would require building a temporary JAR containing our in-memory span exporter plus other Otel-specific code to tell the agent to use that in-memory exporter and then adding system property assignments to the surefire test execution to control the agent. It could be done but is not part of this PR. I did manual tests to confirm the original behavior and to verify the fix.)

### Documentation
Bug fix - no doc change.