### PR TITLE
4.x: Remove dependency on jakarta.activation-api as no longer needed

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/common/common-mp.xml
+++ b/archetypes/archetypes/src/main/archetype/mp/common/common-mp.xml
@@ -38,10 +38,6 @@
                     <value key="artifactId">jandex</value>
                     <value key="scope">runtime</value>
                 </map>
-                <map>
-                    <value key="groupId">jakarta.activation</value>
-                    <value key="artifactId">jakarta.activation-api</value>
-                </map>
                 <map order="0">
                     <value key="groupId">org.junit.jupiter</value>
                     <value key="artifactId">junit-jupiter-api</value>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -85,12 +85,6 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <!-- Jersey on java 9 -->
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>io.helidon.common.testing</groupId>


### PR DESCRIPTION
### Description

Removes `provided` dependency on `jakarta.activation-api`.  In the past I think this was required by Jersey, but at some point that requirement was removed. We had cleaned up a bunch of this previously (see #6138) but possibly missed this one -- or it snuck in later.

Related to #2770

### Documentation

No impact
