### PR TITLE
[4.x]: Fix wrong example for Config.onChange (#8607)

### DIFF
--- a/docs/src/main/asciidoc/se/config/mutability-support.adoc
+++ b/docs/src/main/asciidoc/se/config/mutability-support.adoc
@@ -145,8 +145,8 @@ method on the node of interest.
 include::{sourcedir}/se/config/MutabilitySupportSnippets.java[tag=snippet_3, indent=0]
 ----
 <1> Navigate to the `Config` node on which you want to register.
-<2> Invoke the `onChange` method, passing a function (`Function<Config, Boolean>`).
-The config system invokes that function each time the subtree rooted at the
+<2> Invoke the `onChange` method, passing a consumer (`Consumer<Config>`).
+The config system invokes that consumer each time the subtree rooted at the
 `greeting` node changes. The `changedNode` is a new instance of `Config`
 representing the updated subtree rooted at `greeting`.
 

--- a/docs/src/main/java/io/helidon/docs/se/config/MutabilitySupportSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/config/MutabilitySupportSnippets.java
@@ -50,7 +50,7 @@ class MutabilitySupportSnippets {
     void snippet_3(Config config) {
         // tag::snippet_3[]
         config.get("greeting") // <1>
-                .onChange((changedNode) -> { // <2>
+                .onChange(changedNode -> { // <2>
                     System.out.println("Node " + changedNode.key() + " has changed!");
                 });
         // end::snippet_3[]


### PR DESCRIPTION
### Description

Resolves #8607 

I replaced `Function` on `Consumer` and removed unnecessary parenthese