### PR TITLE
[3.x] Disabled OidcFeature no longer throws an NPE. (#8520)

### DIFF
--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcSupport.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,10 +152,15 @@ public final class OidcSupport implements Service {
     private OidcSupport(Builder builder) {
         this.oidcConfig = builder.oidcConfig;
         this.enabled = builder.enabled;
-        this.corsSupport = prepareCrossOriginSupport(oidcConfig.redirectUri(), oidcConfig.crossOriginConfig());
-        this.oidcConfigFinders = List.copyOf(builder.tenantConfigFinders);
+        if (enabled) {
+            this.corsSupport = prepareCrossOriginSupport(oidcConfig.redirectUri(), oidcConfig.crossOriginConfig());
+            this.oidcConfigFinders = List.copyOf(builder.tenantConfigFinders);
 
-        this.oidcConfigFinders.forEach(tenantConfigFinder -> tenantConfigFinder.onChange(tenants::remove));
+            this.oidcConfigFinders.forEach(tenantConfigFinder -> tenantConfigFinder.onChange(tenants::remove));
+        } else {
+            this.corsSupport = null;
+            this.oidcConfigFinders = List.of();
+        }
     }
 
     /**

--- a/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/OidcSupportTest.java
+++ b/security/providers/oidc/src/test/java/io/helidon/security/providers/oidc/OidcSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import io.helidon.security.providers.common.OutboundConfig;
 import io.helidon.security.providers.common.OutboundTarget;
 import io.helidon.security.providers.common.TokenCredential;
 import io.helidon.security.providers.oidc.common.OidcConfig;
+import io.helidon.webserver.Routing;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -41,6 +42,7 @@ import org.mockito.Mockito;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNot.not;
 import static org.mockito.Mockito.when;
@@ -219,5 +221,19 @@ class OidcSupportTest {
                 .join();
 
         assertThat("Disabled target should have empty headers", response.requestHeaders().size(), is(0));
+    }
+
+    @Test
+    void testDisabledFeature() {
+        OidcSupport oidcSupport = OidcSupport.builder()
+                .enabled(false)
+                .build();
+
+        // make sure we can pass through its lifecycle without getting an exception
+        Routing.Builder builder = Routing.builder();
+        oidcSupport.update(builder);
+
+        assertThat(oidcSupport.hashCode(), not(0));
+        assertThat(oidcSupport.toString(), notNullValue());
     }
 }


### PR DESCRIPTION
(cherry picked from commit b44c0c67c014d853808eb127e1e98b886c991d8b)
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>


### Description

Resolves #8527 
