### PR TITLE
[4.x] Add shutdown handler to control shutdown sequence in a deterministic …

### DIFF
--- a/helidon/src/main/java/io/helidon/Main.java
+++ b/helidon/src/main/java/io/helidon/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,25 @@
 
 package io.helidon;
 
+import java.lang.System.Logger.Level;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Handler;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.SerializationConfig;
+import io.helidon.common.Weights;
 import io.helidon.logging.common.LogConfig;
+import io.helidon.spi.HelidonShutdownHandler;
 import io.helidon.spi.HelidonStartupProvider;
 
 /**
@@ -31,6 +45,10 @@ import io.helidon.spi.HelidonStartupProvider;
  * The default option is to start Helidon injection based application.
  */
 public class Main {
+    private static final Set<HelidonShutdownHandler> SHUTDOWN_HANDLERS = Collections.newSetFromMap(new IdentityHashMap<>());
+    private static final ReentrantLock SHUTDOWN_HANDLER_LOCK = new ReentrantLock();
+    private static final AtomicBoolean SHUTDOWN_HOOK_ADDED = new AtomicBoolean();
+
     static {
         LogConfig.initClass();
     }
@@ -57,9 +75,151 @@ public class Main {
         if (services.isEmpty()) {
             throw new IllegalStateException("Helidon Main class can only be called if a startup provider is available. "
                                                     + "Please use either Helidon Injection, or Helidon MicroProfile "
-                                                    + "(or a custom extension). If neither is available, you should use "
-                                                    + "your own Main class.");
+                                                    + "(or a custom extension). If neither is used, you should define "
+                                                    + "your own Main class, usually configured as 'mainClass' property in "
+                                                    + "your pom.xml.");
         }
-        services.get(0).start(args);
+
+        addShutdownHook();
+
+        services.getFirst().start(args);
+    }
+
+    /**
+     * Add shutdown handler to the list of handlers to be executed on shutdown.
+     * <p>
+     * On shutdown, the handlers are executed in {@link io.helidon.common.Weight Weighted} order, starting with
+     * the highest weight.
+     *
+     * @param handler to execute
+     */
+    public static void addShutdownHandler(HelidonShutdownHandler handler) {
+        // need to make sure we have a shutdown hook, if started through a custom main class, it
+        // would not be added, so add it here (will only be added once)
+        addShutdownHook();
+
+        SHUTDOWN_HANDLER_LOCK.lock();
+        try {
+            SHUTDOWN_HANDLERS.add(handler);
+        } finally {
+            SHUTDOWN_HANDLER_LOCK.unlock();
+        }
+    }
+
+    /**
+     * Remove a shutdown handler from the list of handlers.
+     *
+     * @param handler handler to remove, must be the same instance registered with
+     *                {@link #addShutdownHandler(io.helidon.spi.HelidonShutdownHandler)}
+     */
+    public static void removeShutdownHandler(HelidonShutdownHandler handler) {
+        SHUTDOWN_HANDLER_LOCK.lock();
+        try {
+            SHUTDOWN_HANDLERS.remove(handler);
+        } finally {
+            SHUTDOWN_HANDLER_LOCK.unlock();
+        }
+    }
+
+    private static void addShutdownHook() {
+        if (SHUTDOWN_HOOK_ADDED.compareAndSet(false, true)) {
+            Thread shutdownHook = Thread.ofPlatform()
+                    .daemon(false)
+                    .name("helidon-shutdown-thread")
+                    .unstarted(Main::shutdown);
+
+            Runtime.getRuntime()
+                    .addShutdownHook(shutdownHook);
+
+            // we also need to keep the logging system active until the shutdown hook completes
+            // this introduces a hard dependency on JUL, as we cannot abstract this easily away
+            // this is to workaround https://bugs.openjdk.java.net/browse/JDK-8161253
+            keepLoggingActive(shutdownHook);
+        }
+    }
+
+    private static void shutdown() {
+        SHUTDOWN_HANDLER_LOCK.lock();
+        try {
+            System.Logger logger = System.getLogger(Main.class.getName());
+
+            logger.log(Level.INFO, "Shutdown requested by JVM shutting down");
+            List<HelidonShutdownHandler> handlers = new ArrayList<>(SHUTDOWN_HANDLERS);
+
+            handlers.sort(Weights.weightComparator());
+
+            for (HelidonShutdownHandler handler : handlers) {
+                try {
+                    if (logger.isLoggable(Level.TRACE)) {
+                        logger.log(Level.TRACE, "Calling shutdown handler: " + handler);
+                    }
+                    handler.shutdown();
+                } catch (Exception e) {
+                    logger.log(Level.ERROR, "Failed when calling shutdown handler: " + handler);
+                }
+            }
+
+            SHUTDOWN_HANDLERS.clear();
+            SHUTDOWN_HOOK_ADDED.set(false);
+
+            logger.log(Level.INFO, "Shutdown finished");
+        } finally {
+            SHUTDOWN_HANDLER_LOCK.unlock();
+        }
+    }
+
+    private static void keepLoggingActive(Thread shutdownHook) {
+        Logger rootLogger = LogManager.getLogManager().getLogger("");
+        Handler[] handlers = rootLogger.getHandlers();
+
+        List<Handler> newHandlers = new ArrayList<>();
+
+        boolean added = false;
+        for (Handler handler : handlers) {
+            if (handler instanceof KeepLoggingActiveHandler) {
+                // we want to replace it with our current shutdown hook
+                newHandlers.add(new KeepLoggingActiveHandler(shutdownHook));
+                added = true;
+            } else {
+                newHandlers.add(handler);
+            }
+        }
+        if (!added) {
+            // out handler must be first, so other handlers are not closed before we finish shutdown hook
+            newHandlers.addFirst(new KeepLoggingActiveHandler(shutdownHook));
+        }
+
+        for (Handler handler : handlers) {
+            rootLogger.removeHandler(handler);
+        }
+        for (Handler newHandler : newHandlers) {
+            rootLogger.addHandler(newHandler);
+        }
+    }
+
+    private static final class KeepLoggingActiveHandler extends Handler {
+        private final Thread shutdownHook;
+
+        private KeepLoggingActiveHandler(Thread shutdownHook) {
+            this.shutdownHook = shutdownHook;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            // noop
+        }
+
+        @Override
+        public void flush() {
+            // noop
+        }
+
+        @Override
+        public void close() {
+            try {
+                shutdownHook.join();
+            } catch (InterruptedException ignored) {
+            }
+        }
     }
 }

