### PR TITLE
[4.x] Observers now inherit weight of the ObserveFeature.

### DIFF
--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideExample.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideExample.java
@@ -24,6 +24,7 @@ import io.helidon.security.SecurityContext;
 import io.helidon.security.Subject;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.context.ContextFeature;
 import io.helidon.webserver.security.SecurityHttpFeature;
 
 /**
@@ -77,7 +78,12 @@ public final class OutboundOverrideExample {
         Config clientConfig = Config.create(ConfigSources.classpath("client-service.yaml"));
         Config backendConfig = Config.create(ConfigSources.classpath("backend-service.yaml"));
 
-        server.config(clientConfig.get("security"))
+        // as we use the security http feature directly, we cannot use discovered security feature
+        // this is a unique case where we combine two sets of server set-ups in a single webserver
+        server.featuresDiscoverServices(false)
+                // context feature is a pre-requisite of security
+                .addFeature(ContextFeature.create())
+                .config(clientConfig.get("security"))
                 .routing(routing -> routing
                         .addFeature(SecurityHttpFeature.create(clientConfig.get("security.web-server")))
                         .register(new OverrideService()))

--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExample.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import io.helidon.security.SecurityContext;
 import io.helidon.security.Subject;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.context.ContextFeature;
 import io.helidon.webserver.security.SecurityHttpFeature;
 
 /**
@@ -85,7 +86,12 @@ public final class OutboundOverrideJwtExample {
         Config clientConfig = Config.create(ConfigSources.classpath("client-service-jwt.yaml"));
         Config backendConfig = Config.create(ConfigSources.classpath("backend-service-jwt.yaml"));
 
-        server.routing(routing -> routing
+        // as we use the security http feature directly, we cannot use discovered security feature
+        // this is a unique case where we combine two sets of server set-ups in a single webserver
+        server.featuresDiscoverServices(false)
+                // context feature is a pre-requisite of security
+                .addFeature(ContextFeature.create())
+                .routing(routing -> routing
                         .addFeature(SecurityHttpFeature.create(clientConfig.get("security.web-server")))
                         .register(new JwtOverrideService()))
 

--- a/examples/security/webserver-signatures/src/main/java/io/helidon/examples/security/signatures/SignatureExampleBuilderMain.java
+++ b/examples/security/webserver-signatures/src/main/java/io/helidon/examples/security/signatures/SignatureExampleBuilderMain.java
@@ -39,6 +39,7 @@ import io.helidon.security.providers.httpsign.InboundClientDefinition;
 import io.helidon.security.providers.httpsign.OutboundTargetDefinition;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.context.ContextFeature;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.security.SecurityFeature;
 import io.helidon.webserver.security.SecurityHttpFeature;
@@ -121,7 +122,12 @@ public class SignatureExampleBuilderMain {
     }
 
     static void setup(WebServerConfig.Builder server) {
-        server.routing(SignatureExampleBuilderMain::routing1)
+        // as we explicitly configure SecurityHttpFeature, we must disable automated loading of security,
+        // as it would add another feature with different configuration
+        server.featuresDiscoverServices(false)
+                // context is a required pre-requisite of security
+                .addFeature(ContextFeature.create())
+                .routing(SignatureExampleBuilderMain::routing1)
                 .putSocket("service2", socket -> socket
                         .routing(SignatureExampleBuilderMain::routing2));
     }

--- a/examples/security/webserver-signatures/src/main/java/io/helidon/examples/security/signatures/SignatureExampleConfigMain.java
+++ b/examples/security/webserver-signatures/src/main/java/io/helidon/examples/security/signatures/SignatureExampleConfigMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.context.ContextFeature;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.security.SecurityHttpFeature;
 
@@ -72,7 +73,12 @@ public class SignatureExampleConfigMain {
     }
 
     static void setup(WebServerConfig.Builder server) {
-        server.routing(SignatureExampleConfigMain::routing1)
+        // as we explicitly configure SecurityHttpFeature, we must disable automated loading of security,
+        // as it would add another feature with different configuration
+        server.featuresDiscoverServices(false)
+                // context is a required pre-requisite of security
+                .addFeature(ContextFeature.create())
+                .routing(SignatureExampleConfigMain::routing1)
                 .putSocket("service2", socket -> socket
                         .routing(SignatureExampleConfigMain::routing2));
     }

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 
 import io.helidon.builder.api.RuntimeType;
 import io.helidon.common.LazyValue;
+import io.helidon.common.Weighted;
 import io.helidon.common.config.Config;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
@@ -41,7 +42,7 @@ import io.helidon.webserver.spi.ServerFeature;
  * Helidon Support for OpenAPI.
  */
 @RuntimeType.PrototypedBy(OpenApiFeatureConfig.class)
