### PR TITLE
[4.x] Fix failure with input stream obtained more than once for post with more than one JAX-RS app

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -205,7 +205,7 @@ class JaxRsService implements HttpService {
 
         JaxRsResponseWriter writer = new JaxRsResponseWriter(res);
         requestContext.setWriter(writer);
-        requestContext.setEntityStream(req.content().inputStream());
+        requestContext.setEntityStream(new LazyInputStream(req));
         requestContext.setProperty("io.helidon.jaxrs.remote-host", req.remotePeer().host());
         requestContext.setProperty("io.helidon.jaxrs.remote-port", req.remotePeer().port());
         requestContext.setRequestScopedInitializer(ij -> {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/LazyInputStream.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/LazyInputStream.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.server;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import io.helidon.common.LazyValue;
+import io.helidon.webserver.http.ServerRequest;
+
+/*
+ Only obtains the input stream from request when used.
+ This is to work around the case where we have a Jersey application before other routing for requests with entity.
+ Before this fix, we would request the input stream, and the next component would fail with input stream already requested.
+ */
+class LazyInputStream extends InputStream {
+    private final LazyValue<InputStream> delegate;
+
+    LazyInputStream(ServerRequest req) {
+        delegate = LazyValue.create(() -> req.content().inputStream());
+    }
+
+    @Override
+    public int read() throws IOException {
+        return delegate.get().read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return delegate.get().read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return delegate.get().read(b, off, len);
+    }
+
+    @Override
+    public byte[] readAllBytes() throws IOException {
+        return delegate.get().readAllBytes();
+    }
+
+    @Override
+    public byte[] readNBytes(int len) throws IOException {
+        return delegate.get().readNBytes(len);
+    }
+
+    @Override
+    public int readNBytes(byte[] b, int off, int len) throws IOException {
+        return delegate.get().readNBytes(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return delegate.get().skip(n);
+    }
+
+    @Override
+    public void skipNBytes(long n) throws IOException {
+        delegate.get().skipNBytes(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return delegate.get().available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.get().close();
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        delegate.get().mark(readlimit);
+    }
+
+    @Override
+    public void reset() throws IOException {
+        delegate.get().reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return delegate.get().markSupported();
+    }
+
+    @Override
+    public long transferTo(OutputStream out) throws IOException {
+        return delegate.get().transferTo(out);
+    }
+}

--- a/tests/integration/mp-gh-8349/pom.xml
+++ b/tests/integration/mp-gh-8349/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-gh-8349</artifactId>
+    <name>Helidon Tests Integration MP GH 8349</name>
+    <description>Reproducer for Github issue #8349 - Entity already requested after Jersey returns 404</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-gh-8349/src/main/java/io/helidon/tests/integration/gh8349/Gh8349App1.java
+++ b/tests/integration/mp-gh-8349/src/main/java/io/helidon/tests/integration/gh8349/Gh8349App1.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8349;
+
+import java.util.Set;
+
+import io.helidon.common.Weight;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+
+@ApplicationScoped
+@ApplicationPath("/")
+@Weight(100)
+public class Gh8349App1 extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(Gh8349Resource1.class);
+    }
+
+    @Path("/greet1")
+    public static class Gh8349Resource1 {
+        @POST
+        @Produces(MediaType.TEXT_PLAIN)
+        public String testPost(String entity) {
+            return "Hello World 1!";
+        }
+    }
+}

--- a/tests/integration/mp-gh-8349/src/main/java/io/helidon/tests/integration/gh8349/Gh8349App2.java
+++ b/tests/integration/mp-gh-8349/src/main/java/io/helidon/tests/integration/gh8349/Gh8349App2.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8349;
+
+import java.util.Set;
+
+import io.helidon.common.Weight;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+
+@ApplicationScoped
+@ApplicationPath("/")
+@Weight(50)
+public class Gh8349App2 extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(Gh8349Resource2.class);
+    }
+
+    @Path("/greet2")
+    public static class Gh8349Resource2 {
+        @POST
+        @Produces(MediaType.TEXT_PLAIN)
+        public String testPost(String entity) {
+            return "Hello World 2!";
+        }
+    }
+}

--- a/tests/integration/mp-gh-8349/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-gh-8349/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+        version="4.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/mp-gh-8349/src/main/resources/logging.properties
+++ b/tests/integration/mp-gh-8349/src/main/resources/logging.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+.level=WARNING
+
+io.helidon.level=INFO

--- a/tests/integration/mp-gh-8349/src/test/java/io/helidon/tests/integration/gh8349/Gh8349Test.java
+++ b/tests/integration/mp-gh-8349/src/test/java/io/helidon/tests/integration/gh8349/Gh8349Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8349;
+
+import io.helidon.http.Status;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+class Gh8349Test {
+    private final WebTarget target;
+
+    @Inject
+    Gh8349Test(WebTarget target) {
+        this.target = target;
+    }
+
+    @Test
+    void testApp1() {
+        try (Response response = target.path("/greet1")
+                .request()
+                .post(Entity.text("hello"))) {
+            assertThat(response.getStatus(), is(Status.OK_200.code()));
+
+            String entity = response.readEntity(String.class);
+            assertThat(entity, is("Hello World 1!"));
+        }
+
+    }
+
+    @Test
+    void testApp2() {
+        try (Response response = target.path("/greet2")
+                .request()
+                .post(Entity.text("hello"))) {
+            assertThat(response.getStatus(), is(Status.OK_200.code()));
+
+            String entity = response.readEntity(String.class);
+            assertThat(entity, is("Hello World 2!"));
+        }
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -53,6 +53,7 @@
         <module>mp-gh-4123</module>
         <module>mp-gh-4654</module>
         <module>mp-gh-5328</module>
+        <module>mp-gh-8349</module>
         <module>mp-gh-8478</module>
         <module>mp-gh-8495</module>
         <module>mp-graphql</module>


### PR DESCRIPTION
Added test to validate requests with entity work even if first handled by Jersey (and not processed as there is no resource).

Fixed the exception being thrown by introuding a lazy input stream that only requests the input stream from request when used.


### Description
resolves #8349 
There is no impact on documentation, this fixes a bug.