### PR TITLE
Add `close()` method to `DbClient` to allow proper resource cleanup

### DIFF
--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClient.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import io.helidon.dbclient.spi.DbMapperProvider;
 /**
  * Helidon database client.
  */
-public interface DbClient {
+public interface DbClient extends AutoCloseable {
 
     /**
      * Qualifier used for mapping using {@link io.helidon.common.mapper.MapperManager#map(Object, Class, Class, String...)}.
@@ -76,6 +76,13 @@ public interface DbClient {
      * @throws UnsupportedOperationException when provided class is not supported
      */
     <C> C unwrap(Class<C> cls);
+
+
+    /**
+     * Closes the DbClient and releases any associated resources.
+     */
+    @Override
+    void close();
 
     /**
      * Create Helidon database client.

--- a/dbclient/hikari/src/main/java/io/helidon/dbclient/hikari/HikariConnectionPool.java
+++ b/dbclient/hikari/src/main/java/io/helidon/dbclient/hikari/HikariConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,13 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.config.Config;
 import io.helidon.dbclient.DbClientException;
 import io.helidon.dbclient.hikari.spi.HikariMetricsProvider;
+import io.helidon.dbclient.jdbc.CloseableJdbcConnectionPool;
 import io.helidon.dbclient.jdbc.JdbcConnectionPool;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
-class HikariConnectionPool implements JdbcConnectionPool {
+class HikariConnectionPool implements CloseableJdbcConnectionPool {
 
     private final HikariDataSource dataSource;
     private final String dbType;
@@ -69,6 +70,11 @@ class HikariConnectionPool implements JdbcConnectionPool {
             throw new DbClientException(
                     String.format("Failed to create a connection to %s", dataSource.getJdbcUrl()), ex);
         }
+    }
+
+    @Override
+    public void close() {
+        dataSource.close();
     }
 
     @Override

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/CloseableJdbcConnectionPool.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/CloseableJdbcConnectionPool.java
@@ -12,36 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-package io.helidon.dbclient;
+ */package io.helidon.dbclient.jdbc;
 
 /**
- * Base {@link DbClient} implementation.
+ * CloseableJdbcConnectionPool is an interface that represents a JDBC connection pool that can be closed.
+ * It extends the JdbcConnectionPool interface and the AutoCloseable interface.
+ *
+ * @see JdbcConnectionPool
+ * @see AutoCloseable
  */
-public abstract class DbClientBase implements DbClient {
-
-    private final DbClientContext context;
-
-    /**
-     * Create a new instance.
-     *
-     * @param context context
-     */
-    protected DbClientBase(DbClientContext context) {
-        this.context = context;
-    }
-
-    /**
-     * Get the {@link DbClientContext}.
-     *
-     * @return DbClientContext
-     */
-    public DbClientContext context() {
-        return context;
-    }
-
-    @Override
-    public void close() {
-        // No-op by default
-    }
+public interface CloseableJdbcConnectionPool extends JdbcConnectionPool, AutoCloseable {
 }

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcClient.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.dbclient.jdbc;
 
+import java.lang.System.Logger.Level;
 import java.sql.Connection;
 
 import io.helidon.dbclient.DbClient;
@@ -24,6 +25,7 @@ import io.helidon.dbclient.DbClientBase;
  * Helidon DB implementation for JDBC drivers.
  */
 class JdbcClient extends DbClientBase implements DbClient {
+    private static final System.Logger LOGGER = System.getLogger(JdbcClient.class.getName());
 
     private final JdbcConnectionPool connectionPool;
 
@@ -62,6 +64,17 @@ class JdbcClient extends DbClientBase implements DbClient {
     @Override
     public JdbcClientContext context() {
         return (JdbcClientContext) super.context();
+    }
+
+    @Override
+    public void close() {
+        if (connectionPool instanceof CloseableJdbcConnectionPool) {
+            try {
+                ((AutoCloseable) connectionPool).close();
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Failed to close the connection pool", e);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
### Description:
Fixes #8402

Currently, there is no way to explicitly close a `DbClient` instance, which leads to connection leaks and resource exhaustion, particularly when using JDBC with the Hikari connection pool. This issue becomes evident in testing scenarios where multiple tests create `DbClient` instances, causing the database to refuse new connections after a certain number of tests.

This pull request addresses this issue by:

1. Adding a `close()` method to the `DbClient` interface, allowing users to explicitly close the `DbClient` and release associated resources.

2. Implementing the `close()` method in the `DbClientBase` class with a default no-op implementation.

3. Overriding the `close()` method in the `JdbcClient` class to close the underlying connection pool when the `DbClient` is closed.

4. Introducing a new `CloseableJdbcConnectionPool` interface that extends `JdbcConnectionPool` and `AutoCloseable`, ensuring that the connection pool can be properly closed.

5. Updating the `HikariConnectionPool` class to implement the `CloseableJdbcConnectionPool` interface and close the `HikariDataSource` in the `close()` method.

With these changes, users can now explicitly close the `DbClient` when it is no longer needed, ensuring that resources are properly released. This is particularly useful in testing scenarios where multiple `DbClient` instances are created and need to be cleaned up to prevent resource leaks.

Furthermore, the `DbClient` interface now extends `AutoCloseable`, allowing it to be used in try-with-resources statements for automatic resource management.

Example usage:
```java
try (DbClient dbClient = DbClient.create(config)) {
    // Use the dbClient
    // ...
} // dbClient.close() will be called automatically
```

