### PR TITLE
Generalize OCI metrics support; add tests for the generalization

### DIFF
--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -53,4 +53,58 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/TestObserverPriorities.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                Adding the Helidon MP metrics artifact to the test scope would make the CDI extension test susceptible to changes
+                in the number of automatic metrics registered. The auto-registration does not occur without adding the dep. on
+                the MP metrics artifact.
+
+                So, instead of that, we run an execution of surefire running just the observer priority test and add the Helidon
+                MP metrics library to just this execution. Only surefire version 3.2 and later support this feature, so use a
+                more recent version than the Helidon default for this execution.
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <id>observer-priority-check</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <additionalClasspathDependencies>
+                                <dependency>
+                                    <groupId>io.helidon.microprofile.metrics</groupId>
+                                    <artifactId>helidon-microprofile-metrics</artifactId>
+                                    <version>${helidon.version}</version>
+                                </dependency>
+                            </additionalClasspathDependencies>
+                            <includes>
+                                <include>**/TestObserverPriorities.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -57,8 +57,18 @@
     <build>
         <plugins>
             <plugin>
+                <!--
+                Adding the Helidon MP metrics artifact to the test scope would make the CDI extension test susceptible to changes
+                in the number of automatic metrics registered. The auto-registration does not occur without adding the dep. on
+                the MP metrics artifact.
+
+                So, instead of that, we run surefire twice, once running just the observer priority test with the Helidon
+                MP metrics library added to just thats execution. Only surefire version 3.2 and later support this feature, so
+                use a more recent version than the Helidon default.
+                -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <id>default-test</id>
@@ -68,23 +78,6 @@
                             </excludes>
                         </configuration>
                     </execution>
