### PR TITLE
[4.x] Replace deprecated session.writeTransaction on session.executeWrite in Neo4jHealthCheck

### DIFF
--- a/integrations/neo4j/health/src/main/java/io/helidon/integrations/neo4j/health/Neo4jHealthCheck.java
+++ b/integrations/neo4j/health/src/main/java/io/helidon/integrations/neo4j/health/Neo4jHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class Neo4jHealthCheck implements HealthCheck {
     public HealthCheckResponse call() {
         HealthCheckResponse.Builder builder = HealthCheckResponse.builder();
         try (Session session = this.driver.session()) {
-            return session.writeTransaction(tx -> {
+            return session.executeWrite(tx -> {
                 var result = tx.run(CYPHER);
 
                 var edition = result.single().get("edition").asString();


### PR DESCRIPTION
### Description
There is the deprecated method `session.writeTransaction`. It can be replaced on `session.executeWrite`

- [ ] Create backport 3.x
- [ ] Create backport 2.x

<img width="400" alt="Screenshot 2024-02-19 at 22 20 52" src="https://github.com/helidon-io/helidon/assets/4740207/20eebe41-30e2-4990-9aac-50dc18cf54a9">
