### PR TITLE
3.x: Docs: fix GitHub urls

### DIFF
--- a/docs/community.adoc
+++ b/docs/community.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -33,13 +33,13 @@ Have a question?
 
 * Ask them in in Slack at http://slack.helidon.io[#helidon-user]
 * Or on https://stackoverflow.com/questions/tagged/helidon[Stack Overflow] using the `helidon` tag
-* Read the https://github.com/oracle/helidon/wiki/FAQ[Helidon FAQ]
+* Read the https://github.com/helidon-io/helidon/wiki/FAQ[Helidon FAQ]
 
 == Code and Issues
 
-* Helidon source is hosted on https://github.com/oracle/helidon[GitHub].
+* Helidon source is hosted on https://github.com/helidon-io/helidon[GitHub].
 * If you'd like to report a bug, enhancement request, or check if an
-issue is on our list, visit the https://github.com/oracle/helidon/issues[Helidon GitHub issue tracker].
+issue is on our list, visit the https://github.com/helidon-io/helidon/issues[Helidon GitHub issue tracker].
 
 
 == Stay Informed

--- a/docs/includes/attributes.adoc
+++ b/docs/includes/attributes.adoc
@@ -24,14 +24,16 @@ ifndef::attributes-included[]
 :imagesdir: {rootdir}/images
 
 :helidon-version: 3.2.7-SNAPSHOT
-:helidon-version-is-release: true
+:helidon-version-is-release: false
 
 ifeval::["{helidon-version-is-release}" != "true"]
-:helidon-github-tree-url: https://github.com/oracle/helidon/tree/master
+:helidon-github-tree-url: https://github.com/helidon-io/helidon/tree/helidon-3.x
+:helidon-github-examples-url: https://github.com/helidon-io/helidon-examples/tree/helidon-3.x/examples
 endif::[]
 
 ifeval::["{helidon-version-is-release}" == "true"]
-:helidon-github-tree-url: https://github.com/oracle/helidon/tree/{helidon-version}
+:helidon-github-tree-url: https://github.com/helidon-io/helidon/tree/{helidon-version}
+:helidon-github-examples-url: https://github.com/helidon-io/helidon-examples/tree/{helidon-version}/examples
 endif::[]
 
 // versions
@@ -85,7 +87,7 @@ endif::[]
 :jdk-doc-url: https://docs.oracle.com/en/java/javase/17
 :jdk-javadoc-url: {jdk-doc-url}/docs/api
 
-:helidon-maven-plugin-doc-url: https://github.com/oracle/helidon-build-tools/blob/{version-plugin-helidon}/maven-plugins/helidon-maven-plugin/README.md
+:helidon-maven-plugin-doc-url: https://github.com/helidon-io/helidon-build-tools/blob/{version-plugin-helidon}/maven-plugins/helidon-maven-plugin/README.md
 
 // MicroProfile versioned URLs
 

