### PR TITLE
4.x:  remove netty logging config from logging.properties

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/common/files/src/main/resources/logging.properties.mustache
+++ b/archetypes/archetypes/src/main/archetype/mp/common/files/src/main/resources/logging.properties.mustache
@@ -24,4 +24,3 @@ org.jboss.level=WARNING
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO

--- a/examples/dbclient/jdbc/src/main/resources/logging.properties
+++ b/examples/dbclient/jdbc/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/dbclient/jdbc/src/main/resources/logging.properties
+++ b/examples/dbclient/jdbc/src/main/resources/logging.properties
@@ -33,4 +33,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/dbclient/jdbc/src/main/resources/logging.properties
+++ b/examples/dbclient/jdbc/src/main/resources/logging.properties
@@ -33,4 +33,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/dbclient/mongodb/src/main/resources/logging.properties
+++ b/examples/dbclient/mongodb/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/dbclient/mongodb/src/main/resources/logging.properties
+++ b/examples/dbclient/mongodb/src/main/resources/logging.properties
@@ -33,4 +33,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/dbclient/mongodb/src/main/resources/logging.properties
+++ b/examples/dbclient/mongodb/src/main/resources/logging.properties
@@ -33,4 +33,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/dbclient/pokemons/src/main/resources/logging.properties
+++ b/examples/dbclient/pokemons/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/dbclient/pokemons/src/main/resources/logging.properties
+++ b/examples/dbclient/pokemons/src/main/resources/logging.properties
@@ -33,4 +33,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/dbclient/pokemons/src/main/resources/logging.properties
+++ b/examples/dbclient/pokemons/src/main/resources/logging.properties
@@ -33,4 +33,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/employee-app/src/main/resources/logging.properties
+++ b/examples/employee-app/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/employee-app/src/main/resources/logging.properties
+++ b/examples/employee-app/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/employee-app/src/main/resources/logging.properties
+++ b/examples/employee-app/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/integrations/micrometer/mp/src/main/resources/logging.properties
+++ b/examples/integrations/micrometer/mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/integrations/micrometer/mp/src/main/resources/logging.properties
+++ b/examples/integrations/micrometer/mp/src/main/resources/logging.properties
@@ -32,6 +32,5 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/integrations/micrometer/mp/src/main/resources/logging.properties
+++ b/examples/integrations/micrometer/mp/src/main/resources/logging.properties
@@ -32,6 +32,6 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/messaging/jms-websocket-mp/src/main/resources/logging.properties
+++ b/examples/messaging/jms-websocket-mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/messaging/jms-websocket-mp/src/main/resources/logging.properties
+++ b/examples/messaging/jms-websocket-mp/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/messaging/jms-websocket-mp/src/main/resources/logging.properties
+++ b/examples/messaging/jms-websocket-mp/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/messaging/jms-websocket-se/src/main/resources/logging.properties
+++ b/examples/messaging/jms-websocket-se/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/messaging/jms-websocket-se/src/main/resources/logging.properties
+++ b/examples/messaging/jms-websocket-se/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/messaging/jms-websocket-se/src/main/resources/logging.properties
+++ b/examples/messaging/jms-websocket-se/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/messaging/kafka-websocket-se/src/main/resources/logging.properties
+++ b/examples/messaging/kafka-websocket-se/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/messaging/kafka-websocket-se/src/main/resources/logging.properties
+++ b/examples/messaging/kafka-websocket-se/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/messaging/kafka-websocket-se/src/main/resources/logging.properties
+++ b/examples/messaging/kafka-websocket-se/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/messaging/oracle-aq-websocket-mp/src/main/resources/logging.properties
+++ b/examples/messaging/oracle-aq-websocket-mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/messaging/oracle-aq-websocket-mp/src/main/resources/logging.properties
+++ b/examples/messaging/oracle-aq-websocket-mp/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/messaging/oracle-aq-websocket-mp/src/main/resources/logging.properties
+++ b/examples/messaging/oracle-aq-websocket-mp/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/metrics/exemplar/src/main/resources/logging.properties
+++ b/examples/metrics/exemplar/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/metrics/exemplar/src/main/resources/logging.properties
+++ b/examples/metrics/exemplar/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/metrics/exemplar/src/main/resources/logging.properties
+++ b/examples/metrics/exemplar/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/metrics/filtering/se/src/main/resources/logging.properties
+++ b/examples/metrics/filtering/se/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/metrics/filtering/se/src/main/resources/logging.properties
+++ b/examples/metrics/filtering/se/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/metrics/filtering/se/src/main/resources/logging.properties
+++ b/examples/metrics/filtering/se/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/metrics/http-status-count-se/src/main/resources/logging.properties
+++ b/examples/metrics/http-status-count-se/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/metrics/http-status-count-se/src/main/resources/logging.properties
+++ b/examples/metrics/http-status-count-se/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/metrics/http-status-count-se/src/main/resources/logging.properties
+++ b/examples/metrics/http-status-count-se/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/metrics/kpi/src/main/resources/logging.properties
+++ b/examples/metrics/kpi/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/metrics/kpi/src/main/resources/logging.properties
+++ b/examples/metrics/kpi/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/metrics/kpi/src/main/resources/logging.properties
+++ b/examples/metrics/kpi/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/microprofile/cors/src/test/resources/logging.properties
+++ b/examples/microprofile/cors/src/test/resources/logging.properties
@@ -28,12 +28,10 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 
 # Component specific log levels
 #io.helidon.webserver.cors.level=FINE
