### PR TITLE
[4.x]: Fix static content sending 304 with entity.

### DIFF
--- a/http/http/src/main/java/io/helidon/http/HttpException.java
+++ b/http/http/src/main/java/io/helidon/http/HttpException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ public class HttpException extends RuntimeException {
 
     private final Status status;
     private final boolean keepAlive;
+    private final ServerResponseHeaders headers = ServerResponseHeaders.create();
 
     /**
      * Creates {@link HttpException} associated with {@link Status#INTERNAL_SERVER_ERROR_500}.
@@ -112,5 +113,25 @@ public class HttpException extends RuntimeException {
      */
     public boolean keepAlive() {
         return keepAlive;
+    }
+
+    /**
+     * Set a response header that should be used if this exception is not handled.
+     *
+     * @param header header to set
+     * @return updated instance
+     */
+    public HttpException header(Header header) {
+        headers.set(header);
+        return this;
+    }
+
+    /**
+     * Headers as currently configured in this exception.
+     *
+     * @return headers configured for this exception
+     */
+    public Headers headers() {
+        return headers;
     }
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,10 @@ class RedirectionProcessor {
     }
 
     static boolean redirectionStatusCode(Status status) {
-        return status.family() == Status.Family.REDIRECTION;
+        // 304 is not an actual redirect - it is telling the client to use a cached value, which is outside of scope
+        // of Helidon WebClient, the user must understand such a response, as they had to send an ETag
+        return status.code() != Status.NOT_MODIFIED_304.code()
+            && status.family() == Status.Family.REDIRECTION;
     }
 
     static Http1ClientResponseImpl invokeWithFollowRedirects(Http1ClientRequestImpl request, byte[] entity) {

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -83,6 +83,8 @@ abstract class StaticContentHandler implements StaticContentService {
         etag = unquoteETag(etag);
 
         Header newEtag = HeaderValues.create(HeaderNames.ETAG, true, false, '"' + etag + '"');
+        // Put ETag into the response
+        responseHeaders.set(newEtag);
 
         // Process If-None-Match header
         if (requestHeaders.contains(HeaderNames.IF_NONE_MATCH)) {
@@ -115,9 +117,6 @@ abstract class StaticContentHandler implements StaticContentService {
                 }
             }
         }
-
-        // Put ETag into the response
-        responseHeaders.set(newEtag);
     }
 
     static void processModifyHeaders(Instant modified,

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ class StaticContentHandlerTest {
         when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processEtag("aaa", req, res);
-        verify(res).set(ETAG, ETAG_VALUE);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
     @Test
@@ -79,7 +79,7 @@ class StaticContentHandlerTest {
         when(req.get(IF_NONE_MATCH)).thenReturn(HeaderValues.create(IF_NONE_MATCH, "\"ccc\"", "W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.NOT_MODIFIED_304);
-        verify(res).set(ETAG, ETAG_VALUE);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
     @Test
@@ -90,7 +90,7 @@ class StaticContentHandlerTest {
         when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Status.PRECONDITION_FAILED_412);
-        verify(res).set(ETAG, ETAG_VALUE);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
     @Test
@@ -101,7 +101,7 @@ class StaticContentHandlerTest {
         when(req.get(IF_MATCH)).thenReturn(HeaderValues.create(IF_MATCH, "\"ccc\"", "\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processEtag("aaa", req, res);
-        verify(res).set(ETAG, ETAG_VALUE);
+        verify(res).set(HeaderValues.create(ETAG, true, false, ETAG_VALUE));
     }
 
     @Test

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,6 +191,7 @@ public final class ErrorHandlers {
                     .status(httpException.status())
                     .setKeepAlive(httpException.keepAlive())
                     .request(DirectTransportRequest.create(request.prologue(), request.headers()))
+                    .update(it -> httpException.headers().forEach(it::header))
                     .build());
         } else {
             // to be handled by error handler


### PR DESCRIPTION
This was caused by error handling of HttpException. Now we honor headers in the exception, and we do not send entity if the status is one of the forbidden ones.
Also fixed client, as 304 is not a real redirect, so it cannot have `Location`

### Description
Resolves #8543 
