### PR TITLE
Fix handling of baggage when retrieving current span

### DIFF
--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -154,6 +154,11 @@
             <artifactId>bedrock-testing-support</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -166,19 +171,31 @@
                         <id>default-test</id>
                         <configuration>
                             <excludes>
-                                <exclude>**/B3HeadersPropagationCaseTest.java</exclude>
+                                <exclude>**/B3HeadersPropagationCaseTest.java,**/JaegerBaggagePropagationTest.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
                     <execution>
                         <!-- Run this test in a separate JVM so we don't init GlobalOpenTelemetry multiple times. -->
-                        <id>headers-propagation-test</id>
+                        <id>b3-headers-propagation-test</id>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
                             <includes>
                                 <include>**/B3HeadersPropagationCaseTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Run this test in a separate JVM so we don't init GlobalOpenTelemetry multiple times. -->
+                        <id>all-headers-propagation-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/JaegerBaggagePropagationTest.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerProvider.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,9 @@ import java.util.Optional;
 import io.helidon.common.Prioritized;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.Tracer;
-import io.helidon.tracing.opentelemetry.HelidonOpenTelemetry;
 import io.helidon.tracing.opentelemetry.OpenTelemetryTracerProvider;
 import io.helidon.tracing.spi.TracerProvider;
 
-import io.opentelemetry.context.Context;
 import jakarta.annotation.Priority;
 
 /**
@@ -44,8 +42,7 @@ public class JaegerTracerProvider implements TracerProvider {
 
     @Override
     public Optional<Span> currentSpan() {
-        return Optional.ofNullable(io.opentelemetry.api.trace.Span.fromContextOrNull(Context.current()))
-                .map(HelidonOpenTelemetry::create);
+        return OpenTelemetryTracerProvider.activeSpan();
     }
 
     @Override

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerBaggagePropagationTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerBaggagePropagationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.jaeger;
+
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+import io.helidon.common.testing.junit5.OptionalMatcher;
+import io.helidon.config.Config;
+import io.helidon.tracing.HeaderConsumer;
+import io.helidon.tracing.HeaderProvider;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.Tracer;
+import io.helidon.tracing.TracerBuilder;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+class JaegerBaggagePropagationTest {
+
+    static final String BAGGAGE_KEY = "myKey";
+    static final String BAGGAGE_VALUE = "myValue";
+
+    private static final String OTEL_AUTO_CONFIGURE_PROP = "otel.java.global-autoconfigure.enabled";
+    private static final String OTEL_SDK_DISABLED_PROP = "otel.sdk.disabled";
+    private static String originalOtelSdkAutoConfiguredSetting;
+    private static String originalOtelSdkDisabledSetting;
+
+    private static Config config;
+    private static Tracer tracer;
+
+    @BeforeAll
+    static void init() {
+        config = Config.create().get("tracing");
+        tracer = TracerBuilder.create(config.get("jaeger-all-propagators")).build();
+        originalOtelSdkAutoConfiguredSetting = System.setProperty(OTEL_AUTO_CONFIGURE_PROP, "true");
+        originalOtelSdkDisabledSetting = System.setProperty(OTEL_SDK_DISABLED_PROP, "false");
+    }
+
+    @AfterAll
+    static void wrapup() {
+        if (originalOtelSdkAutoConfiguredSetting != null) {
+            System.setProperty(OTEL_AUTO_CONFIGURE_PROP, originalOtelSdkAutoConfiguredSetting);
+        }
+        if (originalOtelSdkDisabledSetting != null) {
+            System.setProperty(OTEL_SDK_DISABLED_PROP, originalOtelSdkDisabledSetting);
+        }
+    }
+
+    @Test
+    void testBaggageProp() {
+
+        var span = tracer.spanBuilder("testSpan").start();
+        span.baggage(BAGGAGE_KEY, BAGGAGE_VALUE);
+
+        checkBaggage(tracer, span, span::context);
+    }
+
+    @Test
+    void testBaggageBeforeActivatingSpan() {
+        var span = tracer.spanBuilder("activatedTestSpan").start();
+        span.baggage(BAGGAGE_KEY, BAGGAGE_VALUE);
+
+        try (Scope scope = span.activate()) {
+            checkBaggage(tracer, span, this::currentSpanContext);
+        }
+    }
+
+    @Test
+    void testBaggageAfterActivatingSpan() {
+        var span = tracer.spanBuilder("activatedTestSpan").start();
+
+        try (Scope scope = span.activate()) {
+            span.baggage(BAGGAGE_KEY, BAGGAGE_VALUE);
+            checkBaggage(tracer, span, this::currentSpanContext);
+        }
+    }
+
+    private void checkBaggage(Tracer tracer, Span span, Supplier<SpanContext> spanContextSupplier) {
+        try {
+            assertThat("Value after initial storage of baggage",
+                       span.baggage(BAGGAGE_KEY),
+                       OptionalMatcher.optionalValue(is(equalTo(BAGGAGE_VALUE))));
+
+            var headerConsumer = HeaderConsumer.create(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+            tracer.inject(spanContextSupplier.get(), HeaderProvider.empty(), headerConsumer);
+
+            // Make sure the baggage header was set.
+            Optional<String> baggageHeader = headerConsumer.get("baggage");
+            assertThat("Baggage contents in propagated headers",
+                       baggageHeader,
+                       OptionalMatcher.optionalValue(is(equalTo(BAGGAGE_KEY + "=" + BAGGAGE_VALUE))));
+
+            // Now make sure the baggage is propagated to a new span context based on the header.
+            Optional<SpanContext> propagatedSpanContext = tracer.extract(headerConsumer);
+            assertThat("Propagated span context",
+                       propagatedSpanContext,
+                       OptionalMatcher.optionalPresent());
+            Span spanFromContext = tracer.spanBuilder("fromContext").parent(propagatedSpanContext.get()).build();
+            assertThat("Baggage value from propagated span context",
+                       spanFromContext.baggage(BAGGAGE_KEY),
+                       OptionalMatcher.optionalValue(is(BAGGAGE_VALUE)));
+
+            span.end();
+        } catch (Exception ex) {
+            span.end(ex);
+        }
+    }
+
+    private SpanContext currentSpanContext() {
+        return Span.current()
+                .map(Span::context)
+                .orElseThrow(() -> new IllegalStateException("No current span"));
+    }
+}

--- a/tracing/jaeger/src/test/resources/application.yaml
+++ b/tracing/jaeger/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,3 +46,6 @@ tracing:
     int-tags:
       tag5: 145           # JAEGER_TAGS
       tag6: 741           # JAEGER_TAGS
+  jaeger-all-propagators:
+    service: "prop-test"
+    propagation: ["jaeger", "b3", "w3c"]

--- a/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/HelidonOpenTelemetry.java
+++ b/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/HelidonOpenTelemetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Optional;
 import io.helidon.config.Config;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 
@@ -55,6 +56,17 @@ public final class HelidonOpenTelemetry {
      */
     public static io.helidon.tracing.Span create(Span span) {
         return new OpenTelemetrySpan(span);
+    }
+
+    /**
+     * Wrap an open telemetry span.
+     *
+     * @param span open telemetry span
+     * @param baggage open telemetry baggage
+     * @return Helidon (@link io.helidon.tracing.Span}
+     */
+    public static io.helidon.tracing.Span create(Span span, Baggage baggage) {
+        return new OpenTelemetrySpan(span, baggage);
     }
 
 

