### PR TITLE
[3.x] Oidc feature is not failing if not configured.

### DIFF
--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcSupport.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcSupport.java
@@ -577,19 +577,18 @@ public final class OidcSupport implements Service {
         private Builder() {
         }
 
-        private static Config findMyKey(Config rootConfig, String providerName) {
+        private static Optional<Config> findMyKey(Config rootConfig, String providerName) {
             if (rootConfig.key().name().equals(providerName)) {
-                return rootConfig;
+                return Optional.of(rootConfig);
             }
 
             return rootConfig.get("security.providers")
                     .asNodeList()
-                    .get()
+                    .orElseGet(List::of)
                     .stream()
                     .filter(it -> it.get(providerName).exists())
                     .findFirst()
-                    .map(it -> it.get(providerName))
-                    .orElseThrow(() -> new SecurityException("No configuration found for provider named: " + providerName));
+                    .map(it -> it.get(providerName));
         }
 
         @Override
@@ -645,7 +644,10 @@ public final class OidcSupport implements Service {
             // if this is root config, we need to honor `security.enabled`
             config.get("security.enabled").asBoolean().ifPresent(this::enabled);
 
-            config(findMyKey(config, providerName));
+            findMyKey(config, providerName)
+                    .ifPresentOrElse(this::config,
+                                     () -> enabled(false));
+
             return this;
         }
 

--- a/tests/integration/mp-gh-8493/pom.xml
+++ b/tests/integration/mp-gh-8493/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration</artifactId>
+        <version>3.2.8-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-gh-8493</artifactId>
+    <name>Helidon Tests Integration MP GH 8493</name>
+    <description>Reproducer for Github issue #8493 - Oidc should not fail if not configured</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-gh-8493/src/main/java/io/helidon/tests/integration/gh8493/Gh8493Resource.java
+++ b/tests/integration/mp-gh-8493/src/main/java/io/helidon/tests/integration/gh8493/Gh8493Resource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8493;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/greet")
+public class Gh8493Resource {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getDefaultMessage() {
+        return "Hello World!";
+    }
+}

--- a/tests/integration/mp-gh-8493/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-gh-8493/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/mp-gh-8493/src/main/resources/logging.properties
+++ b/tests/integration/mp-gh-8493/src/main/resources/logging.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+.level=WARNING
+
+io.helidon.level=INFO
+io.helidon.security.level=FINEST

--- a/tests/integration/mp-gh-8493/src/test/java/io/helidon/tests/integration/gh8493/Gh8493Test.java
+++ b/tests/integration/mp-gh-8493/src/test/java/io/helidon/tests/integration/gh8493/Gh8493Test.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh8493;
+
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+public class Gh8493Test {
+    private final WebTarget target;
+
+    @Inject
+    public Gh8493Test(WebTarget target) {
+        this.target = target;
+    }
+
+    @Test
+    public void testServerStarted() {
+        String response = target
+                .path("/greet")
+                .request()
+                .get(String.class);
+
+        assertThat(response, is("Hello World!"));
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -53,6 +53,7 @@
         <module>mp-gh-5328</module>
         <module>mp-gh-8478</module>
         <module>mp-gh-8495</module>
+        <module>mp-gh-8493</module>
         <module>kafka</module>
         <module>jpa</module>
         <module>jms</module>


### PR DESCRIPTION
If there is no configuration of oidc provider, it is considered disabled and no longer throws an exception. This is aligned with its documentation. (#8603)

(cherry picked from commit 8372bbce23734149cf4ca5b8db33c9f6e4fbb870)
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #8605 
