### PR TITLE
3.x: upgrade more github actions to v4

### DIFF
--- a/.github/workflows/assign-issue-to-project.yml
+++ b/.github/workflows/assign-issue-to-project.yml
@@ -12,5 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: etc/scripts/actions/assign-issue-to-project.sh $GITHUB_REPOSITORY ${{ github.event.issue.number }} Backlog Triage

--- a/.github/workflows/create-backport-issues.yml
+++ b/.github/workflows/create-backport-issues.yml
@@ -19,5 +19,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: etc/scripts/actions/create-backport-issues.sh $GITHUB_REPOSITORY ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
           git config user.name "Helidon Robot"
           etc/scripts/release.sh release_build
       - name: Upload Staged Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: io-helidon-artifacts-${{ github.ref_name }}
           path: parent/target/nexus-staging/

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -153,7 +153,7 @@ jobs:
         os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4.1.0
         with:
@@ -169,7 +169,7 @@ jobs:
         os: [ ubuntu-20.04, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 22.3.1

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Maven build
         run: etc/scripts/github-build.sh
       - name: Archive Test results
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results


### PR DESCRIPTION
### Description

Upgrade upload-artifact github action to v4. This is to resolve `Node.js 16 actions are deprecated.` warnings.

Also upgrades a couple instances of the `checkout` action that was missed in a previous PR.

### Documentation

No impact