### PR TITLE
2.x: Upgrade upload-artifact github action to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
           git config user.name "Helidon Robot"
           etc/scripts/release.sh release_build
       - name: Upload Staged Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: io-helidon-artifacts-${{ github.ref_name }}
           path: parent/target/nexus-staging/

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Maven build
         run: etc/scripts/github-build.sh
       - name: Archive Test results
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results
@@ -100,7 +100,7 @@ jobs:
       - name: Docs
         run: etc/scripts/site.sh
       - name: Archive Docs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: docs


### PR DESCRIPTION
### Description

Upgrade upload-artifact github action to v4. This is to resolve `Node.js 16 actions are deprecated.` warnings.

### Documentation

No impact