-
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/cors/src/test/resources/logging.properties
+++ b/examples/microprofile/cors/src/test/resources/logging.properties
@@ -34,6 +34,6 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/cors/src/test/resources/logging.properties
+++ b/examples/microprofile/cors/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/http-status-count-mp/src/main/resources/logging.properties
+++ b/examples/microprofile/http-status-count-mp/src/main/resources/logging.properties
@@ -34,4 +34,4 @@ org.jboss.level=WARNING
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/microprofile/http-status-count-mp/src/main/resources/logging.properties
+++ b/examples/microprofile/http-status-count-mp/src/main/resources/logging.properties
@@ -34,4 +34,3 @@ org.jboss.level=WARNING
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/microprofile/http-status-count-mp/src/main/resources/logging.properties
+++ b/examples/microprofile/http-status-count-mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/multipart/src/main/resources/logging.properties
+++ b/examples/microprofile/multipart/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/multipart/src/main/resources/logging.properties
+++ b/examples/microprofile/multipart/src/main/resources/logging.properties
@@ -32,6 +32,5 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/multipart/src/main/resources/logging.properties
+++ b/examples/microprofile/multipart/src/main/resources/logging.properties
@@ -32,6 +32,6 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/openapi/src/main/resources/logging.properties
+++ b/examples/microprofile/openapi/src/main/resources/logging.properties
@@ -32,6 +32,5 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/openapi/src/main/resources/logging.properties
+++ b/examples/microprofile/openapi/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/openapi/src/main/resources/logging.properties
+++ b/examples/microprofile/openapi/src/main/resources/logging.properties
@@ -32,6 +32,6 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/telemetry/greeting/src/main/resources/logging.properties
+++ b/examples/microprofile/telemetry/greeting/src/main/resources/logging.properties
@@ -35,6 +35,6 @@ org.jboss.level=WARNING
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/telemetry/greeting/src/main/resources/logging.properties
+++ b/examples/microprofile/telemetry/greeting/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/telemetry/greeting/src/main/resources/logging.properties
+++ b/examples/microprofile/telemetry/greeting/src/main/resources/logging.properties
@@ -35,6 +35,5 @@ org.jboss.level=WARNING
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/telemetry/secondary/src/main/resources/logging.properties
+++ b/examples/microprofile/telemetry/secondary/src/main/resources/logging.properties
@@ -35,6 +35,6 @@ org.jboss.level=WARNING
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/microprofile/telemetry/secondary/src/main/resources/logging.properties
+++ b/examples/microprofile/telemetry/secondary/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/telemetry/secondary/src/main/resources/logging.properties
+++ b/examples/microprofile/telemetry/secondary/src/main/resources/logging.properties
@@ -35,6 +35,5 @@ org.jboss.level=WARNING
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/openapi/src/main/resources/logging.properties
+++ b/examples/openapi/src/main/resources/logging.properties
@@ -31,5 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-
 io.helidon.openapi.OpenAPISupport.level=FINER

