### PR TITLE
[4.x] Security validation of docs with examples snippets

### DIFF
--- a/docs/src/main/asciidoc/config/io_helidon_security_providers_httpsign_HttpSignProvider.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_security_providers_httpsign_HttpSignProvider.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ This type provides the following service implementations:
           keys: [
           {
               key-id = "service1"
-              hmac.secret = "${CLEAR=password}"
+              hmac.secret = "${CLEAR=changeit}"
           }]
       }
   }
@@ -108,7 +108,7 @@ This type provides the following service implementations:
           # This configures the OutboundTargetDefinition
           signature {
               key-id = "service1"
-              hmac.secret = "${CLEAR=password}"
+              hmac.secret = "${CLEAR=changeit}"
           }
       }]
   }

--- a/docs/src/main/asciidoc/includes/security/providers/http-basic-auth.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/http-basic-auth.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -53,10 +53,10 @@ security:
       realm: "helidon"
       users:
       - login: "john"
-        password: "${CLEAR=password}"
+        password: "${CLEAR=changeit}"
         roles: ["admin"]
       - login: "jack"
-        password: "password"
+        password: "changeit"
         roles: ["user", "admin"]
       outbound:
         - name: "internal-services"
@@ -68,7 +68,7 @@ security:
           hosts: ["*.partner.org"]
           # Uses this username and password
           username: "partner-user-1"
-          password: "${CLEAR=password}"
+          password: "${CLEAR=changeit}"
 ----
 
 ==== How does it work?

--- a/docs/src/main/asciidoc/includes/security/providers/http-digest-auth.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/http-digest-auth.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -52,10 +52,10 @@ security:
       server-secret: "${CLEAR=service-wide-secret-not-known-outside}"
       users:
       - login: "john"
-        password: "${CLEAR=password}"
+        password: "${CLEAR=changeit}"
         roles: ["admin"]
       - login: "jack"
-        password: "password"
+        password: "changeit"
         roles: ["user", "admin"]
 ----
 

--- a/docs/src/main/asciidoc/includes/security/providers/http-signatures.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/http-signatures.adoc
@@ -55,13 +55,13 @@ security:
           keys:
             - key-id: "service1-hmac"
               principal-name: "Service1 - HMAC signature"
-              hmac.secret: "${CLEAR=somePasswordForHmacShouldBeEncrypted}"
+              hmac.secret: "${CLEAR=changeit}"
             - key-id: "service1-rsa"
               principal-name: "Service1 - RSA signature"
               public-key:
                 keystore:
                   resource.path: "src/main/resources/keystore.p12"
-                  passphrase: "password"
+                  passphrase: "changeit"
                   cert.alias: "service_cert"
         outbound:
           - name: "service2-hmac"
@@ -69,7 +69,7 @@ security:
             paths: ["/service2"]
             signature:
               key-id: "service1-hmac"
-              hmac.secret: "${CLEAR=somePasswordForHmacShouldBeEncrypted}"
+              hmac.secret: "${CLEAR=changeit}"
           - name: "service2-rsa"
             hosts: ["localhost"]
             paths: ["/service2-rsa.*"]
@@ -78,7 +78,7 @@ security:
               private-key:
                 keystore:
                   resource.path: "src/main/resources/keystore.p12"
-                  passphrase: "password"
+                  passphrase: "changeit"
                   key.alias: "myPrivateKey"
 ----
 

--- a/docs/src/main/asciidoc/includes/security/providers/idcs-role-mapper.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/idcs-role-mapper.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ security:
         multitenant: false
         oidc-config:
             client-id: "client-id"
-            client-secret: "client-secret"
+            client-secret: "changeit"
             identity-uri: "IDCS identity server address"
 ----
 

--- a/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
@@ -35,7 +35,7 @@ security:
   providers:
   - oidc:
       client-id: "client-id-of-this-service"
-      client-secret: "${CLEAR=client-secret-of-this-service}"
+      client-secret: "${CLEAR=changeit}"
       identity-uri: "https://your-tenant.identity-server.com"
       frontend-uri: "http://my-service:8080"
       audience: "http://my-service"


### PR DESCRIPTION
### Description

align password mentions in documentation (examples snippets) with actual passwords from examples.

