### PR TITLE
2.x: Fix wrong example for Config.onChange (#8596)

### DIFF
--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -842,7 +842,7 @@ public interface Config {
     /**
      * Register a {@link Consumer} that is invoked each time a change occurs on whole Config or on a particular Config node.
      * <p>
-     * A user can subscribe on root Config node and than will be notified on any change of Configuration.
+     * A user can subscribe on root Config node and then will be notified on any change of Configuration.
      * You can also subscribe on any sub-node, i.e. you will receive notification events just about sub-configuration.
      * No matter how much the sub-configuration has changed you will receive just one notification event that is associated
      * with a node you are subscribed on.

--- a/docs/se/config/05_mutability-support.adoc
+++ b/docs/se/config/05_mutability-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -161,19 +161,16 @@ run when any change occurs.
 .Subscribe on `greeting` property changes via `onChange` method
 ----
 config.get("greeting")                                                         // <1>
-        .onChange((changedNode) -> {                                           // <2>
+        .onChange(changedNode -> {                                             // <2>
             System.out.println("Node " + changedNode.key() + " has changed!");
-            return true;                                                       // <3>
         });
 ----
 
 <1> Navigate to the `Config` node on which you want to register.
-<2> Invoke the `onChange` method, passing a function (`Function<Config, Boolean>`).
-The config system invokes that function each time the subtree rooted at the
+<2> Invoke the `onChange` method, passing a consumer (`Consumer<Config>`).
+The config system invokes that consumer each time the subtree rooted at the
 `greeting` node changes. The `changedNode` is a new instance of `Config` 
-representing the updated subtree rooted at `greeting`. 
-<3> The function should return `true` to continue being run on subsequent changes, `false`
-to stop.
+representing the updated subtree rooted at `greeting`.
 
 ==== Subscribing to Events
 The config system also supports the flow publisher/subscriber model for applications


### PR DESCRIPTION
### Description
Resolves #8596 

I replaced `Function` on `Consumer` and removed unnecessary parenthese
