### PR TITLE
Bump graphql-java version to 21.x

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -54,8 +54,8 @@
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.google-protobuf>3.21.7</version.lib.google-protobuf>
         <version.lib.graalvm>23.1.0</version.lib.graalvm>
-        <version.lib.graphql-java>18.6</version.lib.graphql-java>
-        <version.lib.graphql-java.extended.scalars>18.3</version.lib.graphql-java.extended.scalars>
+        <version.lib.graphql-java>21.3</version.lib.graphql-java>
+        <version.lib.graphql-java.extended.scalars>21.0</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
         <version.lib.grpc>1.60.0</version.lib.grpc>
         <version.lib.guava>32.0.1-jre</version.lib.guava>


### PR DESCRIPTION
### Description

The current version of GraphQL doesn't work well applications running as Java Modules. The following error occurs when running with `java -p`

`> helidon-quickstart-se $JAVA_HOME/bin/java  --list-modules -p target/libs/ 
Error occurred during initialization of boot layer java.lang.module.FindException: Two versions of module com.graphqljava found in target/libs (graphql-java-18.6.jar and java-dataloader-3.1.2.jar)`

Updating the library version solves the problem

### Documentation

None
