### PR TITLE
4.x: Fix wrong description for bean validation annotations (#8505)

### DIFF
--- a/docs/src/main/asciidoc/mp/beanvalidation.adoc
+++ b/docs/src/main/asciidoc/mp/beanvalidation.adoc
@@ -104,7 +104,7 @@ Note that `double` and `float` are not supported due to rounding errors (some pr
 
 
 |`@Max`
-a|The annotated element must be a number whose value must be higher or equal to the specified minimum.
+a|The annotated element must be a number whose value must be lower or equal to the specified maximum.
 
 Supported types are:
 
@@ -117,12 +117,13 @@ Note that `double` and `float` are not supported due to rounding errors (some pr
 `Null` elements are considered valid.
 
 |`@DecimalMin`
-a|The annotated element must be a number whose value must be lower or equal to the specified maximum.
+a|The annotated element must be a number whose value must be higher or equal to the specified minimum.
 
 Supported types are:
 
 * `BigDecimal`
 * `BigInteger`
+* `CharSequence`
 * `byte`, `short`, `int`, `long`, and their respective wrappers
 
 Note that `double` and `float` are not supported due to rounding errors (some providers might provide some approximative support).
@@ -137,6 +138,7 @@ Supported types are:
 
 * `BigDecimal`
 * `BigInteger`
+* `CharSequence`
 * `byte`, `short`, `int`, `long`, and their respective wrappers
 
 Note that `double` and `float` are not supported due to rounding errors (some providers might provide some approximative support).
@@ -212,7 +214,7 @@ Supported types are:
 
 
 |`@Past`
-a|The annotated element must be an instant, date or time in the past or in the present.
+a|The annotated element must be an instant, date or time in the past.
 `Now` is defined by the `ClockProvider` attached to the `Validator` or `ValidatorFactory`. The default `clockProvider` defines the current time
 according to the virtual machine, applying the current default time zone if needed.
 
@@ -242,6 +244,10 @@ a|The annotated element must be an instant, date or time in the past or in the p
 `Now` is defined by the `ClockProvider` attached to the `Validator` or `ValidatorFactory`. The default `clockProvider` defines the current time
 according to the virtual machine, applying the current default time zone if needed.
 
+The notion of present is defined relatively to the type on which the constraint is
+used. For instance, if the constraint is on a `Year`, present would mean the whole
+current year.
+
 Supported types are:
 
 *     `java.util.Date`
@@ -263,7 +269,7 @@ Supported types are:
 
 `Null` elements are considered valid.
 
-|`@PastOrPresent`
+|`@Future`
 a|The annotated element must be an instant, date or time in the future.
 `Now` is defined by the `ClockProvider` attached to the `Validator` or `ValidatorFactory`. The default `clockProvider` defines the current time
 according to the virtual machine, applying the current default time zone if needed.
@@ -294,6 +300,10 @@ a|The annotated element must be an instant, date or time in the present or in th
 `Now` is defined by the `ClockProvider` attached to the `Validator` or `ValidatorFactory`. The default `clockProvider` defines the current time
 according to the virtual machine, applying the current default time zone if needed.
 
+The notion of present here is defined relatively to the type on which the constraint is
+used. For instance, if the constraint is on a `Year`, present would mean the whole
+current year.
+
 Supported types are:
 
 *     `java.util.Date`
@@ -315,7 +325,7 @@ Supported types are:
 
 `Null` elements are considered valid.
 
-|`@FutureOrPresent`
+|`@Pattern`
 a|The annotated `CharSequence` must match the specified regular expression.
 The regular expression follows the Java regular expression conventions see `java.util.regex.Pattern`.
 Accepts `CharSequence`.


### PR DESCRIPTION
### Description
Resolves #8505 

I followed [Jakarta Bean Validation Specification](https://jakarta.ee/specifications/bean-validation/3.0/jakarta-bean-validation-spec-3.0.html)
