### PR TITLE
4.x: Support for disabling security providers through configuration.

### DIFF
--- a/docs/src/main/asciidoc/se/security/introduction.adoc
+++ b/docs/src/main/asciidoc/se/security/introduction.adoc
@@ -56,6 +56,8 @@ Helidon Security provides authentication, authorization, and auditing for your H
  logger called "AUDIT" (may be overridden through configuration). AuditProvider
  SPI may be implemented to support other auditing options.
 
+Each feature is implemented with the help of "xref:providers.adoc[Security Providers]".
+
 Security module is quite HTTP centric (as most common use cases are related to
  HTTP REST), though it is not HTTP specific (the security module may be used to
  secure even other transports, such as JMS, Kafka messages etc. if an appropriate
@@ -115,6 +117,13 @@ See xref:tools.adoc[Secure config] for details about encrypting passwords in
 include::{sourcedir}/se/security/IntroductionSnippets.java[tag=snippet_3, indent=0]
 ----
 <1> Uses `io.helidon.Config`
+
+As mentioned above, security features are implemented through providers, which are configured under key
+`security.providers`. Each element of the list is one security provider. The key of the provider must match
+its config key (as documented in xref:providers.adoc[Security Providers] for each supported provider).
+
+A key `enabled` can be used for each provider to provide fine control of which providers are enabled/disabled, for example
+to support different setup in testing and in production environments.
 
 [source,yaml]
 .Security from configuration - application.yaml

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -1128,7 +1128,8 @@ public interface Security {
 
             String name = resolveProviderName(pConf, className, providerSpecificConfig, providerService);
 
-            if (!providerSpecificConfig.get("enabled").asBoolean().orElse(true)) {
+            if (providerSpecificConfig != null
+                    &&!providerSpecificConfig.get("enabled").asBoolean().orElse(true)) {
                 // this provider is marked as disabled, we will ignore it
                 // this is within the provider specific configuration, to support both simple lists (checked above)
                 // and nested provider configuration; this section check (example):

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1082,6 +1082,22 @@ public interface Security {
                                         Map<String, SecurityProviderService> classNameToService,
                                         String knownKeys,
                                         Config pConf) {
+            boolean enabled = pConf.get("enabled").asBoolean().orElse(true);
+            if (!enabled) {
+                // this provider is marked as disabled, we will ignore it
+                // this is checking the top level provider configuration (see below check for provider specific)
+                // this section check (example):
+                /*
+                security.providers:
+                    - type: "some-type
+                      enabled: false
+                 */
+                if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+                    LOGGER.log(System.Logger.Level.TRACE, "Provider with key: " + pConf.key() + " is disabled");
+                }
+                return;
+            }
+
             AtomicReference<SecurityProviderService> service = new AtomicReference<>();
             AtomicReference<Config> providerSpecific = new AtomicReference<>();
 
@@ -1111,6 +1127,23 @@ public interface Security {
             }
 
             String name = resolveProviderName(pConf, className, providerSpecificConfig, providerService);
+
+            if (!providerSpecificConfig.get("enabled").asBoolean().orElse(true)) {
+                // this provider is marked as disabled, we will ignore it
+                // this is within the provider specific configuration, to support both simple lists (checked above)
+                // and nested provider configuration; this section check (example):
+                /*
+                security.providers:
+                    - oidc:
+                        enabled: false
+                 */
+
+                if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+                    LOGGER.log(System.Logger.Level.TRACE, "Provider: " + name + " is disabled");
+                }
+                return;
+            }
+
             boolean isAuthn = pConf.get("is-authentication-provider").asBoolean().orElse(true);
             boolean isAuthz = pConf.get("is-authorization-provider").asBoolean().orElse(true);
             boolean isClientSec = pConf.get("is-client-security-provider").asBoolean().orElse(true);

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -1128,8 +1128,9 @@ public interface Security {
 
             String name = resolveProviderName(pConf, className, providerSpecificConfig, providerService);
 
-            if (providerSpecificConfig != null
-                    &&!providerSpecificConfig.get("enabled").asBoolean().orElse(true)) {
+            if (providerSpecificConfig != null && !providerSpecificConfig.get("enabled")
+                    .asBoolean()
+                    .orElse(true)) {
                 // this provider is marked as disabled, we will ignore it
                 // this is within the provider specific configuration, to support both simple lists (checked above)
                 // and nested provider configuration; this section check (example):

--- a/tests/integration/mp-gh-8495/pom.xml
+++ b/tests/integration/mp-gh-8495/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-gh-8495</artifactId>
+    <name>Helidon Tests Integration MP GH 8495</name>
+    <description>Reproducer for Github issue #8495 - SecurityCdiExtension fails with Oidc</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-gh-8495/src/main/java/io/helidon/tests/integration/gh8495/Gh8495Resource.java
+++ b/tests/integration/mp-gh-8495/src/main/java/io/helidon/tests/integration/gh8495/Gh8495Resource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8495;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/greet")
+public class Gh8495Resource {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getDefaultMessage() {
+        return "Hello World!";
+    }
+}

--- a/tests/integration/mp-gh-8495/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-gh-8495/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/mp-gh-8495/src/main/resources/application.yaml
+++ b/tests/integration/mp-gh-8495/src/main/resources/application.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+security:
+  providers:
+    - oidc:
+        enabled: false

--- a/tests/integration/mp-gh-8495/src/main/resources/logging.properties
+++ b/tests/integration/mp-gh-8495/src/main/resources/logging.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+.level=WARNING
+
+io.helidon.level=INFO
+io.helidon.security.level=FINEST

--- a/tests/integration/mp-gh-8495/src/test/java/io/helidon/tests/integration/gh8495/Gh8495Test.java
+++ b/tests/integration/mp-gh-8495/src/test/java/io/helidon/tests/integration/gh8495/Gh8495Test.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8495;
+
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+public class Gh8495Test {
+    private final WebTarget target;
+
+    @Inject
+    public Gh8495Test(WebTarget target) {
+        this.target = target;
+    }
+
+    @Test
+    public void testServerStarted() {
+        String response = target
+                .path("/greet")
+                .request()
+                .get(String.class);
+
+        assertThat(response, is("Hello World!"));
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -54,6 +54,7 @@
         <module>mp-gh-4654</module>
         <module>mp-gh-5328</module>
         <module>mp-gh-8478</module>
+        <module>mp-gh-8495</module>
         <module>mp-graphql</module>
         <module>mp-security-client</module>
         <module>mp-ws-services</module>


### PR DESCRIPTION
Test added.

### Description

Resolves #8495 
Requires: #8520

### Usage

```yaml
security:
  providers:
    - foo:
        enabled: false
    - bar:
        enabled: false
```

### Documentation
Docs updated.