--- a/docs/includes/guides/maven-build.adoc
+++ b/docs/includes/guides/maven-build.adoc
@@ -41,7 +41,7 @@ link:{helidon-github-examples-url}/quickstarts/helidon-standalone-quickstart-{fl
 This example has a stand-alone POM that you can pattern your own application POM after.
 
 For more details on Helidon application POMs see the
-link:{helidon-github-url}/docs-internal/application-pom.md[Helidon's Application POMS]
+link:{helidon-github-tree-url}/docs-internal/application-pom.md[Helidon's Application POMS]
 
 == Dependency Management
 

--- a/docs/includes/guides/maven-build.adoc
+++ b/docs/includes/guides/maven-build.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -37,11 +37,11 @@ use a Helidon application POM as their parent. This parent POM provides the foll
    Helidon application.
 
 If you want to use your own parent POM, then take a look at the
-link:{helidon-github-tree-url}/examples/quickstarts/helidon-standalone-quickstart-{flavor-lc}[standalone quickstart example].
+link:{helidon-github-examples-url}/quickstarts/helidon-standalone-quickstart-{flavor-lc}[standalone quickstart example].
 This example has a stand-alone POM that you can pattern your own application POM after.
 
 For more details on Helidon application POMs see the
-link:{helidon-github-tree-url}/docs-internal/application-pom.md[Helidon's Application POMS]
+link:{helidon-github-url}/docs-internal/application-pom.md[Helidon's Application POMS]
 
 == Dependency Management
 
@@ -98,7 +98,7 @@ Helidon provides a Maven plugin that, among other things, provides the following
 1. native-image: Build a xref:{guidesdir}/graalnative.adoc[GraalVM native image].
 2. jlink-image:  Build a xref:{guidesdir}/jlink-image.adoc[custom runtime Java image].
 
-For full documentation of the plugin please see the https://github.com/oracle/helidon-build-tools/tree/master/maven-plugins/helidon-maven-plugin[Helidon Maven Plugin README].
+For full documentation of the plugin please see the https://github.com/helidon-io/helidon-build-tools/tree/master/maven-plugins/helidon-maven-plugin[Helidon Maven Plugin README].
 
 If you use the Helidon application parent POM you will have this plugin configured
 for you. If you need to customize the `helidon-maven-plugin` you can do so in a few ways:

--- a/docs/mp/integrations/neo4j.adoc
+++ b/docs/mp/integrations/neo4j.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -221,7 +221,8 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
 
 ----
 
-Full example code is available in link:https://github.com/oracle/helidon/tree/master/examples/integrations/neo4j/neo4j-mp[Helidon GitHub Repository].
+Full example code is available in
+link:{helidon-github-examples-url}/integrations/neo4j/neo4j-mp[Helidon GitHub Repository].
 
 
 == Additional Information

--- a/docs/mp/lra.adoc
+++ b/docs/mp/lra.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -412,7 +412,7 @@ CAUTION: Experimental tool, usage in production is not advised.
 [source,bash]
 .Build and run Helidon LRA coordinator
 ----
-docker build -t helidon/lra-coordinator https://github.com/oracle/helidon.git#:lra/coordinator/server
+docker build -t helidon/lra-coordinator https://github.com/helidon-io/helidon.git#:lra/coordinator/server
 docker run -dp 8070:8070 --name lra-coordinator --network="host" helidon/lra-coordinator
 ----
 

--- a/docs/mp/persistence.adoc
+++ b/docs/mp/persistence.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -518,7 +518,7 @@ once it has been <<DS-Setup,set up>> and
 <<DS-Configuration,configured>>, create an ordinary
 link:{jdk-javadoc-url}/java.sql/javax/sql/DataSource.html[`DataSource`]-typed
 injection point in a
-https://github.com/oracle/helidon/wiki/FAQ#how-do-i-make-a-class-a-cdi-bean[Java
+https://github.com/helidon-io/helidon/wiki/FAQ#how-do-i-make-a-class-a-cdi-bean[Java
 class representing a CDI bean] somewhere in your application,
 link:{jakarta-inject-javadoc-url}/jakarta/inject/named[annotated with
 the name] of the data source you wish to use.
@@ -1399,8 +1399,7 @@ relational database tables, and how to perform other related tasks.
 
 === Examples [[JPA-Examples]]
 
-* link:{helidon-github-tree-url}/examples/integrations/cdi/pokemons[JPA
-  Pokemons Example]
+* link:{helidon-github-examples-url}/integrations/cdi/pokemons[JPA Pokemons Example]
   
 === References [[JPA-References]]
 

--- a/docs/mp/server.adoc
+++ b/docs/mp/server.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -400,4 +400,4 @@ NOTE: The `requestContext.getUriInfo()` method returns the Jakarta RESTful web s
 == Reference
 
 * link:https://helidon.io/docs/v2/apidocs/io.helidon.microprofile.server/module-summary.html[Helidon MicroProfile Server Javadoc]
-* link:https://github.com/oracle/helidon/tree/master/microprofile/server[Helidon MicroProfile Server on GitHub]
+* link:{helidon-github-tree-url}/microprofile/server[Helidon MicroProfile Server on GitHub]

--- a/docs/se/integrations/neo4j.adoc
+++ b/docs/se/integrations/neo4j.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -268,8 +268,7 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
 
 ----
 
-Full example code is available in link:https://github.com/oracle/helidon/tree/master/examples/integrations/neo4j/neo4j-mp[Helidon GitHub Repository].
-
+Full example code is available in link:{helidon-github-examples-url}/integrations/neo4j/neo4j-se[Helidon GitHub Repository].
 
 == Additional Information
 

--- a/docs/se/reactive-messaging.adoc
+++ b/docs/se/reactive-messaging.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -482,7 +482,7 @@ messaging = Messaging.builder()
 
 Don't forget to check out the examples with pre-configured Kafka docker image, for easy testing:
 
-* https://github.com/oracle/helidon/tree/master/examples/messaging
+* link:{helidon-github-examples-url}/messaging[Helidon Messaging Examples]
 
 ==== JMS Connector
 
@@ -621,7 +621,7 @@ messaging = Messaging.builder()
 
 Don't forget to check out the examples with pre-configured ActiveMQ docker image, for easy testing:
 
-* https://github.com/oracle/helidon/tree/master/examples/messaging
+* link:{helidon-github-examples-url}/messaging[Helidon Messaging Examples]
 
 ==== AQ Connector
 

--- a/docs/se/security/providers.adoc
+++ b/docs/se/security/providers.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ include::{rootdir}/includes/security/providers/jwt.adoc[]
 
 == Reference
 
-* link:{https://github.com/oracle/helidon/tree/master/examples/security[Helidon Security Examples]
+* link:{helidon-github-examples-url}/security[Helidon Security Examples]
 * link:{security-provider-oidc-base-url}/module-summary.html[Helidon OIDC JavaDoc]
 * link:{security-provider-httpauth-base-url}/module-summary.html[Helidon HTTP Authentication JavaDoc]
 * link:{security-provider-header-base-url}/module-summary.html[Helidon Header Authentication JavaDoc]

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -131,16 +131,6 @@ update_version(){
         mv ${pom}.tmp ${pom}
     done
 
-    # Hack to update helidon.version in build.gradle files
-    for bfile in `egrep "helidonversion = .*" -r . --include build.gradle | cut -d ':' -f 1 | sort | uniq `
-    do
-        echo "Updating helidonversion property in ${bfile} to ${FULL_VERSION}"
-        cat ${bfile} | \
-            sed -e s@'helidonversion = .*'@"helidonversion = \'${FULL_VERSION}\'"@g \
-            > ${bfile}.tmp
-        mv ${bfile}.tmp ${bfile}
-    done
-
     # Hack to update helidon-version in doc files
     for dfile in `egrep ":helidon-version: .*" -r . --include attributes.adoc | cut -d ':' -f 1 | sort | uniq `
     do

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -153,7 +153,7 @@ update_version(){
 
     # Hack to update helidon-version-is-release in doc files
     # We are a released version if we are not a SNAPSHOT version
-    if [[ ${HELIDON_VERSION} == *-SNAPSHOT ]]; then
+    if [[ ${FULL_VERSION} == *-SNAPSHOT ]]; then
         readonly IS_RELEASED="false"
     else
         readonly IS_RELEASED="true"


### PR DESCRIPTION
### Description

1. Fix URLs in docs (especially to examples) that point to github
2. Update release.sh to not look for gradle files (since we removed examples)
3. Fix issue where `release.sh update_version` was not setting  `helidon-version-is-release` correctly

### Documentation

This fixes documentation.
