### PR TITLE
3.x: Remove dependency on jakarta.activation-api

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/common/common-mp.xml
+++ b/archetypes/helidon/src/main/archetype/mp/common/common-mp.xml
@@ -32,10 +32,6 @@
                     <value key="artifactId">jandex</value>
                     <value key="scope">runtime</value>
                 </map>
-                <map>
-                    <value key="groupId">jakarta.activation</value>
-                    <value key="artifactId">jakarta.activation-api</value>
-                </map>
                 <map order="0">
                     <value key="groupId">org.junit.jupiter</value>
                     <value key="artifactId">junit-jupiter-api</value>

--- a/grpc/metrics/pom.xml
+++ b/grpc/metrics/pom.xml
@@ -71,11 +71,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
             <scope>test</scope>

--- a/integrations/micrometer/cdi/pom.xml
+++ b/integrations/micrometer/cdi/pom.xml
@@ -86,11 +86,6 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/microprofile/fault-tolerance/pom.xml
+++ b/microprofile/fault-tolerance/pom.xml
@@ -104,12 +104,6 @@
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-spi</artifactId>
         </dependency>
-        <!-- To keep HK2 from complaining when run with Java9+ -->
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.metrics</groupId>
             <artifactId>helidon-microprofile-metrics</artifactId>

--- a/microprofile/grpc/server/pom.xml
+++ b/microprofile/grpc/server/pom.xml
@@ -45,18 +45,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <!--
-            Needed by jersey in Java 9
-            Added as a dependency to correctly run tests (without the long exception
-            from hk2). If you run application on Java 9, you need to add this dependency
-            in compile scope to prevent the error messages.
-            -->
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
             <artifactId>helidon-microprofile-config</artifactId>
         </dependency>

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -41,11 +41,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
         </dependency>

--- a/microprofile/tests/tck/tck-fault-tolerance/pom.xml
+++ b/microprofile/tests/tck/tck-fault-tolerance/pom.xml
@@ -47,11 +47,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
             <scope>test</scope>

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -56,11 +56,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -101,11 +101,6 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/tck/tck-openapi/pom.xml
+++ b/microprofile/tests/tck/tck-openapi/pom.xml
@@ -78,11 +78,6 @@
             <artifactId>parsson</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!--
             RestAssured xml-path, used by the TCK, requires the javax flavor of JAX-B, so add the API and impl.
         -->

--- a/microprofile/tracing/pom.xml
+++ b/microprofile/tracing/pom.xml
@@ -77,12 +77,6 @@
             <artifactId>helidon-tracing-tracer-resolver</artifactId>
         </dependency>
         <dependency>
-            <!-- Jersey on java 9 -->
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/security/integration/grpc/pom.xml
+++ b/security/integration/grpc/pom.xml
@@ -117,11 +117,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <!--
             need to use this version to work around the same groupId/artifactId and
             different package names in Jakarta

--- a/security/integration/webserver/pom.xml
+++ b/security/integration/webserver/pom.xml
@@ -105,11 +105,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
             <scope>test</scope>

--- a/security/providers/http-auth/pom.xml
+++ b/security/providers/http-auth/pom.xml
@@ -104,11 +104,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
             <scope>test</scope>

--- a/service-common/rest-cdi/pom.xml
+++ b/service-common/rest-cdi/pom.xml
@@ -49,11 +49,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/tests/integration/jpa/simple/pom.xml
+++ b/tests/integration/jpa/simple/pom.xml
@@ -89,10 +89,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/tests/integration/oidc/pom.xml
+++ b/tests/integration/oidc/pom.xml
@@ -94,11 +94,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <scope>test</scope>

--- a/tests/integration/zipkin-mp-2.2/pom.xml
+++ b/tests/integration/zipkin-mp-2.2/pom.xml
@@ -45,11 +45,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/webserver/jersey/pom.xml
+++ b/webserver/jersey/pom.xml
@@ -67,16 +67,6 @@
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-grizzly2-http</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -233,11 +233,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-testing</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### Description

Removes dependencies on jakarta.activation-api. These were originally included due to an issue with running earlier versions of Jersey on Java 9. But this appears to no longer be required.

Related to:
* #6138 (Helidon 4)
* #8650 (Helidon 4)
* #2770

### Documentation

No impact