### PR TITLE
Clear default propagator when one is explicitly added

### DIFF
--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,6 +161,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     private final Map<String, String> tags = new HashMap<>();
     // this is a backward incompatible change, but the correct choice is Jaeger, not B3
     private final Set<PropagationFormat> propagationFormats = EnumSet.of(PropagationFormat.JAEGER);
+    private boolean isPropagationFormatsDefaulted = true;
     private String serviceName;
     private String protocol = "http";
     private String host = DEFAULT_HTTP_HOST;
@@ -467,6 +468,10 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     @ConfiguredOption(key = "propagation", kind = ConfiguredOption.Kind.LIST, type = PropagationFormat.class, value = "JAEGER")
     public JaegerTracerBuilder addPropagation(PropagationFormat propagationFormat) {
         Objects.requireNonNull(propagationFormat);
+        if (isPropagationFormatsDefaulted) {
+            isPropagationFormatsDefaulted = false;
+            this.propagationFormats.clear();
+        }
         this.propagationFormats.add(propagationFormat);
         return this;
     }

--- a/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/BuilderPropagatorDefaultTest.java
+++ b/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/BuilderPropagatorDefaultTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.jaeger;
+
+import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+class BuilderPropagatorDefaultTest {
+
+    @Test
+    void checkThatPropagatorFormatAssignmentOverridesJaegerDefault() {
+        JaegerTracerBuilder builder = JaegerTracerBuilder.create();
+        builder.addPropagation(JaegerTracerBuilder.PropagationFormat.B3_SINGLE);
+        var props = builder.createPropagators();
+        assertThat("Propagators when default overridden", props, not(hasItem(instanceOf(JaegerPropagator.class))));
+    }
+
+    @Test
+    void checkDefaultedPropagationFormatIsJaeger() {
+        JaegerTracerBuilder builder = JaegerTracerBuilder.create();
+        var props = builder.createPropagators();
+        assertThat("Propagators with only default", props, contains(instanceOf(JaegerPropagator.class)));
+    }
+}


### PR DESCRIPTION
### Description
Resolves #8651 

The `propagationFormats` attribute of the `JaegerTracerBuilder` is an `EnumSet` and is assigned a single default value using a field initializer.

But the `addPropagationFormat` method simply adds its parameter to the `EnumSet` without regard to the default value.

This PR adds logic to clear the default value upon the first explicit addition of a propagation format.

The PR includes tests to make sure the default value is cleared properly and retained properly.

### Documentation
Bug fix; no doc impact.