### PR TITLE
Avoid using replicated default values for Lists when creating from builder or instance

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -354,7 +354,7 @@ final class GenerateAbstractBuilder {
         for (PrototypeProperty property : typeContext.propertyData().properties()) {
             TypeName declaredType = property.typeHandler().declaredType();
             if (declaredType.isSet() || declaredType.isList() || declaredType.isMap()) {
-                // add for Set and Map take care of enforcing distinct values themselves, but do so ourselves for List when
+                // Sets and maps take care of enforcing distinct values themselves, but do so ourselves for lists when
                 // adding values from an existing builder which will already have the default(s).
                 methodBuilder.addContent("add"
                                                  + (declaredType.isList() ? "Distinct" : "")
@@ -415,8 +415,8 @@ final class GenerateAbstractBuilder {
                 methodBuilder.addContentLine("builder." + getterName + "().ifPresent(this::" + setterName + ");");
             } else {
                 if (declaredType.isSet() || declaredType.isList() || declaredType.isMap()) {
-                    // add for Set and Map take care of enforcing distinct values themselves, but do so ourselves for List when
-                    // adding values from an existing instance which will already have the default(s).
+                    // Sets and maps take care of enforcing distinct values themselves, but do so ourselves for lists when
+                    // adding values from an existing builder which will already have the default(s).
                     methodBuilder.addContent("add"
                                                      + (declaredType.isList() ? "Distinct" : "")
                                                      + capitalize(property.name()));

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -467,7 +467,7 @@ final class GenerateAbstractBuilder {
                         .name(child.name() + "DiscoverServices")
                         .defaultValue(String.valueOf(child.configuredOption().providerDiscoverServices())));
             }
-            if (child.typeHandler().declaredType().isList()) {
+            if (isBuilder && child.typeHandler().declaredType().isList()) {
                 classBuilder.addField(builder -> builder.type(boolean.class)
                         .name("is" + capitalize(child.name()) + "Mutated")
                         .accessModifier(AccessModifier.PRIVATE));

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -430,21 +430,22 @@ final class GenerateAbstractBuilder {
 
                         if (isXxxMutated) {
                             if (builder.isXxxMutated) {
-                                xxx.addAll(builder.xxx());
+                                addXxx(builder.xxx());
                             }
                         } else {
                             xxx.clear();
-                            xxx.addAll(builder.xxx());
+                            addXxx(builder.xxx());
                         }
                         */
                         String isMutatedProperty = TypeHandlerList.isMutatedField(property.name());
                         methodBuilder.addContentLine("if (" + isMutatedProperty + ") {")
                                 .addContentLine("if (builder." + isMutatedProperty + ") {")
                                 .addContentLine("add" + capitalize(property.name()) + "(builder." + property.name() + ");")
+                                .addContentLine("}")
+                                .decreaseContentPadding() // Ideally would not be needed but makes for nicer generated code.
                                 .addContentLine("} else {")
                                 .addContentLine(property.name() + ".clear();")
                                 .addContentLine("add" + capitalize(property.name()) + "(builder." + property.name() + ");")
-                                .addContentLine("}")
                                 .addContentLine("}");
 
                     } else {

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -354,8 +354,11 @@ final class GenerateAbstractBuilder {
         for (PrototypeProperty property : typeContext.propertyData().properties()) {
             TypeName declaredType = property.typeHandler().declaredType();
             if (declaredType.isSet() || declaredType.isList() || declaredType.isMap()) {
-                methodBuilder.addContent("add");
-                methodBuilder.addContent(capitalize(property.name()));
+                // add for Set and Map take care of enforcing distinct values themselves, but do so ourselves for List when
+                // adding values from an existing builder which will already have the default(s).
+                methodBuilder.addContent("add"
+                                                 + (declaredType.isList() ? "Distinct" : "")
+                                                 + capitalize(property.name()));
                 methodBuilder.addContent("(prototype.");
                 methodBuilder.addContent(property.typeHandler().getterName());
                 methodBuilder.addContentLine("());");
@@ -412,7 +415,11 @@ final class GenerateAbstractBuilder {
                 methodBuilder.addContentLine("builder." + getterName + "().ifPresent(this::" + setterName + ");");
             } else {
                 if (declaredType.isSet() || declaredType.isList() || declaredType.isMap()) {
-                    methodBuilder.addContent("add" + capitalize(property.name()));
+                    // add for Set and Map take care of enforcing distinct values themselves, but do so ourselves for List when
+                    // adding values from an existing instance which will already have the default(s).
+                    methodBuilder.addContent("add"
+                                                     + (declaredType.isList() ? "Distinct" : "")
+                                                     + capitalize(property.name()));
                 } else {
                     methodBuilder.addContent(setterName);
                 }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -48,7 +48,6 @@ import io.helidon.codegen.classmodel.Field;
 import io.helidon.codegen.classmodel.InnerClass;
 import io.helidon.codegen.classmodel.Javadoc;
 import io.helidon.codegen.classmodel.Method;
-import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 
@@ -448,20 +447,6 @@ abstract class TypeHandlerCollection extends TypeHandler.OneTypeHandler {
                 .clearContent()
                 .addContentLine("Objects.requireNonNull(" + name() + ");") //Overwrites existing content
                 .addContentLine("this." + name() + ".addAll(" + name() + ");")
-                .addContentLine("return self();");
-        classBuilder.addMethod(builder);
-
-        // Primarily for use in preventing default values from being included in a list twice using Builder.from.
-        builder.name("addDistinct" + capitalize(name()))
-                .accessModifier(AccessModifier.PROTECTED)
-                .clearContent()
-                .addContentLine("Objects.requireNonNull(" + name() + ");")
-                .addContentLine(name() + ".forEach(newItem -> {")
-                .addContentLine("    if (!this." + name() + ".contains(newItem)) {")
-                .addContentLine("        this." + name() + ".add(newItem);")
-                .addContentLine("}")
-                .addContentLine("}")
-                .addContentLine(");")
                 .addContentLine("return self();");
         classBuilder.addMethod(builder);
     }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -438,6 +438,7 @@ abstract class TypeHandlerCollection extends TypeHandler.OneTypeHandler {
                 .accessModifier(setterAccessModifier(configured))
                 .addContent(Objects.class)
                 .addContentLine(".requireNonNull(" + name() + ");")
+                .update(this::extraSetterContent)
                 .addContentLine("this." + name() + ".clear();")
                 .addContentLine("this." + name() + ".addAll(" + name() + ");")
                 .addContentLine("return self();");
@@ -446,8 +447,18 @@ abstract class TypeHandlerCollection extends TypeHandler.OneTypeHandler {
         builder.name("add" + capitalize(name()))
                 .clearContent()
                 .addContentLine("Objects.requireNonNull(" + name() + ");") //Overwrites existing content
+                .update(this::extraAdderContent)
                 .addContentLine("this." + name() + ".addAll(" + name() + ");")
                 .addContentLine("return self();");
         classBuilder.addMethod(builder);
     }
+
+    Method.Builder extraSetterContent(Method.Builder builder) {
+        return builder;
+    }
+
+    Method.Builder extraAdderContent(Method.Builder builder) {
+        return builder;
+    }
+
 }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -48,6 +48,7 @@ import io.helidon.codegen.classmodel.Field;
 import io.helidon.codegen.classmodel.InnerClass;
 import io.helidon.codegen.classmodel.Javadoc;
 import io.helidon.codegen.classmodel.Method;
+import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 
@@ -447,6 +448,20 @@ abstract class TypeHandlerCollection extends TypeHandler.OneTypeHandler {
                 .clearContent()
                 .addContentLine("Objects.requireNonNull(" + name() + ");") //Overwrites existing content
                 .addContentLine("this." + name() + ".addAll(" + name() + ");")
+                .addContentLine("return self();");
+        classBuilder.addMethod(builder);
+
+        // Primarily for use in preventing default values from being included in a list twice using Builder.from.
+        builder.name("addDistinct" + capitalize(name()))
+                .accessModifier(AccessModifier.PROTECTED)
+                .clearContent()
+                .addContentLine("Objects.requireNonNull(" + name() + ");")
+                .addContentLine(name() + ".forEach(newItem -> {")
+                .addContentLine("    if (!this." + name() + ".contains(newItem)) {")
+                .addContentLine("        this." + name() + ".add(newItem);")
+                .addContentLine("}")
+                .addContentLine("}")
+                .addContentLine(");")
                 .addContentLine("return self();");
         classBuilder.addMethod(builder);
     }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -388,6 +388,7 @@ abstract class TypeHandlerCollection extends TypeHandler.OneTypeHandler {
                 .addContent(Objects.class)
                 .addContentLine(".requireNonNull(" + singularName + ");")
                 .addContentLine("this." + name() + ".add(" + singularName + ");")
+                .update(this::extraAdderContent)
                 .addContentLine("return self();");
         classBuilder.addMethod(builder);
     }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerList.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerList.java
@@ -30,6 +30,10 @@ class TypeHandlerList extends TypeHandlerCollection {
         super(name, getterName, setterName, declaredType, LIST, "toList()", Optional.empty());
     }
 
+    static String isMutatedField(String propertyName) {
+        return "is" + CodegenUtil.capitalize(propertyName) + "Mutated";
+    }
+
     @Override
     Method.Builder extraAdderContent(Method.Builder builder) {
         return builder.addContentLine(isMutatedField() + " = true;");
@@ -41,6 +45,6 @@ class TypeHandlerList extends TypeHandlerCollection {
     }
 
     private String isMutatedField() {
-        return "is" + CodegenUtil.capitalize(name()) + "Mutated";
+        return isMutatedField(name());
     }
 }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerList.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerList.java
@@ -17,15 +17,11 @@
 package io.helidon.builder.codegen;
 
 import java.util.Optional;
-import java.util.function.Predicate;
 
-import io.helidon.codegen.classmodel.InnerClass;
-import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.codegen.CodegenUtil;
 import io.helidon.codegen.classmodel.Method;
-import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.TypeName;
 
-import static io.helidon.codegen.CodegenUtil.capitalize;
 import static io.helidon.common.types.TypeNames.LIST;
 
 class TypeHandlerList extends TypeHandlerCollection {
@@ -35,38 +31,16 @@ class TypeHandlerList extends TypeHandlerCollection {
     }
 
     @Override
-    void setters(InnerClass.Builder classBuilder,
-                 AnnotationDataOption configured,
-                 FactoryMethods factoryMethods,
-                 TypeName returnType,
-                 Javadoc blueprintJavadoc) {
-        super.setters(classBuilder, configured, factoryMethods, returnType, blueprintJavadoc);
-        declaredDistinctSetter(classBuilder, returnType, blueprintJavadoc);
+    Method.Builder extraAdderContent(Method.Builder builder) {
+        return builder.addContentLine(isMutatedField() + " = true;");
     }
 
-    private void declaredDistinctSetter(InnerClass.Builder classBuilder, TypeName returnType, Javadoc blueprintJavadoc) {
+    @Override
+    Method.Builder extraSetterContent(Method.Builder builder) {
+        return builder.addContentLine(isMutatedField() + " = true;");
+    }
 
-        // Primarily for use in preventing default values from being included in a list twice using Builder.from.
-        classBuilder.addImport(Predicate.class);
-        Method.Builder builder = Method.builder()
-                .name("addDistinct" + capitalize(name()))
-                .accessModifier(AccessModifier.PROTECTED)
-                .returnType(returnType, "updated builder instance")
-                .description("Adds distinct values")
-                .addJavadocTag("see", "#" + getterName() + "()")
-                .addParameter(param -> param.name(name())
-                        .type(argumentTypeName())
-                        .description(blueprintJavadoc.returnDescription()))
-
-                .addContentLine("Objects.requireNonNull(" + name() + ");")
-                .addContentLine(name() + ".stream()")
-                .increaseContentPadding()
-                .increaseContentPadding()
-                .addContentLine(".filter(Predicate.not(this." + name() + "::contains))")
-                .addContentLine(".forEach(this." + name() + "::add);")
-                .decreaseContentPadding()
-                .decreaseContentPadding()
-                .addContentLine("return self();");
-        classBuilder.addMethod(builder);
+    private String isMutatedField() {
+        return "is" + CodegenUtil.capitalize(name()) + "Mutated";
     }
 }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerList.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerList.java
@@ -17,14 +17,56 @@
 package io.helidon.builder.codegen;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 
+import io.helidon.codegen.classmodel.InnerClass;
+import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.codegen.classmodel.Method;
+import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.TypeName;
 
+import static io.helidon.codegen.CodegenUtil.capitalize;
 import static io.helidon.common.types.TypeNames.LIST;
 
 class TypeHandlerList extends TypeHandlerCollection {
 
     TypeHandlerList(String name, String getterName, String setterName, TypeName declaredType) {
         super(name, getterName, setterName, declaredType, LIST, "toList()", Optional.empty());
+    }
+
+    @Override
+    void setters(InnerClass.Builder classBuilder,
+                 AnnotationDataOption configured,
+                 FactoryMethods factoryMethods,
+                 TypeName returnType,
+                 Javadoc blueprintJavadoc) {
+        super.setters(classBuilder, configured, factoryMethods, returnType, blueprintJavadoc);
+        declaredDistinctSetter(classBuilder, returnType, blueprintJavadoc);
+    }
+
+    private void declaredDistinctSetter(InnerClass.Builder classBuilder, TypeName returnType, Javadoc blueprintJavadoc) {
+
+        // Primarily for use in preventing default values from being included in a list twice using Builder.from.
+        classBuilder.addImport(Predicate.class);
+        Method.Builder builder = Method.builder()
+                .name("addDistinct" + capitalize(name()))
+                .accessModifier(AccessModifier.PROTECTED)
+                .returnType(returnType, "updated builder instance")
+                .description("Adds distinct values")
+                .addJavadocTag("see", "#" + getterName() + "()")
+                .addParameter(param -> param.name(name())
+                        .type(argumentTypeName())
+                        .description(blueprintJavadoc.returnDescription()))
+
+                .addContentLine("Objects.requireNonNull(" + name() + ");")
+                .addContentLine(name() + ".stream()")
+                .increaseContentPadding()
+                .increaseContentPadding()
+                .addContentLine(".filter(Predicate.not(this." + name() + "::contains))")
+                .addContentLine(".forEach(this." + name() + "::add);")
+                .decreaseContentPadding()
+                .decreaseContentPadding()
+                .addContentLine("return self();");
+        classBuilder.addMethod(builder);
     }
 }

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/DualValuedDefaultValuesBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/DualValuedDefaultValuesBlueprint.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.builder.test.testsubjects;
+
+import java.util.List;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+interface DualValuedDefaultValuesBlueprint {
+
+    String DEFAULT_1 = "default1";
+    String DEFAULT_2 = "default2";
+
+    @Option.Default({DEFAULT_1, DEFAULT_2})
+    List<String> strings();
+
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SingleValuedDefaultValuesBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SingleValuedDefaultValuesBlueprint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.builder.test.testsubjects;
+
+import java.util.List;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+interface SingleValuedDefaultValuesBlueprint {
+
+    String DEFAULT_STRING = "defaultValue";
+
+    @Option.Default(DEFAULT_STRING)
+    List<String> strings();
+
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SingleValuedDefaultValuesBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SingleValuedDefaultValuesBlueprint.java
@@ -26,6 +26,7 @@ interface SingleValuedDefaultValuesBlueprint {
     String DEFAULT_STRING = "defaultValue";
 
     @Option.Default(DEFAULT_STRING)
+    @Option.Singular
     List<String> strings();
 
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/CustomNamedTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/CustomNamedTest.java
@@ -56,7 +56,11 @@ class CustomNamedTest {
                 .build();
         DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
         String json = mapper.writer(printer).writeValueAsString(customNamed);
-        assertThat(json, equalTo("{\n" + "  \"stringSet\" : [ \"b\", \"a\", \"y\" ]\n" + "}"));
+        assertThat(json, equalTo("""
+                                         {
+                                           "isStringListMutated" : false,
+                                           "stringSet" : [ "b", "a", "y" ]
+                                         }"""));
     }
 
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/CustomNamedTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/CustomNamedTest.java
@@ -56,11 +56,7 @@ class CustomNamedTest {
                 .build();
         DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
         String json = mapper.writer(printer).writeValueAsString(customNamed);
-        assertThat(json, equalTo("""
-                                         {
-                                           "isStringListMutated" : false,
-                                           "stringSet" : [ "b", "a", "y" ]
-                                         }"""));
+        assertThat(json, equalTo("{\n" + "  \"stringSet\" : [ \"b\", \"a\", \"y\" ]\n" + "}"));
     }
 
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ListDefaultValuesTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ListDefaultValuesTest.java
@@ -15,14 +15,18 @@
  */
 package io.helidon.builder.test;
 
+import java.util.List;
+
 import io.helidon.builder.test.testsubjects.DualValuedDefaultValues;
 import io.helidon.builder.test.testsubjects.SingleValuedDefaultValues;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.iterableWithSize;
 
 class ListDefaultValuesTest {
 
@@ -31,11 +35,13 @@ class ListDefaultValuesTest {
         SingleValuedDefaultValues original = SingleValuedDefaultValues.create();
         assertThat("Original value",
                    original.strings(),
-                   hasItem(SingleValuedDefaultValues.DEFAULT_STRING));
+                   allOf(hasItem(SingleValuedDefaultValues.DEFAULT_STRING),
+                         iterableWithSize(1)));
         SingleValuedDefaultValues copy = SingleValuedDefaultValues.builder().from(original).build();
         assertThat("Copied value",
                    copy.strings(),
-                   hasItem(SingleValuedDefaultValues.DEFAULT_STRING));
+                   allOf(hasItem(SingleValuedDefaultValues.DEFAULT_STRING),
+                         iterableWithSize(1)));
 
     }
 
@@ -47,7 +53,8 @@ class ListDefaultValuesTest {
 
         assertThat("Copied value",
                    copy.strings(),
-                   hasItem(SingleValuedDefaultValues.DEFAULT_STRING));
+                   allOf(hasItem(SingleValuedDefaultValues.DEFAULT_STRING),
+                         iterableWithSize(1)));
 
     }
 
@@ -56,12 +63,14 @@ class ListDefaultValuesTest {
         DualValuedDefaultValues original = DualValuedDefaultValues.create();
         assertThat("Original values",
                    original.strings(),
-                   hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2));
+                   allOf(hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2),
+                         iterableWithSize(2)));
 
         DualValuedDefaultValues copy = DualValuedDefaultValues.builder().from(original).build();
         assertThat("Copied values",
                    original.strings(),
-                   hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2));
+                   allOf(hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2),
+                         iterableWithSize(2)));
     }
 
     @Test
@@ -71,6 +80,64 @@ class ListDefaultValuesTest {
         DualValuedDefaultValues copy = DualValuedDefaultValues.builder().from(builder).build();
         assertThat("Copied values",
                    copy.strings(),
-                   hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2));
+                   allOf(hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2),
+                         iterableWithSize(2)));
+    }
+
+    @Test
+    void checkSingleDefaultDoubledInBuilder() {
+        SingleValuedDefaultValues original = SingleValuedDefaultValues.builder()
+                .strings(List.of(SingleValuedDefaultValues.DEFAULT_STRING, SingleValuedDefaultValues.DEFAULT_STRING))
+                .build();
+
+        SingleValuedDefaultValues copy = SingleValuedDefaultValues.builder()
+                .from(original)
+                .build();
+        assertThat("Copied values",
+                   copy.strings(),
+                   allOf(hasItems(SingleValuedDefaultValues.DEFAULT_STRING, SingleValuedDefaultValues.DEFAULT_STRING),
+                         iterableWithSize(2)));
+    }
+
+    @Test
+    void checkSingleDefaultWithUpdate() {
+        String value = "non-default";
+        SingleValuedDefaultValues original = SingleValuedDefaultValues.builder()
+                .addStrings(List.of(value))
+                .build();
+
+        assertThat("Original with update",
+                   original.strings(),
+                   allOf(hasItems(value, SingleValuedDefaultValues.DEFAULT_STRING),
+                         iterableWithSize(2)));
+    }
+
+    @Test
+    void checkDualDefaultWithUpdate() {
+        String value = "non-default";
+        DualValuedDefaultValues original = DualValuedDefaultValues.builder()
+                .addStrings(List.of(value))
+                .build();
+        assertThat("Original with update", original.strings(), allOf(hasItems(value,
+                                                                              DualValuedDefaultValues.DEFAULT_1,
+                                                                              DualValuedDefaultValues.DEFAULT_2),
+                                                                     iterableWithSize(3)));
+    }
+
+    @Test
+    void checkSingleDefaultWithoutUpdate() {
+        SingleValuedDefaultValues original = SingleValuedDefaultValues.create();
+
+        assertThat("Original with no update", original.strings(), allOf(hasItems(SingleValuedDefaultValues.DEFAULT_STRING),
+                                                                        iterableWithSize(1)));
+    }
+
+    @Test
+    void checkDualDefaultWithoutUpdate() {
+        DualValuedDefaultValues original = DualValuedDefaultValues.create();
+
+        assertThat("Original with no updates", original.strings(), allOf(hasItems(DualValuedDefaultValues.DEFAULT_1,
+                                                                                  DualValuedDefaultValues.DEFAULT_2),
+                                                                         iterableWithSize(2)));
     }
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ListDefaultValuesTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ListDefaultValuesTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.builder.test;
+
+import io.helidon.builder.test.testsubjects.DualValuedDefaultValues;
+import io.helidon.builder.test.testsubjects.SingleValuedDefaultValues;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+
+class ListDefaultValuesTest {
+
+    @Test
+    void checkSingleDefaultFromInstance() {
+        SingleValuedDefaultValues original = SingleValuedDefaultValues.create();
+        assertThat("Original value",
+                   original.strings(),
+                   hasItem(SingleValuedDefaultValues.DEFAULT_STRING));
+        SingleValuedDefaultValues copy = SingleValuedDefaultValues.builder().from(original).build();
+        assertThat("Copied value",
+                   copy.strings(),
+                   hasItem(SingleValuedDefaultValues.DEFAULT_STRING));
+
+    }
+
+    @Test
+    void checkSingleDefaultFromBuilder() {
+        SingleValuedDefaultValues.Builder builder = SingleValuedDefaultValues.builder();
+
+        SingleValuedDefaultValues copy = SingleValuedDefaultValues.builder().from(builder).build();
+
+        assertThat("Copied value",
+                   copy.strings(),
+                   hasItem(SingleValuedDefaultValues.DEFAULT_STRING));
+
+    }
+
+    @Test
+    void checkDualDefaultFromInstance() {
+        DualValuedDefaultValues original = DualValuedDefaultValues.create();
+        assertThat("Original values",
+                   original.strings(),
+                   hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2));
+
+        DualValuedDefaultValues copy = DualValuedDefaultValues.builder().from(original).build();
+        assertThat("Copied values",
+                   original.strings(),
+                   hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2));
+    }
+
+    @Test
+    void checkDualDefaultFromBuilder() {
+        DualValuedDefaultValues.Builder builder = DualValuedDefaultValues.builder();
+
+        DualValuedDefaultValues copy = DualValuedDefaultValues.builder().from(builder).build();
+        assertThat("Copied values",
+                   copy.strings(),
+                   hasItems(DualValuedDefaultValues.DEFAULT_1, DualValuedDefaultValues.DEFAULT_2));
+    }
+}


### PR DESCRIPTION
### Description
Resolves #8324 

When populating a new builder's `List` property `XXX` from either a builder or an instance, the generated `from` code used `addXXX`. But the `List` for the property in the new builder had already been initialized with the default values so this code improperly added those default values again.

~~The PR causes the builder to generate a new `protected` method `addDistinctXXX` for each `List` property, and the generated `from` methods now invoke that method instead of `addXXX` to avoid adding duplicate default values to the new builder.~~

This PR enhances the code generator so it:
* Creates (in the builder class) an `isXxxMutated` boolean for each `List` property `xxx`.
* Sets the `isXxxMutated` to `true` in the generated `addXxx` and `xxx` methods.
* Generates the two `from` methods so, before adding the corresponding values from the referenced instance or other builder, checks to see if `isXxxMutated` is true:
   * If so, `from` _merges_ the values in the current builder with those from the other object.
   * If not, `from` _overwrites_ the values in the current builder with those from the other object.

Note: Further, the generator creates each `from(Builder)` method so that, if `this` builder's `xxx` values have been mutated then the values from the other builder are added _only if_ the other builder's values were also mutated. This prevents incorrectly adding defaulted values from the other builder to the mutated values in `this` builder.

The same approach _is not_ currently taken in generating the `from(Prototype)` method. That can be a later refinement if the need arises and would require adding `isXxxMutated` to the generated implementation class and setting it based on the builder's value of `isXxxMutated`.

The PR adds tests for `List` properties with single-valued defaults and dual-valued defaults.

This PR touches some files also touched by Tomas's big PR but these changes are minor and should be easily reconciled.

### Documentation
Bug fix - no doc impact.
