### PR TITLE
[4.x] Plugin updates

### DIFF
--- a/codegen/apt/pom.xml
+++ b/codegen/apt/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>helidon-codegen</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-class-model</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/codegen/class-model/pom.xml
+++ b/codegen/class-model/pom.xml
@@ -34,6 +34,10 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-types</artifactId>
         </dependency>
         <dependency>

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ModelComponent.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ModelComponent.java
@@ -49,8 +49,8 @@ abstract class ModelComponent {
         /**
          * Whether to include import type information among the imports.
          *
-         * @param includeImport
-         * @return
+         * @param includeImport whether imports should be included
+         * @return updated builder instance
          */
         public B includeImport(boolean includeImport) {
             this.includeImport = includeImport;

--- a/codegen/codegen/pom.xml
+++ b/codegen/codegen/pom.xml
@@ -33,6 +33,10 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-types</artifactId>
         </dependency>
         <dependency>

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenException.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenException.java
@@ -23,6 +23,10 @@ import java.util.Optional;
  * This exception can hold {@link #originatingElement()} that may be used to provide more information to the user.
  */
 public class CodegenException extends RuntimeException {
+    /**
+     * Originating element, depends on which codegen implementation is used.
+     * For annotation processor, this could be the Element that caused this exception.
+     */
     private final Object originatingElement;
 
     /**

--- a/codegen/compiler/pom.xml
+++ b/codegen/compiler/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.codegen</groupId>
             <artifactId>helidon-codegen</artifactId>
         </dependency>

--- a/codegen/helidon-copyright/pom.xml
+++ b/codegen/helidon-copyright/pom.xml
@@ -35,6 +35,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-types</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.codegen</groupId>
             <artifactId>helidon-codegen</artifactId>
         </dependency>

--- a/codegen/helidon-copyright/src/main/java/io/helidon/codegen/helidon/copyright/HelidonCopyrightProvider.java
+++ b/codegen/helidon-copyright/src/main/java/io/helidon/codegen/helidon/copyright/HelidonCopyrightProvider.java
@@ -45,6 +45,12 @@ public class HelidonCopyrightProvider implements CopyrightProvider {
              */
             """;
 
+    /**
+     * Default constructor required by the {@link java.util.ServiceLoader}.
+     */
+    public HelidonCopyrightProvider() {
+    }
+
     @Override
     public String copyright(TypeName generator, TypeName trigger, TypeName generatedType) {
         return COPYRIGHT_TEMPLATE.replace("{{year}}", year());

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -54,6 +54,7 @@
                 <executions>
                     <execution>
                         <id>check-dependencies</id>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -33,6 +33,11 @@
 
     <packaging>pom</packaging>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+        <dependency-plugin.skip>false</dependency-plugin.skip>
+    </properties>
+
     <modules>
         <module>codegen</module>
         <module>class-model</module>

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -35,7 +35,6 @@
 
     <properties>
         <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
-        <dependency-plugin.skip>false</dependency-plugin.skip>
     </properties>
 
     <modules>
@@ -46,4 +45,18 @@
         <module>scan</module>
         <module>compiler</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-dependencies</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/buffers/pom.xml
+++ b/common/buffers/pom.xml
@@ -30,10 +30,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/buffers/src/main/java/io/helidon/common/buffers/DataReader.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/DataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -360,7 +360,8 @@ public class DataReader {
      *
      * @param max length to search
      * @return index of the new line, or max if not found
-     * @throws io.helidon.common.buffers.DataReader.IncorrectNewLineException
+     * @throws io.helidon.common.buffers.DataReader.IncorrectNewLineException in case there is a LF without CR,
+     *              or CR without a LF
      */
     public int findNewLine(int max) throws IncorrectNewLineException {
         ensureAvailable();
@@ -424,6 +425,11 @@ public class DataReader {
      * Not enough data available to finish the requested operation.
      */
     public static class InsufficientDataAvailableException extends RuntimeException {
+        /**
+         * Create a new instance. This exception does not have any other constructors.
+         */
+        public InsufficientDataAvailableException() {
+        }
     }
 
     private class Node {

--- a/common/buffers/src/main/java/module-info.java
+++ b/common/buffers/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
  * Byte buffers and byte operations.
  */
 module io.helidon.common.buffers {
-
-    requires io.helidon.common;
 
     exports io.helidon.common.buffers;
 

--- a/common/common/src/main/java/io/helidon/common/Errors.java
+++ b/common/common/src/main/java/io/helidon/common/Errors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,17 @@ public final class Errors extends LinkedList<Errors.ErrorMessage> {
     private static final Set<StackWalker.Option> WALKER_OPTIONS =
             Set.of(StackWalker.Option.RETAIN_CLASS_REFERENCE);
 
+    /**
+     * If there is a fatal error.
+     */
     private final boolean hasFatal;
+    /**
+     * If there is a warning.
+     */
     private final boolean hasWarning;
+    /**
+     * If there is a hint.
+     */
     private final boolean hasHint;
 
     private Errors(Collector collector) {
@@ -191,6 +200,16 @@ public final class Errors extends LinkedList<Errors.ErrorMessage> {
         private boolean hasFatal;
         private boolean hasWarning;
         private boolean hasHint;
+
+        /**
+         * This constructor was accidentally left public, it should be private.
+         *
+         * @deprecated please use {@link io.helidon.common.Errors#collector()} instead
+         */
+        @Deprecated(forRemoval = true, since = "4.0.9")
+        public Collector() {
+            super();
+        }
 
         /**
          * Add a message to the list of messages.
@@ -338,7 +357,9 @@ public final class Errors extends LinkedList<Errors.ErrorMessage> {
      * This exception provides access to all the messages of {@link Errors} that created it.
      */
     public static final class ErrorMessagesException extends RuntimeException {
-
+        /**
+         * List of error messages that triggered this exception.
+         */
         private final List<ErrorMessage> messages;
 
         private ErrorMessagesException(final List<ErrorMessage> messages) {

--- a/common/config/pom.xml
+++ b/common/config/pom.xml
@@ -43,11 +43,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/common/configurable/pom.xml
+++ b/common/configurable/pom.xml
@@ -52,6 +52,11 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>

--- a/common/context/src/main/java/io/helidon/common/context/Context.java
+++ b/common/context/src/main/java/io/helidon/common/context/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,6 +172,16 @@ public interface Context {
         private Context parent;
         private String id;
         private boolean notGlobal = true;
+
+        /**
+         * This constructor was accidentally left public.
+         *
+         * @deprecated use {@link io.helidon.common.context.Context#builder()} instead
+         */
+        @Deprecated(forRemoval = true, since = "4.0.9")
+        public Builder() {
+            super();
+        }
 
         @Override
         public Context build() {

--- a/common/key-util/pom.xml
+++ b/common/key-util/pom.xml
@@ -32,11 +32,24 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-configurable</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.builder</groupId>
             <artifactId>helidon-builder-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,7 +150,6 @@ public interface Value<T> {
      * If a value is present, and the value matches the given predicate,
      * return an {@code Optional} describing the value, otherwise return an
      * empty {@code Optional}.
-     * <p>
      *
      * @param predicate a predicate to apply to the value, if present
      * @return an {@code Optional} describing the value of this {@code Optional}

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -65,6 +65,7 @@
                 <executions>
                     <execution>
                         <id>check-dependencies</id>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -31,7 +31,6 @@
     <name>Helidon Common Project</name>
 
     <properties>
-        <dependency-plugin-check-dependencies.skip>false</dependency-plugin-check-dependencies.skip>
         <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
     </properties>
 
@@ -57,4 +56,18 @@
         <module>types</module>
         <module>uri</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-dependencies</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -30,6 +30,11 @@
     <packaging>pom</packaging>
     <name>Helidon Common Project</name>
 
+    <properties>
+        <dependency-plugin-check-dependencies.skip>false</dependency-plugin-check-dependencies.skip>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>buffers</module>
         <module>common</module>

--- a/common/processor/class-model/pom.xml
+++ b/common/processor/class-model/pom.xml
@@ -33,6 +33,10 @@
 
     <dependencies>
         <dependency>
+            <artifactId>helidon-common</artifactId>
+            <groupId>io.helidon.common</groupId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-types</artifactId>
         </dependency>

--- a/common/processor/class-model/src/main/java/io/helidon/common/processor/classmodel/Content.java
+++ b/common/processor/class-model/src/main/java/io/helidon/common/processor/classmodel/Content.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import io.helidon.common.types.TypeName;
-
-import static io.helidon.common.processor.classmodel.ClassModel.PADDING_TOKEN;
-import static io.helidon.common.processor.classmodel.ClassModel.TYPE_TOKEN;
 
 class Content {
 
@@ -85,9 +82,12 @@ class Content {
     /**
      * Fluent API builder for {@link Content}.
      */
+    @SuppressWarnings("removal")
     static final class Builder implements io.helidon.common.Builder<Builder, Content> {
 
-        private static final Pattern TYPE_NAME_PATTERN = Pattern.compile(TYPE_TOKEN + "(.*?)" + TYPE_TOKEN);
+        private static final Pattern TYPE_NAME_PATTERN =
+                Pattern.compile(io.helidon.common.processor.classmodel.ClassModel.TYPE_TOKEN + "(.*?)"
+                                        + io.helidon.common.processor.classmodel.ClassModel.TYPE_TOKEN);
         private static final Pattern TYPE_IDENTIFICATION_PATTERN = Pattern.compile("[.a-zA-Z0-9_]+");
 
         private final StringBuilder content = new StringBuilder();
@@ -195,7 +195,7 @@ class Content {
          * @return updated builder instance
          */
         Builder padding() {
-            this.content.append(PADDING_TOKEN);
+            this.content.append(io.helidon.common.processor.classmodel.ClassModel.PADDING_TOKEN);
             return this;
         }
 
@@ -207,7 +207,7 @@ class Content {
          * @return updated builder instance
          */
         Builder padding(int repetition) {
-            this.content.append(PADDING_TOKEN.repeat(repetition));
+            this.content.append(io.helidon.common.processor.classmodel.ClassModel.PADDING_TOKEN.repeat(repetition));
             return this;
         }
 
@@ -219,7 +219,7 @@ class Content {
          */
         Builder increasePadding() {
             this.extraPaddingLevel++;
-            this.extraPadding = PADDING_TOKEN.repeat(this.extraPaddingLevel);
+            this.extraPadding = io.helidon.common.processor.classmodel.ClassModel.PADDING_TOKEN.repeat(this.extraPaddingLevel);
             return this;
         }
 
@@ -234,7 +234,7 @@ class Content {
             if (this.extraPaddingLevel < 0) {
                 throw new ClassModelException("Content padding cannot be negative");
             }
-            this.extraPadding = PADDING_TOKEN.repeat(this.extraPaddingLevel);
+            this.extraPadding = io.helidon.common.processor.classmodel.ClassModel.PADDING_TOKEN.repeat(this.extraPaddingLevel);
             return this;
         }
 

--- a/common/processor/class-model/src/main/java/io/helidon/common/processor/classmodel/ModelComponent.java
+++ b/common/processor/class-model/src/main/java/io/helidon/common/processor/classmodel/ModelComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ abstract class ModelComponent {
         /**
          * Whether to include import type information among the imports.
          *
-         * @param includeImport
-         * @return
+         * @param includeImport whether to include imports
+         * @return updated builder instance
          */
         public B includeImport(boolean includeImport) {
             this.includeImport = includeImport;

--- a/common/processor/class-model/src/main/java/io/helidon/common/processor/classmodel/package-info.java
+++ b/common/processor/class-model/src/main/java/io/helidon/common/processor/classmodel/package-info.java
@@ -16,8 +16,6 @@
 
 /**
  * Class model generator for annotation processors.
- *
- * @deprecated use {@code helidon-codegen-class-model} instead.
  */
 @Deprecated(forRemoval = true, since = "4.1.0")
 package io.helidon.common.processor.classmodel;

--- a/common/processor/helidon-copyright/pom.xml
+++ b/common/processor/helidon-copyright/pom.xml
@@ -35,6 +35,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-types</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.processor</groupId>
             <artifactId>helidon-common-processor</artifactId>
         </dependency>

--- a/common/processor/helidon-copyright/src/main/java/io/helidon/common/processor/helidon/copyright/HelidonCopyrightProvider.java
+++ b/common/processor/helidon-copyright/src/main/java/io/helidon/common/processor/helidon/copyright/HelidonCopyrightProvider.java
@@ -48,6 +48,12 @@ public class HelidonCopyrightProvider implements CopyrightProvider {
              */
             """;
 
+    /**
+     * Required by Java {@link java.util.ServiceLoader}.
+     */
+    public HelidonCopyrightProvider() {
+    }
+
     @Override
     public String copyright(TypeName generator, TypeName trigger, TypeName generatedType) {
         return COPYRIGHT_TEMPLATE.replace("{{year}}", year());

--- a/common/processor/helidon-copyright/src/main/java/io/helidon/common/processor/helidon/copyright/package-info.java
+++ b/common/processor/helidon-copyright/src/main/java/io/helidon/common/processor/helidon/copyright/package-info.java
@@ -16,8 +16,8 @@
 
 /**
  * Custom copyright provider that generates Helidon copyright headers.
- *
- * @deprecated use {@code helidon-codegen-helidon-copyright} instead.
+ * <p>
+ * Use {@code helidon-codegen-helidon-copyright} instead.
  */
 @Deprecated(forRemoval = true, since = "4.1.0")
 package io.helidon.common.processor.helidon.copyright;

--- a/common/processor/processor/pom.xml
+++ b/common/processor/processor/pom.xml
@@ -36,11 +36,11 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-types</artifactId>
+            <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.common.processor</groupId>
-            <artifactId>helidon-common-processor-class-model</artifactId>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-types</artifactId>
         </dependency>
     </dependencies>
 

--- a/common/processor/processor/src/main/java/io/helidon/common/processor/package-info.java
+++ b/common/processor/processor/src/main/java/io/helidon/common/processor/package-info.java
@@ -16,8 +16,6 @@
 
 /**
  * Tools for annotation processing.
- *
- * @deprecated use {@code helidon-codegen} instead.
  */
 @Deprecated(forRemoval = true, since = "4.1.0")
 package io.helidon.common.processor;

--- a/common/processor/processor/src/main/java/io/helidon/common/processor/spi/package-info.java
+++ b/common/processor/processor/src/main/java/io/helidon/common/processor/spi/package-info.java
@@ -19,7 +19,6 @@
  *
  * @see io.helidon.common.processor.spi.CopyrightProvider
  * @see io.helidon.common.processor.spi.GeneratedAnnotationProvider
- * @deprecated use {@code helidon-codegen} instead.
  */
 @Deprecated(forRemoval = true, since = "4.1.0")
 package io.helidon.common.processor.spi;

--- a/common/processor/processor/src/main/java/module-info.java
+++ b/common/processor/processor/src/main/java/module-info.java
@@ -22,7 +22,6 @@
 @Deprecated(forRemoval = true, since = "4.1.0")
 module io.helidon.common.processor {
 
-    requires io.helidon.common.processor.classmodel;
     requires jdk.compiler;
 
     requires transitive io.helidon.common.types;

--- a/common/reactive/pom.xml
+++ b/common/reactive/pom.xml
@@ -38,10 +38,6 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-mapper</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/reactive/src/main/java/io/helidon/common/reactive/BufferedEmittingPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/BufferedEmittingPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,18 @@ public class BufferedEmittingPublisher<T> implements Flow.Publisher<T> {
     //         against a completion (isCancelled() and isComplete() are both true)
     private boolean cancelled;
 
+    /**
+     * A new buffered emitting publisher with a custom queue to be used as a buffer.
+     *
+     * @param queue buffer to use
+     */
     protected BufferedEmittingPublisher(Queue<T> queue) {
         buffer = queue;
     }
 
+    /**
+     * A new buffered emitting publisher using {@link java.util.concurrent.ConcurrentLinkedQueue} as the buffer.
+     */
     protected BufferedEmittingPublisher() {
         buffer = new ConcurrentLinkedQueue<>();
     }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/CompletionSingle.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/CompletionSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,20 @@ public abstract class CompletionSingle<T> extends CompletionAwaitable<T> impleme
 
     private final CompletableFuture<Void> cancelFuture = new CompletableFuture<>();
 
+    /**
+     * Create a new completion single using {@link #toNullableStage()} as a supplier for
+     * {@link #setOriginalStage(java.util.function.Supplier)}.
+     */
     protected CompletionSingle() {
         LazyValue<CompletableFuture<T>> lazyStage = LazyValue.create(this::toNullableStage);
         setOriginalStage(lazyStage::get);
     }
 
+    /**
+     * Create a new nullable completable future from this single.
+     *
+     * @return a new nullable completable future
+     */
     protected CompletableFuture<T> toNullableStage() {
         SingleToFuture<T> subscriber = new SingleToFuture<>(this, true);
         this.subscribe(subscriber);

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiFromByteChannel.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiFromByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ class MultiFromByteChannel implements Multi<ByteBuffer> {
     private final int chunkCapacity;
     private final LazyValue<ScheduledExecutorService> executor;
 
-    private final SingleSubscriberHolder<ByteBuffer> subscriber = new SingleSubscriberHolder<>();
+    private final SingleSubscriberHolder<ByteBuffer> subscriber = SingleSubscriberHolder.create();
     private final RequestedCounter requested = new RequestedCounter();
     private final AtomicBoolean publishing = new AtomicBoolean(false);
     private final AtomicInteger retryCounter = new AtomicInteger();

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiMapperPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiMapperPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@ import java.util.Objects;
 import java.util.concurrent.Flow;
 import java.util.function.Function;
 
-import io.helidon.common.mapper.Mapper;
-
 /**
- * Maps the upstream items via a {@link Mapper} function.
+ * Maps the upstream items via a mapper function.
  * @param <T> the upstream value type
  * @param <R> the result value type
  */

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
-import io.helidon.common.mapper.Mapper;
 
 /**
  * Represents a {@link Flow.Publisher} that may: signal one item then completes, complete without
@@ -320,7 +319,7 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
     }
 
     /**
-     * Map this {@link Single} instance to a publisher using the given {@link Mapper}.
+     * Map this {@link Single} instance to a publisher using the given mapper.
      *
      * @param <U>    mapped items type
      * @param mapper mapper

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleMapperPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleMapperPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,8 @@ package io.helidon.common.reactive;
 import java.util.concurrent.Flow;
 import java.util.function.Function;
 
-import io.helidon.common.mapper.Mapper;
-
 /**
- * Maps the upstream item via a {@link Mapper} function.
+ * Maps the upstream item via a mapper function.
  * @param <T> the upstream value type
  * @param <R> the result value type
  */

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleSubscriberHolder.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleSubscriberHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,25 @@ public class SingleSubscriberHolder<T> {
     private final CompletableFuture<Flow.Subscriber<? super T>> subscriber = new CompletableFuture<>();
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicBoolean onSubscribeCalled = new AtomicBoolean(false);
+
+    /**
+     * This constructor should not be exposed.
+     *
+     * @deprecated use {@link #create()} instead.
+     */
+    @Deprecated(forRemoval = true, since = "4.0.9")
+    public SingleSubscriberHolder() {
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @return a new instance to use as a subscriber holder
+     * @param <T> type of the subscriber
+     */
+    public static <T> SingleSubscriberHolder<T> create() {
+        return new SingleSubscriberHolder<>();
+    }
 
     /**
      * Register a new subscriber.

--- a/common/reactive/src/main/java/module-info.java
+++ b/common/reactive/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ module io.helidon.common.reactive {
 
     requires java.logging;
     requires io.helidon.common;
-    requires io.helidon.common.mapper;
 
     exports io.helidon.common.reactive;
 

--- a/common/socket/pom.xml
+++ b/common/socket/pom.xml
@@ -31,6 +31,10 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-buffers</artifactId>
         </dependency>
         <dependency>

--- a/common/testing/http-junit5/pom.xml
+++ b/common/testing/http-junit5/pom.xml
@@ -31,6 +31,8 @@
 
     <properties>
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+        <!-- we want to provide ease of use to users, so helidon-common-testing-junit5 is a transitive dep even if not used -->
+        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
     </properties>
 
     <dependencies>

--- a/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/SocketHttpClient.java
+++ b/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/SocketHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,13 @@ public class SocketHttpClient implements AutoCloseable {
     private boolean connected;
     private BufferedReader socketReader;
 
+    /**
+     * Create a new client connecting to the specified coordinates.
+     *
+     * @param host host to connect to
+     * @param port port to connect to
+     * @param timeout socket timeout
+     */
     protected SocketHttpClient(String host, int port, Duration timeout) {
         this.host = host;
         this.port = port;
@@ -555,7 +562,7 @@ public class SocketHttpClient implements AutoCloseable {
      *
      * @param payload text to be sent
      * @return this http client
-     * @throws IOException
+     * @throws IOException in case the underlying socket throws an exception
      */
     public SocketHttpClient continuePayload(String payload)
             throws IOException {
@@ -572,7 +579,7 @@ public class SocketHttpClient implements AutoCloseable {
      *
      * @param payload of the chunk
      * @return this http client
-     * @throws IOException
+     * @throws IOException in case the underlying socket throws an exception
      */
     public SocketHttpClient sendChunk(String payload) throws IOException {
         continuePayload(Integer.toHexString(payload.length()) + EOL + payload + EOL);

--- a/common/testing/junit5/pom.xml
+++ b/common/testing/junit5/pom.xml
@@ -31,12 +31,6 @@
 
     <dependencies>
         <dependency>
-            <!-- this is to enforce order of compilation, so modules that use this as an annotation processor have it ready -->
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-metadata-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>provided</scope>
@@ -47,19 +41,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgs>
-                        <!-- disable the processor we add for reactor -->
-                        <compilerArgument>-proc:none</compilerArgument>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/common/testing/junit5/src/main/java/io/helidon/common/testing/junit5/RestoreSystemPropertiesExt.java
+++ b/common/testing/junit5/src/main/java/io/helidon/common/testing/junit5/RestoreSystemPropertiesExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,12 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 public class RestoreSystemPropertiesExt implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
     private static final String SYSPROPS_KEY = "systemProps";
+
+    /**
+     * Required for test extensions.
+     */
+    public RestoreSystemPropertiesExt() {
+    }
 
     @Override
     public void beforeTestExecution(ExtensionContext ec) throws Exception {

--- a/common/tls/pom.xml
+++ b/common/tls/pom.xml
@@ -32,16 +32,23 @@
 
     <properties>
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+        <!--
+        Once we remove dependency on Jakarta inject, this can be removed. Current warning:
+        The code being documented uses modules but the packages defined in
+         https://jakarta.ee/specifications/dependency-injection/2.0/apidocs/ are in the unnamed module.
+        -->
+        <javadoc.fail-on-warnings>false</javadoc.fail-on-warnings>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common</artifactId>
+            <artifactId>helidon-inject-api</artifactId>
+            <groupId>io.helidon.inject</groupId>
+            <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config</artifactId>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/common/types/pom.xml
+++ b/common/types/pom.xml
@@ -42,11 +42,6 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-metadata</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/common/types/src/main/java/io/helidon/common/types/TypeInfoBlueprint.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeInfoBlueprint.java
@@ -58,7 +58,7 @@ interface TypeInfoBlueprint extends Annotated {
      *
      * @return the type element kind.
      * @see io.helidon.common.types.TypeValues#KIND_CLASS and other constants on this class prefixed with {@code TYPE}
-     * @deprecated use {@link #kind()} instead
+     * @deprecated use {@link io.helidon.common.types.TypeInfo#kind()} instead
      */
     @Option.Required
     @Option.Deprecated("kind")
@@ -186,7 +186,7 @@ interface TypeInfoBlueprint extends Annotated {
      *
      * @return element modifiers
      * @see io.helidon.common.types.TypeValues#MODIFIER_PUBLIC and other constants prefixed with {@code MODIFIER}
-     * @deprecated use {@link #elementModifiers()} instead
+     * @deprecated use {@link io.helidon.common.types.TypeInfo#elementModifiers()} instead
      */
     @Option.Singular
     @Option.Redundant
@@ -229,7 +229,8 @@ interface TypeInfoBlueprint extends Annotated {
     Optional<Object> originatingElement();
 
     /**
-     * Uses {@link #referencedModuleNames()} to determine if the module name is known for the given type.
+     * Uses {@link io.helidon.common.types.TypeInfo#referencedModuleNames()} to determine if the module name is known for the
+     * given type.
      *
      * @param typeName the type name to lookup
      * @return the module name if it is known

--- a/common/types/src/main/java/io/helidon/common/types/TypedElementInfoBlueprint.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypedElementInfoBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ interface TypedElementInfoBlueprint extends Annotated {
      *
      * @return the element kind
      * @see io.helidon.common.types.TypeInfo
-     * @deprecated use {@link #kind()} instead
+     * @deprecated use {@link io.helidon.common.types.TypedElementInfo#kind()} instead
      */
     @Option.Required
     @Option.Deprecated("kind")
@@ -84,7 +84,7 @@ interface TypedElementInfoBlueprint extends Annotated {
     Optional<String> defaultValue();
 
     /**
-     * The list of known annotations on the type name referenced by {@link #typeName()}.
+     * The list of known annotations on the type name referenced by {@link io.helidon.common.types.TypedElementInfo#typeName()}.
      *
      * @return the list of annotations on this element's (return) type.
      */
@@ -104,7 +104,7 @@ interface TypedElementInfoBlueprint extends Annotated {
      *
      * @return element modifiers
      * @see io.helidon.common.types.TypeInfo
-     * @deprecated use {@link #elementModifiers()} instead
+     * @deprecated use {@link io.helidon.common.types.TypedElementInfo#elementModifiers()} instead
      */
     @Option.Singular
     @Option.Redundant

--- a/common/types/src/main/java/module-info.java
+++ b/common/types/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@
 module io.helidon.common.types {
 
     requires io.helidon.builder.api;
-
-    requires static io.helidon.config.metadata;
 
     requires transitive io.helidon.common;
 

--- a/common/uri/pom.xml
+++ b/common/uri/pom.xml
@@ -30,6 +30,14 @@
 
     <dependencies>
         <dependency>
+            <artifactId>helidon-common</artifactId>
+            <groupId>io.helidon.common</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>helidon-common-mapper</artifactId>
+            <groupId>io.helidon.common</groupId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-parameters</artifactId>
         </dependency>

--- a/common/uri/src/main/java/io/helidon/common/uri/UriBuilderSupport.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriBuilderSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,11 @@ final class UriBuilderSupport {
         private UriInfoCustomMethods() {
         }
 
+        /**
+         * Authority of the request, to be converted to host and port.
+         *
+         * @param authority authority of the request (host:port)
+         */
         @Prototype.BuilderMethod
         static void authority(UriInfo.BuilderBase<?, ?> builder, String authority) {
             int index = authority.lastIndexOf(':');
@@ -69,6 +74,11 @@ final class UriBuilderSupport {
             builder.port(Integer.parseInt(authority.substring(index + 1)));
         }
 
+        /**
+         * Path of the request, to be converted to {@link io.helidon.common.uri.UriPath}.
+         *
+         * @param path of the request
+         */
         @Prototype.BuilderMethod
         static void path(UriInfo.BuilderBase<?, ?> builder, String path) {
             builder.path(UriPath.createFromDecoded(path));

--- a/jersey/connector/pom.xml
+++ b/jersey/connector/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>helidon-webclient-http2</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/microprofile/reactive-streams/src/main/java/module-info.java
+++ b/microprofile/reactive-streams/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import io.helidon.common.features.api.HelidonFlavor;
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module io.helidon.microprofile.reactive {
 
-    requires io.helidon.common.mapper;
     requires io.helidon.common.reactive;
     requires java.logging;
 

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,23 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${version.plugin.dependency}</version>
+                    <executions>
+                        <execution>
+                            <id>check-dependencies</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <phase>none</phase>
+                            <configuration>
+                                <skip>${dependency-plugin-check-dependencies.skip}</skip>
+                                <ignoredPackagings>
+                                    <packaging>pom</packaging>
+                                </ignoredPackagings>
+                                <ignoreNonCompile>true</ignoreNonCompile>
+                                <failOnWarning>true</failOnWarning>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -811,31 +828,6 @@
                 <plugin>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>${version.plugin.ant}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>check-dependencies</id>
-                            <goals>
-                                <goal>analyze-only</goal>
-                            </goals>
-                            <phase>verify</phase>
-                            <configuration>
-                                <skip>${dependency-plugin-check-dependencies.skip}</skip>
-                                <ignoredPackagings>
-                                    <packaging>pom</packaging>
-                                </ignoredPackagings>
-                                <ignoreNonCompile>true</ignoreNonCompile>
-                                <failOnWarning>true</failOnWarning>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
+                    <artifactId>maven-resources-plugin</artifactId>
                     <version>${version.plugin.resources}</version>
                 </plugin>
                 <plugin>
@@ -918,7 +918,7 @@
                             <ignoredPackagings>
                                 <packaging>pom</packaging>
                             </ignoredPackagings>
-                            <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+                            <ignoreNonCompile>true</ignoreNonCompile>
                             <failOnWarning>true</failOnWarning>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,14 @@
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.threshold>Medium</spotbugs.threshold>
 
+        <!-- owasp dependency check -->
         <dependency-check.skip>false</dependency-check.skip>
         <checkstyle.skip>false</checkstyle.skip>
+
+        <!-- Maven dependency check -->
+        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
+        <javadoc.fail-on-warnings>false</javadoc.fail-on-warnings>
+
         <!--
         !Version statement! - begin
 
@@ -264,6 +270,7 @@
                     <configuration>
                         <source>${version.java}</source>
                         <failOnError>true</failOnError>
+                        <failOnWarnings>${javadoc.fail-on-warnings}</failOnWarnings>
                         <!-- we are not interested in each file that is generated -->
                         <quiet>true</quiet>
                         <offline>true</offline>
@@ -520,7 +527,7 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
+                    <artifactId>maven-dependency-plugin</artifactId>
                     <version>${version.plugin.resources}</version>
                 </plugin>
                 <plugin>
@@ -893,6 +900,27 @@
                         <goals>
                             <goal>services</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <skip>${dependency-plugin-check-dependencies.skip}</skip>
+                            <ignoredPackagings>
+                                <packaging>pom</packaging>
+                            </ignoredPackagings>
+                            <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+                            <failOnWarning>true</failOnWarning>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <checkstyle.skip>false</checkstyle.skip>
 
         <!-- Maven dependency check -->
-        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
+        <dependency-plugin-check-dependencies.skip>false</dependency-plugin-check-dependencies.skip>
         <javadoc.fail-on-warnings>false</javadoc.fail-on-warnings>
 
         <!--
@@ -812,6 +812,31 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>${version.plugin.ant}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>check-dependencies</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <phase>verify</phase>
+                            <configuration>
+                                <skip>${dependency-plugin-check-dependencies.skip}</skip>
+                                <ignoredPackagings>
+                                    <packaging>pom</packaging>
+                                </ignoredPackagings>
+                                <ignoreNonCompile>true</ignoreNonCompile>
+                                <failOnWarning>true</failOnWarning>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -900,27 +925,6 @@
                         <goals>
                             <goal>services</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check-dependencies</id>
-                        <goals>
-                            <goal>analyze-only</goal>
-                        </goals>
-                        <phase>verify</phase>
-                        <configuration>
-                            <skip>${dependency-plugin-check-dependencies.skip}</skip>
-                            <ignoredPackagings>
-                                <packaging>pom</packaging>
-                            </ignoredPackagings>
-                            <ignoreNonCompile>true</ignoreNonCompile>
-                            <failOnWarning>true</failOnWarning>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -77,6 +77,14 @@
             <artifactId>helidon-common-features</artifactId>
         </dependency>
         <dependency>
+            <!--
+            This dependency is not required, yet a lot of examples depend on it. Kept in for backward compatibility.
+            This used to be a transitive dependency of another module.
+             -->
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
 - javadoc plugin can now be configured to fail on warning (default is `false`)
- dependency plugin check dependencies now configured in plugin management
- dependency plugin check phase is set to `none`
- dependency plugin check dependencies can be configured to skip (skip defaults to `false`)
- updated `common` and `codegen` modules to use the new possible restrictions
- fixed all problems that could be fixed, skipping where appropriate

This change may have impact on dependency structure of projects, as some modules had dependencies that were not used. Nevertheless these dependencies were wrong.

Fixing also our own modules that failed because of this.