### PR TITLE
4.x: Fix buffering of content in our Jersey integration.

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -379,8 +379,7 @@ class JaxRsService implements HttpService {
 
         @Override
         public boolean enableResponseBuffering() {
-            // Jersey should not try to do the buffering
-            return true;
+            return true;        // enable buffering in Jersey
         }
 
         public void await() {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +190,8 @@ class JaxRsService implements HttpService {
         ContainerRequest requestContext = new ContainerRequest(uris.baseUri,
                                                                uris.requestUri,
                                                                req.prologue().method().text(),
-                                                               new HelidonMpSecurityContext(), new MapPropertiesDelegate(),
+                                                               new HelidonMpSecurityContext(),
+                                                               new MapPropertiesDelegate(),
                                                                resourceConfig);
         /*
          MP CORS supports needs a way to obtain the UriInfo from the request context.
@@ -379,7 +380,7 @@ class JaxRsService implements HttpService {
         @Override
         public boolean enableResponseBuffering() {
             // Jersey should not try to do the buffering
-            return false;
+            return true;
         }
 
         public void await() {

--- a/microprofile/tests/tck/tck-core-profile/pom.xml
+++ b/microprofile/tests/tck/tck-core-profile/pom.xml
@@ -48,7 +48,7 @@
                         <configuration>
                             <target>
                                 <!-- If you use proxy you need to set it as a system properties -->
-                                <get skipexisting="true" src="https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip&amp;mirror_id=1281" dest="jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip"/>
+                                <get skipexisting="true" src="https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip" dest="jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip"/>
                                 <unzip src="jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip" dest="./target"/>
                                 <chmod file="artifact-install.sh" perm="+x"/>
                                 <exec executable="sh">

--- a/microprofile/tests/tck/tck-core-profile/pom.xml
+++ b/microprofile/tests/tck/tck-core-profile/pom.xml
@@ -48,7 +48,7 @@
                         <configuration>
                             <target>
                                 <!-- If you use proxy you need to set it as a system properties -->
-                                <get skipexisting="true" src="https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip" dest="jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip"/>
+                                <get skipexisting="true" src="https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip&amp;mirror_id=1281" dest="jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip"/>
                                 <unzip src="jakarta-core-profile-tck-${version.lib.microprofile-core-profile}.zip" dest="./target"/>
                                 <chmod file="artifact-install.sh" perm="+x"/>
                                 <exec executable="sh">

--- a/microprofile/tests/tck/tck-jsonb/pom.xml
+++ b/microprofile/tests/tck/tck-jsonb/pom.xml
@@ -48,7 +48,7 @@
                         <configuration>
                             <target>
                                 <!-- If you use proxy you need to set it as a system properties -->
-                                <get skipexisting="true" src="https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/promoted/eftl/jakarta-jsonb-tck-${version.lib.jakarta.jsonb-api}.zip" dest="jakarta-jsonb-tck-${version.lib.jakarta.jsonb-api}.zip"/>
+                                <get skipexisting="true" src="https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/promoted/eftl/jakarta-jsonb-tck-${version.lib.jakarta.jsonb-api}.zip" dest="jakarta-jsonb-tck-${version.lib.jakarta.jsonb-api}.zip"/>
                                 <unzip src="jakarta-jsonb-tck-${version.lib.jakarta.jsonb-api}.zip" dest="./target"/>
                                 <chmod file="target/jsonb-tck/artifacts/artifact-install.sh" perm="+x"/>
                                 <exec dir="target/jsonb-tck/artifacts" executable="sh">

--- a/microprofile/tests/tck/tck-restful/pom.xml
+++ b/microprofile/tests/tck/tck-restful/pom.xml
@@ -48,7 +48,7 @@
                         <configuration>
                             <target>
                                 <!-- If you use proxy you need to set it as a system properties -->
-                                <get skipexisting="true" src="https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-restful-ws-tck-${version.lib.microprofile-restful-tck}.zip" dest="jakarta-restful-ws-tck-${version.lib.microprofile-restful-tck}.zip"/>
+                                <get skipexisting="true" src="https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-restful-ws-tck-${version.lib.microprofile-restful-tck}.zip" dest="jakarta-restful-ws-tck-${version.lib.microprofile-restful-tck}.zip"/>
                                 <unzip src="jakarta-restful-ws-tck-${version.lib.microprofile-restful-tck}.zip" dest="./target"/>
                                 <chmod file="artifact-install.sh" perm="+x"/>
                                 <exec executable="sh">

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/MaxPayloadSizeTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/MaxPayloadSizeTest.java
@@ -100,7 +100,7 @@ class MaxPayloadSizeTest {
                         it.write(PAYLOAD_BYTES);
                         it.write(PAYLOAD_BYTES);
                         it.write(PAYLOAD_BYTES);
-                    } catch (IOException e) {
+                    } catch (IOException | UncheckedIOException e) {
                         // ignored -- possible connection reset
                     }
                 })) {


### PR DESCRIPTION
### Description
Fix buffering of content in Jersey (our integration), to use `Content-Length` instead of chunked encoding for smaller entities.
