### PR TITLE
Refactors JtaConnection to allow status enforcement by JTA implementation

### DIFF
--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -30,10 +30,13 @@
     <name>Helidon CDI Integrations JPA</name>
 
     <properties>
-      <doclint>-syntax</doclint>
-      <eclipselink.skip>false</eclipselink.skip>
-      <hibernate.skip>false</hibernate.skip>
-      <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+        <doclint>-syntax</doclint>
+        <eclipselink.skip>false</eclipselink.skip>
+        <helidon.jta.immediateEnlistment>false</helidon.jta.immediateEnlistment>
+        <helidon.jta.interposedSynchronizations>true</helidon.jta.interposedSynchronizations>
+        <helidon.jta.preemptiveEnlistmentChecks>true</helidon.jta.preemptiveEnlistmentChecks>
+        <hibernate.skip>false</hibernate.skip>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
     </properties>
 
     <dependencies>
@@ -291,6 +294,9 @@
                     <reportNameSuffix>eclipselink</reportNameSuffix>
                     <skip>${eclipselink.skip}</skip>
                     <systemPropertyVariables>
+                        <helidon.jta.immediateEnlistment>${helidon.jta.immediateEnlistment}</helidon.jta.immediateEnlistment>
+                        <helidon.jta.interposedSynchronizations>${helidon.jta.interposedSynchronizations}</helidon.jta.interposedSynchronizations>
+                        <helidon.jta.preemptiveEnlistmentChecks>${helidon.jta.preemptiveEnlistmentChecks}</helidon.jta.preemptiveEnlistmentChecks>
                         <java.util.logging.config.file>${project.basedir}/src/test/logging.properties</java.util.logging.config.file>
                     </systemPropertyVariables>
                     <testClassesDirectory>${project.build.directory}/eclipselink/test-classes</testClassesDirectory>

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JtaAdaptingDataSourceProvider.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JtaAdaptingDataSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,8 @@ final class JtaAdaptingDataSourceProvider implements PersistenceUnitInfoBean.Dat
 
     private final boolean immediateEnlistment;
 
+    private final boolean preemptiveEnlistmentChecks;
+
     private final ExceptionConverter exceptionConverter;
 
 
@@ -118,6 +120,8 @@ final class JtaAdaptingDataSourceProvider implements PersistenceUnitInfoBean.Dat
             Boolean.parseBoolean(System.getProperty("helidon.jta.interposedSynchronizations", "true"));
         this.immediateEnlistment =
             Boolean.parseBoolean(System.getProperty("helidon.jta.immediateEnlistment", "false"));
+        this.preemptiveEnlistmentChecks =
+            Boolean.parseBoolean(System.getProperty("helidon.jta.preemptiveEnlistmentChecks", "true"));
         Instance<ExceptionConverter> i = objects.select(ExceptionConverter.class);
         this.exceptionConverter = i.isUnsatisfied() ? null : i.get();
     }
@@ -167,7 +171,8 @@ final class JtaAdaptingDataSourceProvider implements PersistenceUnitInfoBean.Dat
                                                                                 this.interposedSynchronizations,
                                                                                 this.exceptionConverter,
                                                                                 this.objects.select(DataSource.class).get(),
