### PR TITLE
Use delegation instead of inheritance from BufferedOutputStream

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -401,7 +401,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         return responseBuffer;
     }
 
-    private static class BlockingOutputStream extends OutputStream {
+    static class BlockingOutputStream extends OutputStream {
         private final ServerResponseHeaders headers;
         private final WritableHeaders<?> trailers;
         private final Supplier<Status> status;
@@ -720,23 +720,45 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
     }
 
     /**
-     * A buffered output stream that wraps a {@link BlockingOutputStream} and informs
-     * it before it is finally flushed and closed.
+     * A special stream that provides buffering for a delegate and special handling
+     * of close logic. Note that due to some locking issues in the JDK, this class
+     * must use delegation with {@link BufferedOutputStream} instead of subclassing.
      */
-    static class ClosingBufferedOutputStream extends BufferedOutputStream {
+    static class ClosingBufferedOutputStream extends OutputStream {
 
         private final BlockingOutputStream delegate;
+        private final BufferedOutputStream bufferedDelegate;
 
         ClosingBufferedOutputStream(BlockingOutputStream out, int size) {
-            super(out, size);
             this.delegate = out;
+            this.bufferedDelegate = new BufferedOutputStream(out, size);
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            bufferedDelegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            bufferedDelegate.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            bufferedDelegate.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            bufferedDelegate.flush();
         }
 
         @Override
         public void close() {
             delegate.closing();     // inform of imminent call to close for last flush
             try {
-                super.close();
+                bufferedDelegate.close();
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/ClosingBufferedOutputStreamTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/ClosingBufferedOutputStreamTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.http1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static io.helidon.webserver.http1.Http1ServerResponse.BlockingOutputStream;
+import static io.helidon.webserver.http1.Http1ServerResponse.ClosingBufferedOutputStream;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ClosingBufferedOutputStreamTest {
+
+    private final List<String> delegateCalls = new ArrayList<>();
+
+    @Test
+    void closingBeforeCloseTest() {
+        BlockingOutputStream bos = mockBlockingOutputStream();
+        ClosingBufferedOutputStream cbos = new ClosingBufferedOutputStream(bos, 1);
+        cbos.commit();
+        cbos.close();
+        assertThat(delegateCalls, contains("closing", "close"));
+    }
+
+    private BlockingOutputStream mockBlockingOutputStream() {
+        BlockingOutputStream bos = Mockito.mock(BlockingOutputStream.class);
+        Mockito.doAnswer(i -> {
+            delegateCalls.add("closing");
+            return null;
+        }).when(bos).closing();
+        Mockito.doAnswer(i -> {
+            delegateCalls.add("close");
+            return null;
+        }).when(bos).close();
+        return bos;
+    }
+}


### PR DESCRIPTION
### Description

Uses delegation instead of inheritance from BufferedOutputStream to ensure use of VT-friendly locks in the JDK code. Avoids thread pinning due to synchronized blocks in the JDK.

### Documentation

None