--- a/helidon/src/main/java/io/helidon/spi/HelidonShutdownHandler.java
+++ b/helidon/src/main/java/io/helidon/spi/HelidonShutdownHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
+package io.helidon.spi;
+
 /**
- * Types needed to start a Helidon application.
+ * Handles shutdown of the VM.
+ * <p>
+ * Register an instance with {@link io.helidon.Main#addShutdownHandler(HelidonShutdownHandler)},
+ * remove with {@link io.helidon.Main#removeShutdownHandler(HelidonShutdownHandler)}.
+ * Shutdown handlers are compared via instances, not via equals methods.
  */
-module io.helidon {
-    // this is required due to a bug in JDK (see Main for details and link)
-    requires java.logging;
-
-    requires io.helidon.common;
-    requires io.helidon.logging.common;
-
-    exports io.helidon;
-    exports io.helidon.spi;
-
-    uses io.helidon.spi.HelidonStartupProvider;
-
+@FunctionalInterface
+public interface HelidonShutdownHandler {
+    /**
+     * Handle the shutdown work of this component.
+     */
+    void shutdown();
 }

--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,23 +17,21 @@ package io.helidon.microprofile.cdi;
 
 import java.lang.annotation.Annotation;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import io.helidon.Main;
 import io.helidon.common.SerializationConfig;
 import io.helidon.common.Version;
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.common.features.HelidonFeatures;
@@ -41,6 +39,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.config.mp.MpConfig;
 import io.helidon.config.mp.MpConfigProviderResolver;
 import io.helidon.logging.common.LogConfig;
+import io.helidon.spi.HelidonShutdownHandler;
 
 import jakarta.enterprise.context.BeforeDestroyed;
 import jakarta.enterprise.context.Destroyed;
@@ -114,7 +113,7 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
         CDI.setCDIProvider(new HelidonCdiProvider());
     }
 
