### PR TITLE
4.x: Upgrade netty to 4.1.108.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -125,7 +125,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
-        <version.lib.netty>4.1.100.Final</version.lib.netty>
+        <version.lib.netty>4.1.108.Final</version.lib.netty>
         <version.lib.oci>3.35.0</version.lib.oci>
         <version.lib.ojdbc.family>21</version.lib.ojdbc.family>
         <!--


### PR DESCRIPTION
### Description

Upgrades netty version to 4.1.108.Final

Helidon 4 does not use Netty directly anymore, but we still manage the version for third parties that have transitive dependencies on it (primarily io.grpc).