### PR TITLE
Generalize the OCI metrics integration, using qualified injection of `Config`

### DIFF
--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetrics.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetrics.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Marks a {@link io.helidon.config.Config} object as containing settings for OCI metrics integration.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
+@Qualifier
+public @interface OciMetrics {
+}

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class OciMetricsBean {
 
     // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
     void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object ignore,
-                            Config config, Monitoring monitoringClient) {
+                            @OciMetrics Config config, Monitoring monitoringClient) {
         Config ocimetrics = config.get("ocimetrics");
         OciMetricsSupport.Builder builder = OciMetricsSupport.builder()
                 .config(ocimetrics)

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,5 +27,6 @@ public class OciMetricsCdiExtension implements Extension {
     // A new bean is added to handle the Observer Method as injection does not work here
     void addOciMetricsBean(@Observes BeforeBeanDiscovery event) {
         event.addAnnotatedType(OciMetricsBean.class, OciMetricsBean.class.getName());
+        event.addAnnotatedType(OciMetricsConfigProducer.class, OciMetricsConfigProducer.class.getName());
     }
 }

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsConfigProducer.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsConfigProducer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Produces;
+
+import io.helidon.config.Config;
+
+@Priority(0)
+class OciMetricsConfigProducer {
+
+    @Produces
+    @OciMetrics
+    public Config config(Config config) {
+        return config;
+    }
+}

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsConfigProducer.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsConfigProducer.java
@@ -20,12 +20,21 @@ import javax.enterprise.inject.Produces;
 
 import io.helidon.config.Config;
 
-@Priority(0)
+/**
+ * Default producer for a {@link io.helidon.config.Config} instance for use by the OCI metrics integration
+ * library.
+ *
+ * The very high priority (which means very low importance) allows other libraries to use a lower-priority-value
+ * (more important) implementation to override this behavior.
+ */
+@Priority(Integer.MAX_VALUE - 1)
 class OciMetricsConfigProducer {
 
     @Produces
     @OciMetrics
-    public Config config(Config config) {
+    private static Config config(Config config) {
+        // Intentionally returns the *unqualified* Config instance created by an *unqualified* producer
+        // method elsewhere.
         return config;
     }
 }

--- a/integrations/oci/metrics/cdi/src/main/java/module-info.java
+++ b/integrations/oci/metrics/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ module io.helidon.integrations.oci.metrics.cdi {
     requires oci.java.sdk.monitoring;
 
     requires jakarta.interceptor.api;
+    requires jakarta.inject.api;
     provides javax.enterprise.inject.spi.Extension with io.helidon.integrations.oci.metrics.cdi.OciMetricsCdiExtension;
 
     opens io.helidon.integrations.oci.metrics.cdi to weld.core.impl, io.helidon.microprofile.cdi;


### PR DESCRIPTION
### Description
Configuration for the OCI metrics integration might come from different sources. This PR slightly generalizes how the `Config` is injected into the bean which starts up the integration.

The "start-up" bean now injects a `@Qualified` `Config` instance and provides a default producer for that qualified `Config` which is the normally-injected `Config` itself. There is no change in the behavior of this library when used as in the past.

The change is if another library includes a higher-priority bean which also produces the qualified `Config` bean, in which case this library uses _that_ config instance instead.

### Documentation
No functional change, and we do not intend for users to take advantage of this generalization themselves. 

No doc impact.