### PR TITLE
Include requested URI config in ListenerConfig; fix config keys

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import io.helidon.common.uri.UriInfo;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.http.Header;
 import io.helidon.http.HttpPrologue;
+import io.helidon.http.RequestedUriDiscoveryContext;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.WritableHeaders;
@@ -47,6 +48,11 @@ import io.helidon.webserver.http.RoutingRequest;
  * HTTP/2 server request.
  */
 class Http2ServerRequest implements RoutingRequest {
+    private static final RequestedUriDiscoveryContext DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT =
+            RequestedUriDiscoveryContext.builder()
+                    .build();
+
+
     private static final Runnable NO_OP_RUNNABLE = () -> {
     };
     private final Http2Headers http2Headers;
@@ -228,11 +234,13 @@ class Http2ServerRequest implements RoutingRequest {
     }
 
     private UriInfo createUriInfo() {
-        return ctx.listenerContext().config().requestedUriDiscoveryContext().uriInfo(remotePeer().address().toString(),
-                                                                                     localPeer().address().toString(),
-                                                                                     path.path(),
-                                                                                     headers,
-                                                                                     query(),
-                                                                                     isSecure());
+        return ctx.listenerContext().config().requestedUriDiscoveryContext()
+                .orElse(DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT)
+                .uriInfo(remotePeer().address().toString(),
+                         localPeer().address().toString(),
+                         path.path(),
+                         headers,
+                         query(),
+                         isSecure());
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -345,7 +345,8 @@ interface ListenerConfigBlueprint {
      *
      * @return discovery context
      */
-    RequestedUriDiscoveryContext requestedUriDiscoveryContext();
+    @Option.Configured("requested-uri-discovery")
+    Optional<RequestedUriDiscoveryContext> requestedUriDiscoveryContext();
 
     /**
      * Update the server socket with configured socket options.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
+import io.helidon.http.RequestedUriDiscoveryContext;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.WritableHeaders;
@@ -45,6 +46,11 @@ import io.helidon.webserver.http.RoutingRequest;
  * Http 1 server request base.
  */
 abstract class Http1ServerRequest implements RoutingRequest {
+
+    private static final RequestedUriDiscoveryContext DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT =
+            RequestedUriDiscoveryContext.builder()
+            .build();
+
     private final ServerRequestHeaders headers;
     private final ConnectionContext ctx;
     private final HttpSecurity security;
@@ -215,11 +221,13 @@ abstract class Http1ServerRequest implements RoutingRequest {
     }
 
     private UriInfo createUriInfo() {
-        return ctx.listenerContext().config().requestedUriDiscoveryContext().uriInfo(remotePeer().address().toString(),
-                                                                                     localPeer().address().toString(),
-                                                                                     path.path(),
-                                                                                     headers,
-                                                                                     query(),
-                                                                                     isSecure());
+        return ctx.listenerContext().config().requestedUriDiscoveryContext()
+                .orElse(DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT)
+                .uriInfo(remotePeer().address().toString(),
+                         localPeer().address().toString(),
+                         path.path(),
+                         headers,
+                         query(),
+                         isSecure());
     }
 }


### PR DESCRIPTION
### Description

Resolves #8367 

The `ListenerConfigBlueprint` declared `requestedUriDiscoveryContext` but did not annotated it with `@Option.Configured` so Helidon never looked for configuration for it.

Changes:
1. Change declaration of `requestedUriDiscoveryContext` on `ListenerConfigBlueprint` so it is configured as `requested-uri-discovery` and optional.
2. Change http1 and http2 server requests to use a default discovery context if they are asked for one but none was configured.
3. Do some initial clean-up of key names in `RequestedUriDiscoveryContext`. It does not yet use the new builder approach and will at some point but for time that is not part of this PR.

Several unit tests from 3.x were not carried forward to 4.x when we brought over the requested URI discovery support because of the refactoring among the webserver and httpx components. I will create a separate issue for restoring the tests in some form.

### Documentation

Bug fix; no doc impact.