### PR TITLE
Fix OTel agent detector test that was polluting the JVM for later tests

### DIFF
--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -32,6 +32,11 @@
         Support for MicroProfile Telemetry
     </description>
 
+    <properties>
+        <!-- The default for the following is 5000 ms. Reducing it speeds up tests significantly. -->
+        <otel.bsp.schedule.delay>100</otel.bsp.schedule.delay>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.tracing.providers</groupId>
@@ -141,8 +146,9 @@
                     <execution>
                         <id>default-test</id>
                         <configuration>
-                            <!-- The default for the following is 5000 ms. Reducing it significantly speeds up tests. -->
-                            <argLine>-Dotel.bsp.schedule.delay=100</argLine>
+                            <systemPropertyVariables>
+                                <otel.bsp.schedule.delay>${otel.bsp.schedule.delay}</otel.bsp.schedule.delay>
+                            </systemPropertyVariables>
                         </configuration>
                     </execution>
                 </executions>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -143,7 +143,6 @@
                         <configuration>
                             <!-- The default for the following is 5000 ms. Reducing it significantly speeds up tests. -->
                             <argLine>-Dotel.bsp.schedule.delay=100</argLine>
-
                         </configuration>
                     </execution>
                 </executions>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -137,12 +137,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
-                    <!-- The default for the following is 5000 ms. Reducing it significantly speeds up tests. -->
-                    <argLine>-Dotel.bsp.schedule.delay=100</argLine>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <!-- The default for the following is 5000 ms. Reducing it significantly speeds up tests. -->
+                            <argLine>-Dotel.bsp.schedule.delay=100</argLine>
+
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AgentDetectorTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/AgentDetectorTest.java
@@ -24,6 +24,7 @@ import io.helidon.microprofile.testing.junit5.HelidonTest;
 import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
 
 import jakarta.enterprise.inject.spi.CDI;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,9 +55,18 @@ class AgentDetectorTest {
 
     @Test
     void checkEnvVariable(){
-        System.setProperty(HelidonOpenTelemetry.IO_OPENTELEMETRY_JAVAAGENT, "true");
-        Config config = CDI.current().select(Config.class).get();
-        boolean present = HelidonOpenTelemetry.AgentDetector.isAgentPresent(config);
-        assertThat(present, is(true));
+        var originalAgentPropertyValue = System.setProperty(HelidonOpenTelemetry.IO_OPENTELEMETRY_JAVAAGENT, "true");
+        try {
+            Config config = CDI.current().select(Config.class).get();
+            boolean present = HelidonOpenTelemetry.AgentDetector.isAgentPresent(config);
+            assertThat(present, is(true));
+        } finally {
+            // Restore or clear the agent setting to avoid polluting other tests which might follow.
+            if (originalAgentPropertyValue != null) {
+                System.setProperty(HelidonOpenTelemetry.IO_OPENTELEMETRY_JAVAAGENT, originalAgentPropertyValue);
+            } else {
+                System.clearProperty(HelidonOpenTelemetry.IO_OPENTELEMETRY_JAVAAGENT);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description
Resolves #8448 

Some pipeline runs and some developers' local builds experienced reliable failures, other pipeline runs and developers saw no problems.

There had been some conjecture that some static storage was contributing to this problem.

Instead, the problem turned out to be a bug in the `AgentDetectorTest` class.

#### Background
Our `AgentDetector` examines config and system properties (and the OTel context) to try to determine if the OTel agent is present. Our `OpenTelemetryProducer` uses the `AgentDetector` to decide whether to use the `OpenTelemetry` instance that the agent will already have set (if the agent is present) or to initialize and set an `OpenTelemetry` instance according to current config settings (if the agent is absent).

Some of our tests use an in-memory `TestSpanExporter` to see if spans were managed as expected. The use of this test exporter is conveyed through configuration that is set at test-time and so _will not_ be used if the agent is detected.

#### The problem

The `AgentDetectorTest` set a system property to make sure that the detector correctly responded, but the test did not reset or clear the system property after the test.

If the agent test ran before other tests that depended on our custom in-memory collector, the later tests would fail because tests would skip using the configuration to prepare OTel and, therefore, the in-memory collector. Because span data would not  be sent to the in-memory collector in those cases, tests that expected span data in order to check it would fail. The non-deterministic ordering of test execution explains why some builds saw failures while others did not.


#### The fix
The PR changes the `AgentDetectorTest` to restore or clear the system property at the end of the test to avoid disrupting later tests.

The PR also removes the changes to the surefire plug-in config that forces tests into their own JVMs since that workaround is no longer needed.

I verified the problem and the fix by temporarily forcing the order of the tests so the agent detector test preceded at least one of the tests that failed.

### Documentation
No impact.