### PR TITLE
Respect named port selection in MicrometerSupport for endpoint

### DIFF
--- a/integrations/micrometer/cdi/src/test/java/io/helidon/integrations/micrometer/cdi/AlternateSocketTest.java
+++ b/integrations/micrometer/cdi/src/test/java/io/helidon/integrations/micrometer/cdi/AlternateSocketTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.micrometer.cdi;
+
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import io.helidon.microprofile.tests.junit5.Socket;
+
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddConfig(key = "server.sockets.1.name", value = "micrometer-socket")
+@AddConfig(key = "server.sockets.1.bind-address", value = "0.0.0.0")
+@AddConfig(key = "micrometer.routing", value = AlternateSocketTest.SOCKET_NAME)
+@AddConfig(key = "micrometer.web-context", value = AlternateSocketTest.WEB_CONTEXT)
+class AlternateSocketTest {
+
+    static final String WEB_CONTEXT = "/mymicrometer";
+    static final String SOCKET_NAME = "micrometer-socket";
+
+    @Inject
+    @Socket(SOCKET_NAME)
+    private WebTarget webTargetForNamedSocket;
+
+    @Inject
+    private WebTarget webTargetDefault;
+
+    @Test
+    void testAlternateSocket(SeContainer seContainer) {
+        Response response = webTargetForNamedSocket.path(WEB_CONTEXT)
+                .request()
+                .get();
+
+        assertThat("Access to named socket", response.getStatus(), is(Response.Status.OK.getStatusCode()));
+
+        Response defaultResponse = webTargetDefault.path(WEB_CONTEXT)
+                .request()
+                .get();
+        assertThat("Access to default socket", defaultResponse.getStatus(), is(Response.Status.NOT_FOUND.getStatusCode()));
+    }
+
+}

--- a/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerSupport.java
+++ b/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class MicrometerSupport extends HelidonRestServiceSupport {
 
     @Override
     protected void postConfigureEndpoint(Routing.Rules defaultRules, Routing.Rules serviceEndpointRoutingRules) {
-        defaultRules
+        serviceEndpointRoutingRules
                 .any(new MetricsContextHandler(registry()))
                 .get(context(), this::getOrOptions)
                 .options(context(), this::getOrOptions);


### PR DESCRIPTION
### Description
Resolves #8517 

The `MicrometerSupport` object uses the configured settings for `web-context` and `routing` but applied them to the routing for _normal application endpoints_, not for the _service routing_ as it should have.

This PR corrects that, setting the endpoint and routing on the service routing instead.

### Documentation
No impact.