### PR TITLE
[3.x] PostgreSQL JDBC driver updated to 42.4.4.

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -145,7 +145,7 @@
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.perfmark-api>0.25.0</version.lib.perfmark-api>
         <version.lib.parsson>1.0.5</version.lib.parsson>
-        <version.lib.postgresql>42.4.3</version.lib.postgresql>
+        <version.lib.postgresql>42.4.4</version.lib.postgresql>
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>2.0.9</version.lib.slf4j>
         <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>


### PR DESCRIPTION
Conservative update of PostgreSQL JDBC driver for already released version.