### PR TITLE
4.x: Releasing entity count down latch even if connection is set to close.

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -420,7 +420,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
 
         routing.route(ctx, request, response);
 
-        consumeEntity(request, response);
+        consumeEntity(request, response, entityReadLatch);
         try {
             entityReadLatch.await();
         } catch (InterruptedException e) {
@@ -433,9 +433,10 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         }
     }
 
-    private void consumeEntity(Http1ServerRequest request, Http1ServerResponse response) {
+    private void consumeEntity(Http1ServerRequest request, Http1ServerResponse response, CountDownLatch entityReadLatch) {
         if (response.headers().contains(HeaderValues.CONNECTION_CLOSE) || request.content().consumed()) {
             // we do not care about request entity if connection is getting closed
+            entityReadLatch.countDown();
             return;
         }
         // consume the entity if not consumed by routing


### PR DESCRIPTION
### Description
Related to #8317 

When connection is set to close, we never release the latch.