--- a/examples/openapi/src/main/resources/logging.properties
+++ b/examples/openapi/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/openapi/src/main/resources/logging.properties
+++ b/examples/openapi/src/main/resources/logging.properties
@@ -31,5 +31,5 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 io.helidon.openapi.OpenAPISupport.level=FINER

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
@@ -35,6 +35,6 @@ org.jboss.level=WARNING
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
@@ -35,6 +35,5 @@ org.jboss.level=WARNING
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
@@ -29,13 +29,10 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 # Quiet Weld
 org.jboss.level=WARNING
 
-#
 # Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
-#org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
@@ -36,6 +36,6 @@ org.jboss.level=WARNING
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/examples/webserver/multiport/src/main/resources/logging.properties
+++ b/examples/webserver/multiport/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/webserver/multiport/src/main/resources/logging.properties
+++ b/examples/webserver/multiport/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/webserver/multiport/src/main/resources/logging.properties
+++ b/examples/webserver/multiport/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/examples/webserver/tutorial/src/main/resources/logging.properties
+++ b/examples/webserver/tutorial/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/webserver/tutorial/src/main/resources/logging.properties
+++ b/examples/webserver/tutorial/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/examples/webserver/tutorial/src/main/resources/logging.properties
+++ b/examples/webserver/tutorial/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/integrations/micrometer/cdi/src/test/resources/logging.properties
+++ b/integrations/micrometer/cdi/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integrations/micrometer/cdi/src/test/resources/logging.properties
+++ b/integrations/micrometer/cdi/src/test/resources/logging.properties
@@ -31,10 +31,8 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-
 #io.helidon.microprofile.metrics.MetricsCdiExtension.level=FINEST
 #io.helidon.microprofile.metrics.Interceptor*.level=FINEST
-
 #org.jboss.weld.Bootstrap.level = FINEST
 #org.jboss.weld.Bean.level=FINEST
 #org.jboss.weld.Context.level=FINEST

--- a/integrations/micrometer/cdi/src/test/resources/logging.properties
+++ b/integrations/micrometer/cdi/src/test/resources/logging.properties
@@ -31,7 +31,7 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #io.helidon.microprofile.metrics.MetricsCdiExtension.level=FINEST
 #io.helidon.microprofile.metrics.Interceptor*.level=FINEST
 

--- a/microprofile/metrics/src/test/resources/logging.properties
+++ b/microprofile/metrics/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/microprofile/metrics/src/test/resources/logging.properties
+++ b/microprofile/metrics/src/test/resources/logging.properties
@@ -31,7 +31,7 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #io.helidon.microprofile.metrics.MetricsCdiExtension.level=FINEST
 #io.helidon.microprofile.metrics.MetricsInterceptorBase.level=FINEST
 

--- a/microprofile/metrics/src/test/resources/logging.properties
+++ b/microprofile/metrics/src/test/resources/logging.properties
@@ -31,10 +31,8 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-
 #io.helidon.microprofile.metrics.MetricsCdiExtension.level=FINEST
 #io.helidon.microprofile.metrics.MetricsInterceptorBase.level=FINEST
-
 #org.jboss.weld.Bootstrap.level = FINEST
 #org.jboss.weld.Bean.level=FINEST
 #org.jboss.weld.Context.level=FINEST

