### PR TITLE
Support for a new annotation @WithExecutor to use with @Asynchronous in FT

### DIFF
--- a/microprofile/fault-tolerance/pom.xml
+++ b/microprofile/fault-tolerance/pom.xml
@@ -123,6 +123,11 @@
             <artifactId>helidon-microprofile-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -243,7 +243,7 @@ public class FaultToleranceExtension implements Extension {
         if (withExecutor != null) {
             Set<Bean<?>> beans = bm.getBeans(ExecutorService.class, withExecutor);
             if (beans.isEmpty()) {
-                throw new FaultToleranceDefinitionException("Unable to resolved named executor service '"
+                throw new FaultToleranceDefinitionException("Unable to resolve named executor service '"
                         + withExecutor.value() + "' at "
                         + method.getDeclaringClass().getName() + "::"
                         + method.getName());

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,6 @@ abstract class MethodAntn {
     private static final System.Logger LOGGER = System.getLogger(MethodAntn.class.getName());
 
     private static final AnnotationFinder ANNOTATION_FINDER = AnnotationFinder.create(Retry.class.getPackage());
-
-    private final AnnotatedType<?> annotatedType;
 
     private final AnnotatedMethod<?> annotatedMethod;
 
@@ -80,7 +78,6 @@ abstract class MethodAntn {
      */
     MethodAntn(AnnotatedMethod<?> annotatedMethod) {
         this.annotatedMethod = annotatedMethod;
-        this.annotatedType = annotatedMethod.getDeclaringType();
     }
 
     Method method() {

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,8 @@ class MethodIntrospector {
 
     private final Bulkhead bulkhead;
 
+    private final WithExecutor withExecutor;
+
     private Tag methodNameTag;
 
     /**
@@ -78,6 +80,7 @@ class MethodIntrospector {
         this.timeout = isAnnotationEnabled(Timeout.class) ? new TimeoutAntn(annotatedMethod) : null;
         this.bulkhead = isAnnotationEnabled(Bulkhead.class) ? new BulkheadAntn(annotatedMethod) : null;
         this.fallback = isAnnotationEnabled(Fallback.class) ? new FallbackAntn(annotatedMethod) : null;
+        this.withExecutor = method.getAnnotation(WithExecutor.class);
     }
 
     /**
@@ -147,6 +150,14 @@ class MethodIntrospector {
 
     Bulkhead getBulkhead() {
         return bulkhead;
+    }
+
+    boolean hasWithExecutor() {
+        return withExecutor != null;
+    }
+
+    WithExecutor withExecutor() {
+        return withExecutor;
     }
 
     /**

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -43,12 +43,10 @@ import io.helidon.faulttolerance.Retry;
 import io.helidon.faulttolerance.RetryTimeoutException;
 import io.helidon.faulttolerance.Timeout;
 
-import jakarta.enterprise.inject.UnsatisfiedResolutionException;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.interceptor.InvocationContext;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 import org.eclipse.microprofile.metrics.Counter;
 
 import static io.helidon.faulttolerance.SupplierHelper.toRuntimeException;
@@ -343,12 +341,8 @@ class MethodInvoker implements FtSupplier<Object> {
         // Handle a user-provided executor via @WithExecutor
         if (introspector.hasWithExecutor()) {
             WithExecutor withExecutor = introspector.withExecutor();
-            try {
-                ExecutorService executorService = CDI.current().select(ExecutorService.class, withExecutor).get();
-                asyncBuilder.executor(executorService);
-            } catch (UnsatisfiedResolutionException e) {
-                throw new FaultToleranceException(e);
-            }
+            ExecutorService executorService = CDI.current().select(ExecutorService.class, withExecutor).get();
+            asyncBuilder.executor(executorService);
         }
 
         // Invoke async call

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/WithExecutor.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/WithExecutor.java
@@ -27,11 +27,11 @@ import jakarta.interceptor.InterceptorBinding;
 
 /**
  * Annotation used to specify an executor for an asynchronous call. Can be used
- * for example to create platform instead of virtual threads.
+ * e.g. to create platform instead of virtual threads. Targets only a method.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD})
 @Inherited
 @Qualifier
 @InterceptorBinding

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/WithExecutor.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/WithExecutor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.faulttolerance;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+import jakarta.interceptor.InterceptorBinding;
+
+/**
+ * Annotation used to specify an executor for an asynchronous call. Can be used
+ * for example to create platform instead of virtual threads.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+@Qualifier
+@InterceptorBinding
+public @interface WithExecutor {
+
+    /**
+     * Name of the executor to use in async method.
+     *
+     * @return name of executor
+     */
+    String value() default "";
+}

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AsynchronousBean.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AsynchronousBean.java
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.enterprise.inject.Produces;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Fallback;
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 
 /**
  * A stateful bean that defines some async methods.
@@ -187,16 +186,5 @@ class AsynchronousBean {
     @WithExecutor("platform-thread-executor")
     ExecutorService executorService() {
         return Executors.newFixedThreadPool(10);
-    }
-
-    /**
-     * Bad executor name, should throw a {@link FaultToleranceException}.
-     *
-     * @return A future.
-     */
-    @Asynchronous
-    @WithExecutor("does-not-exist")
-    CompletableFuture<String> asyncWithBadExecutor() {
-        return CompletableFuture.completedFuture("failed");
     }
 }

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AsynchronousTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AsynchronousTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,13 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
 
 import io.helidon.microprofile.testing.junit5.AddBean;
-
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for asynchronous invocations using {@code Asynchronous}.
@@ -122,5 +123,20 @@ class AsynchronousTest extends FaultToleranceTest {
         CompletableFuture<String> completableFuture = bean.asyncCompletableFutureWithFallbackFailure();
         assertThat(completableFuture.get(), is("fallback"));
         assertThat(bean.wasCalled(), is(true));
+    }
+
+    @Test
+    void testAsyncWithExecutor() throws Exception {
+        assertThat(bean.wasCalled(), is(false));
+        CompletableFuture<String> future = bean.asyncWithExecutor();
+        future.get();
+        assertThat(bean.wasCalled(), is(true));
+    }
+
+    @Test
+    void testAsyncWithBadExecutor() {
+        assertThat(bean.wasCalled(), is(false));
+        assertThrows(FaultToleranceException.class, () -> bean.asyncWithBadExecutor());
+        assertThat(bean.wasCalled(), is(false));
     }
 }

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AsynchronousTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AsynchronousTest.java
@@ -22,12 +22,10 @@ import java.util.concurrent.Future;
 
 import io.helidon.microprofile.testing.junit5.AddBean;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for asynchronous invocations using {@code Asynchronous}.
@@ -131,12 +129,5 @@ class AsynchronousTest extends FaultToleranceTest {
         CompletableFuture<String> future = bean.asyncWithExecutor();
         future.get();
         assertThat(bean.wasCalled(), is(true));
-    }
-
-    @Test
-    void testAsyncWithBadExecutor() {
-        assertThat(bean.wasCalled(), is(false));
-        assertThrows(FaultToleranceException.class, () -> bean.asyncWithBadExecutor());
-        assertThat(bean.wasCalled(), is(false));
     }
 }

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/ValidateWithExecutorTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/ValidateWithExecutorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.faulttolerance;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ValidateWithExecutorTest {
+
+    static class BadWithExecutorBean {
+
+        @Asynchronous
+        @WithExecutor("does-not-exist")
+        public CompletableFuture<?> shouldNotBeCalled() {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Test
+    void badExecutorTest() throws Exception {
+        Method method = BadWithExecutorBean.class.getMethod("shouldNotBeCalled");
+        WithExecutor withExecutor = method.getAnnotation(WithExecutor.class);
+        BeanManager bm = Mockito.mock(BeanManager.class);
+        Mockito.when(bm.getBeans(ExecutorService.class, withExecutor)).thenReturn(Collections.emptySet());
+        assertThrows(FaultToleranceDefinitionException.class,
+                     () -> FaultToleranceExtension.validateWithExecutor(bm, method));
+    }
+}

--- a/microprofile/fault-tolerance/src/test/resources/application.yaml
+++ b/microprofile/fault-tolerance/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,11 @@
 # limitations under the License.
 #
 
-executor:
-  core-pool-size: 8
-
-scheduled-executor:
-  core-pool-size: 8
+fault-tolerance:
+  executor-service:
+    name: platform-threads
+    should-prestart: true
+    virtual-threads: false
+    is-deamon: false
+    core-pool-size: 5
+    max-pool-size: 10


### PR DESCRIPTION
### Description

Support for a new annotation @WithExecutor to override the default executor service to use when making an asynchronous call. Uses CDI to find a provider based on this annotation. Issue #8591.

### Documentation

Documentation will be provided in a follow-up PR.
