### PR TITLE
3.x: Upgrade oci sdk to 3.39.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -130,7 +130,7 @@
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.108.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
-        <version.lib.oci>3.34.0</version.lib.oci>
+        <version.lib.oci>3.39.0</version.lib.oci>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <!-- Manage okio version for dependency convergence -->


### PR DESCRIPTION
### Description

 Upgrade oci sdk to 3.39.0

### Documentation

No impact