-                                                                                this.immediateEnlistment));
+                                                                                this.immediateEnlistment,
+                                                                                this.preemptiveEnlistmentChecks));
     }
 
     private JtaAdaptingDataSource getNamedJtaDataSource(String name) {
@@ -179,7 +184,8 @@ final class JtaAdaptingDataSourceProvider implements PersistenceUnitInfoBean.Dat
                                                                                 this.exceptionConverter,
                                                                                 this.objects.select(DataSource.class,
                                                                                                     NamedLiteral.of(n)).get(),
-                                                                                this.immediateEnlistment));
+                                                                                this.immediateEnlistment,
+                                                                                this.preemptiveEnlistmentChecks));
     }
 
     private DataSource getNamedNonJtaDataSource(String name) {

--- a/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/JtaAdaptingDataSource.java
+++ b/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/JtaAdaptingDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,9 @@ public final class JtaAdaptingDataSource extends AbstractDataSource {
      * made immediately upon {@link Connection} allocation
      *
      * @exception NullPointerException if {@code ts}, {@code tsr} or {@code ds} is {@code null}
+     *
+     * @see #JtaAdaptingDataSource(TransactionSupplier, TransactionSynchronizationRegistry, boolean, ExceptionConverter,
+     * DataSource, boolean, boolean)
      */
     public JtaAdaptingDataSource(TransactionSupplier ts,
                                  TransactionSynchronizationRegistry tsr,
@@ -87,6 +90,49 @@ public final class JtaAdaptingDataSource extends AbstractDataSource {
                                  ExceptionConverter ec,
                                  DataSource ds,
                                  boolean immediateEnlistment) {
+        this(ts, tsr, interposedSynchronizations, ec, ds, immediateEnlistment, true);
+    }
+
+    /**
+     * Creates a new {@link JtaAdaptingDataSource} that wraps the supplied {@link DataSource} and helps its {@linkplain
+     * DataSource#getConnection() connections} participate in XA transactions.
+     *
+     * <p>Behavior is left deliberately undefined if the supplied {@link DataSource}'s {@link
+     * DataSource#getConnection()} or {@link DataSource#getConnection(String, String)} methods are implemented to return
+     * or augment the return value of an invocation of the {@link javax.sql.PooledConnection#getConnection()
+     * XAConnection#getConnection()} method.  Less formally, and in general, this class is deliberately not designed to
+     * work with JDBC constructs that are already XA-aware.</p>
+     *
+     * @param ts a {@link TransactionSupplier}; must not be {@code null}
+     *
+     * @param tsr a {@link TransactionSynchronizationRegistry}; must not be {@code null}
+     *
+     * @param interposedSynchronizations whether any {@link jakarta.transaction.Synchronization Synchronization}s
+     * registered should be registered as interposed synchronizations; see {@link
+     * TransactionSynchronizationRegistry#registerInterposedSynchronization(jakarta.transaction.Synchronization)} and
+     * {@link jakarta.transaction.Transaction#registerSynchronization(jakarta.transaction.Synchronization)}
+     *
+     * @param ec an {@link ExceptionConverter}; may be {@code null} in which case a default implementation will be used
+     * instead
+     *
+     * @param ds a {@link DataSource} that may not be XA-compliant; must not be {@code null}; normally supplied by a
+     * connection pool implementation
+     *
+     * @param immediateEnlistment whether attempts to enlist new {@link Connection}s in a global transaction should be
+     * made immediately upon {@link Connection} allocation
+     *
+     * @param preemptiveEnlistmentChecks whether early checks will be made to see if an enlistment attempt will succeed,
+     * or whether enlistment validation will be performed by the JTA implementation
+     *
+     * @exception NullPointerException if {@code ts}, {@code tsr} or {@code ds} is {@code null}
+     */
+    public JtaAdaptingDataSource(TransactionSupplier ts,
+                                 TransactionSynchronizationRegistry tsr,
+                                 boolean interposedSynchronizations,
+                                 ExceptionConverter ec,
+                                 DataSource ds,
+                                 boolean immediateEnlistment,
+                                 boolean preemptiveEnlistmentChecks) {
         super();
         Objects.requireNonNull(ts, "ts");
         Objects.requireNonNull(tsr, "tsr");
@@ -99,9 +145,24 @@ public final class JtaAdaptingDataSource extends AbstractDataSource {
             // the (inherited) PooledConnection#close() method, which reads, in part: "An application never calls this
             // method directly; it is called by the connection pool module, or manager."  As of this writing this branch
             // of this constructor implements this non-standard behavior.
-            this.acs =
-                (u, p) -> xa(ts, tsr, interposedSynchronizations, ec, xads.getXAConnection(u, p), immediateEnlistment, true);
-            this.uacs = () -> xa(ts, tsr, interposedSynchronizations, ec, xads.getXAConnection(), immediateEnlistment, true);
+            this.acs = (u, p) ->
+                xa(ts,
+                   tsr,
+                   interposedSynchronizations,
+                   ec,
+                   xads.getXAConnection(u, p),
+                   immediateEnlistment,
+                   preemptiveEnlistmentChecks,
+                   true);
+            this.uacs = () ->
+                xa(ts,
+                   tsr,
+                   interposedSynchronizations,
+                   ec,
+                   xads.getXAConnection(),
+                   immediateEnlistment,
+                   preemptiveEnlistmentChecks,
+                   true);
         } else {
             Objects.requireNonNull(ds, "ds");
             this.acs =
@@ -156,6 +217,59 @@ public final class JtaAdaptingDataSource extends AbstractDataSource {
                                  XADataSource xads,
                                  boolean immediateEnlistment,
                                  boolean closeXac) {
+        this(ts, tsr, interposedSynchronizations, ec, xads, immediateEnlistment, true, closeXac);
+    }
+
+    /**
+     * Creates a new {@link JtaAdaptingDataSource} that adapts the supplied {@link XADataSource} and helps {@link
+     * Connection}s it indirectly supplies (by way of its {@linkplain XADataSource#getXAConnection() associated
+     * <code>XAConnection</code>}) participate in XA transactions.
+     *
+     * @param ts a {@link TransactionSupplier}; must not be {@code null}
+     *
+     * @param tsr a {@link TransactionSynchronizationRegistry}; must not be {@code null}
+     *
+     * @param interposedSynchronizations whether any {@link jakarta.transaction.Synchronization Synchronization}s
+     * registered should be registered as interposed synchronizations; see {@link
+     * TransactionSynchronizationRegistry#registerInterposedSynchronization(jakarta.transaction.Synchronization)} and
+     * {@link jakarta.transaction.Transaction#registerSynchronization(jakarta.transaction.Synchronization)}
+     *
+     * @param ec an {@link ExceptionConverter}; may be {@code null} in which case a default implementation will be used
+     * instead
+     *
+     * @param xads an {@link XADataSource} supplied by a connection pool implementation; must not be {@code null}
+     *
+     * @param immediateEnlistment whether attempts to enlist new {@link Connection}s in a global transaction should be
+     * made immediately upon {@link Connection} allocation
+     *
+     * @param preemptiveEnlistmentChecks whether early checks will be made to see if an enlistment attempt will succeed,
+     * or whether enlistment validation will be performed by the JTA implementation
+     *
+     * @param closeXac whether or not {@link XAConnection}s {@linkplain XADataSource#getXAConnection() supplied} by the
+     * supplied {@link XADataSource} should be {@linkplain javax.sql.PooledConnection#close() closed} when {@linkplain
+     * XAConnection#getConnection() their <code>Connection</code>}s are {@linkplain Connection#close() closed} (in a
+     * non-standard fashion)
+     *
+     * @exception NullPointerException if {@code ts}, {@code tsr} or {@code xads} is {@code null}
+     *
+     * @deprecated This constructor exists only to handle certain XA-aware connection pools that allow an end-user
+     * caller to "borrow" {@link XAConnection}s and to "return" them using their {@link
+     * javax.sql.PooledConnection#close() close()} methods, a non-standard practice which is discouraged by the
+     * documentation of {@link javax.sql.PooledConnection} (from which {@link XAConnection} inherits).  For
+     * such connection pools, {@link XAConnection}s that are "borrowed" must be returned in this manner to avoid leaks.
+     * This constructor implements this behavior.  Before using it, you should make sure that the connection pool in
+     * question implementing or supplying the {@link XADataSource} has the behavior described above; normally an {@link
+     * XAConnection} should not be used directly or closed by end-user code.
+     */
+    @Deprecated(since = "3.1.0")
+    public JtaAdaptingDataSource(TransactionSupplier ts,
+                                 TransactionSynchronizationRegistry tsr,
+                                 boolean interposedSynchronizations,
+                                 ExceptionConverter ec,
+                                 XADataSource xads,
+                                 boolean immediateEnlistment,
+                                 boolean preemptiveEnlistmentChecks,
+                                 boolean closeXac) {
         super();
         Objects.requireNonNull(xads, "xads");
         Objects.requireNonNull(ts, "ts");
@@ -168,8 +282,24 @@ public final class JtaAdaptingDataSource extends AbstractDataSource {
         // is called by the connection pool module, or manager."  As of this writing this constructor permits this
         // non-standard behavior when closeXac is true.
         this.acs =
-            (u, p) -> xa(ts, tsr, interposedSynchronizations, ec, xads.getXAConnection(u, p), immediateEnlistment, closeXac);
-        this.uacs = () -> xa(ts, tsr, interposedSynchronizations, ec, xads.getXAConnection(), immediateEnlistment, closeXac);
+            (u, p) ->
+            xa(ts,
+               tsr,
+               interposedSynchronizations,
+               ec,
+               xads.getXAConnection(u, p),
+               immediateEnlistment,
+               preemptiveEnlistmentChecks,
+               closeXac);
+        this.uacs = () ->
+            xa(ts,
+               tsr,
+               interposedSynchronizations,
+               ec,
+               xads.getXAConnection(),
+               immediateEnlistment,
+               preemptiveEnlistmentChecks,
+               closeXac);
     }
 
     @Override // DataSource
@@ -189,12 +319,14 @@ public final class JtaAdaptingDataSource extends AbstractDataSource {
 
 
     @Deprecated
+    @SuppressWarnings("ParameterNumber")
     private static JtaConnection xa(TransactionSupplier ts,
                                     TransactionSynchronizationRegistry tsr,
                                     boolean interposedSynchronizations,
                                     ExceptionConverter ec,
                                     XAConnection xac,
                                     boolean immediateEnlistment,
+                                    boolean preemptiveEnlistmentChecks,
                                     boolean closeXac)
         throws SQLException {
         if (closeXac) {
@@ -204,13 +336,16 @@ public final class JtaAdaptingDataSource extends AbstractDataSource {
             // reads: "An application never calls this method directly; it is called by the connection pool module, or
             // manager." This branch of this method implements this non-standard behavior, ensuring that both the
             // Connection and its sourcing XAConnection are closed appropriately.
-            return new JtaConnection(ts,
-                                     tsr,
-                                     interposedSynchronizations,
-                                     ec,
-                                     xac.getConnection(),
-                                     xac::getXAResource,
-                                     immediateEnlistment) {
+            return
+                new JtaConnection(ts,
+                                  tsr,
+                                  interposedSynchronizations,
+                                  ec,
+                                  xac.getConnection(),
+                                  xac::getXAResource,
+                                  null, // no Xid consumer
+                                  immediateEnlistment,
+                                  preemptiveEnlistmentChecks) {
                 @Override
                 protected void onClose() throws SQLException {
                     xac.close();
@@ -224,7 +359,9 @@ public final class JtaAdaptingDataSource extends AbstractDataSource {
                               ec,
                               xac.getConnection(),
                               xac::getXAResource,
-                              immediateEnlistment);
+                              null, // no Xid consumer
+                              immediateEnlistment,
+                              preemptiveEnlistmentChecks);
     }
 
 

--- a/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/JtaConnection.java
+++ b/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/JtaConnection.java
@@ -1275,7 +1275,7 @@ class JtaConnection extends ConditionallyCloseableConnection {
 
         this.validateTransactionStatusForEnlistment(currentThreadTransactionStatus);
 
-        if (!super.getAutoCommit()) {
+        if (this.preemptiveEnlistmentChecks && !super.getAutoCommit()) {
             // There is, as far as we can tell, a global transaction on the current thread, and super.getAutoCommit()
             // (super. on purpose, not this., to prevent a circular call to enlist()) returned false, and we aren't
             // (yet) enlisted with the global transaction, so autoCommit must have been disabled on purpose by the

--- a/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/JtaConnection.java
+++ b/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/JtaConnection.java
@@ -1112,6 +1112,7 @@ class JtaConnection extends ConditionallyCloseableConnection {
         if (currentThreadTransactionStatus == Status.STATUS_NO_TRANSACTION) {
             return false;
         }
+
         Enlistment enlistment = this.enlistment; // volatile read
         if (enlistment != null) {
             if (enlistment.threadId() != Thread.currentThread().threadId()) {
@@ -1213,6 +1214,9 @@ class JtaConnection extends ConditionallyCloseableConnection {
             }
         }
 
+        // Violates checkstyle, but if it didn't we could do:
+        // assert enlistment == null;
+
         this.validateTransactionStatusForEnlistment(currentThreadTransactionStatus);
 
         if (!super.getAutoCommit()) {
@@ -1222,7 +1226,7 @@ class JtaConnection extends ConditionallyCloseableConnection {
             // been disabled on purpose by the caller, not by the transaction enlistment machinery. In such a case, we
             // don't want to permit enlistment, because a local transaction may be in progress and we don't want to have
             // its effects mixed in.
-            throw new SQLTransientException("autoCommit was false during active transaction enlistment",
+            throw new SQLTransientException("autoCommit was false during transaction enlistment",
                                             INVALID_TRANSACTION_STATE_NO_SUBCLASS);
         }
 

--- a/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/LocalXAResource.java
+++ b/integrations/jta/jdbc/src/main/java/io/helidon/integrations/jta/jdbc/LocalXAResource.java
@@ -722,6 +722,23 @@ final class LocalXAResource implements XAResource {
         // T1: Associated
         // T2: Association Suspended
 
+        /*
+          digraph "Transaction States (Jakarta Transactions Specification)" {
+              t0 [label="Not Associated\n(t0)"];
+              t1 [label="Associated\n(t1)"];
+              t2 [label="Association\nSuspended\n(t2)"];
+
+              t0 -> t1 [label="start()"];
+              t0 -> t1 [label="start() [TMJOIN]"];
+
+              t1 -> t0 [label="end() [TMFAIL, TMSUCCESS"];
+              t1 -> t2 [label="end() [TMSUSPEND]"];
+
+              t2 -> t0 [label="end() [TMFAIL, TMSUCCESS]"]
+              t2 -> t1 [label="start() [TMRESUME]"];
+          }
+        */
+
         // Branch States: (XA specification, table 6-4)
         // S0: Non-existent Transaction
         // S1: Active

--- a/integrations/jta/jdbc/src/test/java/io/helidon/integrations/jta/jdbc/TestNarayanaBehavior.java
+++ b/integrations/jta/jdbc/src/test/java/io/helidon/integrations/jta/jdbc/TestNarayanaBehavior.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.jta.jdbc;
+
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.Thread.currentThread;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static jakarta.transaction.Status.STATUS_ACTIVE;
+import static jakarta.transaction.Status.STATUS_NO_TRANSACTION;
+import static jakarta.transaction.Status.STATUS_ROLLEDBACK;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class TestNarayanaBehavior {
+
+    private static final JTAEnvironmentBean jtaEnvironmentBean = new JTAEnvironmentBean();
+
+    private TransactionManager tm;
+
+    private TransactionSynchronizationRegistry tsr;
+
+    private TestNarayanaBehavior() {
+        super();
+    }
+
+    @BeforeEach
+    final void initializeTransactionManager() throws SystemException {
+        this.tm = jtaEnvironmentBean.getTransactionManager(); // com.arjuna.ats.jta.TransactionManager.transactionManager();
+        this.tm.setTransactionTimeout(20 * 60); // 20 minutes for debugging
+    }
+
+    @BeforeEach
+    final void initializeTransactionSynchronizationRegistry() throws SystemException {
+        this.tsr = jtaEnvironmentBean.getTransactionSynchronizationRegistry();
+    }
+
+    @AfterEach
+    final void rollback() throws SystemException {
+        if (this.tm.getStatus() != STATUS_NO_TRANSACTION) {
+            this.tm.rollback();
+        }
+    }
+
+    @AfterEach
+    final void resetTransactionTimeout() throws SystemException {
+        this.tm.setTransactionTimeout(0); // set back to the default
+    }
+
+    @Test
+    final void testCanCallGetResourceInAfterCompletion() throws NotSupportedException, SystemException {
+        tm.begin();
+        boolean[] afterCompletionCalled = new boolean[] { false };
+        final Synchronization s = new Synchronization() {
+                @Override
+                public final void beforeCompletion() {}
+                @Override
+                public final void afterCompletion(final int status) {
+                    try {
+                        // (Kind of interesting you have access to the TSR after the transaction is over.)
+                        assertThat(tsr.getResource("MARCO"), is("POLO"));
+                    } finally {
+                        afterCompletionCalled[0] = true;
+                    }
+                }
+            };
+        tsr.registerInterposedSynchronization(s);
+        tm.setRollbackOnly();
+        // (Kind of interesting you can put resources when the transaction is marked for rollback.)
+        tsr.putResource("MARCO", "POLO");
+        tm.rollback();
+        assertThat(afterCompletionCalled[0], is(true));
+        assertThrows(IllegalStateException.class, () -> tsr.getResource("MARCO"));
+    }
+    
+    @Test
+    final void testCanCallGetResourceAfterSettingRollbackOnly() throws NotSupportedException, SystemException {
+        tm.begin();
+        tsr.putResource("MARCO", "POLO");
+        tm.setRollbackOnly();
+        assertThat(tsr.getResource("MARCO"), is("POLO"));
+    }
+
+    @Test
+    final void testCanCallPutResourceAfterSettingRollbackOnly() throws NotSupportedException, SystemException {
+        tm.begin();
+        tm.setRollbackOnly();
+        // Interesting. You can put a resource after rollback only, but, for example, you can't enlist a resource. Nor
+        // can you register a Synchronization. But you could, laboriously, accomplish both those things using this
+        // facility. So I'm not sure why the probibitions that exist are in place.
+        tsr.putResource("MARCO", "POLO");
+        assertThat(tsr.getResource("MARCO"), is("POLO"));
+    }
+
+    @Test
+    final void testCannotRegisterInterposedSynchronizationAfterSettingRollbackOnly()
+        throws NotSupportedException, SystemException {
+        tm.begin();
+        final Synchronization s = new Synchronization() {
+                @Override
+                public final void beforeCompletion() {}
+                @Override
+                public final void afterCompletion(final int status) {}
+            };
+        tm.setRollbackOnly();
+        // If you set the rollback only status first, as we just did, then you cannot register a synchronization; see
+        // below. It is not *immediately* obvious why this is prohibited by the specification.  See
+        // https://www.eclipse.org/lists/jta-dev/msg00323.html.
+        assertThrows(IllegalStateException.class, () -> this.tsr.registerInterposedSynchronization(s));
+    }
+
+    @Test
+    final void testCannotRegisterSynchronizationAfterSettingRollbackOnly() throws NotSupportedException, SystemException {
+        tm.begin();
+        final Transaction t = tm.getTransaction();
+        final Synchronization s = new Synchronization() {
+                @Override
+                public final void beforeCompletion() {}
+                @Override
+                public final void afterCompletion(final int status) {}
+            };
+        tm.setRollbackOnly();
+        // If you set the rollback only status first, as we just did, then you cannot register a synchronization; see
+        // below. It is not *immediately* obvious why this is prohibited by the specification.  See
+        // https://www.eclipse.org/lists/jta-dev/msg00323.html.
+        assertThrows(RollbackException.class, () -> t.registerSynchronization(s));
+    }
+
+    @Test
+    final void testCannotEnlistResourceAfterSettingRollbackOnly()
+        throws NotSupportedException, SystemException {
+        tm.begin();
+        tm.setRollbackOnly();
+        assertThrows(RollbackException.class, () -> tm.getTransaction().enlistResource(new NoOpXAResource()));
+    }
+
+    @Test
+    final void testTimeout() throws InterruptedException, NotSupportedException, SystemException {
+        tm.setTransactionTimeout(1); // 1 second; the minimum settable value (0 means "use the default" (!))
+        tm.begin();
+
+        // For this test, where transaction reaping is set to happen soon, it still won't happen in under 1000
+        // milliseconds, so this assertion is OK unless the testing environment is completely pathological. For
+        // real-world scenarios, you shouldn't assume anything about the initial status.
+        assertThat(tm.getStatus(), is(STATUS_ACTIVE));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Thread mainThread = currentThread();
+        boolean[] afterCompletionCalled = new boolean[] { false };
+
+        tsr.registerInterposedSynchronization(new Synchronization() {
+                @Override
+                public void beforeCompletion() {
+                    // Perhaps surprisingly you can put things in the TSR even while the two-phase commit process is
+                    // starting.
+                    tsr.putResource("MARCO", "POLO");
+                }
+                @Override
+                public void afterCompletion(int status) {
+                    try {
+                        // Perhaps surprisingly, you can get things out of the TSR even after the transaction is
+                        // disassociated and the two-phase commit process has committed. Note that this means among
+                        // other things that the specification's (strange) prohibition on registering synchronizations
+                        // when a transaction is in the marked-for-rollback state can be easily bypassed, in which case
+                        // I wonder why it exists?
+                        assertThat(tsr.getResource("MARCO"), is("POLO"));
+                        assertThat(status, is(STATUS_ROLLEDBACK));
+                        assertThat(currentThread(), not(mainThread));
+                    } finally {
+                        afterCompletionCalled[0] = true;
+                        latch.countDown();
+                    }
+                }
+            });
+
+        // Wait for the transaction to roll back on the reaper thread, not the main thread. The transaction timeout is 1
+        // second (see above); here we wait for 2 seconds max. If this fails with an InterruptedException, which should be
+        // impossible, check the logs for Narayana warning that the assertions in the synchronization above failed.
+        latch.await(2, SECONDS);
+
+        // Make sure the Synchronization fired.
+        assertThat(afterCompletionCalled[0], is(Boolean.TRUE));
+
+        // In this case, we never issued a rollback ourselves and we never acquired a Transaction. Here we show that you
+        // can get a Transaction that, perhaps somewhat surprisingly, but correctly, is initially in a rolled back
+        // state.
+        //
+        // Verify there *was* a transaction but now it is rolled back, so is essentially useless other than as a
+        // tombstone.
+        Transaction t = tm.getTransaction();
+        assertThat(t, notNullValue());
+        assertThat(t.getStatus(), is(STATUS_ROLLEDBACK));
+
+        // Verify that all the other status accessors return the same thing.
+        assertThat(tm.getStatus(), is(STATUS_ROLLEDBACK));
+        assertThat(tsr.getTransactionStatus(), is(STATUS_ROLLEDBACK));
+
+        // Verify that indeed you cannot enlist any XAResource in the transaction when it is in the rolled back state.
+        assertThrows(IllegalStateException.class, () -> t.enlistResource(new NoOpXAResource()));
+
+        // Verify that even though the current transaction is rolled back you can still roll it back again (no-op) and
+        // disassociate it from the current thread.
+        tm.rollback();
+        assertThat(tm.getStatus(), is(STATUS_NO_TRANSACTION));
+        assertThat(tsr.getTransactionStatus(), is(STATUS_NO_TRANSACTION));
+
+        // The Transaction itself remains in status STATUS_ROLLEDBACK. Notably it never enters STATUS_NO_TRANSACTION.
+        assertThat(t.getStatus(), is(STATUS_ROLLEDBACK));
+    }
+
+}


### PR DESCRIPTION
This pull request refactors `JtaConnection` (and makes requisite changes in other files to accommodate) so that if desired all enlistment validation can be performed by the JTA implementation, rather than proactively by the Helidon classes.

This pull request is in response to #8441 but it is not clear that the desired use case is supportable. The refactorings help more cleanly separate responsibilities, however.

The refactorings are behind a system property for the moment (`helidon.jta.preemptiveEnlistmentChecks`). To run an application with these refactorings in effect, pass `false` for this value (it is `true` by default for backwards compatibility).

Documentation impact: none; this is an internal refactoring only.