### PR TITLE
Adds support for injecting UniversalConnectionPool instances

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -571,6 +571,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.integrations.cdi</groupId>
+            <artifactId>helidon-integrations-cdi-configurable</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.cdi</groupId>
             <artifactId>helidon-integrations-cdi-delegates</artifactId>
         </dependency>
         <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -764,6 +764,11 @@
             </dependency>
             <dependency>
                 <groupId>io.helidon.integrations.cdi</groupId>
+                <artifactId>helidon-integrations-cdi-configurable</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.integrations.cdi</groupId>
                 <artifactId>helidon-integrations-cdi-delegates</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
@@ -1062,29 +1067,29 @@
             </dependency>
             <!-- MicroStream -->
             <dependency>
-            	<groupId>io.helidon.integrations.microstream</groupId>
-            	<artifactId>helidon-integrations-microstream</artifactId>
-            	<version>${helidon.version}</version>
+              <groupId>io.helidon.integrations.microstream</groupId>
+              <artifactId>helidon-integrations-microstream</artifactId>
+              <version>${helidon.version}</version>
             </dependency>
             <dependency>
-            	<groupId>io.helidon.integrations.microstream</groupId>
-            	<artifactId>helidon-integrations-microstream-cdi</artifactId>
-            	<version>${helidon.version}</version>
+              <groupId>io.helidon.integrations.microstream</groupId>
+              <artifactId>helidon-integrations-microstream-cdi</artifactId>
+              <version>${helidon.version}</version>
             </dependency>
             <dependency>
-            	<groupId>io.helidon.integrations.microstream</groupId>
-            	<artifactId>helidon-integrations-microstream-health</artifactId>
-            	<version>${helidon.version}</version>
+              <groupId>io.helidon.integrations.microstream</groupId>
+              <artifactId>helidon-integrations-microstream-health</artifactId>
+              <version>${helidon.version}</version>
             </dependency>
             <dependency>
-            	<groupId>io.helidon.integrations.microstream</groupId>
-            	<artifactId>helidon-integrations-microstream-metrics</artifactId>
-            	<version>${helidon.version}</version>
+              <groupId>io.helidon.integrations.microstream</groupId>
+              <artifactId>helidon-integrations-microstream-metrics</artifactId>
+              <version>${helidon.version}</version>
             </dependency>
             <dependency>
-            	<groupId>io.helidon.integrations.microstream</groupId>
-            	<artifactId>helidon-integrations-microstream-cache</artifactId>
-            	<version>${helidon.version}</version>
+              <groupId>io.helidon.integrations.microstream</groupId>
+              <artifactId>helidon-integrations-microstream-cache</artifactId>
+              <version>${helidon.version}</version>
             </dependency>
 
             <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1067,29 +1067,29 @@
             </dependency>
             <!-- MicroStream -->
             <dependency>
-              <groupId>io.helidon.integrations.microstream</groupId>
-              <artifactId>helidon-integrations-microstream</artifactId>
-              <version>${helidon.version}</version>
+                <groupId>io.helidon.integrations.microstream</groupId>
+                <artifactId>helidon-integrations-microstream</artifactId>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
-              <groupId>io.helidon.integrations.microstream</groupId>
-              <artifactId>helidon-integrations-microstream-cdi</artifactId>
-              <version>${helidon.version}</version>
+                <groupId>io.helidon.integrations.microstream</groupId>
+                <artifactId>helidon-integrations-microstream-cdi</artifactId>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
-              <groupId>io.helidon.integrations.microstream</groupId>
-              <artifactId>helidon-integrations-microstream-health</artifactId>
-              <version>${helidon.version}</version>
+                <groupId>io.helidon.integrations.microstream</groupId>
+                <artifactId>helidon-integrations-microstream-health</artifactId>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
-              <groupId>io.helidon.integrations.microstream</groupId>
-              <artifactId>helidon-integrations-microstream-metrics</artifactId>
-              <version>${helidon.version}</version>
+                <groupId>io.helidon.integrations.microstream</groupId>
+                <artifactId>helidon-integrations-microstream-metrics</artifactId>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
-              <groupId>io.helidon.integrations.microstream</groupId>
-              <artifactId>helidon-integrations-microstream-cache</artifactId>
-              <version>${helidon.version}</version>
+                <groupId>io.helidon.integrations.microstream</groupId>
+                <artifactId>helidon-integrations-microstream-cache</artifactId>
+                <version>${helidon.version}</version>
             </dependency>
 
             <dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -127,11 +127,12 @@
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.100.Final</version.lib.netty>
         <version.lib.oci>3.34.0</version.lib.oci>
+        <version.lib.ojdbc.family>21</version.lib.ojdbc.family>
         <!--
             UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.
             Until this bug is fixed do not upgrade past version 21.9.0.0.
         -->
-        <version.lib.ojdbc>21.9.0.0</version.lib.ojdbc>
+        <version.lib.ojdbc>${version.lib.ojdbc.family}.9.0.0</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
         <version.lib.okio>3.4.0</version.lib.okio>

--- a/etc/javadoc/ojdbc/element-list
+++ b/etc/javadoc/ojdbc/element-list
@@ -1,0 +1,12 @@
+oracle.jdbc
+oracle.jdbc.aq
+oracle.jdbc.babelfish
+oracle.jdbc.datasource
+oracle.jdbc.datasource.impl
+oracle.jdbc.dcn
+oracle.jdbc.pool
+oracle.jdbc.replay
+oracle.jdbc.xa
+oracle.jdbc.xa.client
+oracle.sql
+oracle.sql.json

--- a/etc/javadoc/ucp/element-list
+++ b/etc/javadoc/ucp/element-list
@@ -1,0 +1,5 @@
+oracle.ucp
+oracle.ucp.admin
+oracle.ucp.jdbc
+oracle.ucp.jdbc.oracle
+oracle.ucp.util.logging

--- a/integrations/cdi/common-cdi/configurable/pom.xml
+++ b/integrations/cdi/common-cdi/configurable/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,23 +22,15 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.integrations.cdi</groupId>
-        <artifactId>helidon-integrations-cdi-project</artifactId>
+        <artifactId>helidon-integrations-cdi-common-project</artifactId>
         <version>4.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>helidon-integrations-cdi-datasource</artifactId>
-    <name>Helidon CDI Integrations DataSource</name>
-
-    <properties>
-        <!-- maven-javadoc-plugin property -->
-        <show>package</show>
-    </properties>
+    <artifactId>helidon-integrations-cdi-configurable</artifactId>
+    <name>Helidon CDI Integrations Common Configurable</name>
 
     <dependencies>
+
         <!-- Compile-scoped dependencies. -->
-        <dependency>
-            <groupId>io.helidon.integrations.cdi</groupId>
-            <artifactId>helidon-integrations-cdi-configurable</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
@@ -46,16 +38,6 @@
         </dependency>
 
         <!-- Provided-scoped dependencies. -->
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
@@ -66,12 +48,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile.config</groupId>
-            <artifactId>helidon-microprofile-config</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>

