### PR TITLE
Fixes bug in OkeWorkloadIdentityAdpSupplier.available() method

### DIFF
--- a/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/OkeWorkloadIdentityAdpSupplier.java
+++ b/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/OkeWorkloadIdentityAdpSupplier.java
@@ -15,8 +15,10 @@
  */
 package io.helidon.integrations.oci.sdk.cdi;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Optional;
@@ -172,8 +174,8 @@ class OkeWorkloadIdentityAdpSupplier implements AdpSupplier<OkeWorkloadIdentityA
      *
      * @return {@code true} if and only if the file identified by the value of the {@code
      * OCI_KUBERNETES_SERVICE_ACCOUNT_CERT_PATH} environment variable, or the default value "{@code
-     * /var/run/secrets/kubernetes.io/serviceaccount/ca.crt}", {@linkplain BasicFileAttributes#isRegularFile() is a
-     * regular file}; {@code false} in all other cases
+     * /var/run/secrets/kubernetes.io/serviceaccount/ca.crt}", exists and {@linkplain
+     * BasicFileAttributes#isRegularFile() is a regular file}; {@code false} in all other cases
      *
      * @exception UncheckedIOException if there was an error checking attributes of the (extant) file
      */
@@ -184,6 +186,8 @@ class OkeWorkloadIdentityAdpSupplier implements AdpSupplier<OkeWorkloadIdentityA
                                        .orElse("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")),
                                BasicFileAttributes.class)
                 .isRegularFile(); // (symbolic links are followed by default)
+        } catch (FileNotFoundException | NoSuchFileException e) {
+            return false;
         } catch (IOException e) {
             throw new UncheckedIOException(e.getMessage(), e);
         }

--- a/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/TestOkeWorkloadIdentityAdpSupplier.java
+++ b/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/TestOkeWorkloadIdentityAdpSupplier.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.sdk.cdi;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.integrations.oci.sdk.cdi.OkeWorkloadIdentityAdpSupplier.available;
+
+class TestOkeWorkloadIdentityAdpSupplier {
+
+    private TestOkeWorkloadIdentityAdpSupplier() {
+        super();
+    }
+
+    @Test
+    void testAvailability() {
+        available(); // make sure this does not throw any exception, whether its backing file exists or not
+    }
+
+}


### PR DESCRIPTION
`OkeWorkloadIdentityAdpSupplier` could fail its availability check; this PR corrects that.