### PR TITLE
2.x: Add versions.xml so Helidon 2 archetypes can be tested with latest helidon CLI

### DIFF
--- a/archetypes/catalog/pom.xml
+++ b/archetypes/catalog/pom.xml
@@ -117,6 +117,13 @@
                                     <files>
                                         <file target="cli-data/latest">${project.version}</file>
                                     </files>
+                                    <templates>
+                                        <template source="versions.xml.mustache" target="cli-data/versions.xml">
+                                            <variables>
+                                                <variable name="version" value="${project.version}"/>
+                                            </variables>
+                                        </template>
+                                    </templates>
                                 </directory>
                             </directories>
                         </configuration>

--- a/archetypes/catalog/versions.xml.mustache
+++ b/archetypes/catalog/versions.xml.mustache
@@ -1,0 +1,22 @@
+<!--
+
+    Copyright (c) 2023 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<data>
+    <archetypes>
+        <version>{{version}}</version>
+    </archetypes>
+</data>


### PR DESCRIPTION
### Description

Backports fix from 4.x/3.x that creates the versions.xml file so that you can run the helidon CLI directly against the Helidon 2 built archetypes.

See #7176

### Documentation

No impact