### PR TITLE
[4.x] Replace deprecated session.readTransaction on session.executeRead

### DIFF
--- a/docs/src/main/java/io/helidon/docs/mp/integrations/Neo4jSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/integrations/Neo4jSnippets.java
@@ -84,7 +84,7 @@ class Neo4jSnippets {
                                 return m, collect(d) as directors, collect({name:a.name, roles: r.roles}) as actors
                                 """;
 
-                    return session.readTransaction(tx -> tx.run(query).list(r -> {
+                    return session.executeRead(tx -> tx.run(query).list(r -> {
                         var movieNode = r.get("m").asNode();
 
                         var directors = r.get("directors").asList(v -> {

--- a/docs/src/main/java/io/helidon/docs/se/integrations/Neo4jSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/integrations/Neo4jSnippets.java
@@ -66,7 +66,7 @@ class Neo4jSnippets {
                             return m, collect(d) as directors, collect({name:a.name, roles: r.roles}) as actors
                             """;
 
-                return session.readTransaction(tx -> tx.run(query).list(r -> {
+                return session.executeRead(tx -> tx.run(query).list(r -> {
                     var movieNode = r.get("m").asNode();
 
                     var directors = r.get("directors").asList(v -> {

--- a/examples/integrations/neo4j/src/main/java/io/helidon/examples/integrations/neo4j/domain/MovieRepository.java
+++ b/examples/integrations/neo4j/src/main/java/io/helidon/examples/integrations/neo4j/domain/MovieRepository.java
@@ -26,7 +26,7 @@ import org.neo4j.driver.Value;
 /*
  * Helidon changes are under the copyright of:
  *
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public final class MovieRepository {
                     + "match (m) <- [r:ACTED_IN] - (a:Person) "
                     + "return m, collect(d) as directors, collect({name:a.name, roles: r.roles}) as actors";
 
-            return session.readTransaction(tx -> tx.run(query).list(r -> {
+            return session.executeRead(tx -> tx.run(query).list(r -> {
                 var movieNode = r.get("m").asNode();
 
                 var directors = r.get("directors").asList(v -> {


### PR DESCRIPTION
### Description
There are usages of the deprecated method `org.neo4j.driver.Session.readTransaction` in the code and the docs. It can be replaced on `session.executeRead`.
<img width="400" alt="Screenshot 2024-02-25 at 10 43 27" src="https://github.com/helidon-io/helidon/assets/4740207/d5a1adc9-edac-4af9-aa82-894a3d9569a4">


### Documentation
The deprecated method was replaced in two places in the docs:
* [se neo4j example](https://helidon.io/docs/v4/se/integrations/neo4j#_examples)
* [mp neo4j example](https://helidon.io/docs/v4/mp/integrations/neo4j#_examples)