--- a/tests/apps/bookstore/bookstore-mp/src/main/resources/logging.properties
+++ b/tests/apps/bookstore/bookstore-mp/src/main/resources/logging.properties
@@ -32,6 +32,5 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/tests/apps/bookstore/bookstore-mp/src/main/resources/logging.properties
+++ b/tests/apps/bookstore/bookstore-mp/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/apps/bookstore/bookstore-mp/src/main/resources/logging.properties
+++ b/tests/apps/bookstore/bookstore-mp/src/main/resources/logging.properties
@@ -32,6 +32,6 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/tests/functional/config-profiles/src/main/resources/logging.properties
+++ b/tests/functional/config-profiles/src/main/resources/logging.properties
@@ -31,4 +31,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+

--- a/tests/functional/config-profiles/src/main/resources/logging.properties
+++ b/tests/functional/config-profiles/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/functional/config-profiles/src/main/resources/logging.properties
+++ b/tests/functional/config-profiles/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-

--- a/tests/functional/param-converter-provider/src/main/resources/logging.properties
+++ b/tests/functional/param-converter-provider/src/main/resources/logging.properties
@@ -31,4 +31,3 @@ org.jboss.level=WARNING
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO

--- a/tests/functional/param-converter-provider/src/main/resources/logging.properties
+++ b/tests/functional/param-converter-provider/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/native-image/mp-3/src/main/resources/logging.properties
+++ b/tests/integration/native-image/mp-3/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/native-image/mp-3/src/main/resources/logging.properties
+++ b/tests/integration/native-image/mp-3/src/main/resources/logging.properties
@@ -32,6 +32,5 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/tests/integration/native-image/mp-3/src/main/resources/logging.properties
+++ b/tests/integration/native-image/mp-3/src/main/resources/logging.properties
@@ -32,6 +32,6 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/tests/integration/native-image/se-1/src/main/resources/logging.properties
+++ b/tests/integration/native-image/se-1/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/native-image/se-1/src/main/resources/logging.properties
+++ b/tests/integration/native-image/se-1/src/main/resources/logging.properties
@@ -31,7 +31,7 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 
 io.helidon.webserver.staticcontent.ClassPathContentHandler.level=FINEST
 io.helidon.webserver.staticcontent.FileSystemContentHandler.level=FINEST

--- a/tests/integration/native-image/se-1/src/main/resources/logging.properties
+++ b/tests/integration/native-image/se-1/src/main/resources/logging.properties
@@ -32,6 +32,5 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
 
-
 io.helidon.webserver.staticcontent.ClassPathContentHandler.level=FINEST
 io.helidon.webserver.staticcontent.FileSystemContentHandler.level=FINEST

--- a/tests/integration/security/gh2297/src/main/resources/logging.properties
+++ b/tests/integration/security/gh2297/src/main/resources/logging.properties
@@ -32,6 +32,6 @@ AUDIT.level=FINEST
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/tests/integration/security/gh2297/src/main/resources/logging.properties
+++ b/tests/integration/security/gh2297/src/main/resources/logging.properties
@@ -32,6 +32,5 @@ AUDIT.level=FINEST
 #io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/tests/integration/security/gh2297/src/main/resources/logging.properties
+++ b/tests/integration/security/gh2297/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/security/gh2772/src/main/resources/logging.properties
+++ b/tests/integration/security/gh2772/src/main/resources/logging.properties
@@ -32,6 +32,6 @@ AUDIT.level=FINEST
 io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-#io.netty.level=INFO
+
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO

--- a/tests/integration/security/gh2772/src/main/resources/logging.properties
+++ b/tests/integration/security/gh2772/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/security/gh2772/src/main/resources/logging.properties
+++ b/tests/integration/security/gh2772/src/main/resources/logging.properties
@@ -32,6 +32,5 @@ AUDIT.level=FINEST
 io.helidon.security.level=INFO
 #io.helidon.microprofile.level=INFO
 #io.helidon.common.level=INFO
-
 #org.glassfish.jersey.level=INFO
 #org.jboss.weld=INFO


### PR DESCRIPTION
### Description

Removes Netty logging configuration from `logging.properties`

Fixes #8531

### Documentation

No impact