### PR TITLE
Support for a new annotation @WithExecutor to use with @Asynchronous

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,9 +37,12 @@ import static io.helidon.microprofile.faulttolerance.FaultToleranceParameter.get
 abstract class MethodAntn {
     private static final System.Logger LOGGER = System.getLogger(MethodAntn.class.getName());
 
-    private static final AnnotationFinder ANNOTATION_FINDER = AnnotationFinder.create(Retry.class.getPackage());
-
-    private final AnnotatedType<?> annotatedType;
+    /**
+     * Annotation finder for annotations in either this package or the microprofile
+     * fault tolerance package.
+     */
+    private static final AnnotationFinder ANNOTATION_FINDER =
+            AnnotationFinder.create(Retry.class.getPackage(), MethodAntn.class.getPackage());
 
     private final AnnotatedMethod<?> annotatedMethod;
 
@@ -80,7 +83,7 @@ abstract class MethodAntn {
      */
     MethodAntn(AnnotatedMethod<?> annotatedMethod) {
         this.annotatedMethod = annotatedMethod;
-        this.annotatedType = annotatedMethod.getDeclaringType();
+        AnnotatedType<?> annotatedType = annotatedMethod.getDeclaringType();
     }
 
     Method method() {

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,8 @@ class MethodIntrospector {
 
     private final Bulkhead bulkhead;
 
+    private final WithExecutor withExecutor;
+
     private Tag methodNameTag;
 
     /**
@@ -78,6 +80,7 @@ class MethodIntrospector {
         this.timeout = isAnnotationEnabled(Timeout.class) ? new TimeoutAntn(annotatedMethod) : null;
         this.bulkhead = isAnnotationEnabled(Bulkhead.class) ? new BulkheadAntn(annotatedMethod) : null;
         this.fallback = isAnnotationEnabled(Fallback.class) ? new FallbackAntn(annotatedMethod) : null;
+        this.withExecutor = method.getAnnotation(WithExecutor.class);
     }
 
     /**
@@ -147,6 +150,14 @@ class MethodIntrospector {
 
     Bulkhead getBulkhead() {
         return bulkhead;
+    }
+
+    boolean hasWithExecutor() {
+        return withExecutor != null;
+    }
+
+    WithExecutor withExecutor() {
+        return withExecutor;
     }
 
     /**

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/WithExecutor.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/WithExecutor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.faulttolerance;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+import jakarta.interceptor.InterceptorBinding;
+
+/**
+ * Annotation used to specify an executor for an asynchronous call. Can be used
+ * for example to create platform instead of virtual threads.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+@Qualifier
+@InterceptorBinding
+public @interface WithExecutor {
+
+    /**
+     * Name of the executor to use in async method.
+     *
+     * @return name of executor
+     */
+    String value() default "";
+}

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AsynchronousTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AsynchronousTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,13 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
 
 import io.helidon.microprofile.testing.junit5.AddBean;
-
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for asynchronous invocations using {@code Asynchronous}.
@@ -122,5 +123,20 @@ class AsynchronousTest extends FaultToleranceTest {
         CompletableFuture<String> completableFuture = bean.asyncCompletableFutureWithFallbackFailure();
         assertThat(completableFuture.get(), is("fallback"));
         assertThat(bean.wasCalled(), is(true));
+    }
+
+    @Test
+    void testAsyncWithExecutor() throws Exception {
+        assertThat(bean.wasCalled(), is(false));
+        CompletableFuture<String> future = bean.asyncWithExecutor();
+        future.get();
+        assertThat(bean.wasCalled(), is(true));
+    }
+
+    @Test
+    void testAsyncWithBadExecutor() {
+        assertThat(bean.wasCalled(), is(false));
+        assertThrows(FaultToleranceException.class, () -> bean.asyncWithBadExecutor());
+        assertThat(bean.wasCalled(), is(false));
     }
 }


### PR DESCRIPTION
### Description

Support for a new annotation @WithExecutor to override the default executor service to use when making an asynchronous call. Uses CDI to find a provider based on this annotation.

### Documentation

Needs documentation, will be provided in a follow-up PR.
