### PR TITLE
Fix Span.current() behavior with OTel - return Optional.empty() if there is no current span

### DIFF
--- a/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/tracing/opentelemetry/src/main/java/io/helidon/tracing/opentelemetry/OpenTelemetryTracerProvider.java
@@ -91,10 +91,17 @@ public class OpenTelemetryTracerProvider implements TracerProvider {
      * @return optional of the current span
      */
     public static Optional<Span> activeSpan() {
-        // OTel returns a no-op span if there is no current one.
-        io.opentelemetry.api.trace.Span otelSpan = io.opentelemetry.api.trace.Span.current();
+        io.opentelemetry.context.Context otelContext = io.opentelemetry.context.Context.current();
 
-        // OTel returns empty baggage if there is no current one.
+        // OTel Span.current() returns a no-op span if there is no current one. Use fromContextOrNull instead to distinguish.
+        io.opentelemetry.api.trace.Span otelSpan =
+                io.opentelemetry.api.trace.Span.fromContextOrNull(otelContext);
+
+        if (otelSpan == null) {
+            return Optional.empty();
+        }
+
+        // OTel Baggage.current() returns empty baggage if there is no current one. That's OK for baggage.
         io.opentelemetry.api.baggage.Baggage otelBaggage = io.opentelemetry.api.baggage.Baggage.current();
 
         // Create the span directly with the retrieved baggage. Ideally, it will be our writable baggage because we had put it

--- a/tracing/opentelemetry/src/test/java/io/helidon/tracing/opentelemetry/TestSpanAndBaggage.java
+++ b/tracing/opentelemetry/src/test/java/io/helidon/tracing/opentelemetry/TestSpanAndBaggage.java
@@ -113,14 +113,11 @@ class TestSpanAndBaggage {
             outerSpan.end(e);
         }
 
-        // There was no active span before outerSpan was activated, so expect the "default" ad-hoc span ID of all zeroes.
+        // There was no active span before outerSpan was activated, so expect an empty current span.
         Optional<Span> currentSpanAfterTryResourcesBlock = Span.current();
         assertThat("Current span just after try-resources block",
                    currentSpanAfterTryResourcesBlock,
-                   OptionalMatcher.optionalPresent());
-        assertThat("Current span just after try-resources block",
-                   currentSpanAfterTryResourcesBlock.get().context().spanId(),
-                   containsString("00000000"));
+                   OptionalMatcher.optionalEmpty());
     }
 
 


### PR DESCRIPTION
### Description
Resolves #8573 

For some time, our OTel implementation of `Span.current()` used OTel's `Span.current()` which (also for some time) always returns a value. If there is no current span, OTel returns a new no-op span (with the trace and span IDs set to 0). (Because Jaeger has come to rely on OTel as well, this affected the Jaeger current span behavior as well.)

But our `Span.current()` contract says we return `Optional.empty()` if there is no current span.

This PR instead uses OTel's `Span.fromContextOrNull` to retrieve the actual current span if there is one or 'null' if there is none. Then our code wraps that in an `Optional`, thus honoring the documented contract.

### Documentation
Bug fix; no doc impact