### PR TITLE
4.x: generate a .gitignore files from archetype

### DIFF
--- a/archetypes/archetypes/src/main/archetype/common/common.xml
+++ b/archetypes/archetypes/src/main/archetype/common/common.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@
             <includes>
                 <include>.helidon.mustache</include>
                 <include>README.md.mustache</include>
+                <include>.gitignore.mustache</include>
                 <include if="${flavor} == 'se'">src/main/java/**/Main.java.mustache</include>
             </includes>
         </templates>

--- a/archetypes/archetypes/src/main/archetype/common/files/.gitignore.mustache
+++ b/archetypes/archetypes/src/main/archetype/common/files/.gitignore.mustache
@@ -1,0 +1,38 @@
+# Compiled class file
+*.class
+
+# Maven
+target/
+.m2/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# IntelliJ Idea
+.idea/
+*.iws
+*.ipr
+*.iml
+*.releaseBackup
+atlassian-ide-plugin.xml
+
+# Netbeans
+nbactions.xml
+nb-configuration.xml
+
+# Eclipse
+.settings
+.settings/
+.project
+.classpath
+.factorypath
+
+{{#gitignore}}
+{{.}}
+{{/gitignore}}

--- a/archetypes/archetypes/src/main/archetype/mp/custom/database-outputs.xml
+++ b/archetypes/archetypes/src/main/archetype/mp/custom/database-outputs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -477,6 +477,10 @@ Start your database before running this example.
 Example docker commands to start databases in temporary containers:
 {{start-db}}
 ]]></value>
+            </list>
+            <list key="gitignore">
+                <value>ObjectStore/</value>
+                <value>PutObjectStoreDirHere/</value>
             </list>
         </model>
     </output>

--- a/archetypes/archetypes/src/main/archetype/se/custom/database-output.xml
+++ b/archetypes/archetypes/src/main/archetype/se/custom/database-output.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -426,6 +426,10 @@ Start your database before running this example.
 Example docker commands to start databases in temporary containers:
 {{start-db}}
 ]]></value>
+            </list>
+            <list key="gitignore">
+                <value>ObjectStore/</value>
+                <value>PutObjectStoreDirHere/</value>
             </list>
         </model>
     </output>


### PR DESCRIPTION
### Description

fix #8383

The archetype now generate a `.gitignore` file for every project.

### Documentation

no impact
