### PR TITLE
Replace deprecated OutputStreamMultiBuilder.timeout(long,TimeUnit) on OutputStreamMultiBuilder.timeout(Duration)

### DIFF
--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ package io.helidon.common.reactive;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteBuffer;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
+import static java.time.Duration.ofMillis;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -56,7 +56,7 @@ public class MultiFromOutputStreamTest {
     @Test
     void testMultiTimeout() {
         MultiFromOutputStream osMulti = IoMulti.builderOutputStream()
-                .timeout(200, TimeUnit.MILLISECONDS)
+                .timeout(ofMillis(200))
                 .build();
 
         TestSubscriber<ByteBuffer> testSubscriber = new TestSubscriber<>();


### PR DESCRIPTION
### Description
There is usage deprecated method `OutputStreamMultiBuilder.timeout(long,TimeUnit)`. It can be replaced on `OutputStreamMultiBuilder.timeout(Duration)`

<img width="400" alt="Screenshot 2024-02-21 at 21 18 35" src="https://github.com/helidon-io/helidon/assets/4740207/6979467e-673a-4871-a28f-a72117bf1f52">
