### PR TITLE
[3.x] Replace deprecated Multi.from(Stream) on Multi.create(Stream)

### DIFF
--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/KafkaSeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -425,7 +425,7 @@ public class KafkaSeTest extends AbstractKafkaTest {
         Messaging messaging = Messaging.builder()
                 .connector(kafkaConnector)
                 .publisher(toKafka,
-                        Multi.from(IntStream.rangeClosed(1, 3).boxed())
+                        Multi.create(IntStream.rangeClosed(1, 3).boxed())
                                 .map(KafkaMessage::of)
                                 .peek(msg -> msg.getHeaders()
                                         .add("secret header",


### PR DESCRIPTION
### Description
Backport 3.x - https://github.com/helidon-io/helidon/pull/8424