--- a/integrations/cdi/common-cdi/configurable/pom.xml
+++ b/integrations/cdi/common-cdi/configurable/pom.xml
@@ -44,34 +44,5 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Runtime-scoped dependencies. -->
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>jandex</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Test-scoped dependencies. -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile.cdi</groupId>
-            <artifactId>helidon-microprofile-cdi</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/integrations/cdi/common-cdi/configurable/src/main/java/io/helidon/integrations/cdi/configurable/AbstractConfigurableExtension.java
+++ b/integrations/cdi/common-cdi/configurable/src/main/java/io/helidon/integrations/cdi/configurable/AbstractConfigurableExtension.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.cdi.configurable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.literal.NamedLiteral;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
+import jakarta.inject.Named;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * A convenient, abstract {@link Extension} whose subclasses arrange for instances of a particular type to be configured
+ * via MicroProfile Config and added as CDI beans.
+ *
+ * <p>There are four kinds of names defined by this extension:</p>
+ *
+ * <ol>
+ *
+ * <li><strong>Type name</strong>: the class name of the kind of object this extension manages. Example: {@code
+ * javax.sql.DataSource}</li>
+ *
+ * <li><strong>Name</strong>: a name designating one of potentially many such objects. Example: {@code prod}</li>
+ *
+ * <li><strong>Property name</strong>: a name of a property of the kind of object this extension manages. Example:
+ * {@code user}</li>
+ *
+ * <li><strong>Configuration property name</strong>: a name of a MicroProfile Config configuration property that
+ * logically contains at least the other three kinds of names. Example: {@code javax.sql.DataSource.prod.user}</li>
+ *
+ * </ol>
+ *
+ * <h2>Thread Safety</h2>
+ *
+ * <p>As with all CDI portable extensions, this class' instances are not safe for concurrent use by multiple
+ * threads.</p>
+ *
+ * @param <T> the type for which this {@link AbstractConfigurableExtension} implementation installs instances
+ */
+public abstract class AbstractConfigurableExtension<T> implements Extension {
+
+    private final Map<String, Properties> masterProperties;
+
+    private final Map<String, Properties> explicitlySetProperties;
+
+    private final Config config;
+
+    /**
+     * Creates a new {@link AbstractConfigurableExtension}.
+     */
+    protected AbstractConfigurableExtension() {
+        super();
+        this.masterProperties = new HashMap<>();
+        this.explicitlySetProperties = new HashMap<>();
+        this.config = ConfigProvider.getConfig();
+    }
+
+    /**
+     * Returns a {@link Matcher} given a <em>configuration property name</em> that can logically identify and provide
+     * access to at least its three component names.
+     *
+     * <p>Implementations of this method must not return {@code null}.</p>
+     *
+     * <p>Given a {@link String} that is a configuration property name, like
+     * <code>com.foo.Bar.<em>name</em>.<em>propertyName</em></code>, any implementation of this method must return a
+     * non-{@code null} {@link Matcher} that is capable of being supplied to the {@link #getName(Matcher)} and {@link
+     * #getPropertyName(Matcher)} methods.</p>
+     *
+     * @param configPropertyName a <em>configuration property name</em> that logically contains a <em>type name</em>, a
+     * <em>name</em> and a <em>property name</em>; must not be {@code null}
+     *
+     * @return a non-{@code null} {@link Matcher}
+     *
+     * @exception NullPointerException if {@code configPropertyName} is {@code null}
+     *
+     * @see #getName(Matcher)
+     *
+     * @see #getPropertyName(Matcher)
+     */
+    protected abstract Matcher getPropertyPatternMatcher(String configPropertyName);
+
+    /**
+     * Given a {@link Matcher} that has been produced by the {@link #getPropertyPatternMatcher(String)} method, returns
+     * the relevant name.
+     *
+     * <p>Implementations of this method may return {@code null}.</p>
+     *
+     * @param propertyPatternMatcher a {@link Matcher} produced by the {@link #getPropertyPatternMatcher(String)}
+     * method; must not be {@code null}
+     *
+     * @return a name, or {@code null}
+     *
+     * @exception NullPointerException if {@code propertyPatternMatcher} is {@code null}
+     *
+     * @see #getPropertyPatternMatcher(String)
+     */
+    protected abstract String getName(Matcher propertyPatternMatcher);
+
+    /**
+     * Given a {@link Matcher} that has been produced by the {@link #getPropertyPatternMatcher(String)} method, returns
+     * the relevant <em>property name</em>, or {@code null} if there is no such property name.
+     *
+     * <p>Most implementations of this method will use the {@link Matcher#group(int)} method to produce the required
+     * property name.</p>
+     *
+     * <p>Implementations of this method may return {@code null}.</p>
+     *
+     * @param propertyPatternMatcher a {@link Matcher} produced by the {@link #getPropertyPatternMatcher(String)}
+     * method; must not be {@code null}
+     *
+     * @return a property name, or {@code null}
+     *
+     * @exception NullPointerException if {@code propertyPatternMatcher} is {@code null}
+     *
+     * @see #getPropertyPatternMatcher(String)
+     */
+    protected abstract String getPropertyName(Matcher propertyPatternMatcher);
+
+    /**
+     * Called internally to permit subclasses to add a {@code T}-typed bean, qualified with at least the supplied {@link
+     * Named}, using the supplied {@link BeanConfigurator}.
+     *
+     * <p>Implementations of this method will be called from an observer method that is observing the {@link
+     * AfterBeanDiscovery} container lifecycle event.</p>
+     *
+     * @param beanConfigurator the {@link BeanConfigurator} to use to actually add a new bean; must not be {@code null}
+     *
+     * @param name a {@link Named} instance qualifying the {@code T}-typed bean to be added; may be {@code
+     * null}
+     *
+     * @param properties a {@link Properties} instance containing properties relevant to the object; must not be {@code
+     * null}
+     *
+     * @exception NullPointerException if {@code beanConfigurator} or {@code properties} is {@code null}
+     *
+     * @see AfterBeanDiscovery
+     */
+    protected abstract void addBean(BeanConfigurator<T> beanConfigurator,
+                                    Named name,
+                                    Properties properties);
+
+    /**
+     * Returns the {@link Config} instance used to acquire MicroProfile Config configuration property values.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * @return a non-{@code null} {@link Config} instance
+     *
+     * @see Config
+     */
+    protected final Config getConfig() {
+        return this.config;
+    }
+
+    /**
+     * Returns a {@link Set} of <em>names</em> known to this {@link AbstractConfigurableExtension} implementation.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>The {@link Set} returned by this method is {@linkplain Collections#unmodifiableSet(Set) unmodifiable}.</p>
+     *
+     * @return a non-{@code null}, {@linkplain Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>} of known
+     * names
+     */
+    protected final Set<String> getNames() {
+        if (this.masterProperties.isEmpty()) {
+            if (this.explicitlySetProperties.isEmpty()) {
+                return Set.of();
+            }
+            return Collections.unmodifiableSet(this.explicitlySetProperties.keySet());
+        }
+        return Collections.unmodifiableSet(this.masterProperties.keySet());
+    }
+
+    /**
+     * Adds additional synthesized properties (<em>property names</em> and their values) to an internal map of such
+     * properties whose contents will be processed eventually by the {@link #addBean(BeanConfigurator, Named,
+     * Properties)} method.
+     *
+     * <p>This method may return {@code null}.</p>
+     *
+     * @param name the <em>name</em> of the object under which the supplied {@link Properties} will be indexed; may be
+     * {@code null}
+     *
+     * @param properties the {@link Properties} to put consisting of property names and their values; must not be {@code
+     * null}
+     *
+     * @return the prior {@link Properties} indexed under the supplied {@code name}, or {@code null}
+     *
+     * @exception NullPointerException if {@code properties} is {@code null}
+     */
+    protected final Properties putProperties(String name, Properties properties) {
+        return this.explicitlySetProperties.put(name, Objects.requireNonNull(properties, "properties"));
+    }
+
+    /**
+     * <strong>{@linkplain Map#clear() Clears}</strong>, and then builds or rebuilds, an internal map of properties
+     * whose contents will be processed eventually by the {@link #addBean(BeanConfigurator, Named, Properties)} method.
+     *
+     * <p>If no subclass explicitly calls this method, it will be called by the {@link #addBean(BeanConfigurator, Named,
+     * Properties)} method just prior to its other activities.</p>
+     *
+     * <p>Once the {@link #addBean(BeanConfigurator, Named, Properties)} method has run to completion, while this method
+     * may be called freely, its use is discouraged and its effects will no longer be used.</p>
+     *
+     * @see #addBean(BeanConfigurator, Named, Properties)
+     */
+    protected final void initializeMasterProperties() {
+        this.masterProperties.clear();
+        Set<? extends String> allConfigPropertyNames = this.getConfigPropertyNames();
+        if (allConfigPropertyNames != null && !allConfigPropertyNames.isEmpty()) {
+            for (String configPropertyName : allConfigPropertyNames) {
+                Optional<String> propertyValue = this.config.getOptionalValue(configPropertyName, String.class);
+                if (propertyValue.isPresent()) {
+                    Matcher matcher = this.getPropertyPatternMatcher(configPropertyName);
+                    if (matcher != null && matcher.matches()) {
+                        this.masterProperties.computeIfAbsent(this.getName(matcher), n -> new Properties())
+                            .setProperty(this.getPropertyName(matcher), propertyValue.get());
+                        /*
+                        String name = this.getName(matcher);
+                        Properties properties = this.masterProperties.computeIfAbsent(name, n -> new Properties());
+                        properties.setProperty(this.getPropertyName(matcher), propertyValue.get());
+                        */
+                    }
+                }
+            }
+        }
+        this.masterProperties.putAll(this.explicitlySetProperties);
+    }
+
+    /**
+     * Returns a {@link Set} of all known <em>configuration property names</em>.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>The {@link Set} returned by this method is {@linkplain Collections#unmodifiableSet(Set) unmodifiable}.</p>
+     *
+     * <p>The {@link Set} returned by this method is not safe for concurrent use by multiple threads.</p>
+     *
+     * <p>Any other semantics of the {@link Set} returned by this method are governed by the <a
+     * href="https://github.com/eclipse/microprofile-config" target="_parent">MicroProfile Config</a> specification.</p>
+     *
+     * @return a non-{@code null}, {@linkplain Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>} of all
+     * known configuration property names
+     *
+     * @see Config#getConfigSources()
+     *
+     * @see org.eclipse.microprofile.config.spi.ConfigSource#getPropertyNames()
+     */
+    protected final Set<String> getConfigPropertyNames() {
+        Iterable<String> propertyNames = this.config.getPropertyNames();
+        if (propertyNames == null) {
+            return Set.of();
+        }
+        Set<String> set = new HashSet<>();
+        propertyNames.iterator().forEachRemaining(n -> set.add(n));
+        return Set.copyOf(set);
+    }
+
+    private void afterBeanDiscovery(@Observes AfterBeanDiscovery event) {
+        if (event != null) {
+            if (this.masterProperties.isEmpty()) {
+                this.initializeMasterProperties();
+            }
+            Set<? extends Entry<? extends String, ? extends Properties>> masterPropertiesEntries =
+                this.masterProperties.entrySet();
+            if (masterPropertiesEntries != null && !masterPropertiesEntries.isEmpty()) {
+                for (Entry<? extends String, ? extends Properties> entry : masterPropertiesEntries) {
+                    if (entry != null) {
+                        this.addBean(event.addBean(), NamedLiteral.of(entry.getKey()), entry.getValue());
+                    }
+                }
+            }
+        }
+        this.masterProperties.clear();
+        this.explicitlySetProperties.clear();
+    }
+
+}

