### PR TITLE
4.x: Upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
           git config user.name "Helidon Robot"
           etc/scripts/release.sh release_build
       - name: Upload Staged Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: io-helidon-artifacts-${{ github.ref_name }}
           path: parent/target/nexus-staging/


### PR DESCRIPTION
### Description

Upgrades the `upload-artifact` GitHub action to v4. There are some significant [behavioral changes in v4](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new), but our use is simple so these changes should not impact us much.

### Documentation

No impact