### PR TITLE
4.x: Add version check to release script

### DIFF
--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -175,6 +175,14 @@ update_version(){
 }
 
 release_build(){
+
+    VERSION_FROM_BRANCH_NAME=$(git branch --show-current | cut -d- -f2)
+    if [ "${FULL_VERSION}" != "${VERSION_FROM_BRANCH_NAME}" ]; then
+      echo "ERROR: version derived from pom files (${FULL_VERSION}) does not match version used in branch name (${VERSION_FROM_BRANCH_NAME})."
+      echo "Failing release build"
+      exit 1
+    fi
+
     # Do the release work in a branch
     local GIT_BRANCH="release/${FULL_VERSION}"
     git branch -D "${GIT_BRANCH}" > /dev/null 2>&1 || true

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This adds a check to the release script to make sure that when we push to a release branch the version we are releasing (derived from the version in the pom files) matches the version used in the release branch.  This is an extra check to avoid human error where we forget to update the SNAPSHOT version in the poms before releasing.