-
-                </executions>
-            </plugin>
-            <plugin>
-                <!--
-                Adding the Helidon MP metrics artifact to the test scope would make the CDI extension test susceptible to changes
-                in the number of automatic metrics registered. The auto-registration does not occur without adding the dep. on
-                the MP metrics artifact.
-
-                So, instead of that, we run an execution of surefire running just the observer priority test and add the Helidon
-                MP metrics library to just this execution. Only surefire version 3.2 and later support this feature, so use a
-                more recent version than the Helidon default for this execution.
-                -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
-                <executions>
                     <execution>
                         <id>observer-priority-check</id>
                         <goals>

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,28 +30,78 @@ import com.oracle.bmc.monitoring.Monitoring;
 import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 /**
- * OCI metrics integration CDI extension.
+ * CDI bean for preparing OCI metrics integration.
+ * <p>
+ * This bean relies on the OCI SDK integration to manufacture a {@link com.oracle.bmc.monitoring.Monitoring} instance.
+ * It is also extensible in case an upstream library needs to fine-tune the way the OCI metrics integration is set up.
+ * </p>
  */
 
 // This bean is added to handle injection on the ObserverMethod as it does not work on an Extension class.
 @Singleton
 public class OciMetricsBean {
 
+    private Config ociMetricsConfig;
+    private OciMetricsSupport ociMetricsSupport;
+
+    /**
+     * For CDI use only.
+     */
+    @Deprecated
+    public OciMetricsBean() {
+    }
+
+    /**
+     * Returns the config key to use for retrieving OCI metrics settings from the root config.
+     *
+     * @return config key for OCI metrics settings
+     */
+    protected String configKey() {
+        return "ocimetrics";
+    }
+
+    /**
+     * Returns the builder for constructing a new {@link io.helidon.integrations.oci.metrics.OciMetricsSupport} instance,
+     * initialized using the config retrieved using the {@link #configKey()} return value and the provided
+     * {@link com.oracle.bmc.monitoring.Monitoring} instance.
+     *
+     * @param monitoring monitoring implementation to be used in preparing the {@code OciMetricsSupport.Builder}.
+     * @return resulting builder
+     */
+    protected OciMetricsSupport.Builder ociMetricsSupportBuilder(Monitoring monitoring) {
+        return OciMetricsSupport.builder()
+                .config(ociMetricsConfig)
+                .monitoringClient(monitoring);
+    }
+
+    /**
+     * Returns the OCI metrics config settings previously retrieved from the config root.
+     *
+     * @return  OCI metrics config node
+     */
+    protected Config ociMetricsConfig() {
+        return ociMetricsConfig;
+    }
+
     // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
     void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object ignore,
                             Config config, Monitoring monitoringClient) {
-        Config ocimetrics = config.get("ocimetrics");
-        OciMetricsSupport.Builder builder = OciMetricsSupport.builder()
-                .config(ocimetrics)
-                .monitoringClient(monitoringClient);
+        ociMetricsConfig = config.get(configKey());
+        OciMetricsSupport.Builder builder = ociMetricsSupportBuilder(monitoringClient);
         if (builder.enabled()) {
-            activateOciMetricsSupport(ocimetrics, builder);
+            activateOciMetricsSupport(ociMetricsConfig, builder);
         }
     }
 
     void activateOciMetricsSupport(Config ocimetrics, OciMetricsSupport.Builder builder) {
+        ociMetricsSupport = builder.build();
         RoutingBuilders.create(ocimetrics)
                 .routingBuilder()
-                .register(builder.build());
+                .register(ociMetricsSupport);
+    }
+
+    // For testing
+    OciMetricsSupport ociMetricsSupport() {
+        return ociMetricsSupport;
     }
 }

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -276,9 +276,9 @@ class OciMetricsCdiExtensionTest {
     static class MockOciMetricsBean extends OciMetricsBean {
         // Override so we can test if this is invoked when enabled or skipped when disabled
         @Override
-        void activateOciMetricsSupport(Config config, OciMetricsSupport.Builder builder) {
+        protected void activateOciMetricsSupport(Config rootConfig, Config ociMetricsConfig, OciMetricsSupport.Builder builder) {
             activateOciMetricsSupportIsInvoked = true;
-            super.activateOciMetricsSupport(config, builder);
+            super.activateOciMetricsSupport(rootConfig, ociMetricsConfig, builder);
         }
     }
 }

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OverridingOciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OverridingOciMetricsBean.java
@@ -20,6 +20,7 @@ import javax.enterprise.inject.Alternative;
 import javax.inject.Singleton;
 import javax.interceptor.Interceptor;
 
+import io.helidon.config.Config;
 import io.helidon.integrations.oci.metrics.OciMetricsSupport;
 
 import com.oracle.bmc.monitoring.Monitoring;
@@ -39,11 +40,13 @@ class OverridingOciMetricsBean extends OciMetricsBean {
     }
 
     @Override
-    protected OciMetricsSupport.Builder ociMetricsSupportBuilder(Monitoring monitoring) {
-        OciMetricsSupport.Builder result = super.ociMetricsSupportBuilder(monitoring);
+    protected OciMetricsSupport.Builder ociMetricsSupportBuilder(Config rootConfig,
+                                                                 Config ociMetricsConfig,
+                                                                 Monitoring monitoring) {
+        OciMetricsSupport.Builder result = super.ociMetricsSupportBuilder(rootConfig, rootConfig, monitoring);
         // Example using synonyms for two of the config keys.
-        ociMetricsConfig().get("product").asString().ifPresent(result::namespace);
-        ociMetricsConfig().get("fleet").asString().ifPresent(result::resourceGroup);
+        ociMetricsConfig.get("product").asString().ifPresent(result::namespace);
+        ociMetricsConfig.get("fleet").asString().ifPresent(result::resourceGroup);
         return result;
     }
 }

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OverridingOciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OverridingOciMetricsBean.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Singleton;
+import javax.interceptor.Interceptor;
+
+import io.helidon.integrations.oci.metrics.OciMetricsSupport;
+
+import com.oracle.bmc.monitoring.Monitoring;
+
+/**
+ * Example of an overriding bean implementation to test that overrides work. (See
+ * {@link io.helidon.integrations.oci.metrics.cdi.TestOverridingBean}.)
+ */
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+@Alternative
+@Singleton
+class OverridingOciMetricsBean extends OciMetricsBean {
+
+    @Override
+    protected String configKey() {
+        return "oci.metrics";
+    }
+
+    @Override
+    protected OciMetricsSupport.Builder ociMetricsSupportBuilder(Monitoring monitoring) {
+        OciMetricsSupport.Builder result = super.ociMetricsSupportBuilder(monitoring);
+        // Example using synonyms for two of the config keys.
+        ociMetricsConfig().get("product").asString().ifPresent(result::namespace);
+        ociMetricsConfig().get("fleet").asString().ifPresent(result::resourceGroup);
+        return result;
+    }
+}

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/TestObserverPriorities.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/TestObserverPriorities.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import javax.annotation.Priority;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.ws.rs.Priorities;
+
+import io.helidon.config.Config;
+import io.helidon.microprofile.server.ServerCdiExtension;
+
+import com.oracle.bmc.monitoring.Monitoring;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+class TestObserverPriorities {
+
+    @Test
+    void compareObserverAgainstMetricsCdiExtensionObserver() throws NoSuchMethodException, ClassNotFoundException {
+        Method ourObserverMethod = OciMetricsBean.class.getDeclaredMethod("registerOciMetrics",
+                                                                          Object.class,
+                                                                          Config.class,
+                                                                          Monitoring.class);
+        Class<?> metricsCdiExtension = Class.forName("io.helidon.microprofile.metrics.MetricsCdiExtension");
+        Method metricsCdiExtensionRegisteringMethod = metricsCdiExtension.getDeclaredMethod("registerService",
+                                                                                                  Object.class,
+                                                                                                  BeanManager.class,
+                                                                                                  ServerCdiExtension.class);
+        assertThat("Observer priority compared to metrics CDI extension observer priority",
+                   priority(ourObserverMethod),
+                   is(greaterThan(priority(metricsCdiExtensionRegisteringMethod))));
+    }
+
+    private static int priority(Method method) {
+        return Arrays.stream(method.getParameters())
+                .filter(p -> p.isAnnotationPresent(Observes.class))
+                .filter(p -> p.isAnnotationPresent(Priority.class))
+                .map(p -> p.getAnnotation(Priority.class).value())
+                .findFirst()
+                .orElse(Priorities.USER);
+
+    }
+}

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/TestOverridingBean.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/TestOverridingBean.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics.cdi;
+
+import java.lang.reflect.Field;
+
+import javax.inject.Inject;
+
+import io.helidon.integrations.oci.metrics.OciMetricsSupport;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddBean(OverridingOciMetricsBean.class)
+@AddConfig(key = "oci.metrics.product", value = TestOverridingBean.PRODUCT)
+@AddConfig(key = "oci.metrics.fleet", value = TestOverridingBean.FLEET)
+@AddBean(OciMetricsCdiExtensionTest.MockMonitoring.class)
+class TestOverridingBean {
+
+    static final String PRODUCT = "overriding-product-name";
+    static final String FLEET = "overriding-fleet";
+
+    // The injected bean should be the test one which overrides the default implementation.
+    @Inject
+    private OciMetricsBean bean;
+
+    @Test
+    void checkOverriding() throws NoSuchFieldException, IllegalAccessException {
+        assertThat("Config key", bean.configKey(), is(equalTo("oci.metrics")));
+        assertThat("Injected bean", bean, instanceOf(OverridingOciMetricsBean.class));
+        OciMetricsSupport ociMetricsSupport = bean.ociMetricsSupport();
+
+        String namespace = getStringField("namespace", ociMetricsSupport);
+        String resourceGroup = getStringField("resourceGroup", ociMetricsSupport);
+
+        assertThat("Effective namespace", namespace, is(equalTo(PRODUCT)));
+        assertThat("Effective namespace", resourceGroup, is(equalTo(FLEET)));
+    }
+
+    private String getStringField(String fieldName, OciMetricsSupport ociMetricsSupport)
+            throws NoSuchFieldException, IllegalAccessException {
+        // Except for testing, there is no need for OciMetricsSupport to expose methods returning the namespace and resource
+        // group so just use reflection rather than add those methods. It's only a test so using reflection is not so bad.
+        Field field = OciMetricsSupport.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (String) field.get(ociMetricsSupport);
+    }
+}


### PR DESCRIPTION
### Description
This PR slightly generalizes how the OCI metrics integration is set up.

Most of the work continues to be done in `OciMetricsBean` but this class can now be extended in two ways:
* customize what config prefix is used to fetch OCI metrics integration settings from the root node
* customize how the `OciMetricsSupport.Builder` is prepared
* allow other work around starting the `OciMetricsSupport` instance

The PR includes an example customization of the bean as well as tests using the customization to make sure the customized bean (designated as a CDI `@Alternate` and with a more urgent `@Priority` than the normal bean implementation) is used.

As noted in the original bean class comments, it's essential that the observer method in the bean run _after_ an observer method in the Helidon MP metrics extension. The PR adds a test using reflection to verify this requirement.

### Documentation
No impact.

This generalization is intended for use by library authors familiar with Helidon's workings as opposed to application developers. As a result, beyond the JavaDoc in the PR there is no need to update the user documentation.