### PR TITLE
4.x: ErrorHandlers class swallows exception object if response can't be reset

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
@@ -212,7 +212,7 @@ public final class ErrorHandlers {
         if (!response.reset()) {
             ctx.log(LOGGER, System.Logger.Level.WARNING, "Unable to reset response for error handler.");
             throw new CloseConnectionException(
-                    "Cannot send response of a simple handler, status and headers already written");
+                    "Cannot send response of a simple handler, status and headers already written", e);
         }
         try {
             it.handle(request, response, e);


### PR DESCRIPTION
### Description
https://github.com/helidon-io/helidon/issues/8021

### Documentation
Probably we don't want to log the exception in the logger as a warning, but I understand it could be useful to include the root exception in the cause.