--- a/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/OpenTelemetryTracerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,13 +93,13 @@ public class OpenTelemetryTracerProvider implements TracerProvider {
     public static Optional<Span> activeSpan() {
         // OTel returns a no-op span if there is no current one.
         io.opentelemetry.api.trace.Span otelSpan = io.opentelemetry.api.trace.Span.current();
-        Span helidonSpan = HelidonOpenTelemetry.create(otelSpan);
 
         // OTel returns empty baggage if there is no current one.
         io.opentelemetry.api.baggage.Baggage otelBaggage = io.opentelemetry.api.baggage.Baggage.current();
 
-        otelBaggage.forEach((key, baggageEntry) -> helidonSpan.baggage(key, baggageEntry.getValue()));
-        return Optional.of(helidonSpan);
+        // Create the span directly with the retrieved baggage. Ideally, it will be our writable baggage because we had put it
+        // there in the context.
+        return Optional.of(HelidonOpenTelemetry.create(otelSpan, otelBaggage));
     }
 
     @Override

--- a/tracing/opentelemetry/src/test/java/io/helidon/tracing/opentelemetry/TestSpanAndBaggage.java
+++ b/tracing/opentelemetry/src/test/java/io/helidon/tracing/opentelemetry/TestSpanAndBaggage.java
@@ -18,20 +18,25 @@ package io.helidon.tracing.opentelemetry;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Supplier;
 
 import io.helidon.common.testing.junit5.OptionalMatcher;
+import io.helidon.tracing.HeaderConsumer;
 import io.helidon.tracing.HeaderProvider;
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.Tracer;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
@@ -41,6 +46,10 @@ class TestSpanAndBaggage {
     private static final String OTEL_SDK_DISABLED_PROP = "otel.sdk.disabled";
     private static String originalOtelSdkAutoConfiguredSetting;
     private static String originalOtelSdkDisabledSetting;
+
+    private static final String BAGGAGE_KEY = "mykey";
+    private static final String BAGGAGE_VALUE = "myvalue";
+
 
     @BeforeAll
     static void init() {
@@ -126,4 +135,80 @@ class TestSpanAndBaggage {
         assertThat("Inbound baggage bag1", span.baggage("bag1"), OptionalMatcher.optionalValue(is("val1")));
         assertThat("Inbound baggage bag1", span.baggage("bag2"), OptionalMatcher.optionalValue(is("val2")));
     }
+
+
+    @Test
+    void testBaggageWithoutActivation() {
+        final var tracer = io.helidon.tracing.Tracer.global();
+        final var span = tracer.spanBuilder("baggageCanaryMinimal").start();
+        try {
+            // Set baggage and confirm that it's known in the span
+            span.baggage(BAGGAGE_KEY, BAGGAGE_VALUE);
+            checkBaggage(tracer, span, span::context);
+        } catch (final Exception x) {
+            span.end(x);
+        } finally {
+            span.end();
+        }
+    }
+
+    @Test
+    void testBaggageAddedBeforeActivation() {
+        final var tracer = io.helidon.tracing.Tracer.global();
+        final var span = tracer.spanBuilder("baggageCanaryMinimal").start();
+
+        try {
+            // Set baggage and confirm that it's known in the span
+            span.baggage(BAGGAGE_KEY, BAGGAGE_VALUE);
+            try (Scope scope = span.activate()) {
+                checkBaggage(tracer, span, this::currentSpanContext);
+            }
+        } catch (final Exception x) {
+            span.end(x);
+        } finally {
+            span.end();
+        }
+    }
+
+    @Test
+    void testBaggageAddedAfterActivation() {
+        final String BAGGAGE_KEY = "mykey";
+        final String BAGGAGE_VALUE = "myvalue";
+        final var tracer = io.helidon.tracing.Tracer.global();
+        final var span = tracer.spanBuilder("baggageCanaryMinimal").start();
+        try {
+            // Set baggage and confirm that it's known in the span
+            try (Scope scope = span.activate()) {
+                span.baggage(BAGGAGE_KEY, BAGGAGE_VALUE);
+                checkBaggage(tracer, span, this::currentSpanContext);
+            }
+        } catch (final Exception x) {
+            span.end(x);
+        } finally {
+            span.end();
+        }
+    }
+
+    private void checkBaggage(Tracer tracer, Span span, Supplier<SpanContext> spanContextSupplier) {
+        String value = span.baggage(BAGGAGE_KEY).orElseThrow();
+        assertThat("baggage value right after set", value, Matchers.is(Matchers.equalTo(BAGGAGE_VALUE)));
+
+        // Inject the span (context) into the consumer
+        final var consumer = HeaderConsumer
+                .create(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+        tracer.inject(spanContextSupplier.get(), HeaderProvider.empty(), consumer);
+        // Confirm that baggage was NOT propagated (the bug)
+        final var allKeys = consumer.keys();
+        assertThat("Injected headers", allKeys, hasItem("baggage"));
+        assertThat("Injected baggage expression",
+                   consumer.get("baggage"),
+                   OptionalMatcher.optionalValue(Matchers.equalTo(BAGGAGE_KEY + "=" + BAGGAGE_VALUE)));
+    }
+
+    private SpanContext currentSpanContext() {
+        return Span.current()
+                .map(Span::context)
+                .orElseThrow(() -> new IllegalStateException("No current span"));
+    }
+
 }


### PR DESCRIPTION
### Description
Resolves #8548 

OpenTelemetry separates baggage from spans and stores them separately in the OTel context. In contrast, the Helidon tracing API treats baggage as a characteristic of a span.

Earlier PRs fixed a problem in which Helidon failed to store the baggage associated with a span correctly in the OTel context. This PR fixes a problem in reconstituting the correct current span from what is in the OTel context, making sure the new reconstituted span draws from _both_ the OTel span in the context _and_ the OTel baggage in the context.

The central fix is in `OpenTelemetryTracerProvider` and its `currentSpan` method (which now delegates to `activeSpan` so the Jaeger code can also use it). The `Span` constructed for `currentSpan`/`activeSpan` now holds a reference to the OTel `Baggage` instance from the Otel `Context`. 

Normally, that baggage will be our writeable baggage implementation of OTel's `Baggage` interface. That implementation allows the Helidon `Span` wrapper around the OTel span to permit updates to its baggage. By storing a reference to that baggage in the reconstituted span, changes to the baggage via the baggage methods on the reconstituted `Span` will write through to the baggage that is stored in the context. 

But, it's possible that _immutable_ Otel baggage might be in the OTel context when the current span is reconstructed. The Helidon `OpenTelemetrySpan` method for updating baggage therefore must now check to see if its baggage is writeable or not and act accordingly.

The PR also contains new tests for OTel and Jaeger (which relies on the OTel implementation internally).

### Documentation
Bug fix; no doc changes.