### PR TITLE
4.x: Upgrade github checkout action to v4

### DIFF
--- a/.github/workflows/assign-issue-to-project.yml
+++ b/.github/workflows/assign-issue-to-project.yml
@@ -12,5 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: etc/scripts/actions/assign-issue-to-project.sh $GITHUB_REPOSITORY ${{ github.event.issue.number }} Backlog Triage

--- a/.github/workflows/create-backport-issues.yml
+++ b/.github/workflows/create-backport-issues.yml
@@ -37,5 +37,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: etc/scripts/actions/create-backport-issues.sh $GITHUB_REPOSITORY ${{ github.event.inputs.issue }} ${{ github.event.inputs.version }} ${{ github.event.inputs.target-2 }} ${{ github.event.inputs.target-3 }} ${{ github.event.inputs.target-4 }}


### PR DESCRIPTION
### Description

Upgrade github checkout action to v4. This is to resolve `Node.js 16 actions are deprecated`. warnings.

### Documentation

No impact
