### PR TITLE
4.x: Archetype - Kubernetes uses `ClusterIP` instead of `NodePort`

### DIFF
--- a/archetypes/archetypes/src/main/archetype/common/files/app.yaml.mustache
+++ b/archetypes/archetypes/src/main/archetype/common/files/app.yaml.mustache
@@ -5,13 +5,15 @@ metadata:
   labels:
     app: {{artifactId}}
 spec:
-  type: NodePort
+  type: ClusterIP
+  clusterIP: 10.43.32.195   # Use the clusterIP of your choice
   selector:
     app: {{artifactId}}
   ports:
-  - port: 8080
-    targetPort: 8080
-    name: http
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
 ---
 kind: Deployment
 apiVersion: apps/v1

--- a/archetypes/archetypes/src/main/archetype/common/files/app.yaml.mustache
+++ b/archetypes/archetypes/src/main/archetype/common/files/app.yaml.mustache
@@ -6,7 +6,6 @@ metadata:
     app: {{artifactId}}
 spec:
   type: ClusterIP
-  clusterIP: 10.43.32.195   # Use the clusterIP of your choice
   selector:
     app: {{artifactId}}
   ports:

--- a/archetypes/archetypes/src/main/archetype/common/packaging.xml
+++ b/archetypes/archetypes/src/main/archetype/common/packaging.xml
@@ -37,8 +37,7 @@
                     </templates>
                     <model>
                     <list key="readme-sections">
-                    <value order="50" template="mustache">
-                        <![CDATA[
+                    <value order="50" template="mustache"><![CDATA[
 ## Run the application in Kubernetes
 
 If you don’t have access to a Kubernetes cluster, you can [install one](https://helidon.io/docs/latest/#/about/kubernetes) on your desktop.
@@ -59,20 +58,20 @@ kubectl get pods                            # Verify connectivity to cluster
 ### Deploy the application to Kubernetes
 
 ```
-kubectl create -f app.yaml                  # Deploy application
-kubectl get pods                            # Wait for quickstart pod to be RUNNING
-kubectl get service  {{artifactId}}         # Get service info
+kubectl create -f app.yaml                              # Deploy application
+kubectl get pods                                        # Wait for quickstart pod to be RUNNING
+kubectl get service  {{artifactId}}                     # Get service info
+kubectl port-forward service/{{artifactId}} 8081:8080   # Forward service port to 8081
 ```
 
-Note the PORTs. You can now exercise the application as you did before but use the second
-port number (the NodePort) instead of 8080.
+You can now exercise the application as you did before but use the port number 8081.
 
 After you’re done, cleanup.
 
 ```
 kubectl delete -f app.yaml
 ```
-                                ]]>
+]]>
                             </value>
                         </list>
                     </model>


### PR DESCRIPTION
### Description

Change Kubernetes service configuration to use ClusterIP instead of NodePort

fix  #8460

### Documentation

no impact
