### PR TITLE
1.x:  upgrade netty to 4.1.108.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -87,7 +87,7 @@
         <version.lib.mockito>2.23.4</version.lib.mockito>
         <version.lib.mysql-connector-java>8.0.29</version.lib.mysql-connector-java>
         <version.lib.narayana>5.9.3.Final</version.lib.narayana>
-        <version.lib.netty>4.1.100.Final</version.lib.netty>
+        <version.lib.netty>4.1.108.Final</version.lib.netty>
         <version.lib.oci-java-sdk-objectstorage>2.66.0</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>19.3.0.0</version.lib.ojdbc8>
         <version.lib.opentracing>0.32.0</version.lib.opentracing>
@@ -225,56 +225,6 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>${version.lib.el-impl}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler-proxy</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-dns</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver-dns</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http2</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-buffer</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
-                <version>${version.lib.netty}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse</groupId>
@@ -669,6 +619,13 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
                 <version>${version.lib.google-protobuf}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${version.lib.netty}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -43,9 +43,11 @@ source ${WS_DIR}/etc/scripts/pipeline-env.sh
 
 die(){ cat ${RESULT_FILE} ; echo "Dependency report in ${WS_DIR}/target" ; echo "${1}" ; exit 1 ;}
 
+# Setting NVD_API_KEY is not required but improves behavior of NVD API thrott    ling
 mvn ${MAVEN_ARGS} -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN org.owasp:dependency-check-maven:aggregate \
         -f ${WS_DIR}/pom.xml \
         -Dtop.parent.basedir="${WS_DIR}" \
+        -Dnvd-api-key=${NVD_API_KEY} \
         > ${RESULT_FILE} || die "Error running the Maven command"
 
 grep -i "One or more dependencies were identified with known vulnerabilities" ${RESULT_FILE} \

--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.plugin.spotbugs>3.1.12</version.plugin.spotbugs>
         <version.plugin.surefire.provider.junit>1.0.3</version.plugin.surefire.provider.junit>
         <version.plugin.surefire>2.19.1</version.plugin.surefire>
-        <version.plugin.dependency-check>8.4.3</version.plugin.dependency-check>
+        <version.plugin.dependency-check>9.1.0</version.plugin.dependency-check>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2016, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/resources/META-INF/native-image/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/resources/META-INF/native-image/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/native-image.properties
@@ -55,4 +55,6 @@ Args=--report-unsupported-elements-at-runtime \
   --initialize-at-run-time=io.netty.internal.tcnative.SSL \
   --initialize-at-run-time=io.netty.internal.tcnative.SSLPrivateKeyMethod \
   --initialize-at-run-time=io.netty.util.internal.logging.Log4JLogger \
-  --initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils
+  --initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils \
+  --initialize-at-run-time=io.helidon.webserver.NettyInitializer \
+  --initialize-at-run-time=io.netty.handler.ssl.JdkSslServerContext


### PR DESCRIPTION
### Description

* Upgrade Netty to 4.1.108.Final
* Use netty-bom for version management
* Update native-image.properties for webserver 
* Upgrade owasp-dependency-check to 9.1.0

### Documentation

No impact