-    private static volatile Thread shutdownHook;
+    private static volatile HelidonShutdownHandler shutdownHandler;
     private final WeldBootstrap bootstrap;
     private final String id;
 
@@ -148,7 +147,6 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
         LOGGER.fine("Container initialized in " + t + " millis");
     }
 
-    @SuppressWarnings("unchecked")
     private HelidonContainerImpl init() {
         LOGGER.fine(() -> "Initializing CDI container " + id);
 
@@ -246,7 +244,7 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
 
     /**
      * Start this container.
-     * @return
+     * @return container instance
      */
     @Override
     public SeContainer start() {
@@ -308,15 +306,7 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
         bootstrap.validateBeans();
         bootstrap.endInitialization();
 
-        // adding a shutdown hook
-        // we need to workaround that logging stops printing output during shutdown hooks
-        // let's add a Handler
-        // this is to workaround https://bugs.openjdk.java.net/browse/JDK-8161253
-
-        shutdownHook = new Thread(new CdiShutdownHook(cdi),
-                                  "helidon-cdi-shutdown-hook");
-
-        keepLoggingActive(shutdownHook);
+        shutdownHandler = new CdiShutdownHandler(cdi);
 
         bm.getEvent().select(Initialized.Literal.APPLICATION).fire(new ContainerInitialized(id));
         bm.getEvent().select(Any.Literal.INSTANCE).fire(new Startup());
@@ -328,38 +318,8 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
                               Version.VERSION,
                               config.getOptionalValue("features.print-details", Boolean.class).orElse(false));
 
-        // shutdown hook should be added after all initialization is done, otherwise a race condition may happen
-        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        Main.addShutdownHandler(shutdownHandler);
         return this;
-    }
-
-    private void keepLoggingActive(Thread shutdownHook) {
-        Logger rootLogger = LogManager.getLogManager().getLogger("");
-        Handler[] handlers = rootLogger.getHandlers();
-
-        List<Handler> newHandlers = new ArrayList<>();
-
-        boolean added = false;
-        for (Handler handler : handlers) {
-            if (handler instanceof KeepLoggingActiveHandler) {
-                // we want to replace it with our current shutdown hook
-                newHandlers.add(new KeepLoggingActiveHandler(shutdownHook));
-                added = true;
-            } else {
-                newHandlers.add(handler);
-            }
-        }
-        if (!added) {
-            // out handler must be first, so other handlers are not closed before we finish shutdown hook
-            newHandlers.add(0, new KeepLoggingActiveHandler(shutdownHook));
-        }
-
-        for (Handler handler : handlers) {
-            rootLogger.removeHandler(handler);
-        }
-        for (Handler newHandler : newHandlers) {
-            rootLogger.addHandler(newHandler);
-        }
     }
 
     private void exitOnStarted() {
@@ -408,9 +368,9 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
             ContainerInstanceHolder.reset();
 
             if (!FROM_SHUTDOWN_HOOK.get()) {
-                Thread thread = shutdownHook;
-                if (thread != null) {
-                    Runtime.getRuntime().removeShutdownHook(thread);
+                var usedShutdownHandler = shutdownHandler;
+                if (usedShutdownHandler != null) {
+                    Main.removeShutdownHandler(usedShutdownHandler);
                 }
             }
         }
@@ -462,44 +422,23 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
         }
     }
 
