### PR TITLE
4.x: Move example WebClient code into a snippet

### DIFF
--- a/docs/src/main/asciidoc/se/webclient.adoc
+++ b/docs/src/main/asciidoc/se/webclient.adoc
@@ -102,17 +102,19 @@ request methods. These methods will create a new instance of link:{webclient-jav
 
 === Customizing the Request
 
-Configuration can be set for every request type before it is sent. Below are some examples of the optional parameters.
+Configuration can be set for every request type before it is sent.
 
-|===
-|Parameter |Description
+.Customizing a request
+[source,java]
+----
+include::{sourcedir}/se/WebClientSnippets.java[tag=snippet_12, indent=0]
+----
 
-|`uri("http://example.com")`   |Overrides baseUri from WebClient
-|`path("/path")`   |Adds path to the uri
-|`queryParam("query", "parameter")`   |Adds query parameter to the request
-|`fragment("someFragment")`   |Adds fragment to the request
-|`headers(headers -> headers.addAccept(MediaType.APPLICATION_JSON))`   |Adds header to the request
-|===
+<1> Overrides `baseUri` from WebClient
+<2> Adds path to the uri
+<3> Adds query parameter to the request
+<4> Adds fragment to the request
+<5> Adds header to the request
 
 For more information about these optional parameters, check out link:{webclient-javadoc-base-url}.api/io/helidon/webclient/api/ClientRequestBase.html[ClientRequestBase] API, which is a parent class of link:{webclient-javadoc-base-url}.api/io/helidon/webclient/api/HttpClientRequest.html[HttpClientRequest].
 

--- a/docs/src/main/java/io/helidon/docs/se/WebClientSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/WebClientSnippets.java
@@ -15,10 +15,12 @@
  */
 package io.helidon.docs.se;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.http.Method;
 import io.helidon.http.media.MediaSupport;
 import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.HttpClientRequest;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.WebClient;
@@ -158,6 +160,20 @@ class WebClientSnippets {
                                            .build())
                 .build();
         // end::snippet_11[]
+    }
+
+    void snippet_12() {
+        WebClient client = WebClient.builder()
+                .baseUri("http://localhost")
+                .build();
+        // tag::snippet_12[]
+        client.get()
+                .uri("http://example.com") // <1>
+                .path("/path") // <2>
+                .queryParam("query", "parameter") // <3>
+                .fragment("someFragment") // <4>
+                .headers(headers -> headers.accept(MediaTypes.APPLICATION_JSON)); // <5>
+        // end::snippet_12[]
     }
 
 }


### PR DESCRIPTION
### Description

Corrects a WebClient code examples and moves example WebClient code into a snippet.

Fixes #8653

### Documentation

Doc fix.
