### PR TITLE
4.x: Make HttpRouting an interface

### DIFF
--- a/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusRouting.java
+++ b/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusRouting.java
@@ -42,6 +42,9 @@ public class TyrusRouting implements Routing {
         this.extensions = builder.extensions;
     }
 
+    @Override
+    public Class<? extends Routing> routingType() { return TyrusRouting.class; }
+
     /**
      * Builder for WebSocket routing.
      *

--- a/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusRouting.java
+++ b/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ public class TyrusRouting implements Routing {
     }
 
     @Override
-    public Class<? extends Routing> routingType() { return TyrusRouting.class; }
+    public Class<? extends Routing> routingType() {
+        return TyrusRouting.class;
+    }
 
     /**
      * Builder for WebSocket routing.

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ public class GrpcRouting implements Routing {
     }
 
     @Override
-    public Class<? extends Routing> routingType() { return GrpcRouting.class; }
+    public Class<? extends Routing> routingType() {
+        return GrpcRouting.class;
+    }
 
     /**
      * New routing builder.

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
@@ -42,6 +42,9 @@ public class GrpcRouting implements Routing {
         this.routes = new ArrayList<>(builder.routes);
     }
 
+    @Override
+    public Class<? extends Routing> routingType() { return GrpcRouting.class; }
+
     /**
      * New routing builder.
      *

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RouterImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RouterImpl.java
@@ -30,7 +30,7 @@ class RouterImpl implements Router {
         builder.routings.values()
                 .forEach(it -> {
                     Routing routing = it.build();
-                    routings.put(routing.getClass(), routing);
+                    routings.put(routing.routingType(), routing);
                 });
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RouterImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RouterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Routing.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Routing.java
@@ -20,4 +20,12 @@ package io.helidon.webserver;
  * Routing abstraction.
  */
 public interface Routing extends ServerLifecycle {
+
+    /**
+     * The class used by a {@link Router} to identify this {@link Routing} type and associate a connection with it.
+     *
+     * @return this routing type
+     */
+	public default Class<? extends Routing> routingType() { return getClass(); }
+
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Routing.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Routing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ public interface Routing extends ServerLifecycle {
      *
      * @return this routing type
      */
-	public default Class<? extends Routing> routingType() { return getClass(); }
+    default Class<? extends Routing> routingType() {
+        return getClass();
+    }
 
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public interface HttpRouting extends Routing, Prototype.Api {
      *
      * @return a new instance
      */
-    public static Builder builder() {
+    static Builder builder() {
         return HttpRoutingImpl.builder();
     }
 
@@ -48,7 +48,7 @@ public interface HttpRouting extends Routing, Prototype.Api {
      *
      * @return new default router
      */
-    public static HttpRouting create() {
+    static HttpRouting create() {
         return HttpRouting.builder()
                 .route(HttpRoute.builder()
                                .handler((req, res) -> res.send("Helidon WebServer works!"))
@@ -61,15 +61,24 @@ public interface HttpRouting extends Routing, Prototype.Api {
      *
      * @return empty routing
      */
-    public static HttpRouting empty() {
+    static HttpRouting empty() {
         return HttpRoutingImpl.empty();
     }
 
     @Override
-    public default Class<? extends Routing> routingType() { return HttpRouting.class; }
+    default Class<? extends Routing> routingType() {
+        return HttpRouting.class;
+    }
 
 
-    public void route(ConnectionContext ctx, RoutingRequest request, RoutingResponse response);
+    /**
+     * Route a request.
+     *
+     * @param ctx the underlying connection context
+     * @param request the request to route
+     * @param response the response for the request
+     */
+    void route(ConnectionContext ctx, RoutingRequest request, RoutingResponse response);
 
 
     /**
@@ -77,13 +86,13 @@ public interface HttpRouting extends Routing, Prototype.Api {
      *
      * @return security
      */
-    public HttpSecurity security();
+    HttpSecurity security();
 
 
     /**
      * Fluent API builder for {@link HttpRouting}.
      */
-    public interface Builder extends HttpRules, io.helidon.common.Builder<Builder, HttpRouting> {
+    interface Builder extends HttpRules, io.helidon.common.Builder<Builder, HttpRouting> {
         @Override
         Builder register(HttpService... service);
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
@@ -16,52 +16,23 @@
 
 package io.helidon.webserver.http;
 
-import java.util.ArrayList;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import io.helidon.builder.api.Prototype;
-import io.helidon.common.Weights;
-import io.helidon.http.DirectHandler;
-import io.helidon.http.HttpException;
-import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
-import io.helidon.http.NotFoundException;
 import io.helidon.http.PathMatcher;
-import io.helidon.http.RequestException;
-import io.helidon.http.Status;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.Routing;
-import io.helidon.webserver.ServerLifecycle;
 
 /**
  * HTTP routing.
  * This routing is capable of handling any HTTP version.
  */
-public final class HttpRouting implements Routing, Prototype.Api {
-    private static final System.Logger LOGGER = System.getLogger(HttpRouting.class.getName());
-    private static final HttpRouting EMPTY = HttpRouting.builder().build();
-
-    private final Filters filters;
-    private final ServiceRoute rootRoute;
-    private final List<HttpFeature> features;
-    private final int maxReRouteCount;
-    private final HttpSecurity security;
-
-    private HttpRouting(RealBuilder builder) {
-        ErrorHandlers errorHandlers = ErrorHandlers.create(builder.errorHandlers);
-        this.filters = Filters.create(errorHandlers, List.copyOf(builder.filters));
-        this.rootRoute = builder.rootRules.build();
-        this.features = List.copyOf(builder.features);
-        this.maxReRouteCount = builder.maxReRouteCount;
-        this.security = builder.security;
-    }
+public interface HttpRouting extends Routing, Prototype.Api {
 
     /**
      * Creates new instance of {@link HttpRouting.Builder router builder}.
@@ -69,7 +40,7 @@ public final class HttpRouting implements Routing, Prototype.Api {
      * @return a new instance
      */
     public static Builder builder() {
-        return new BuilderImpl();
+        return HttpRoutingImpl.builder();
     }
 
     /**
@@ -91,52 +62,23 @@ public final class HttpRouting implements Routing, Prototype.Api {
      * @return empty routing
      */
     public static HttpRouting empty() {
-        return EMPTY;
-    }
-
-    /**
-     * Route a request.
-     * Handler HTTP filters and finds a route.
-     *
-     * @param ctx      context
-     * @param request  routing request
-     * @param response routing response
-     */
-    public void route(ConnectionContext ctx, RoutingRequest request, RoutingResponse response) {
-        RoutingExecutor routingExecutor = new RoutingExecutor(ctx, rootRoute, request, response, maxReRouteCount);
-        // we cannot throw an exception to the filters, as then the filter would not have information about actual status
-        // code, so error handling is done in routing executor and for each filter
-        filters.filter(ctx, request, response, routingExecutor);
+        return HttpRoutingImpl.empty();
     }
 
     @Override
-    public void beforeStart() {
-        filters.beforeStart();
-        rootRoute.beforeStart();
-        features.forEach(ServerLifecycle::beforeStart);
-    }
+    public default Class<? extends Routing> routingType() { return HttpRouting.class; }
 
-    @Override
-    public void afterStop() {
-        filters.afterStop();
-        rootRoute.afterStop();
-        features.forEach(ServerLifecycle::afterStop);
-    }
+
+    public void route(ConnectionContext ctx, RoutingRequest request, RoutingResponse response);
+
 
     /**
      * Security associated with this routing.
      *
      * @return security
      */
-    public HttpSecurity security() {
-        return security;
-    }
+    public HttpSecurity security();
 
-    private enum RoutingResult {
-        ROUTE,
-        FINISH,
-        NONE
-    }
 
     /**
      * Fluent API builder for {@link HttpRouting}.
@@ -507,285 +449,5 @@ public final class HttpRouting implements Routing, Prototype.Api {
          * @return builder that is a copy of this builder
          */
         Builder copy();
-    }
-
-    static class BuilderImpl implements Builder {
-        // collects features, before build, these will be ordered by weight and registered
-        private final List<HttpFeature> features = new ArrayList<>();
-        private final HttpRoutingFeature mainRouting = new HttpRoutingFeature();
-        private HttpSecurity security = HttpSecurity.create();
-        private int maxReRouteCount = 10;
-
-        private BuilderImpl() {
-        }
-
-        private BuilderImpl(List<HttpFeature> features, HttpRoutingFeature mainRouting, HttpSecurity security, int maxReroute) {
-            this.features.addAll(features);
-            this.mainRouting.copyFrom(mainRouting);
-            this.security = security;
-            this.maxReRouteCount = maxReroute;
-        }
-
-        @Override
-        public HttpRouting build() {
-            features.add(mainRouting);
-
-            Weights.sort(features);
-
-            RealBuilder realBuilder = new RealBuilder(features,
-                                                      security,
-                                                      maxReRouteCount);
-
-            // now we need to do the final setup in the correct order
-            for (HttpFeature feature : features) {
-                if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
-                    LOGGER.log(System.Logger.Level.TRACE, "Setting up feature: " + feature.getClass().getName());
-                }
-                feature.setup(realBuilder);
-            }
-
-            return new HttpRouting(realBuilder);
-        }
-
-        @Override
-        public Builder register(HttpService... service) {
-            mainRouting.service(service);
-            return this;
-        }
-
-        @Override
-        public Builder register(String path, HttpService... service) {
-            mainRouting.service(path, service);
-            return this;
-        }
-
-        @Override
-        public Builder route(HttpRoute route) {
-            mainRouting.route(route);
-            return this;
-        }
-
-        @Override
-        public Builder addFilter(Filter filter) {
-            mainRouting.filter(filter);
-            return this;
-        }
-
-        @Override
-        public Builder addFeature(Supplier<? extends HttpFeature> feature) {
-            HttpFeature httpFeature = feature.get();
-            features.add(httpFeature);
-            return this;
-        }
-
-        @Override
-        public <T extends Throwable> Builder error(Class<T> exceptionClass, ErrorHandler<? super T> handler) {
-            mainRouting.error(exceptionClass, handler);
-            return this;
-        }
-
-        @Override
-        public Builder maxReRouteCount(int maxReRouteCount) {
-            this.maxReRouteCount = maxReRouteCount;
-            return this;
-        }
-
-        @Override
-        public Builder security(HttpSecurity security) {
-            this.security = security;
-            return this;
-        }
-
-        @Override
-        public Builder copy() {
-            return new BuilderImpl(features, mainRouting, security, maxReRouteCount);
-        }
-    }
-
-    private static final class RoutingExecutor implements Callable<Void> {
-        private final ConnectionContext ctx;
-        private final RoutingRequest request;
-        private final RoutingResponse response;
-        private final ServiceRoute rootRoute;
-        private final int maxReRouteCount;
-
-        private RoutingExecutor(ConnectionContext ctx,
-                                ServiceRoute rootRoute,
-                                RoutingRequest request,
-                                RoutingResponse response,
-                                int maxReRouteCount) {
-            this.ctx = ctx;
-            this.rootRoute = rootRoute;
-            this.request = request;
-            this.response = response;
-            this.maxReRouteCount = maxReRouteCount;
-        }
-
-        @Override
-        public Void call() throws Exception {
-            // initial attempt - most common case, handled separately
-            RoutingResult result = doRoute(ctx, request, response);
-
-            if (result == RoutingResult.FINISH) {
-                response.commit();
-                return null;
-            }
-            if (result == RoutingResult.NONE) {
-                throw new NotFoundException("Not Found");
-            }
-
-            // rerouting, do the more heavyweight while loop
-            int counter = 1;
-            while (result == RoutingResult.ROUTE) {
-                counter++;
-                if (counter == maxReRouteCount) {
-                    LOGGER.log(System.Logger.Level.ERROR, "Rerouted more than " + maxReRouteCount
-                            + " times. Will not attempt further routing");
-
-                    throw new HttpException("Too many reroutes", Status.INTERNAL_SERVER_ERROR_500, true);
-                }
-
-                result = doRoute(ctx, request, response);
-            }
-
-            // finished and done
-            if (result == RoutingResult.FINISH) {
-                response.commit();
-                return null;
-            }
-            throw new NotFoundException("Not Found");
-        }
-
-        private RoutingResult doRoute(ConnectionContext ctx, RoutingRequest request, RoutingResponse response) throws Exception {
-            HttpPrologue prologue = request.prologue();
-            RouteCrawler crawler = rootRoute.crawler(ctx, request);
-
-            while (crawler.hasNext()) {
-                response.resetRouting();
-                RouteCrawler.CrawlerItem next = crawler.next();
-                request.path(next.path());
-
-                next.handler().handle(request, response);
-                if (response.shouldReroute()) {
-                    if (response.isSent()) {
-                        LOGGER.log(System.Logger.Level.WARNING, "Request to " + request.prologue()
-                                + " in inconsistent state. Request to re-route, but response was already sent. Ignoring "
-                                + "reroute.");
-                        return RoutingResult.FINISH;
-                    }
-                    HttpPrologue newPrologue = response.reroutePrologue(prologue);
-                    request.prologue(newPrologue);
-                    response.resetRouting();
-                    return RoutingResult.ROUTE;
-                }
-                if (response.isNexted()) {
-                    if (response.isSent()) {
-                        LOGGER.log(System.Logger.Level.WARNING, "Request to " + request.prologue()
-                                + " in inconsistent state. Request to next, but response was already sent. "
-                                + "Ignoring next().");
-                        return RoutingResult.FINISH;
-                    }
-                    continue;
-                }
-                if (response.hasEntity()) {
-                    return RoutingResult.FINISH;
-                }
-
-                // not nexted, not rerouted - invalid state
-                // user must send a response within the current thread
-                LOGGER.log(System.Logger.Level.WARNING,
-                           "A route MUST call either send, reroute, or next on ServerResponse on the request thread. "
-                                   + "Neither of these was called for request: " + request.prologue()
-                                   + "; Handler: " + next.handler());
-
-                throw RequestException.builder()
-                        // we cannot share the information above with a client
-                        .message("Internal Server Error")
-                        .type(DirectHandler.EventType.INTERNAL_ERROR)
-                        .build();
-            }
-
-            return RoutingResult.NONE;
-        }
-    }
-
-    private static final class RealBuilder implements Builder {
-        private final List<Filter> filters = new ArrayList<>();
-        private final Map<Class<? extends Throwable>, ErrorHandler<?>> errorHandlers = new IdentityHashMap<>();
-        private final ServiceRules rootRules = new ServiceRules();
-        private final List<HttpFeature> features;
-
-        private HttpSecurity security;
-        private int maxReRouteCount;
-
-        private RealBuilder(List<HttpFeature> features,
-                            HttpSecurity security,
-                            int maxReRouteCount) {
-
-            // we need a new instance, as features may add additional features
-            this.features = new ArrayList<>(features);
-            this.security = security;
-            this.maxReRouteCount = maxReRouteCount;
-        }
-
-        @Override
-        public HttpRouting build() {
-            throw new UnsupportedOperationException("This builder is internal and never built");
-        }
-
-        @Override
-        public Builder register(HttpService... service) {
-            rootRules.register(service);
-            return this;
-        }
-
-        @Override
-        public Builder register(String pathPattern, HttpService... service) {
-            rootRules.register(pathPattern, service);
-            return this;
-        }
-
-        @Override
-        public Builder route(HttpRoute route) {
-            rootRules.route(route);
-            return this;
-        }
-
-        @Override
-        public Builder addFilter(Filter filter) {
-            filters.add(filter);
-            return this;
-        }
-
-        @Override
-        public Builder addFeature(Supplier<? extends HttpFeature> feature) {
-            HttpFeature it = feature.get();
-            features.add(it);
-            it.setup(this);
-            return this;
-        }
-
-        @Override
-        public <T extends Throwable> Builder error(Class<T> exceptionClass, ErrorHandler<? super T> handler) {
-            errorHandlers.put(exceptionClass, handler);
-            return this;
-        }
-
-        @Override
-        public Builder maxReRouteCount(int maxReRouteCount) {
-            this.maxReRouteCount = maxReRouteCount;
-            return this;
-        }
-
-        @Override
-        public Builder security(HttpSecurity security) {
-            this.security = security;
-            return this;
-        }
-
-        @Override
-        public Builder copy() {
-            throw new UnsupportedOperationException("This builder should only be used internally by Helidon and never copied");
-        }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingImpl.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+import io.helidon.common.Weights;
+import io.helidon.http.DirectHandler;
+import io.helidon.http.HttpException;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.NotFoundException;
+import io.helidon.http.RequestException;
+import io.helidon.http.Status;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerLifecycle;
+
+final class HttpRoutingImpl implements HttpRouting {
+    private static final System.Logger LOGGER = System.getLogger(HttpRoutingImpl.class.getName());
+    private static final HttpRoutingImpl EMPTY = builder().build();
+
+    private final Filters filters;
+    private final ServiceRoute rootRoute;
+    private final List<HttpFeature> features;
+    private final int maxReRouteCount;
+    private final HttpSecurity security;
+
+    HttpRoutingImpl(RealBuilder builder) {
+        ErrorHandlers errorHandlers = ErrorHandlers.create(builder.errorHandlers);
+        this.filters = Filters.create(errorHandlers, List.copyOf(builder.filters));
+        this.rootRoute = builder.rootRules.build();
+        this.features = List.copyOf(builder.features);
+        this.maxReRouteCount = builder.maxReRouteCount;
+        this.security = builder.security;
+    }
+
+    static BuilderImpl builder() {
+        return new BuilderImpl();
+    }
+
+    /**
+     * Empty routing (all requests will return {@link Status#NOT_FOUND_404}.
+     *
+     * @return empty routing
+     */
+    static HttpRoutingImpl empty() {
+        return EMPTY;
+    }
+
+    @Override
+    public void route(ConnectionContext ctx, RoutingRequest request, RoutingResponse response) {
+        RoutingExecutor routingExecutor = new RoutingExecutor(ctx, rootRoute, request, response, maxReRouteCount);
+        // we cannot throw an exception to the filters, as then the filter would not have information about actual status
+        // code, so error handling is done in routing executor and for each filter
+        filters.filter(ctx, request, response, routingExecutor);
+    }
+
+    @Override
+    public void beforeStart() {
+        filters.beforeStart();
+        rootRoute.beforeStart();
+        features.forEach(ServerLifecycle::beforeStart);
+    }
+
+    @Override
+    public void afterStop() {
+        filters.afterStop();
+        rootRoute.afterStop();
+        features.forEach(ServerLifecycle::afterStop);
+    }
+
+    @Override
+    public HttpSecurity security() {
+        return security;
+    }
+
+
+    private enum RoutingResult {
+        ROUTE,
+        FINISH,
+        NONE
+    }
+
+    private static final class RoutingExecutor implements Callable<Void> {
+        private final ConnectionContext ctx;
+        private final RoutingRequest request;
+        private final RoutingResponse response;
+        private final ServiceRoute rootRoute;
+        private final int maxReRouteCount;
+
+        private RoutingExecutor(ConnectionContext ctx,
+                                ServiceRoute rootRoute,
+                                RoutingRequest request,
+                                RoutingResponse response,
+                                int maxReRouteCount) {
+            this.ctx = ctx;
+            this.rootRoute = rootRoute;
+            this.request = request;
+            this.response = response;
+            this.maxReRouteCount = maxReRouteCount;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            // initial attempt - most common case, handled separately
+            RoutingResult result = doRoute(ctx, request, response);
+
+            if (result == RoutingResult.FINISH) {
+                response.commit();
+                return null;
+            }
+            if (result == RoutingResult.NONE) {
+                throw new NotFoundException("Endpoint not found");
+            }
+
+            // rerouting, do the more heavyweight while loop
+            int counter = 1;
+            while (result == RoutingResult.ROUTE) {
+                counter++;
+                if (counter == maxReRouteCount) {
+                    LOGGER.log(System.Logger.Level.ERROR, "Rerouted more than " + maxReRouteCount
+                            + " times. Will not attempt further routing");
+
+                    throw new HttpException("Too many reroutes", Status.INTERNAL_SERVER_ERROR_500, true);
+                }
+
+                result = doRoute(ctx, request, response);
+            }
+
+            // finished and done
+            if (result == RoutingResult.FINISH) {
+                response.commit();
+                return null;
+            }
+            throw new NotFoundException("Endpoint not found");
+        }
+
+        private RoutingResult doRoute(ConnectionContext ctx, RoutingRequest request, RoutingResponse response) throws Exception {
+            HttpPrologue prologue = request.prologue();
+            RouteCrawler crawler = rootRoute.crawler(ctx, request);
+
+            while (crawler.hasNext()) {
+                response.resetRouting();
+                RouteCrawler.CrawlerItem next = crawler.next();
+                request.path(next.path());
+
+                next.handler().handle(request, response);
+                if (response.shouldReroute()) {
+                    if (response.isSent()) {
+                        LOGGER.log(System.Logger.Level.WARNING, "Request to " + request.prologue()
+                                + " in inconsistent state. Request to re-route, but response was already sent. Ignoring "
+                                + "reroute.");
+                        return RoutingResult.FINISH;
+                    }
+                    HttpPrologue newPrologue = response.reroutePrologue(prologue);
+                    request.prologue(newPrologue);
+                    response.resetRouting();
+                    return RoutingResult.ROUTE;
+                }
+                if (response.isNexted()) {
+                    if (response.isSent()) {
+                        LOGGER.log(System.Logger.Level.WARNING, "Request to " + request.prologue()
+                                + " in inconsistent state. Request to next, but response was already sent. "
+                                + "Ignoring next().");
+                        return RoutingResult.FINISH;
+                    }
+                    continue;
+                }
+                if (response.hasEntity()) {
+                    return RoutingResult.FINISH;
+                }
+
+                // not nexted, not rerouted - invalid state
+                // user must send a response within the current thread
+                LOGGER.log(System.Logger.Level.WARNING,
+                           "A route MUST call either send, reroute, or next on ServerResponse on the request thread. "
+                                   + "Neither of these was called for request: " + request.prologue()
+                                   + "; Handler: " + next.handler());
+
+                throw RequestException.builder()
+                        // we cannot share the information above with a client
+                        .message("Internal Server Error")
+                        .type(DirectHandler.EventType.INTERNAL_ERROR)
+                        .build();
+            }
+
+            return RoutingResult.NONE;
+        }
+    }
+
+
+    private static class BuilderImpl implements Builder {
+        // collects features, before build, these will be ordered by weight and registered
+        private final List<HttpFeature> features = new ArrayList<>();
+        private final HttpRoutingFeature mainRouting = new HttpRoutingFeature();
+        private HttpSecurity security = HttpSecurity.create();
+        private int maxReRouteCount = 10;
+
+        private BuilderImpl() {}
+
+        private BuilderImpl(List<HttpFeature> features, HttpRoutingFeature mainRouting, HttpSecurity security, int maxReroute) {
+            this.features.addAll(features);
+            this.mainRouting.copyFrom(mainRouting);
+            this.security = security;
+            this.maxReRouteCount = maxReroute;
+        }
+
+        @Override
+        public HttpRoutingImpl build() {
+            features.add(mainRouting);
+
+            Weights.sort(features);
+
+            RealBuilder realBuilder = new RealBuilder(features,
+                security,
+                maxReRouteCount);
+
+            // now we need to do the final setup in the correct order
+            for (HttpFeature feature : features) {
+                if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+                    LOGGER.log(System.Logger.Level.TRACE, "Setting up feature: " + feature.getClass().getName());
+                }
+                feature.setup(realBuilder);
+            }
+
+            return new HttpRoutingImpl(realBuilder);
+        }
+
+        @Override
+        public Builder register(HttpService... service) {
+            mainRouting.service(service);
+            return this;
+        }
+
+        @Override
+        public Builder register(String path, HttpService... service) {
+            mainRouting.service(path, service);
+            return this;
+        }
+
+        @Override
+        public Builder route(HttpRoute route) {
+            mainRouting.route(route);
+            return this;
+        }
+
+        @Override
+        public Builder addFilter(Filter filter) {
+            mainRouting.filter(filter);
+            return this;
+        }
+
+        @Override
+        public Builder addFeature(Supplier<? extends HttpFeature> feature) {
+            HttpFeature httpFeature = feature.get();
+            features.add(httpFeature);
+            return this;
+        }
+
+        @Override
+        public <T extends Throwable> Builder error(Class<T> exceptionClass, ErrorHandler<? super T> handler) {
+            mainRouting.error(exceptionClass, handler);
+            return this;
+        }
+
+        @Override
+        public Builder maxReRouteCount(int maxReRouteCount) {
+            this.maxReRouteCount = maxReRouteCount;
+            return this;
+        }
+
+        @Override
+        public Builder security(HttpSecurity security) {
+            this.security = security;
+            return this;
+        }
+
+        @Override
+        public Builder copy() {
+            return new BuilderImpl(features, mainRouting, security, maxReRouteCount);
+        }
+    }
+
+    private static final class RealBuilder implements Builder {
+        private final List<Filter> filters = new ArrayList<>();
+        private final Map<Class<? extends Throwable>, ErrorHandler<?>> errorHandlers = new IdentityHashMap<>();
+        private final ServiceRules rootRules = new ServiceRules();
+        private final List<HttpFeature> features;
+
+        private HttpSecurity security;
+        private int maxReRouteCount;
+
+        private RealBuilder(List<HttpFeature> features,
+            HttpSecurity security,
+            int maxReRouteCount) {
+
+            // we need a new instance, as features may add additional features
+            this.features = new ArrayList<>(features);
+            this.security = security;
+            this.maxReRouteCount = maxReRouteCount;
+        }
+
+        @Override
+        public HttpRouting build() {
+            throw new UnsupportedOperationException("This builder is internal and never built");
+        }
+
+        @Override
+        public Builder register(HttpService... service) {
+            rootRules.register(service);
+            return this;
+        }
+
+        @Override
+        public Builder register(String pathPattern, HttpService... service) {
+            rootRules.register(pathPattern, service);
+            return this;
+        }
+
+        @Override
+        public Builder route(HttpRoute route) {
+            rootRules.route(route);
+            return this;
+        }
+
+        @Override
+        public Builder addFilter(Filter filter) {
+            filters.add(filter);
+            return this;
+        }
+
+        @Override
+        public Builder addFeature(Supplier<? extends HttpFeature> feature) {
+            HttpFeature it = feature.get();
+            features.add(it);
+            it.setup(this);
+            return this;
+        }
+
+        @Override
+        public <T extends Throwable> Builder error(Class<T> exceptionClass, ErrorHandler<? super T> handler) {
+            errorHandlers.put(exceptionClass, handler);
+            return this;
+        }
+
+        @Override
+        public Builder maxReRouteCount(int maxReRouteCount) {
+            this.maxReRouteCount = maxReRouteCount;
+            return this;
+        }
+
+        @Override
+        public Builder security(HttpSecurity security) {
+            this.security = security;
+            return this;
+        }
+
+        @Override
+        public Builder copy() {
+            throw new UnsupportedOperationException("This builder should only be used internally by Helidon and never copied");
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import io.helidon.http.NotFoundException;
 import io.helidon.http.RequestException;
 import io.helidon.http.Status;
 import io.helidon.webserver.ConnectionContext;
-import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerLifecycle;
 
 final class HttpRoutingImpl implements HttpRouting {
@@ -215,7 +214,8 @@ final class HttpRoutingImpl implements HttpRouting {
         private HttpSecurity security = HttpSecurity.create();
         private int maxReRouteCount = 10;
 
-        private BuilderImpl() {}
+        private BuilderImpl() {
+        }
 
         private BuilderImpl(List<HttpFeature> features, HttpRoutingFeature mainRouting, HttpSecurity security, int maxReroute) {
             this.features.addAll(features);

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsRouting.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsRouting.java
@@ -37,6 +37,9 @@ public class WsRouting implements Routing {
         this.routes = new ArrayList<>(builder.routes);
     }
 
+    @Override
+    public Class<? extends Routing> routingType() { return WsRouting.class; }
+
     /**
      * Builder for WebSocket routing.
      *

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsRouting.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,9 @@ public class WsRouting implements Routing {
     }
 
     @Override
-    public Class<? extends Routing> routingType() { return WsRouting.class; }
+    public Class<? extends Routing> routingType() {
+        return WsRouting.class;
+    }
 
     /**
      * Builder for WebSocket routing.


### PR DESCRIPTION
### Description
Currently `HttpRoute` is an interface whereas `HttpRouting` isn't. Being able to implement your own `HttpRouting` type can be useful when moving an existing service to Helidon; for example if there already is custom routing logic for it. In addition, making this change seems ideologically correct because it allows for more configurability, and almost everything else that can be specified in a `WebServer` builder is an interface.

Another issue that's addressed as a side-effect is that while other routing classes (e.g. `GrpcRouting`) aren't final, using a custom implementation isn't easily possible. The reason for this is that the `RouterImpl` indexes `Routing` instances by their class and its `routing` method is always called with a fixed class. Therefore, when trying to use a custom implementation, it wouldn't be found.


### Documentation
The `HttpRouting` class is replaced by an interface and all implementation/builder code previously in it is moved to the new package-private `HttpRoutingImpl` class. This should not break existing applications because `HttpRouting` was `final` (so no subclasses can be defined) and its constructor was `private` (so it cannot be called directly).

The `routingType()` method is added to the `Routing` interface with a `default` implementation consistent with the previous behaviour. Its result is used by `RouterImpl` to determine the correct `Routing` instance to use. I'm not sure returning a `Class` here is the best solution, but it is what was previously used.

Resolves #8572 