### PR TITLE
4.x: Introducing a test to validate that combination of config annotations…

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,6 +237,8 @@ public class FaultToleranceExtension implements Extension {
 
     void close(@Observes BeforeShutdown shutdown) {
         FaultToleranceMetrics.close();
+        // we need to clear method cache, as the next start could use different config
+        MethodInvoker.clearMethodStatesMap();
     }
 
     /**

--- a/tests/integration/mp-gh-8478/pom.xml
+++ b/tests/integration/mp-gh-8478/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-gh-8478</artifactId>
+    <name>Helidon Tests Integration MP GH 8478</name>
+    <description>Reproducer for Github issue #8478 - Fault tolerance config fails in HelidonTest </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-gh-8478/src/main/java/io/helidon/tests/integration/gh8478/Gh8478Resource.java
+++ b/tests/integration/mp-gh-8478/src/main/java/io/helidon/tests/integration/gh8478/Gh8478Resource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8478;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@Path("/greet")
+@Retry
+@Timeout
+public class Gh8478Resource {
+    private static final Logger LOGGER = Logger.getLogger(Gh8478Resource.class.getName());
+
+    static final AtomicInteger COUNTER = new AtomicInteger();
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getDefaultMessage() throws InterruptedException {
+        COUNTER.incrementAndGet();
+
+        LOGGER.info("Attempt #" + COUNTER.get() + " before sleep.");
+        Thread.sleep(100);
+        if (COUNTER.get() == 3) {
+            LOGGER.info("Attempt #" + COUNTER.get() + " returning response.");
+            return "Hello World!";
+        }
+
+        LOGGER.info("Attempt #" + COUNTER.get() + " throwing exception.");
+        throw new ForbiddenException("Intentional exception");
+    }
+}

--- a/tests/integration/mp-gh-8478/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-gh-8478/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/mp-gh-8478/src/main/resources/application.yaml
+++ b/tests/integration/mp-gh-8478/src/main/resources/application.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 8080
+  host: 0.0.0.0
+
+io.helidon.tests.integration.gh8478.Gh8478Resource/Retry/enabled: true
+io.helidon.tests.integration.gh8478.Gh8478Resource/Timeout/enabled: true
+io.helidon.tests.integration.gh8478.Gh8478Resource/Retry/maxRetries: 3
+io.helidon.tests.integration.gh8478.Gh8478Resource/Timeout/value: 5000

--- a/tests/integration/mp-gh-8478/src/main/resources/logging.properties
+++ b/tests/integration/mp-gh-8478/src/main/resources/logging.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=io.helidon.common.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+.level=WARNING
+
+io.helidon.level=INFO

--- a/tests/integration/mp-gh-8478/src/test/java/io/helidon/tests/integration/gh8478/Gh8478Test.java
+++ b/tests/integration/mp-gh-8478/src/test/java/io/helidon/tests/integration/gh8478/Gh8478Test.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8478;
+
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@HelidonTest
+@AddConfig(key ="io.helidon.tests.integration.gh8478.Gh8478Resource/Retry/enabled", value = "true")
+@AddConfig(key ="io.helidon.tests.integration.gh8478.Gh8478Resource/Retry/maxRetries", value = "1")
+@AddConfig(key ="io.helidon.tests.integration.gh8478.Gh8478Resource/Timeout/enabled", value = "true")
+@AddConfig(key ="io.helidon.tests.integration.gh8478.Gh8478Resource/Timeout/value", value = "10000")
+class Gh8478Test {
+    @Inject
+    private WebTarget target;
+
+    @BeforeEach
+    void setUp() {
+        Gh8478Resource.COUNTER.set(0);
+    }
+
+    @Test
+    void test() {
+        assertThrows(ForbiddenException.class, () -> target
+                .path("/greet")
+                .request()
+                .get(String.class));
+    }
+}

--- a/tests/integration/mp-gh-8478/src/test/java/io/helidon/tests/integration/gh8478/Gh8478YamlTest.java
+++ b/tests/integration/mp-gh-8478/src/test/java/io/helidon/tests/integration/gh8478/Gh8478YamlTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8478;
+
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+class Gh8478YamlTest {
+    @Inject
+    private WebTarget target;
+
+    @BeforeEach
+    void setUp() {
+        Gh8478Resource.COUNTER.set(0);
+    }
+
+    @Test
+    void test() {
+        String response = target
+                .path("/greet")
+                .request()
+                .get(String.class);
+
+        assertThat(response, is("Hello World!"));
+    }
+}

--- a/tests/integration/mp-gh-8478/src/test/resources/application.yaml
+++ b/tests/integration/mp-gh-8478/src/test/resources/application.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+config_ordinal: 500
+io.helidon.tests.integration.gh8478.Gh8478Resource/Retry/enabled: true
+io.helidon.tests.integration.gh8478.Gh8478Resource/Timeout/enabled: false
+io.helidon.tests.integration.gh8478.Gh8478Resource/Retry/maxRetries: 3

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -53,6 +53,7 @@
         <module>mp-gh-4123</module>
         <module>mp-gh-4654</module>
         <module>mp-gh-5328</module>
+        <module>mp-gh-8478</module>
         <module>mp-graphql</module>
         <module>mp-security-client</module>
         <module>mp-ws-services</module>


### PR DESCRIPTION
… and test yaml works in HelidonTest together with FaultTolerance.
And actual fix of the problem - the same way this was fixed in 2.x.

Related to https://github.com/helidon-io/helidon/issues/8478
"forward port" of https://github.com/helidon-io/helidon/pull/8487

###Description
This was a bug in 2.x that is fixed as a side effect of other changes in 3.x. Adding a test to make sure we continue supporting this.