### PR TITLE
Properly handle opaque origin ("null") in CORS processing

### DIFF
--- a/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
+++ b/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
@@ -61,7 +61,10 @@ public class CorsSupportHelper<Q, R> {
 
     static final Logger LOGGER = Logger.getLogger(CorsSupportHelper.class.getName());
 
+    static final String OPAQUE_ORIGIN = "null"; // browsers might send this as Origin header if origin info is untrusted
+
     private static final Supplier<Optional<CrossOriginConfig>> EMPTY_SECONDARY_SUPPLIER = Optional::empty;
+
 
     private final String name;
 
@@ -392,7 +395,7 @@ public class CorsSupportHelper<Q, R> {
 
             return new RequestTypeInfo(originLocation,
                                        hostLocation,
-                                       originLocation.equals(hostLocation));
+                                       originLocation.equals(hostLocation) || originLocation.equals(OPAQUE_ORIGIN));
         }
     }
 
@@ -403,6 +406,9 @@ public class CorsSupportHelper<Q, R> {
         // Fast decision if there is no Origin header.
         if (originOpt.isEmpty()) {
             LogHelper.logIsRequestTypeNormalNoOrigin(silent, requestAdapter);
+            return true;
+        } else if (originOpt.get().equals(OPAQUE_ORIGIN)) {
+            LogHelper.logIsRequestTypeNormalOpaqueOrigin(silent, requestAdapter);
             return true;
         }
 
@@ -421,7 +427,7 @@ public class CorsSupportHelper<Q, R> {
         int originLastColon = origin.lastIndexOf(':');
 
         return origin + (
-                (originEndOfScheme == originLastColon)
+                (originEndOfScheme == originLastColon && originEndOfScheme >= 0)
                         ? ":" + portForScheme(origin.substring(0, originEndOfScheme))
                         : "");
     }

--- a/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
+++ b/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
@@ -407,9 +407,10 @@ public class CorsSupportHelper<Q, R> {
         if (originOpt.isEmpty()) {
             LogHelper.logIsRequestTypeNormalNoOrigin(silent, requestAdapter);
             return true;
-        } else if (originOpt.get().equals(OPAQUE_ORIGIN)) {
-            LogHelper.logIsRequestTypeNormalOpaqueOrigin(silent, requestAdapter);
-            return true;
+        }
+        if (isOriginOpaque(originOpt.get())) {
+            LogHelper.logOpaqueOrigin(silent, requestAdapter);
+            // Do not return. Continue processing having noted the opaque origin.
         }
 
         RequestTypeInfo result = requestType(originOpt.get(), requestAdapter.requestedUri());
@@ -420,6 +421,10 @@ public class CorsSupportHelper<Q, R> {
                                          result.originLocation,
                                          result.hostLocation);
         return result.isNormal;
+    }
+
+    static boolean isOriginOpaque(String origin) {
+        return origin.equals(OPAQUE_ORIGIN);
     }
 
     private static String originLocation(String origin) {

--- a/cors/src/main/java/io/helidon/cors/LogHelper.java
+++ b/cors/src/main/java/io/helidon/cors/LogHelper.java
@@ -79,6 +79,16 @@ class LogHelper {
                                                    List.of("header " + HeaderNames.ORIGIN + " is absent")));
     }
 
+    static <T> void logIsRequestTypeNormalOpaqueOrigin(boolean silent, CorsRequestAdapter<T> requestAdapter) {
+        if (silent || !CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {
+            return;
+        }
+        CorsSupportHelper.LOGGER.log(DECISION_LEVEL,
+                                     String.format("Request %s is not cross-host: %s",
+                                                   requestAdapter,
+                                                   List.of("header " + HeaderNames.ORIGIN + " value is opaque")));
+    }
+
     static <T> void logIsRequestTypeNormal(boolean result, boolean silent, CorsRequestAdapter<T> requestAdapter,
             Optional<String> originOpt, String effectiveOrigin, String host) {
         if (silent || !CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {

--- a/cors/src/main/java/io/helidon/cors/LogHelper.java
+++ b/cors/src/main/java/io/helidon/cors/LogHelper.java
@@ -79,14 +79,14 @@ class LogHelper {
                                                    List.of("header " + HeaderNames.ORIGIN + " is absent")));
     }
 
-    static <T> void logIsRequestTypeNormalOpaqueOrigin(boolean silent, CorsRequestAdapter<T> requestAdapter) {
+    static <T> void logOpaqueOrigin(boolean silent, CorsRequestAdapter<T> requestAdapter) {
         if (silent || !CorsSupportHelper.LOGGER.isLoggable(DECISION_LEVEL)) {
             return;
         }
         CorsSupportHelper.LOGGER.log(DECISION_LEVEL,
-                                     String.format("Request %s is not cross-host: %s",
+                                     String.format("Request %s specifies opaque origin: %s",
                                                    requestAdapter,
-                                                   List.of("header " + HeaderNames.ORIGIN + " value is opaque")));
+                                                   List.of("header " + HeaderNames.ORIGIN)));
     }
 
     static <T> void logIsRequestTypeNormal(boolean result, boolean silent, CorsRequestAdapter<T> requestAdapter,

--- a/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
+++ b/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
@@ -76,6 +76,14 @@ class CorsSupportHelperTest {
     }
 
     @Test
+    void opaqueOrigin() {
+        assertThat("Opaque origin",
+                   CorsSupportHelper.requestType(CorsSupportHelper.OPAQUE_ORIGIN,
+                                                 uriInfo("ok.com", 8010, false)).isNormal(),
+                   is(true));
+    }
+
+    @Test
     void sameNodeSamePort() {
         assertThat("Default origin port",
                    CorsSupportHelper.requestType("http://ok.com",

--- a/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
+++ b/cors/src/test/java/io/helidon/cors/CorsSupportHelperTest.java
@@ -78,9 +78,12 @@ class CorsSupportHelperTest {
     @Test
     void opaqueOrigin() {
         assertThat("Opaque origin",
-                   CorsSupportHelper.requestType(CorsSupportHelper.OPAQUE_ORIGIN,
-                                                 uriInfo("ok.com", 8010, false)).isNormal(),
+                   CorsSupportHelper.isOriginOpaque(CorsSupportHelper.OPAQUE_ORIGIN),
                    is(true));
+
+        assertThat("Non-opaque origin",
+                   CorsSupportHelper.isOriginOpaque("http://ok.com"),
+                   is(false));
     }
 
     @Test


### PR DESCRIPTION
### Description
Resolves #8497 

If a browser (or other client) that can participate in CORS detects an untrusted origin, it can/might/must send the "opaque" origin (seemingly universally the string `null`) as the `Origin` header.

The Helidon CORS logic did not handle this case.  "Usual" origins have `scheme://host[:port]` so have at least one colon which terminates the scheme. The code expected this but `null` has no colon.

Includes a new test.

### Documentation
No impact.