--- a/integrations/cdi/common-cdi/configurable/src/main/java/io/helidon/integrations/cdi/configurable/package-info.java
+++ b/integrations/cdi/common-cdi/configurable/src/main/java/io/helidon/integrations/cdi/configurable/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes and interfaces that help to produce things from configuration.
+ */
+package io.helidon.integrations.cdi.configurable;

--- a/integrations/cdi/common-cdi/configurable/src/main/java/module-info.java
+++ b/integrations/cdi/common-cdi/configurable/src/main/java/module-info.java
@@ -21,7 +21,7 @@
 module io.helidon.integrations.cdi.configurable {
 
     requires transitive jakarta.cdi;
-    requires transitive microprofile.config.api;
+    requires microprofile.config.api;
 
     exports io.helidon.integrations.cdi.configurable;
 

--- a/integrations/cdi/common-cdi/configurable/src/main/java/module-info.java
+++ b/integrations/cdi/common-cdi/configurable/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,14 @@
  */
 
 /**
- * Provides classes and interfaces to assist in the development of
- * {@link javax.sql.DataSource}-related CDI portable extensions.
- *
- * @see
- * io.helidon.integrations.datasource.cdi.AbstractDataSourceExtension
+ * Provides classes and interfaces that assist in producing things from configuration.
  */
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
-module io.helidon.integrations.datasource.cdi {
+module io.helidon.integrations.cdi.configurable {
 
     requires transitive jakarta.cdi;
-    requires transitive jakarta.inject;
-    requires transitive java.sql;
-    requires transitive io.helidon.integrations.cdi.configurable;
     requires transitive microprofile.config.api;
-    exports io.helidon.integrations.datasource.cdi;
+
+    exports io.helidon.integrations.cdi.configurable;
 
 }

--- a/integrations/cdi/common-cdi/pom.xml
+++ b/integrations/cdi/common-cdi/pom.xml
@@ -30,6 +30,7 @@
     <name>Helidon CDI Integrations Common</name>
 
     <modules>
+        <module>configurable</module>
         <module>delegates</module>
         <module>reference-counted-context</module>
     </modules>

--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -46,11 +46,6 @@
             <artifactId>HikariCP</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.config</groupId>
-            <artifactId>microprofile-config-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
 
         <!-- Provided-scoped dependencies. -->
         <dependency>

--- a/integrations/cdi/datasource-hikaricp/src/main/java/io/helidon/integrations/datasource/hikaricp/cdi/HikariCPBackedDataSourceExtension.java
+++ b/integrations/cdi/datasource-hikaricp/src/main/java/io/helidon/integrations/datasource/hikaricp/cdi/HikariCPBackedDataSourceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ import jakarta.enterprise.inject.spi.WithAnnotations;
 import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Named;
-import org.eclipse.microprofile.config.Config;
 
 /**
  * An {@link Extension} that arranges for named {@link DataSource}
@@ -160,13 +159,13 @@ public class HikariCPBackedDataSourceExtension extends AbstractDataSourceExtensi
                 if (dataSourceDefinitions != null && !dataSourceDefinitions.isEmpty()) {
                     for (final DataSourceDefinition dsd : dataSourceDefinitions) {
                         assert dsd != null;
-                        final Set<String> knownDataSourceNames = this.getDataSourceNames();
+                        final Set<String> knownDataSourceNames = this.names();
                         assert knownDataSourceNames != null;
                         final String dataSourceName = dsd.name();
                         if (!knownDataSourceNames.contains(dataSourceName)) {
                             final Entry<? extends String, ? extends Properties> entry = toProperties(dsd);
                             if (entry != null) {
-                                this.putDataSourceProperties(dataSourceName, entry.getValue());
+                                this.put(dataSourceName, entry.getValue());
                             }
                         }
                     }
@@ -183,8 +182,6 @@ public class HikariCPBackedDataSourceExtension extends AbstractDataSourceExtensi
                 if (type instanceof Class && DataSource.class.isAssignableFrom((Class<?>) type)) {
                     final Set<? extends Annotation> qualifiers = injectionPoint.getQualifiers();
                     if (qualifiers != null && !qualifiers.isEmpty()) {
-                        final Config config = this.getConfig();
-                        assert config != null;
                         for (final Annotation qualifier : qualifiers) {
                             if (qualifier instanceof Named) {
                                 final String dataSourceName = ((Named) qualifier).value();
@@ -202,10 +199,9 @@ public class HikariCPBackedDataSourceExtension extends AbstractDataSourceExtensi
                                     // bootstrap here by issuing a
                                     // request for a commonly present
                                     // data source property value.
-                                    config.getOptionalValue("javax.sql.DataSource."
-                                                            + dataSourceName
-                                                            + ".dataSourceClassName",
-                                                            String.class);
+                                    configPropertyValue("javax.sql.DataSource."
+                                                        + dataSourceName
+                                                        + ".dataSourceClassName");
                                 }
                             }
                         }

--- a/integrations/cdi/datasource-hikaricp/src/main/java/module-info.java
+++ b/integrations/cdi/datasource-hikaricp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 /**
  * CDI integration for the <a
- * href="https://github.com/brettwooldridge/HikariCP/blob/HikariCP-2.7.8/README.md#-hikaricpits-fasterhikari-hikal%C4%93-origin-japanese-light-ray"
+ * href="https://github.com/brettwooldridge/HikariCP/blob/HikariCP-5.1.0/README.md#-hikaricpits-fasterhikari-hikal%C4%93-origin-japanese-light-ray"
  * target="_parent">Hikari connection pool</a>.
  *
  * @see
@@ -27,9 +27,8 @@ module io.helidon.integrations.datasource.hikaricp.cdi {
 
     requires com.zaxxer.hikari;
     requires jakarta.annotation;
-    requires microprofile.config.api;
 
-    requires static microprofile.metrics.api;
+    requires microprofile.metrics.api;
 
     requires transitive io.helidon.integrations.datasource.cdi;
     requires transitive jakarta.cdi;

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UCPBackedDataSourceExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UCPBackedDataSourceExtension.java
@@ -37,7 +37,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.CreationException;
 import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
 import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Named;
@@ -48,16 +47,20 @@ import oracle.ucp.jdbc.PoolXADataSource;
 import oracle.ucp.jdbc.PoolXADataSourceImpl;
 
 /**
- * An {@link Extension} that arranges for named {@link DataSource} injection points to be satisfied by the <a
- * href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html">Oracle Universal Connection
- * Pool</a>.
+ * An {@link AbstractDataSourceExtension} that arranges for named {@link DataSource} injection points to be satisfied by
+ * the <a href="https://docs.oracle.com/en/database/oracle/oracle-database/21/jjucp/index.html">Oracle Universal
+ * Connection Pool</a>.
  *
  * <p>In accordance with the CDI specification, instances of this class are not necessarily safe for concurrent use by
  * multiple threads.</p>
  */
 public class UCPBackedDataSourceExtension extends AbstractDataSourceExtension {
 
-    private static final Pattern DATASOURCE_NAME_PATTERN =
+    /**
+     * A {@link Pattern} capable of producing {@link Matcher} instances that identify certain portions of a
+     * configuration property name.
+     */
+    static final Pattern DATASOURCE_NAME_PATTERN =
         Pattern.compile("^(?:javax\\.sql\\.|oracle\\.ucp\\.jdbc\\.Pool)(XA)?DataSource\\.([^.]+)\\.(.*)$");
     // Capturing groups:                                               (1 )              (2    )   (3 )
     //                                                                 Are we XA?        DS name   DS Property
@@ -66,7 +69,10 @@ public class UCPBackedDataSourceExtension extends AbstractDataSourceExtension {
 
     /**
      * Creates a new {@link UCPBackedDataSourceExtension}.
+     *
+     * @deprecated For use by CDI only.
      */
+    @Deprecated // For use by CDI only
     public UCPBackedDataSourceExtension() {
         super();
         this.xa = new HashMap<>();

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
@@ -37,16 +37,16 @@ import oracle.ucp.jdbc.PoolDataSource;
 
 /**
  * An {@link AbstractConfigurableExtension} that provides injection support for {@link UniversalConnectionPoolManager}
- * and {@link UniversalConnectionPool} instances.
+ * and {@linkplain Named named} {@link UniversalConnectionPool} instances.
  *
  * <p>As with all portable extensions, to begin to make use of the features enabled by this class, ensure its containing
- * artifact (normally a jar file) is on the classpath of your CDI-enabled application.</p>
+ * artifact (normally a jar file) is on the runtime classpath of your CDI-enabled application.</p>
  *
  * <p>To support injection of the {@link UniversalConnectionPoolManager}, use normal CDI injection idioms:</p>
  *
  * {@snippet :
  *   // Inject the UniversalConnectionPoolManager into a private field named ucpManager:
- *   @jakarta.inject.Inject
+ *   @jakarta.inject.Inject // @link substring="jakarta.inject.Inject" target="jakarta.inject.Inject"
  *   private oracle.ucp.admin.UniversalConnectionPoolManager ucpManager;
  *   }
  *
@@ -70,8 +70,8 @@ import oracle.ucp.jdbc.PoolDataSource;
  *
  * {@snippet :
  *   // Inject a UniversalConnectionPool whose getName() method returns test into a private field named ucp:
- *   @jakarta.inject.Inject
- *   @jakarta.inject.Named("test")
+ *   @jakarta.inject.Inject // @link substring="jakarta.inject.Inject" target="jakarta.inject.Inject"
+ *   @jakarta.inject.Named("test") // @link substring="jakarta.inject.Named" target="jakarta.inject.Named"
  *   private oracle.ucp.UniversalConnectionPool ucp; // assert "test".equals(ucp.getName());
  *   }
  *

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
@@ -39,6 +39,49 @@ import oracle.ucp.jdbc.PoolDataSource;
  * An {@link AbstractConfigurableExtension} that provides injection support for {@link UniversalConnectionPoolManager}
  * and {@link UniversalConnectionPool} instances.
  *
+ * <p>As with all portable extensions, to begin to make use of the features enabled by this class, ensure its containing
+ * artifact (normally a jar file) is on the classpath of your CDI-enabled application.</p>
+ *
+ * <p>To support injection of the {@link UniversalConnectionPoolManager}, use normal CDI injection idioms:</p>
+ *
+ * {@snippet :
+ *   // Inject the UniversalConnectionPoolManager into a private field named ucpManager:
+ *   @jakarta.inject.Inject
+ *   private oracle.ucp.admin.UniversalConnectionPoolManager ucpManager;
+ *   }
+ *
+ * <p>To support injection of a {@link UniversalConnectionPool} named {@code test}, first ensure that enough MicroProfile
+ * Config configuration is present to create a valid {@link PoolDataSource}. For example, the following sample system
+ * properties are sufficient for a {@link PoolDataSource} named {@code test} to be created:</p>
+ *
+ * {@snippet lang="properties" :
+ *   # @link substring="oracle.ucp.jdbc.PoolDataSource" target="PoolDataSource" @link substring="oracle.jdbc.pool.OracleDataSource" target="oracle.jdbc.pool.OracleDataSource" :
+ *   oracle.ucp.jdbc.PoolDataSource.test.connectionFactoryClassName=oracle.jdbc.pool.OracleDataSource
+ *   oracle.ucp.jdbc.PoolDataSource.test.URL=jdbc:oracle:thin://@localhost:1521/XE
+ *   oracle.ucp.jdbc.PoolDataSource.test.user=scott
+ *   oracle.ucp.jdbc.PoolDataSource.test.password=tiger
+ *   }
+ *
+ * <p>See the {@link UCPBackedDataSourceExtension} documentation for more information about how {@link PoolDataSource}
+ * instances are made eligible for injection from configuration such as this.</p>
+ *
+ * <p>With configuration such as the above, you can now inject the implicit {@link UniversalConnectionPool} it also
+ * defines:</p>
+ *
+ * {@snippet :
+ *   // Inject a UniversalConnectionPool whose getName() method returns test into a private field named ucp:
+ *   @jakarta.inject.Inject
+ *   @jakarta.inject.Named("test")
+ *   private oracle.ucp.UniversalConnectionPool ucp; // assert "test".equals(ucp.getName());
+ *   }
+ *
+ * <p><strong>Note:</strong> Working directly with a {@link UniversalConnectionPool} is for advanced use cases
+ * only. Injecting and working with {@link PoolDataSource} instances is much more common, and {@link PoolDataSource} is
+ * the interface recommended by Oracle's documentation for users to interact with. See {@link
+ * UCPBackedDataSourceExtension}'s documentation for more details.</p>
+ *
+ * @see UniversalConnectionPool
+ *
  * @see UCPBackedDataSourceExtension
  */
 public class UniversalConnectionPoolExtension extends AbstractConfigurableExtension<UniversalConnectionPool> {

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.datasource.ucp.cdi;
+
+import java.util.Properties;
+import java.util.regex.Matcher;
+
+import io.helidon.integrations.cdi.configurable.AbstractConfigurableExtension;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.CreationException;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.inject.Named;
+import oracle.ucp.UniversalConnectionPool;
+import oracle.ucp.UniversalConnectionPoolAdapter;
+import oracle.ucp.UniversalConnectionPoolException;
+import oracle.ucp.admin.UniversalConnectionPoolManager;
+import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
+import oracle.ucp.jdbc.PoolDataSource;
+
+/**
+ * An {@link AbstractConfigurableExtension} that provides injection support for {@link UniversalConnectionPoolManager}
+ * and {@link UniversalConnectionPool} instances.
+ *
+ * @see UCPBackedDataSourceExtension
+ */
+public class UniversalConnectionPoolExtension extends AbstractConfigurableExtension<UniversalConnectionPool> {
+
+    /**
+     * Creates a new {@link UniversalConnectionPoolExtension}.
+     *
+     * @deprecated For use by CDI only.
+     */
+    @Deprecated // For use by CDI only
+    public UniversalConnectionPoolExtension() {
+        super();
+    }
+
+    @Override
+    protected final Matcher getPropertyPatternMatcher(String configPropertyName) {
+        return
+            configPropertyName == null ? null : UCPBackedDataSourceExtension.DATASOURCE_NAME_PATTERN.matcher(configPropertyName);
+    }
+
+    @Override
+    protected final String getName(Matcher propertyPatternMatcher) {
+        return propertyPatternMatcher == null ? null : propertyPatternMatcher.group(2);
+    }
+
+    @Override
+    protected final String getPropertyName(Matcher propertyPatternMatcher) {
+        return propertyPatternMatcher == null ? null : propertyPatternMatcher.group(3);
+    }
+
+    private void installManager(@Observes AfterBeanDiscovery event) {
+        event.addBean()
+            .addTransitiveTypeClosure(UniversalConnectionPoolManager.class)
+            .scope(ApplicationScoped.class)
+            .produceWith(instance -> {
+                    UniversalConnectionPoolManager ucpm;
+                    try {
+                        ucpm = UniversalConnectionPoolManagerImpl.getUniversalConnectionPoolManager();
+                    } catch (final UniversalConnectionPoolException e) {
+                        throw new CreationException(e.getMessage(), e);
+                    }
+                    instance.select(new TypeLiteral<Event<UniversalConnectionPoolManager>>() {})
+                        .get()
+                        .fire(ucpm);
+                    return ucpm;
+                });
+    }
+
+    @Override
+    protected void addBean(BeanConfigurator<UniversalConnectionPool> beanConfigurator,
+                           Named name,
+                           Properties properties) {
+        beanConfigurator
+            .addQualifier(name)
+            .addTransitiveTypeClosure(UniversalConnectionPool.class)
+            .scope(ApplicationScoped.class)
+            .produceWith(instance -> {
+                    PoolDataSource pds = instance.select(PoolDataSource.class, name).get();
+                    UniversalConnectionPoolManager ucpm = instance.select(UniversalConnectionPoolManager.class).get();
+                    UniversalConnectionPool ucp;
+                    try {
+                        ucpm.createConnectionPool((UniversalConnectionPoolAdapter) pds);
+                        ucp = ucpm.getConnectionPool(pds.getConnectionPoolName());
+                    } catch (UniversalConnectionPoolException e) {
+                        throw new CreationException(e.getMessage(), e);
+                    }
+                    instance.select(new TypeLiteral<Event<UniversalConnectionPool>>() {})
+                        .get()
+                        .fire(ucp);
+                    return ucp;
+                })
+            .disposeWith((ucp, instance) -> {
+                    try {
+                        ucp.stop();
+                        UniversalConnectionPoolManager ucpm = instance.select(UniversalConnectionPoolManager.class).get();
+                        ucpm.destroyConnectionPool(ucp.getName());
+                    } catch (UniversalConnectionPoolException e) {
+                        throw new CreationException(e.getMessage(), e);
+                    }
+                });
+    }
+
+}

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UniversalConnectionPoolExtension.java
@@ -35,6 +35,8 @@ import oracle.ucp.admin.UniversalConnectionPoolManager;
 import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
 import oracle.ucp.jdbc.PoolDataSource;
 
+import static io.helidon.integrations.datasource.ucp.cdi.UCPBackedDataSourceExtension.DATASOURCE_NAME_PATTERN;
+
 /**
  * An {@link AbstractConfigurableExtension} that provides injection support for {@link UniversalConnectionPoolManager}
  * and {@linkplain Named named} {@link UniversalConnectionPool} instances.
@@ -97,19 +99,18 @@ public class UniversalConnectionPoolExtension extends AbstractConfigurableExtens
     }
 
     @Override
-    protected final Matcher getPropertyPatternMatcher(String configPropertyName) {
-        return
-            configPropertyName == null ? null : UCPBackedDataSourceExtension.DATASOURCE_NAME_PATTERN.matcher(configPropertyName);
+    protected final Matcher matcher(String configPropertyName) {
+        return configPropertyName == null ? null : DATASOURCE_NAME_PATTERN.matcher(configPropertyName);
     }
 
     @Override
-    protected final String getName(Matcher propertyPatternMatcher) {
-        return propertyPatternMatcher == null ? null : propertyPatternMatcher.group(2);
+    protected final String name(Matcher configPropertyNameMatcher) {
+        return configPropertyNameMatcher == null ? null : configPropertyNameMatcher.group(2);
     }
 
     @Override
-    protected final String getPropertyName(Matcher propertyPatternMatcher) {
-        return propertyPatternMatcher == null ? null : propertyPatternMatcher.group(3);
+    protected final String propertyName(Matcher configPropertyNameMatcher) {
+        return configPropertyNameMatcher == null ? null : configPropertyNameMatcher.group(3);
     }
 
     private void installManager(@Observes AfterBeanDiscovery event) {

--- a/integrations/cdi/datasource-ucp/src/main/java/module-info.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/module-info.java
@@ -26,6 +26,7 @@
 @SuppressWarnings({ "requires-automatic"})
 module io.helidon.integrations.datasource.ucp.cdi {
 
+    requires com.oracle.database.jdbc; // com.oracle.database.ucp needs this (!)
     requires com.oracle.database.ucp;
     requires java.desktop; // For java.beans
     requires java.naming; // PoolDataSourceImpl implements javax.naming.Referenceable

--- a/integrations/cdi/datasource-ucp/src/main/java/module-info.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ module io.helidon.integrations.datasource.ucp.cdi {
     exports io.helidon.integrations.datasource.ucp.cdi;
 
     provides jakarta.enterprise.inject.spi.Extension
-            with io.helidon.integrations.datasource.ucp.cdi.UCPBackedDataSourceExtension;
+        with io.helidon.integrations.datasource.ucp.cdi.UCPBackedDataSourceExtension,
+             io.helidon.integrations.datasource.ucp.cdi.UniversalConnectionPoolExtension;
 
 }

--- a/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
+++ b/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
@@ -27,6 +27,7 @@ import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import oracle.ucp.UniversalConnectionPool;
 import oracle.ucp.jdbc.PoolDataSource;
 import oracle.ucp.jdbc.PoolDataSourceImpl;
 import oracle.ucp.jdbc.PoolXADataSource;
@@ -48,6 +49,10 @@ class TestDataSourceAcquisition {
     @Named("test")
     private DataSource test;
 
+    @Inject
+    @Named("test")
+    private UniversalConnectionPool testUcp;
+  
     private Server server;
 
     TestDataSourceAcquisition() {
@@ -81,6 +86,8 @@ class TestDataSourceAcquisition {
     private void onStartup(@Observes @Initialized(ApplicationScoped.class) final Object event) throws SQLException {
         assertThat(this.test, notNullValue());
         assertThat(this.test.toString(), notNullValue());
+        assertThat(this.testUcp, notNullValue());
+        assertThat(this.testUcp.getName(), is("test"));
         final PoolDataSourceImpl contextualInstance =
             (PoolDataSourceImpl) ((WeldClientProxy) this.test).getMetadata().getContextualInstance();
         assertThat(contextualInstance.getDescription(), is("A test datasource"));

--- a/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/AbstractDataSourceExtension.java
+++ b/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/AbstractDataSourceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,52 +16,57 @@
 package io.helidon.integrations.datasource.cdi;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 
 import javax.sql.DataSource;
 
-import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.literal.NamedLiteral;
-import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
-import jakarta.enterprise.inject.spi.Extension;
+import io.helidon.integrations.cdi.configurable.AbstractConfigurableExtension;
+
 import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
 import jakarta.inject.Named;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.spi.ConfigSource;
 
 /**
- * An abstract {@link Extension} whose subclasses arrange for {@link
- * DataSource} instances to be added as CDI beans.
+ * An {@link AbstractConfigurableExtension} whose subclasses arrange for {@link DataSource} instances to be added as CDI
+ * beans.
  *
  * <h2>Thread Safety</h2>
  *
- * <p>As with all CDI portable extensions, this class' instances are
- * not safe for concurrent use by multiple threads.</p>
+ * <p>As with all CDI portable extensions, this class' instances are not safe for concurrent use by multiple
+ * threads.</p>
  */
-public abstract class AbstractDataSourceExtension implements Extension {
-
-    private final Map<String, Properties> masterProperties;
-
-    private final Map<String, Properties> explicitlySetProperties;
-
-    private final Config config;
+public abstract class AbstractDataSourceExtension extends AbstractConfigurableExtension<DataSource> {
 
     /**
      * Creates a new {@link AbstractDataSourceExtension}.
      */
     protected AbstractDataSourceExtension() {
         super();
-        this.masterProperties = new HashMap<>();
-        this.explicitlySetProperties = new HashMap<>();
-        this.config = ConfigProvider.getConfig();
+    }
+
+    /**
+     * Calls the {@link #getConfigPropertyNames()} method and returns its return value.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>This method exists for backwards compatibility only and the {@link #getConfigPropertyNames()} method is
+     * preferred.</p>
+     *
+     * @return the return value of an invocation of the {@link #getConfigPropertyNames()} method
+     *
+     * @see #getConfigPropertyNames()
+     *
+     * @deprecated Please use the {@link #getConfigPropertyNames()} method instead.
+     */
+    @Deprecated
+    protected final Set<String> getPropertyNames() {
+        return this.getConfigPropertyNames();
+    }
+
+    @Override
+    protected final Matcher getPropertyPatternMatcher(String configPropertyName) {
+        return this.getDataSourcePropertyPatternMatcher(configPropertyName);
     }
 
     /**
@@ -70,15 +75,12 @@ public abstract class AbstractDataSourceExtension implements Extension {
      * <p>Implementations of this method must not return {@code null}.</p>
      *
      * <p>Given a {@link String} like
-     * <code>javax.sql.DataSource.<em>dataSourceName</em>.<em>dataSourcePropertyName</em></code>,
-     * any implementation of this method should return a non-{@code
-     * null} {@link Matcher} that is capable of being supplied to the
-     * {@link #getDataSourceName(Matcher)} and {@link
-     * #getDataSourcePropertyName(Matcher)} methods.</p>
+     * <code>javax.sql.DataSource.<em>dataSourceName</em>.<em>dataSourcePropertyName</em></code>, any implementation of
+     * this method should return a non-{@code null} {@link Matcher} that is capable of being supplied to the {@link
+     * #getDataSourceName(Matcher)} and {@link #getDataSourcePropertyName(Matcher)} methods.</p>
      *
-     * @param configPropertyName the name of a configuration property
-     * that logically contains a <em>data source name</em> and a
-     * <em>data source property name</em>; must not be {@code null}
+     * @param configPropertyName the name of a configuration property that logically contains a <em>data source
+     * name</em> and a <em>data source property name</em>; must not be {@code null}
      *
      * @return a non-{@code null} {@link Matcher}
      *
@@ -88,17 +90,19 @@ public abstract class AbstractDataSourceExtension implements Extension {
      */
     protected abstract Matcher getDataSourcePropertyPatternMatcher(String configPropertyName);
 
+    @Override
+    protected final String getName(Matcher propertyPatternMatcher) {
+        return this.getDataSourceName(propertyPatternMatcher);
+    }
+
     /**
-     * Given a {@link Matcher} that has been produced by the {@link
-     * #getDataSourcePropertyPatternMatcher(String)} method, returns
-     * the relevant data source name.
+     * Given a {@link Matcher} that has been produced by the {@link #getDataSourcePropertyPatternMatcher(String)}
+     * method, returns the relevant data source name.
      *
      * <p>Implementations of this method may return {@code null}.</p>
      *
-     * @param dataSourcePropertyPatternMatcher a {@link Matcher}
-     * produced by the {@link
-     * #getDataSourcePropertyPatternMatcher(String)} method; must not
-     * be {@code null}
+     * @param dataSourcePropertyPatternMatcher a {@link Matcher} produced by the {@link
+     * #getDataSourcePropertyPatternMatcher(String)} method; must not be {@code null}
      *
      * @return a data source name, or {@code null}
      *
@@ -106,17 +110,19 @@ public abstract class AbstractDataSourceExtension implements Extension {
      */
     protected abstract String getDataSourceName(Matcher dataSourcePropertyPatternMatcher);
 
+    @Override
+    protected final String getPropertyName(Matcher propertyPatternMatcher) {
+        return this.getDataSourcePropertyName(propertyPatternMatcher);
+    }
+
     /**
-     * Given a {@link Matcher} that has been produced by the {@link
-     * #getDataSourcePropertyPatternMatcher(String)} method, returns
-     * the relevant data source property name.
+     * Given a {@link Matcher} that has been produced by the {@link #getDataSourcePropertyPatternMatcher(String)}
+     * method, returns the relevant data source property name.
      *
      * <p>Implementations of this method may return {@code null}.</p>
      *
-     * @param dataSourcePropertyPatternMatcher a {@link Matcher}
-     * produced by the {@link
-     * #getDataSourcePropertyPatternMatcher(String)} method; must not
-     * be {@code null}
+     * @param dataSourcePropertyPatternMatcher a {@link Matcher} produced by the {@link
+     * #getDataSourcePropertyPatternMatcher(String)} method; must not be {@code null}
      *
      * @return a data source property name, or {@code null}
      *
@@ -125,185 +131,42 @@ public abstract class AbstractDataSourceExtension implements Extension {
     protected abstract String getDataSourcePropertyName(Matcher dataSourcePropertyPatternMatcher);
 
     /**
-     * Called to permit subclasses to add a {@link DataSource}-typed
-     * bean using the supplied {@link BeanConfigurator}.
-     *
-     * <p>Implementations of this method will be called from an
-     * observer method that is observing the {@link
-     * AfterBeanDiscovery} container lifecycle event.</p>
-     *
-     * @param beanConfigurator the {@link BeanConfigurator} to use to
-     * actually add a new bean; must not be {@code null}
-     *
-     * @param name a {@link Named} instance qualifying the {@link
-     * DataSource}-typed bean to be added; may be {@code null}
-     *
-     * @param properties a {@link Properties} instance containing
-     * properties relevant to the data source; must not be {@code
-     * null}
-     */
-    protected abstract void addBean(BeanConfigurator<DataSource> beanConfigurator,
-                                    Named name,
-                                    Properties properties);
-
-    /**
-     * Returns the {@link Config} instance used to acquire
-     * configuration property values.
+     * Returns a {@link Set} of data source names known to this {@link AbstractDataSourceExtension} implementation.
      *
      * <p>This method never returns {@code null}.</p>
      *
-     * @return a non-{@code null} {@link Config} instance
+     * <p>The {@link Set} returned by this method is {@linkplain Collections#unmodifiableSet(Set) unmodifiable}.</p>
      *
-     * @see Config
+     * @return a non-{@code null}, {@linkplain Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>} of known
+     * data source names
+     *
+     * @deprecated Please use the {@link #getNames()} method instead.
      */
-    protected final Config getConfig() {
-        return this.config;
-    }
-
-    /**
-     * Returns a {@link Set} of data source names known to this {@link
-     * AbstractDataSourceExtension} implementation.
-     *
-     * <p>This method never returns {@code null}.</p>
-     *
-     * <p>The {@link Set} returned by this method is {@linkplain
-     * Collections#unmodifiableSet(Set) unmodifiable}.</p>
-     *
-     * @return a non-{@code null}, {@linkplain
-     * Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>}
-     * of known data source names
-     */
+    @Deprecated // for backwards compatibility only
     protected final Set<String> getDataSourceNames() {
-        final Set<String> returnValue;
-        if (this.masterProperties.isEmpty()) {
-            if (this.explicitlySetProperties.isEmpty()) {
-                returnValue = Collections.emptySet();
-            } else {
-                returnValue = Collections.unmodifiableSet(this.explicitlySetProperties.keySet());
-            }
-        } else {
-            returnValue = Collections.unmodifiableSet(this.masterProperties.keySet());
-        }
-        return returnValue;
+        return this.getNames();
     }
 
     /**
-     * Adds additional synthesized properties to an internal map of
-     * data source properties whose contents will be processed
-     * eventually by the {@link #addBean(BeanConfigurator, Named,
-     * Properties)} method.
+     * Adds additional synthesized properties to an internal map of data source properties whose contents will be
+     * processed eventually by the {@link #addBean(BeanConfigurator, Named, Properties)} method.
      *
      * <p>This method may return {@code null}.</p>
      *
-     * @param dataSourceName the name of the data source under which
-     * the supplied {@link Properties} will be indexed; may be {@code
-     * null}
+     * @param dataSourceName the name of the data source under which the supplied {@link Properties} will be indexed;
+     * may be {@code null}
      *
-     * @param properties the {@link Properties} to put; may be {@code null}
+     * @param properties the {@link Properties} to put; must not be {@code null}
      *
-     * @return the prior {@link Properties} indexed under the supplied
-     * {@code dataSourceName}, or {@code null}
+     * @return the prior {@link Properties} indexed under the supplied {@code dataSourceName}, or {@code null}
+     *
+     * @exception NullPointerException if {@code properties} is {@code null}
+     *
+     * @deprecated Please use the {@link #putProperties(String, Properties)} method instead.
      */
+    @Deprecated // for backwards compatibility only
     protected final Properties putDataSourceProperties(final String dataSourceName, final Properties properties) {
-        return this.explicitlySetProperties.put(dataSourceName, properties);
-    }
-
-    /**
-     * <strong>{@linkplain Map#clear() Clears}</strong> and then
-     * builds or rebuilds an internal map of data source properties
-     * whose contents will be processed eventually by the {@link
-     * #addBean(BeanConfigurator, Named, Properties)} method.
-     *
-     * <p>If no subclass explicitly calls this method, it will be
-     * called by the {@link #addBean(BeanConfigurator, Named,
-     * Properties)} method just prior to its other activities.</p>
-     *
-     * <p>Once the {@link #addBean(BeanConfigurator, Named,
-     * Properties)} method has run to completion, while this method
-     * may be called freely its use is discouraged and its effects
-     * will no longer be used.</p>
-     *
-     * @see #addBean(BeanConfigurator, Named, Properties)
-     */
-    protected final void initializeMasterProperties() {
-        this.masterProperties.clear();
-        final Set<? extends String> allPropertyNames = this.getPropertyNames();
-        if (allPropertyNames != null && !allPropertyNames.isEmpty()) {
-            for (final String propertyName : allPropertyNames) {
-                final Optional<String> propertyValue = this.config.getOptionalValue(propertyName, String.class);
-                if (propertyValue != null && propertyValue.isPresent()) {
-                    final Matcher matcher = this.getDataSourcePropertyPatternMatcher(propertyName);
-                    if (matcher != null && matcher.matches()) {
-                        final String dataSourceName = this.getDataSourceName(matcher);
-                        Properties properties = this.masterProperties.get(dataSourceName);
-                        if (properties == null) {
-                            properties = new Properties();
-                            this.masterProperties.put(dataSourceName, properties);
-                        }
-                        final String dataSourcePropertyName = this.getDataSourcePropertyName(matcher);
-                        properties.setProperty(dataSourcePropertyName, propertyValue.get());
-                    }
-                }
-            }
-        }
-        this.masterProperties.putAll(this.explicitlySetProperties);
-    }
-
-    /**
-     * Returns a {@link Set} of all known configuration property
-     * names.
-     *
-     * <p>This method never returns {@code null}.</p>
-     *
-     * <p>The {@link Set} returned by this method is {@linkplain
-     * Collections#unmodifiableSet(Set) unmodifiable}.</p>
-     *
-     * <p>The {@link Set} returned by this method is not safe for
-     * concurrent use by multiple threads.</p>
-     *
-     * <p>Any other semantics of the {@link Set} returned by this
-     * method are governed by the <a
-     * href="https://github.com/eclipse/microprofile-config"
-     * target="_parent">MicroProfile Config</a> specification.</p>
-     *
-     * @return a non-{@code null}, {@linkplain
-     * Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>}
-     * of all known configuration property names
-     *
-     * @see Config#getConfigSources()
-     *
-     * @see ConfigSource#getPropertyNames()
-     */
-    protected final Set<String> getPropertyNames() {
-        final Set<String> returnValue;
-        final Iterable<String> propertyNames = this.config.getPropertyNames();
-        if (propertyNames == null) {
-            returnValue = Collections.emptySet();
-        } else {
-            final Set<String> set = new HashSet<>();
-            propertyNames.iterator().forEachRemaining(n -> set.add(n));
-            returnValue = Set.copyOf(set);
-        }
-        return returnValue;
-    }
-
-    private void afterBeanDiscovery(@Observes final AfterBeanDiscovery event) {
-        if (event != null) {
-            if (this.masterProperties.isEmpty()) {
-                this.initializeMasterProperties();
-            }
-            final Set<? extends Entry<? extends String, ? extends Properties>> masterPropertiesEntries =
-                this.masterProperties.entrySet();
-            if (masterPropertiesEntries != null && !masterPropertiesEntries.isEmpty()) {
-                for (final Entry<? extends String, ? extends Properties> entry : masterPropertiesEntries) {
-                    if (entry != null) {
-                        this.addBean(event.addBean(), NamedLiteral.of(entry.getKey()), entry.getValue());
-                    }
-                }
-            }
-        }
-        this.masterProperties.clear();
-        this.explicitlySetProperties.clear();
+        return this.putProperties(dataSourceName, properties);
     }
 
 }

--- a/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/AbstractDataSourceExtension.java
+++ b/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/AbstractDataSourceExtension.java
@@ -26,6 +26,8 @@ import io.helidon.integrations.cdi.configurable.AbstractConfigurableExtension;
 
 import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
 import jakarta.inject.Named;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
  * An {@link AbstractConfigurableExtension} whose subclasses arrange for {@link DataSource} instances to be added as CDI
@@ -38,34 +40,54 @@ import jakarta.inject.Named;
  */
 public abstract class AbstractDataSourceExtension extends AbstractConfigurableExtension<DataSource> {
 
+    private final Config config;
+
     /**
      * Creates a new {@link AbstractDataSourceExtension}.
      */
     protected AbstractDataSourceExtension() {
         super();
+        this.config = ConfigProvider.getConfig();
     }
 
     /**
-     * Calls the {@link #getConfigPropertyNames()} method and returns its return value.
+     * Returns the {@link Config} instance used to {@linkplain #configPropertyValue(String) acquire configuration
+     * property values}.
      *
      * <p>This method never returns {@code null}.</p>
      *
-     * <p>This method exists for backwards compatibility only and the {@link #getConfigPropertyNames()} method is
+     * <p>This method exists for backwards compatibility only and its usage is discouraged.</p>
+     *
+     * @return a non-{@code null} {@link Config} instance
+     *
+     * @deprecated This method exists for backwards compatibility only and has no replacement.
+     */
+    @Deprecated // For backwards compatibility only.
+    protected final Config getConfig() {
+        return this.config;
+    }
+
+    /**
+     * Calls the {@link #configPropertyNames()} method and returns its return value.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>This method exists for backwards compatibility only and the {@link #configPropertyNames()} method is
      * preferred.</p>
      *
-     * @return the return value of an invocation of the {@link #getConfigPropertyNames()} method
+     * @return the return value of an invocation of the {@link #configPropertyNames()} method
      *
-     * @see #getConfigPropertyNames()
+     * @see #configPropertyNames()
      *
-     * @deprecated Please use the {@link #getConfigPropertyNames()} method instead.
+     * @deprecated This method exists for backwards compatibility only. Please use the {@link #configPropertyNames()} method instead.
      */
     @Deprecated
     protected final Set<String> getPropertyNames() {
-        return this.getConfigPropertyNames();
+        return this.configPropertyNames();
     }
 
     @Override
-    protected final Matcher getPropertyPatternMatcher(String configPropertyName) {
+    protected final Matcher matcher(String configPropertyName) {
         return this.getDataSourcePropertyPatternMatcher(configPropertyName);
     }
 
@@ -74,8 +96,8 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      *
      * <p>Implementations of this method must not return {@code null}.</p>
      *
-     * <p>Implementations of this method must not invoke the {@link #getPropertyPatternMatcher(String)} method or an
-     * infinite loop may result.</p>
+     * <p>Implementations of this method must not invoke the {@link #matcher(String)} method or an infinite loop may
+     * result.</p>
      *
      * <p>Given a {@link String} like
      * <code>javax.sql.DataSource.<em>dataSourceName</em>.<em>dataSourcePropertyName</em></code>, any implementation of
@@ -94,7 +116,7 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
     protected abstract Matcher getDataSourcePropertyPatternMatcher(String configPropertyName);
 
     @Override
-    protected final String getName(Matcher propertyPatternMatcher) {
+    protected final String name(Matcher propertyPatternMatcher) {
         return this.getDataSourceName(propertyPatternMatcher);
     }
 
@@ -104,7 +126,7 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      *
      * <p>Implementations of this method may return {@code null}.</p>
      *
-     * <p>Implementations of this method must not invoke the {@link #getName(Matcher)} method or an infinite loop may
+     * <p>Implementations of this method must not invoke the {@link #name(Matcher)} method or an infinite loop may
      * result.</p>
      *
      * @param dataSourcePropertyPatternMatcher a {@link Matcher} produced by the {@link
@@ -117,7 +139,7 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
     protected abstract String getDataSourceName(Matcher dataSourcePropertyPatternMatcher);
 
     @Override
-    protected final String getPropertyName(Matcher propertyPatternMatcher) {
+    protected final String propertyName(Matcher propertyPatternMatcher) {
         return this.getDataSourcePropertyName(propertyPatternMatcher);
     }
 
@@ -127,8 +149,8 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      *
      * <p>Implementations of this method may return {@code null}.</p>
      *
-     * <p>Implementations of this method must not invoke the {@link #getPropertyName(Matcher)} method or an infinite
-     * loop may result.</p>
+     * <p>Implementations of this method must not invoke the {@link #propertyName(Matcher)} method or an infinite loop
+     * may result.</p>
      *
      * @param dataSourcePropertyPatternMatcher a {@link Matcher} produced by the {@link
      * #getDataSourcePropertyPatternMatcher(String)} method; must not be {@code null}
@@ -149,12 +171,12 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      * @return a non-{@code null}, {@linkplain Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>} of known
      * data source names
      *
-     * @deprecated This method exists for backwards compatibility only. Please use the {@link #getNames()} method
+     * @deprecated This method exists for backwards compatibility only. Please use the {@link #names()} method
      * instead.
      */
     @Deprecated // for backwards compatibility only
     protected final Set<String> getDataSourceNames() {
-        return this.getNames();
+        return this.names();
     }
 
     /**
@@ -172,11 +194,12 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      *
      * @exception NullPointerException if {@code properties} is {@code null}
      *
-     * @deprecated Please use the {@link #putProperties(String, Properties)} method instead.
+     * @deprecated This method exists for backwards compatibility only. Please use the {@link #put(String, Properties)}
+     * method instead.
      */
     @Deprecated // for backwards compatibility only
     protected final Properties putDataSourceProperties(final String dataSourceName, final Properties properties) {
-        return this.putProperties(dataSourceName, properties);
+        return this.put(dataSourceName, properties);
     }
 
     /**

--- a/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/AbstractDataSourceExtension.java
+++ b/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/AbstractDataSourceExtension.java
@@ -74,6 +74,9 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      *
      * <p>Implementations of this method must not return {@code null}.</p>
      *
+     * <p>Implementations of this method must not invoke the {@link #getPropertyPatternMatcher(String)} method or an
+     * infinite loop may result.</p>
+     *
      * <p>Given a {@link String} like
      * <code>javax.sql.DataSource.<em>dataSourceName</em>.<em>dataSourcePropertyName</em></code>, any implementation of
      * this method should return a non-{@code null} {@link Matcher} that is capable of being supplied to the {@link
@@ -101,6 +104,9 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      *
      * <p>Implementations of this method may return {@code null}.</p>
      *
+     * <p>Implementations of this method must not invoke the {@link #getName(Matcher)} method or an infinite loop may
+     * result.</p>
+     *
      * @param dataSourcePropertyPatternMatcher a {@link Matcher} produced by the {@link
      * #getDataSourcePropertyPatternMatcher(String)} method; must not be {@code null}
      *
@@ -121,6 +127,9 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      *
      * <p>Implementations of this method may return {@code null}.</p>
      *
+     * <p>Implementations of this method must not invoke the {@link #getPropertyName(Matcher)} method or an infinite
+     * loop may result.</p>
+     *
      * @param dataSourcePropertyPatternMatcher a {@link Matcher} produced by the {@link
      * #getDataSourcePropertyPatternMatcher(String)} method; must not be {@code null}
      *
@@ -140,7 +149,8 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
      * @return a non-{@code null}, {@linkplain Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>} of known
      * data source names
      *
-     * @deprecated Please use the {@link #getNames()} method instead.
+     * @deprecated This method exists for backwards compatibility only. Please use the {@link #getNames()} method
+     * instead.
      */
     @Deprecated // for backwards compatibility only
     protected final Set<String> getDataSourceNames() {
@@ -167,6 +177,17 @@ public abstract class AbstractDataSourceExtension extends AbstractConfigurableEx
     @Deprecated // for backwards compatibility only
     protected final Properties putDataSourceProperties(final String dataSourceName, final Properties properties) {
         return this.putProperties(dataSourceName, properties);
+    }
+
+    /**
+     * Calls the {@link #initializeNamedProperties()} method.
+     *
+     * @deprecated This method exists for backwards compatibility only. Please use the {@link
+     * #initializeNamedProperties()} method instead.
+     */
+    @Deprecated // for backwards compatibility only
+    protected final void initializeMasterProperties() {
+        this.initializeNamedProperties();
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,8 @@
         <javadoc.link.narayana>https://narayana.io/docs/api/</javadoc.link.narayana>
         <javadoc.link.eclipselink>https://www.eclipse.org/eclipselink/api/4.0/</javadoc.link.eclipselink>
         <javadoc.link.hibernate>https://docs.jboss.org/hibernate/orm/${version.lib.hibernate.family}/javadocs/</javadoc.link.hibernate>
+        <javadoc.link.ojdbc>https://docs.oracle.com/en/database/oracle/oracle-database/${version.lib.ojdbc.family}/jajdb/</javadoc.link.ojdbc>
+        <javadoc.link.ucp>https://docs.oracle.com/en/database/oracle/oracle-database/${version.lib.ojdbc.family}/jjuar/</javadoc.link.ucp>
 
         <javadoc.jackson.version>2.14</javadoc.jackson.version>
         <javadoc.link.jackson-annotations>https://fasterxml.github.io/jackson-annotations/javadoc/${javadoc.jackson.version}/</javadoc.link.jackson-annotations>
@@ -398,6 +400,14 @@
                             <offlineLink>
                                 <url>${javadoc.link.hibernate}</url>
                                 <location>${javadoc.pkg.dir}/hibernate</location>
+                            </offlineLink>
+                            <offlineLink>
+                                <url>${javadoc.link.ojdbc}</url>
+                                <location>${javadoc.pkg.dir}/ojdbc</location>
+                            </offlineLink>
+                            <offlineLink>
+                                <url>${javadoc.link.ucp}</url>
+                                <location>${javadoc.pkg.dir}/ucp</location>
                             </offlineLink>
                         </offlineLinks>
                         <additionalJOptions combine.children="append">


### PR DESCRIPTION
# Overview

This PR provides support for injecting [`UniversalConnectionPool`](https://docs.oracle.com/en/database/oracle/oracle-database/21/jjuar/oracle/ucp/UniversalConnectionPool.html) instances, as well as the sole [`UniversalConnectionPoolManager`](https://docs.oracle.com/en/database/oracle/oracle-database/21/jjuar/oracle/ucp/admin/UniversalConnectionPoolManager.html) instance.

To accomplish this it refactors the existing `AbstractDataSourceExtension` class to extend from a new-but-behaviorally-equivalent type-agnostic superclass, `AbstractConfigurableExtension`, then authors a new `UniversalConnectionPoolExtension` that also extends from it.

Making use of `UniversalConnectionPool` and `UniversalConnectionPoolManager` instances is something that only advanced use cases will do.

## Motivation

For advanced use cases that require access to a `UniversalConnectionPool` instance that underlies a `PoolDataSource`, acquiring one is not straightforward. We should provide the ability to inject one, just as we provide the ability already to inject its related `PoolDataSource`.

## Installation

To install the facilities enabled by this PR, an end user should ensure that the `io.helidon.integrations.cdi:helidon-integrations-cdi-datasource-ucp` artifact is on her runtime classpath. This artifact already exists and this PR simply adds features to it. Existing users of [our Universal Connection Pool integration will have to take no additional action](https://helidon.io/docs/v4/mp/persistence#DS-UCP-Project-Setup).

### Maven Coordinates

```xml
<dependency>
  <groupId>io.helidon.integrations.cdi</groupId>
  <artifactId>helidon-integrations-cdi-datasource-ucp</artifactId>
  <scope>runtime</scope>
</dependency>
```

## Usage

To use the facilities enabled by this PR, first an end user should ensure that there is configuration in place to create a Universal Connection Pool-managed data source, as [described in our documentation](https://helidon.io/docs/v4/mp/persistence#DS-Configuration-UCP-Oracle-Example). (The documentation there shows the creation of a Universal Connection Pool-managed data source named `test`.)

Next, she should use normal CDI facilities to inject this data source, its corresponding `UniversalConnectionPool`, or both:
```java
import javax.sql.DataSource;
import jakarta.inject.Inject;
import jakarta.inject.Named;
import oracle.ucp.UniversalConnectionPool;
import oracle.ucp.admin.UniversalConnectionPoolManager;
import oracle.ucp.jdbc.PoolDataSource;

// Injects a PoolDataSource as an implementation of a DataSource, qualified with the
// "test" name, as exists currently in Helidon 4.0.5:
@Inject
@Named("test")
private javax.sql.DataSource ds; // assert ds instanceof PoolDataSource;

// Injects the exact same object:
@Inject
@Named("test)
private PoolDataSource pds; // assert pds.getConnectionPoolName().equals("test");

// NEW: Injects the backing UniversalConnectionPool, qualified with the "test" name
// (a feature for advanced use cases this PR enables):
@Inject
@Named("test")
private UniversalConnectionPool ucp; // assert ucp.getName().equals("test");

// Inject the sole UniversalConnectionPoolManager (a feature for advanced use cases
// this PR enables):
@Inject
private UniversalConnectionPoolManager ucpm;
```

## Backwards Compatibility Notes

This PR maintains the existing signatures in `AbstractDataSourceExtension`, so no impact to our existing code or users' existing code is expected.

## Documentation Impact

This supports advanced, esoteric use cases only, so we mayor may not want to document it explicitly, as ordinary users should not be interacting with the underlying pool directly, but, rather, working with `PoolDataSource` instances, which the existing `UCPBackedDataSourceExtension` class already provides support for. I worry that too much documentation here will lead to users trying to create already-existing data sources again by mistakenly manipulating the pool. This is a side effect of the way that the Universal Connection Pool APIs are designed.