### PR TITLE
[4.x] Replace deprecated classInfo.classAnnotation(DotName) on classInfo.declaredAnnotation(DotName)

### DIFF
--- a/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/InspectionService.java
+++ b/microprofile/lra/jax-rs/src/main/java/io/helidon/microprofile/lra/InspectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,7 +191,7 @@ class InspectionService {
 
     AnnotationInstance deepScanClassLevelLraAnnotation(ClassInfo classInfo) {
         if (classInfo == null) return null;
-        AnnotationInstance lraClassAnnotation = classInfo.classAnnotation(DotName.createSimple(LRA.class.getName()));
+        AnnotationInstance lraClassAnnotation = classInfo.declaredAnnotation(DotName.createSimple(LRA.class.getName()));
         if (lraClassAnnotation != null) {
             return lraClassAnnotation;
         }


### PR DESCRIPTION
### Description
There is the deprecated method `classInfo.classAnnotation(DotName)`. It can be replaced on `classInfo.declaredAnnotation(DotName)`.

<img width="722" alt="Screenshot 2024-02-24 at 00 39 42" src="https://github.com/helidon-io/helidon/assets/4740207/c21053c3-4f3c-49b6-bc59-8b09a533698b">

- [x] Check branches for backport
