### PR TITLE
2.x: Upgrade OCI sdk to 3.39.0

### DIFF
--- a/archetypes/oci-mp/src/main/resources/server/src/test/java/__pkg__/server/GreetResourceMockedTest.java.mustache
+++ b/archetypes/oci-mp/src/main/resources/server/src/test/java/__pkg__/server/GreetResourceMockedTest.java.mustache
@@ -141,13 +141,34 @@ class GreetResourceMockedTest {
         public CreateAlarmResponse createAlarm(CreateAlarmRequest createAlarmRequest) {return null;}
 
         @Override
+        public CreateAlarmSuppressionResponse createAlarmSuppression(CreateAlarmSuppressionRequest createAlarmSuppressionRequest) {
+            return null;
+        }
+
+        @Override
         public DeleteAlarmResponse deleteAlarm(DeleteAlarmRequest deleteAlarmRequest) {return null;}
+
+        @Override
+        public DeleteAlarmSuppressionResponse deleteAlarmSuppression(DeleteAlarmSuppressionRequest deleteAlarmSuppressionRequest) {
+            return null;
+        }
 
         @Override
         public GetAlarmResponse getAlarm(GetAlarmRequest getAlarmRequest) {return null;}
 
         @Override
         public GetAlarmHistoryResponse getAlarmHistory(GetAlarmHistoryRequest getAlarmHistoryRequest) {return null;}
+
+        @Override
+        public GetAlarmSuppressionResponse getAlarmSuppression(GetAlarmSuppressionRequest getAlarmSuppressionRequest) {
+            return null;
+        }
+
+        @Override
+        public ListAlarmSuppressionsResponse listAlarmSuppressions(ListAlarmSuppressionsRequest listAlarmSuppressionsRequest) {
+            return null;
+        }
+
 
         @Override
         public ListAlarmsResponse listAlarms(ListAlarmsRequest listAlarmsRequest) {return null;}
@@ -180,6 +201,11 @@ class GreetResourceMockedTest {
 
         @Override
         public RetrieveDimensionStatesResponse retrieveDimensionStates(RetrieveDimensionStatesRequest retrieveDimensionStatesRequest) {
+            return null;
+        }
+
+        @Override
+        public SummarizeAlarmSuppressionHistoryResponse summarizeAlarmSuppressionHistory(SummarizeAlarmSuppressionHistoryRequest summarizeAlarmSuppressionHistoryRequest) {
             return null;
         }
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -124,7 +124,7 @@
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.netty>4.1.108.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
-        <version.lib.oci>3.26.0</version.lib.oci>
+        <version.lib.oci>3.39.0</version.lib.oci>
         <version.lib.oci-java-sdk-objectstorage>${version.lib.oci}</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>


### PR DESCRIPTION
### Description

Upgrade OCI sdk to 3.39.0

### Documentation

No impact