-public final class OpenApiFeature implements ServerFeature, RuntimeType.Api<OpenApiFeatureConfig> {
+public final class OpenApiFeature implements Weighted, ServerFeature, RuntimeType.Api<OpenApiFeatureConfig> {
 
     static final String OPENAPI_ID = "openapi";
     static final double WEIGHT = 90;
@@ -169,6 +170,11 @@ public final class OpenApiFeature implements ServerFeature, RuntimeType.Api<Open
     @Override
     public String type() {
         return OPENAPI_ID;
+    }
+
+    @Override
+    public double weight() {
+        return config.weight();
     }
 
     /**

--- a/webserver/access-log/src/main/java/io/helidon/webserver/accesslog/AccessLogFeature.java
+++ b/webserver/access-log/src/main/java/io/helidon/webserver/accesslog/AccessLogFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Weighted;
 import io.helidon.config.Config;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRouting;
@@ -31,7 +32,7 @@ import io.helidon.webserver.spi.ServerFeature;
  * Service that adds support for Access logging to Server.
  */
 @RuntimeType.PrototypedBy(AccessLogConfig.class)
-public final class AccessLogFeature implements ServerFeature, RuntimeType.Api<AccessLogConfig> {
+public final class AccessLogFeature implements Weighted, ServerFeature, RuntimeType.Api<AccessLogConfig> {
     /**
      * Name of the {@link System#getLogger(String)} used to log access log records.
      * The message logged contains all information, so the format should be modified
@@ -142,6 +143,11 @@ public final class AccessLogFeature implements ServerFeature, RuntimeType.Api<Ac
     @Override
     public String type() {
         return ACCESS_LOG_ID;
+    }
+
+    @Override
+    public double weight() {
+        return config.weight();
     }
 
     AccessLogHttpFeature httpFeature(String socketName) {

--- a/webserver/context/src/main/java/io/helidon/webserver/context/ContextFeature.java
+++ b/webserver/context/src/main/java/io/helidon/webserver/context/ContextFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import io.helidon.webserver.spi.ServerFeature;
  * When added to the processing, further processing will be executed in a request specific context.
  */
 @RuntimeType.PrototypedBy(ContextFeatureConfig.class)
-public class ContextFeature implements ServerFeature, RuntimeType.Api<ContextFeatureConfig> {
+public class ContextFeature implements Weighted, ServerFeature, RuntimeType.Api<ContextFeatureConfig> {
     /**
      * Default weight of the feature. It is quite high, as context is used by a lot of other features.
      */
@@ -122,5 +122,10 @@ public class ContextFeature implements ServerFeature, RuntimeType.Api<ContextFea
     @Override
     public ContextFeatureConfig prototype() {
         return config;
+    }
+
+    @Override
+    public double weight() {
+        return config.weight();
     }
 }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsFeature.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Weighted;
 import io.helidon.common.config.Config;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.spi.ServerFeature;
@@ -29,7 +30,7 @@ import io.helidon.webserver.spi.ServerFeature;
  * Adds CORS support to Helidon WebServer.
  */
 @RuntimeType.PrototypedBy(CorsConfig.class)
-public class CorsFeature implements ServerFeature, RuntimeType.Api<CorsConfig> {
+public class CorsFeature implements Weighted, ServerFeature, RuntimeType.Api<CorsConfig> {
     /**
      * Default weight of the feature.
      */
@@ -133,5 +134,10 @@ public class CorsFeature implements ServerFeature, RuntimeType.Api<CorsConfig> {
     @Override
     public CorsConfig prototype() {
         return config;
+    }
+
+    @Override
+    public double weight() {
+        return config.weight();
     }
 }

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserver.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import io.helidon.builder.api.RuntimeType;
-import io.helidon.http.HttpException;
-import io.helidon.http.Status;
+import io.helidon.webserver.http.HttpFeature;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.observe.DisabledObserverFeature;
 import io.helidon.webserver.observe.spi.Observer;
 import io.helidon.webserver.spi.ServerFeature;
 
@@ -98,14 +98,27 @@ public class InfoObserver implements Observer, RuntimeType.Api<InfoObserverConfi
         if (config.enabled()) {
             for (HttpRouting.Builder routing : observeEndpointRouting) {
                 // register the service itself
-                routing.register(endpoint, new InfoService(this.config.values()));
+                routing.addFeature(new InfoHttpFeature(endpoint, this.config));
             }
         } else {
             for (HttpRouting.Builder builder : observeEndpointRouting) {
-                builder.any(endpoint + "/*", (req, res) -> {
-                    throw new HttpException("Info endpoint is disabled", Status.SERVICE_UNAVAILABLE_503, true);
-                });
+                builder.addFeature(DisabledObserverFeature.create("Info", endpoint + "/*"));
             }
+        }
+    }
+
+    private static class InfoHttpFeature implements HttpFeature {
+        private final String endpoint;
+        private final InfoObserverConfig config;
+
+        private InfoHttpFeature(String endpoint, InfoObserverConfig config) {
+            this.endpoint = endpoint;
+            this.config = config;
+        }
+
+        @Override
+        public void setup(HttpRouting.Builder routing) {
+            routing.register(endpoint, new InfoService(this.config.values()));
         }
     }
 }

--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserver.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import io.helidon.builder.api.RuntimeType;
-import io.helidon.http.HttpException;
-import io.helidon.http.Status;
+import io.helidon.webserver.http.HttpFeature;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.observe.DisabledObserverFeature;
 import io.helidon.webserver.observe.spi.Observer;
 import io.helidon.webserver.spi.ServerFeature;
 
@@ -98,14 +98,27 @@ public class LogObserver implements Observer, RuntimeType.Api<LogObserverConfig>
         if (config.enabled()) {
             for (HttpRouting.Builder routing : observeEndpointRouting) {
                 // register the service itself
-                routing.register(endpoint, new LogService(this.config));
+                routing.addFeature(new LogHttpFeature(endpoint, this.config));
             }
         } else {
             for (HttpRouting.Builder builder : observeEndpointRouting) {
-                builder.any(endpoint + "/*", (req, res) -> {
-                    throw new HttpException("Log endpoint is disabled", Status.SERVICE_UNAVAILABLE_503, true);
-                });
+                builder.addFeature(DisabledObserverFeature.create("Log", endpoint + "/*"));
             }
+        }
+    }
+
+    private static class LogHttpFeature implements HttpFeature {
+        private final String endpoint;
+        private final LogObserverConfig config;
+
+        private LogHttpFeature(String endpoint, LogObserverConfig config) {
+            this.endpoint = endpoint;
+            this.config = config;
+        }
+
+        @Override
+        public void setup(HttpRouting.Builder routing) {
+            routing.register(endpoint, new LogService(this.config));
         }
     }
 }

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/DisabledObserverFeature.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/DisabledObserverFeature.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe;
+
+import io.helidon.http.HttpException;
+import io.helidon.http.Status;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRouting;
+
+/**
+ * An {@link io.helidon.webserver.http.HttpFeature} that marks endpoint as disabled.
+ */
+public class DisabledObserverFeature implements HttpFeature {
+    private final String observerName;
+    private final String endpoint;
+
+    private DisabledObserverFeature(String observerName, String endpoint) {
+        this.observerName = observerName;
+        this.endpoint = endpoint;
+    }
+
+    /**
+     * Create a new disabled feature. Any requests to the endpoint will end with
+     * {@link io.helidon.http.Status#SERVICE_UNAVAILABLE_503}.
+     *
+     * @param observerName name of the observer, such as {@code Health}
+     * @param endpoint endpoint of the observer, such as {@code /observe/health/*}
+     * @return a new feature that returns unavailable for the endpoint for any method
+     */
+    public static DisabledObserverFeature create(String observerName, String endpoint) {
+        return new DisabledObserverFeature(observerName, endpoint);
+    }
+
+    @Override
+    public void setup(HttpRouting.Builder routing) {
+        routing.any(endpoint, (req, res) -> {
+            throw new HttpException(observerName + " endpoint is disabled", Status.SERVICE_UNAVAILABLE_503, true);
+        });
+    }
+}

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeature.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/ObserveFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ public class ObserveFeature implements ServerFeature, Weighted, RuntimeType.Api<
                     .map(it -> featureContext.socket(it).httpRouting())
                     .toList();
         }
-
+        // we must guarantee that each observer adding its own HttpFeature adds it with correct weight
         if (enabled) {
             for (Observer observer : observers) {
                 observer.register(featureContext, observeEndpointRouting, endpoint(config.endpoint()));

--- a/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/spi/Observer.java
+++ b/webserver/observe/observe/src/main/java/io/helidon/webserver/observe/spi/Observer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,11 @@ public interface Observer extends NamedService {
      * This is used by the observe feature.
      * Do NOT use this method directly, kindly start with {@link io.helidon.webserver.observe.ObserveFeature} and register
      * it with the server builder.
+     * <p>
+     * Implementations of observers should register all they need through an {@link io.helidon.webserver.http.HttpFeature},
+     * to make sure the weight of the {@link io.helidon.webserver.observe.ObserveFeature} is honored when routing is
+     * set up. If you do not use an HttpFeature, the registration will always happen later than the default (business) routing
+     * feature.
      *
      * @param featureContext         access to all routing builders, for cases where this observer needs to register additional
      *                               components to other sockets

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityFeature.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Weighted;
 import io.helidon.security.Security;
 import io.helidon.webserver.spi.ServerFeature;
 
@@ -40,7 +41,7 @@ import static io.helidon.webserver.WebServer.DEFAULT_SOCKET_NAME;
  * If configured, it also adds protection points to endpoints.
  */
 @RuntimeType.PrototypedBy(SecurityFeatureConfig.class)
-public class SecurityFeature implements ServerFeature, RuntimeType.Api<SecurityFeatureConfig> {
+public class SecurityFeature implements Weighted, ServerFeature, RuntimeType.Api<SecurityFeatureConfig> {
     static final double WEIGHT = 800;
     static final String SECURITY_ID = "security";
     private static final System.Logger LOGGER = System.getLogger(SecurityFeature.class.getName());
@@ -328,6 +329,11 @@ public class SecurityFeature implements ServerFeature, RuntimeType.Api<SecurityF
                                           featureConfig.weight(),
                                           defaults,
                                           configurations);
+    }
+
+    @Override
+    public double weight() {
+        return featureConfig.weight();
     }
 
     private SecurityHttpFeature routingFeature(SecurityHandler defaults, List<PathsConfig> configs) {

--- a/webserver/tests/observe/pom.xml
+++ b/webserver/tests/observe/pom.xml
@@ -37,5 +37,6 @@
         <module>health</module>
         <module>observe</module>
         <module>security</module>
+        <module>weighted</module>
     </modules>
 </project>

--- a/webserver/tests/observe/weighted/pom.xml
+++ b/webserver/tests/observe/weighted/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.webserver.tests.observe</groupId>
+        <artifactId>helidon-webserver-tests-observe-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-webserver-tests-observe-weighted</artifactId>
+    <name>Helidon WebServer Tests Observe Weighted</name>
+    <description>Test that we can change weight of observer to change weight of endpoints</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-info</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.observe</groupId>
+            <artifactId>helidon-webserver-observe-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/webserver/tests/observe/weighted/src/test/java/io/helidon/webserver/tests/observe/weighted/WeightedTest.java
+++ b/webserver/tests/observe/weighted/src/test/java/io/helidon/webserver/tests/observe/weighted/WeightedTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.observe.weighted;
+
+import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class WeightedTest {
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder routing) {
+        routing.get("/greet", (req, res) -> res.send("Hello World!"))
+                .get("/observe/*", (req, res) -> res.send("User's observe endpoint"));
+    }
+
+    @Test
+    void testInfoObserver(WebClient client) {
+        JsonObject jsonObject = client.get("/observe/info/name")
+                .requestEntity(JsonObject.class);
+        assertThat("JSON: " + jsonObject, jsonObject.getString("name"), is("name"));
+        assertThat("JSON: " + jsonObject, jsonObject.getString("value"), is("ObserveTest"));
+
+        jsonObject = client.get("/observe/info")
+                .requestEntity(JsonObject.class);
+        assertThat("JSON: " + jsonObject, jsonObject.getString("name"), is("ObserveTest"));
+        assertThat("JSON: " + jsonObject, jsonObject.getString("description"), is("Test for observability features"));
+        assertThat("JSON: " + jsonObject, jsonObject.getString("version"), is("1.0.0"));
+    }
+
+    @Test
+    void testMetricsObserver(WebClient client) {
+        ClientResponseTyped<String> response = client.get("/observe/metrics")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat("Entity: " + response.entity(), response.entity(), startsWith("# HELP"));
+    }
+
+    @Test
+    void testHealthObserver(WebClient client) {
+        ClientResponseTyped<String> response = client.get("/observe/health")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.NO_CONTENT_204));
+    }
+
+    @Test
+    void testLogObserver(WebClient client) {
+        ClientResponseTyped<JsonObject> response = client.get("/observe/log/loggers")
+                .request(JsonObject.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        JsonObject entity = response.entity();
+        assertThat("Entity: " + entity, entity.getJsonArray("levels").getString(0), is("OFF"));
+    }
+
+    @Test
+    void testLogObserverLogger(WebClient client) {
+        ClientResponseTyped<JsonObject> response = client.get("/observe/log/loggers/io.helidon.webserver.ServerListener")
+                .request(JsonObject.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        JsonObject entity = response.entity();
+        assertThat("Entity: " + entity, entity.getJsonObject("io.helidon.webserver.ServerListener"), notNullValue());
+    }
+
+    @Test
+    void testConfigObserver(WebClient client) {
+        ClientResponseTyped<String> response = client.get("/observe/config/profile")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        String entity = response.entity();
+        assertThat("Entity: " + entity, entity, not("should not be seen"));
+    }
+
+    @Test
+    void testConfigObserverValue(WebClient client) {
+        ClientResponseTyped<String> response = client.get("/observe/config/values/app.text")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        String entity = response.entity();
+        assertThat("Entity: " + entity, entity, containsString("should be seen"));
+    }
+
+    @Test
+    void testFallbackToUserRouting(WebClient client) {
+        ClientResponseTyped<String> response = client.get("/observe/notthere")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        String entity = response.entity();
+        assertThat("Entity: " + entity, entity, is("User's observe endpoint"));
+    }
+}

--- a/webserver/tests/observe/weighted/src/test/resources/application.yaml
+++ b/webserver/tests/observe/weighted/src/test/resources/application.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  features:
+    observe:
+      weight: 120 # make sure this has higher than default weight, so it is before user's endpoints
+      observers:
+        log:
+          permit-all: true
+        config:
+          permit-all: true
+        info:
+          values:
+            name: "ObserveTest"
+            description: "Test for observability features"
+            version: "1.0.0"
+
+app:
+  text: "should be seen"

--- a/webserver/tests/observe/weighted/src/test/resources/logging-test.properties
+++ b/webserver/tests/observe/weighted/src/test/resources/logging-test.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS %4$s %3$s %5$s%6$s%n
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+io.helidon.webserver.level=INFO

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ import java.util.logging.Logger;
 
 import io.helidon.common.SerializationConfig;
 import io.helidon.common.Version;
+import io.helidon.common.Weighted;
+import io.helidon.common.Weights;
 import io.helidon.common.context.Context;
 import io.helidon.common.features.HelidonFeatures;
 import io.helidon.common.features.api.HelidonFlavor;
@@ -81,8 +83,10 @@ class LoomServer implements WebServer {
         List<ServerFeature> features = serverConfig.features();
         ServerFeatureContextImpl featureContext = ServerFeatureContextImpl.create(serverConfig);
         for (ServerFeature feature : features) {
+            featureContext.weight(Weights.find(feature, Weighted.DEFAULT_WEIGHT));
             feature.setup(featureContext);
         }
+        featureContext.weight(Weighted.DEFAULT_WEIGHT);
 
         Timer idleConnectionTimer = new Timer("helidon-idle-connection-timer", true);
         Map<String, ServerListener> listenerMap = new HashMap<>();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerFeatureContextImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerFeatureContextImpl.java
@@ -318,7 +318,12 @@ class ServerFeatureContextImpl implements ServerFeature.ServerFeatureContext {
 
         @Override
         public HttpRouting.Builder addFeature(HttpFeature feature) {
-            delegate.addFeature(new WeightedHttpFeature(feature, Weights.find(feature, weight.get())));
+            double foundWeight = Weights.find(feature, -1);
+            if (foundWeight == -1) {
+                delegate.addFeature(new WeightedHttpFeature(feature, weight.get()));
+            } else {
+                delegate.addFeature(feature);
+            }
             return this;
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -460,6 +460,18 @@ public final class HttpRouting implements Routing, Prototype.Api {
          * @return updated builder
          */
         Builder addFilter(Filter filter);
+
+        /**
+         * Add a new feature.
+         * If a feature is added from within a feature, it will inherit weight of the feature adding it and will be fully
+         * registered at the same time.
+         *
+         * @param feature feature to add
+         * @return updated builder
+         */
+        default Builder addFeature(HttpFeature feature) {
+            return addFeature((Supplier<? extends HttpFeature>) feature);
+        }
 
         /**
          * Add a new feature.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/spi/ServerFeatureProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/spi/ServerFeatureProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,32 @@ import io.helidon.common.config.ConfiguredProvider;
 
 /**
  * Server features provider is a {@link java.util.ServiceLoader} provider API to discover server wide features.
+ * <p>
+ * When creating a custom feature, one of the aspects important for how it is configured with the server, and with routing,
+ * is the {@link io.helidon.common.Weight}.
+ * <p>
+ * There are three places where weight is taken into account:
+ * <ol>
+ *     <li>When discovering server features from the service loader, the weight of this provider implementation is used</li>
+ *     <li>When setting up server features within the server (and as a default for {@link io.helidon.webserver.http.HttpFeature}
+ *     added by a server feature), the {@link io.helidon.common.Weight} or {@link io.helidon.common.Weighted} of the
+ *     {@link io.helidon.webserver.spi.ServerFeature} implementation is used to order the features</li>
+ *     <li>When configuring {@link io.helidon.webserver.http.HttpFeature} from a server feature, the weight of that
+ *     implementation can override the default from the server feature, and the weight is used to order all HTTP features,
+ *     including user routing (which has the default weight of {@value io.helidon.common.Weighted#DEFAULT_WEIGHT})</li>
+ * </ol>
+ * The following weights are used by features of Helidon:
+ * <ul>
+ *     <li>Context: 1100</li>
+ *     <li>Access Log: 1000</li>
+ *     <li>Tracing: 900</li>
+ *     <li>CORS: 950</li>
+ *     <li>Security: 800</li>
+ *     <li>User routing (all handlers): 100</li>
+ *     <li>OpenAPI: 90</li>
+ *     <li>Observe (metrics, health, etc.): 80</li>
+ * </ul>
+ * For some features the weight can be modified using configuration, key is always {@code weight}.
  *
  * @param <T> type of the server feature the provider provides
  */


### PR DESCRIPTION
HttpFeatures now inherit weight of ServerFeatures. As ObserveFeature weight can be configured, we can control whether it is executed before or after user routing (default is after).

Resolves #8550 

This now works as designed. You can configure `ObserveFeature` weight through configuration to be higher than default (100) to be invoked first. 