### PR TITLE
[4.x] Replace deprecated Multi.from(Stream) on Multi.create(Stream)

### DIFF
--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
@@ -431,7 +431,7 @@ public class KafkaSeTest extends AbstractKafkaTest {
         Messaging messaging = Messaging.builder()
                 .connector(kafkaConnector)
                 .publisher(toKafka,
-                        Multi.from(IntStream.rangeClosed(1, 3).boxed())
+                        Multi.create(IntStream.rangeClosed(1, 3).boxed())
                                 .map(KafkaMessage::of)
                                 .peek(msg -> msg.getHeaders()
                                         .add("secret header",


### PR DESCRIPTION
### Description
There is usage of the deprecated method `io.helidon.common.reactive.Multi.from(java.util.stream.Stream)` in the code. It can be replaced on `io.helidon.common.reactive.Multi.create(java.util.stream.Stream)`.

<img width="400" alt="Screenshot 2024-02-27 at 10 36 57" src="https://github.com/helidon-io/helidon/assets/4740207/0d57a1d9-23d6-4d48-b8b8-7d060b49b490">

- [ ]Check  Backport
