### PR TITLE
4.x: Update javadocs of Meter builders to cross reference MeterRegistry.getOrCreate()

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/Counter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,10 @@ public interface Counter extends Meter {
     long count();
 
     /**
-     * Builder for a new counter.
+     * Builder for a new counter. The actually building of the counter
+     * is performed by the registry.
+     *
+     * @see MeterRegistry#getOrCreate(Meter.Builder)
      */
     interface Builder extends Meter.Builder<Builder, Counter> {
     }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Counter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Counter.java
@@ -50,8 +50,7 @@ public interface Counter extends Meter {
     long count();
 
     /**
-     * Builder for a new counter. The actually building of the counter
-     * is performed by the registry.
+     * Builder for a new counter.
      *
      * @see MeterRegistry#getOrCreate(Meter.Builder)
      */

--- a/metrics/api/src/main/java/io/helidon/metrics/api/DistributionSummary.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/DistributionSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,8 @@ public interface DistributionSummary extends Meter {
 
     /**
      * Builder for a {@link io.helidon.metrics.api.DistributionSummary}.
+     *
+     * @see MeterRegistry#getOrCreate(Meter.Builder)
      */
     interface Builder extends Meter.Builder<Builder, DistributionSummary> {
 

--- a/metrics/api/src/main/java/io/helidon/metrics/api/FunctionalCounter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/FunctionalCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ public interface FunctionalCounter extends Meter {
 
     /**
      * Builder for a {@link io.helidon.metrics.api.FunctionalCounter}.
+     *
+     * @see MeterRegistry#getOrCreate(Meter.Builder)
      *
      * @param <T> type of the state object
      */

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Gauge.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Gauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,8 @@ public interface Gauge<N extends Number> extends Meter {
 
     /**
      * Builder for a new gauge.
+     *
+     * @see MeterRegistry#getOrCreate(Meter.Builder)
      *
      * @param <N> specific subtype of {@code Number} for the gauge this builder will produce
      */

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Meter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Meter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,8 @@ public interface Meter extends Wrapper {
      * registering it which is implementation-specific and therefore should be performed only by each implementation.
      * We do not want developers to see a {@code build()} operation that they should not invoke.
      * </p>
+     *
+     * @see MeterRegistry#getOrCreate(Builder)
      *
      * @param <B> type of the builder
      * @param <M> type of the meter the builder creates

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Timer.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -189,6 +189,8 @@ public interface Timer extends Meter, HistogramSupport {
 
     /**
      * Builder for a new {@link io.helidon.metrics.api.Timer}.
+     *
+     * @see MeterRegistry#getOrCreate(Meter.Builder)
      */
     interface Builder extends Meter.Builder<Builder, Timer> {
 


### PR DESCRIPTION

### Description

The various Meter builders in `io.helidon.metrics.api` do not behave like a typical builder in that they do not expose a `build()` method. Instead the builder is passed to `MeterRegistry.getOrCreate()`.

This PR adds javadoc cross-references to make that a little easier to discover.

### Documentation

Updates javadoc
