### PR TITLE
More carefully handle re-creation of global meter registry

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -202,6 +202,7 @@ interface MetricsConfigBlueprint {
      *
      * @return metrics configuration
      */
+    @Option.Redundant
     Config config();
 
     /**

--- a/metrics/providers/micrometer/pom.xml
+++ b/metrics/providers/micrometer/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MMeterRegistry.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MMeterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,6 +217,7 @@ class MMeterRegistry implements io.helidon.metrics.api.MeterRegistry {
     public void close() {
         onAddListeners.clear();
         onRemoveListeners.clear();
+        List.copyOf(meters.values()).forEach(this::remove);
         meters.clear();
         buildersByPromMeterId.clear();
         scopeMembership.clear();
@@ -472,7 +473,7 @@ class MMeterRegistry implements io.helidon.metrics.api.MeterRegistry {
             if (builder == null) {
                 if (scope.isEmpty()) {
                     LOGGER.log(Level.DEBUG, "Processing meter creation with no scope from the meter or configuration: "
-                            + addedMeter);
+                            + addedMeter.getId());
                 }
                 id = neutralIdForAddedMeter;
                 mMeter = MMeter.create(id, addedMeter, scope);
@@ -506,7 +507,7 @@ class MMeterRegistry implements io.helidon.metrics.api.MeterRegistry {
         try {
             MMeter<?> removedHelidonMeter = meters.remove(removedMeter);
             if (removedHelidonMeter == null) {
-                LOGGER.log(Level.WARNING, "No matching neutral meter for implementation meter " + removedMeter);
+                LOGGER.log(Level.WARNING, "No matching neutral meter for implementation meter " + removedMeter.getId());
             } else {
                 recordRemove(removedHelidonMeter);
             }
@@ -586,7 +587,7 @@ class MMeterRegistry implements io.helidon.metrics.api.MeterRegistry {
                 */
 
                 LOGGER.log(Level.WARNING,
-                           "Unexpected discovery of unknown previously-created meter; creating wrapper for " + meter);
+                           "Unexpected discovery of unknown previously-created meter; creating wrapper for " + meter.getId());
                 result = wrapMeter(id, meter, mBuilder.scope());
                 recordNewMeter(id, result, meter, effectiveScope);
             }

--- a/metrics/providers/micrometer/src/main/java/module-info.java
+++ b/metrics/providers/micrometer/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ module io.helidon.metrics.providers.micrometer {
     requires micrometer.core;
     requires static micrometer.registry.prometheus;
     requires io.helidon.common;
-    requires io.helidon.common.config;
     requires io.helidon.common.media.type;
+    requires io.helidon.config;
     requires simpleclient.common;
     requires simpleclient.tracer.common;
     requires simpleclient;


### PR DESCRIPTION
### Description
Resolves #8382 

The global meter registry can be reconfigured with new `MetricsConfig` even if it has been previously initialized.

This should be rare but can happen. In such cases, the Helidon metrics implementation using Micrometer did not remove previously-registered meters from the Micrometer meter registry. It just cleared out the Helidon data structures.

When Helidon creates a new meter registry, it automatically registers any pre-defined meters (such as the base metrics for various JVM quantities). The warnings reported in the issue resulted when Helidon, as it was registering the predefined meters for the new meter registry, unexpectedly found those meters already registered in the Micrometer meter registry because of the prior initialization of a prior global registry.

This PR does several things:
1. When the global meter registry is reconfigured, Helidon now removes any previously-registered meters as part of closing the Helidon meter registry. This removes them from the Micrometer meter registry as well so when predefined meters are added again via the Helidon metrics API they do not already exist in the Micrometer registry.
2. As an optimization, the code skips the reconfiguration of the global registry (and the removal and reregistration of predefined meters) if the `MetricsConfig` provided for the _re_-configuration is consistent with the `MetricsConfig` used when the previous global registry was created. 
   
   As part of this optimization, the `config` setting for `MetricsConfig` is now marked as redundant so it is not used in the generated `equals` or `hashCode` methods. To decide if the previous and new `MetricsConfig` objects are consistent we don't care if the configuration objects (if any) are equal--just that the behavior induced by the `MetricsConfig` settings will be the same. For example, this can happen if one config instance explicitly sets values that happen to be the defaults there are used if the config node is `MISSING`.
4. The warning message (and some other related ones not involved in this issue) used the Micrometer  `Meter.toString()` which did not have a helpful implementation. Now those messages log the meter ID which is at least readable.

### Documentation
Bug fix; no doc impact