-    private static final class CdiShutdownHook implements Runnable {
+    @Weight(Weighted.DEFAULT_WEIGHT + 100) // higher than inject
+    private static final class CdiShutdownHandler implements HelidonShutdownHandler {
         private final HelidonCdi cdi;
 
-        private CdiShutdownHook(HelidonCdi cdi) {
+        private CdiShutdownHandler(HelidonCdi cdi) {
             this.cdi = cdi;
         }
 
         @Override
-        public void run() {
-            LOGGER.info("Shutdown requested by JVM shutting down");
+        public void shutdown() {
             FROM_SHUTDOWN_HOOK.set(true);
             cdi.close();
-            LOGGER.info("Shutdown finished");
-        }
-    }
-    private static final class KeepLoggingActiveHandler extends Handler {
-        private final Thread shutdownHook;
-
-        private KeepLoggingActiveHandler(Thread shutdownHook) {
-            this.shutdownHook = shutdownHook;
         }
 
         @Override
-        public void publish(LogRecord record) {
-            // noop
-        }
-
-        @Override
-        public void flush() {
-            // noop
-        }
-
-        @Override
-        public void close() {
-            try {
-                shutdownHook.join();
-            } catch (InterruptedException ignored) {
-            }
+        public String toString() {
+            return "Helidon CDI shutdown handler";
         }
     }
 }

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon</groupId>
+            <artifactId>helidon</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http</groupId>
             <artifactId>helidon-http</artifactId>
         </dependency>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -17,7 +17,6 @@
 package io.helidon.webserver;
 
 import java.lang.management.ManagementFactory;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,11 +31,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-import java.util.logging.Handler;
-import java.util.logging.LogManager;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 
+import io.helidon.Main;
 import io.helidon.common.SerializationConfig;
 import io.helidon.common.Version;
 import io.helidon.common.Weighted;
@@ -47,6 +43,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.media.MediaContext;
+import io.helidon.spi.HelidonShutdownHandler;
 import io.helidon.webserver.http.DirectHandlers;
 import io.helidon.webserver.spi.ServerFeature;
 
@@ -63,7 +60,7 @@ class LoomServer implements WebServer {
     private final WebServerConfig serverConfig;
     private final boolean registerShutdownHook;
 
-    private volatile Thread shutdownHook;
+    private volatile HelidonShutdownHandler shutdownHandler;
     private volatile List<ListenerFuture> startFutures;
     private volatile boolean alreadyStarted = false;
 
@@ -235,29 +232,14 @@ class LoomServer implements WebServer {
     }
 
     private void registerShutdownHook() {
-        this.shutdownHook = new Thread(() -> {
-            LOGGER.log(System.Logger.Level.INFO, "Shutdown requested by JVM shutting down");
-            listeners.values().forEach(ServerListener::stop);
-            if (startFutures != null) {
-                startFutures.forEach(future -> future.future().cancel(true));
-            }
-
-            running.set(false);
-
-            LOGGER.log(System.Logger.Level.INFO, "Shutdown finished");
-        }, "webserver-shutdown-hook");
-
-        Runtime.getRuntime().addShutdownHook(shutdownHook);
-        // we also need to keep the logging system active until the shutdown hook completes
-        // this introduces a hard dependency on JUL, as we cannot abstract this easily away
-        // this is to workaround https://bugs.openjdk.java.net/browse/JDK-8161253
-        keepLoggingActive(shutdownHook);
+        this.shutdownHandler = new ServerShutdownHandler(listeners, startFutures, running, context.id());
+        Main.addShutdownHandler(this.shutdownHandler);
     }
 
     private void deregisterShutdownHook() {
-        if (shutdownHook != null) {
-            Runtime.getRuntime().removeShutdownHook(shutdownHook);
-            shutdownHook = null;
+        if (shutdownHandler != null) {
+            Main.removeShutdownHandler(shutdownHandler);
+            shutdownHandler = null;
         }
     }
 
@@ -290,61 +272,38 @@ class LoomServer implements WebServer {
         return result;
     }
 
-    private void keepLoggingActive(Thread shutdownHook) {
-        Logger rootLogger = LogManager.getLogManager().getLogger("");
-        Handler[] handlers = rootLogger.getHandlers();
-
-        List<Handler> newHandlers = new ArrayList<>();
-
-        boolean added = false;
-        for (Handler handler : handlers) {
-            if (handler instanceof KeepLoggingActiveHandler) {
-                // we want to replace it with our current shutdown hook
-                newHandlers.add(new KeepLoggingActiveHandler(shutdownHook));
-                added = true;
-            } else {
-                newHandlers.add(handler);
-            }
-        }
-        if (!added) {
-            // out handler must be first, so other handlers are not closed before we finish shutdown hook
-            newHandlers.add(0, new KeepLoggingActiveHandler(shutdownHook));
-        }
-
-        for (Handler handler : handlers) {
-            rootLogger.removeHandler(handler);
-        }
-        for (Handler newHandler : newHandlers) {
-            rootLogger.addHandler(newHandler);
-        }
-    }
-
     private record ListenerFuture(ServerListener listener, Future<?> future) {
     }
 
-    private static final class KeepLoggingActiveHandler extends Handler {
-        private final Thread shutdownHook;
+    private static final class ServerShutdownHandler implements HelidonShutdownHandler {
+        private final Map<String, ServerListener> listeners;
+        private final List<ListenerFuture> startFutures;
+        private final AtomicBoolean running;
+        private final String id;
 
-        private KeepLoggingActiveHandler(Thread shutdownHook) {
-            this.shutdownHook = shutdownHook;
+        private ServerShutdownHandler(Map<String, ServerListener> listeners,
+                                      List<ListenerFuture> startFutures,
+                                      AtomicBoolean running,
+                                      String id) {
+            this.listeners = listeners;
+            this.startFutures = startFutures;
+            this.running = running;
+            this.id = id;
         }
 
         @Override
-        public void publish(LogRecord record) {
-            // noop
-        }
-
-        @Override
-        public void flush() {
-            // noop
-        }
-
-        @Override
-        public void close() {
-            try {
-                shutdownHook.join();
-            } catch (InterruptedException ignored) {
+        public void shutdown() {
+            listeners.values().forEach(ServerListener::stop);
+            if (startFutures != null) {
+                startFutures.forEach(future -> future.future().cancel(true));
             }
+
+            running.set(false);
+        }
+
+        @Override
+        public String toString() {
+            return "WebServer shutdown handler for id: " + id;
         }
     }
 }

--- a/webserver/webserver/src/main/java/module-info.java
+++ b/webserver/webserver/src/main/java/module-info.java
@@ -32,8 +32,8 @@ module io.helidon.webserver {
     requires io.helidon.common.task;
     requires io.helidon.common.uri;
     requires io.helidon.logging.common;
-    requires java.logging; // only used to keep logging active until shutdown hook finishes
     requires java.management;
+    requires io.helidon;
 
     requires transitive io.helidon.common.buffers;
     requires transitive io.helidon.common.context;


### PR DESCRIPTION
…way (instead of shutdown hooks in multiple components)

Resolves. #8685 

### Description
Currently we add shutdown hooks when needed. Shutdown hooks are threads that are started in a non-deterministic order by the JVM when the process is about to exit.

This PR introduces a service `HelidonShutdownHandler` than can be either provided through `ServiceLoader`, or registered manually on `io.helidon.Main` and that honors `Weight`.

A single shutdown hook is introduced that invokes all the shutdown handlers in weighted order (higher weight first).

The `Main` also adds the required `java.util.logging` "hack" to keep logging active until the VM shuts down (does not work, and did not work in native image). Once the issue is fixed in Java, we can remove this "hack".

Replaced existing workaround and shutdown hook in `LoomServer` and `HelidonContainerImpl`.

This is a preparation for Helidon Service Registry/Inject.
