### PR TITLE
Allows transition from HEADERS to END in HTTP2 client stream

### DIFF
--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -446,11 +446,11 @@ class Http2ClientStream implements Http2Stream, ReleasableResource {
                                       flowControl().outbound());
     }
 
-    private enum ReadState {
+    enum ReadState {
         END,
         TRAILERS(END),
         DATA(TRAILERS, END),
-        HEADERS(DATA, TRAILERS),
+        HEADERS(DATA, TRAILERS, END),
         CONTINUE_100_HEADERS(HEADERS, DATA, END),
         INIT(CONTINUE_100_HEADERS, HEADERS);
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/ReadStateTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/ReadStateTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.http2;
+
+import org.junit.jupiter.api.Test;
+
+import io.helidon.webclient.http2.Http2ClientStream.ReadState;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReadStateTest {
+
+    @Test
+    void checkAllValidTransitions() {
+        ReadState.INIT.check(ReadState.CONTINUE_100_HEADERS);
+        ReadState.INIT.check(ReadState.HEADERS);
+
+        ReadState.CONTINUE_100_HEADERS.check(ReadState.HEADERS);
+        ReadState.CONTINUE_100_HEADERS.check(ReadState.DATA);
+        ReadState.CONTINUE_100_HEADERS.check(ReadState.END);
+
+        ReadState.HEADERS.check(ReadState.DATA);
+        ReadState.HEADERS.check(ReadState.TRAILERS);
+        ReadState.HEADERS.check(ReadState.END);
+
+        ReadState.DATA.check(ReadState.TRAILERS);
+        ReadState.DATA.check(ReadState.END);
+
+        ReadState.TRAILERS.check(ReadState.END);
+    }
+
+    @Test
+    void checkSomeInvalidTransitions() {
+        assertThrows(IllegalStateException.class, () -> ReadState.CONTINUE_100_HEADERS.check(ReadState.INIT));
+        assertThrows(IllegalStateException.class, () -> ReadState.HEADERS.check(ReadState.INIT));
+
+        assertThrows(IllegalStateException.class, () -> ReadState.HEADERS.check(ReadState.CONTINUE_100_HEADERS));
+        assertThrows(IllegalStateException.class, () -> ReadState.DATA.check(ReadState.CONTINUE_100_HEADERS));
+        assertThrows(IllegalStateException.class, () -> ReadState.END.check(ReadState.CONTINUE_100_HEADERS));
+
+        assertThrows(IllegalStateException.class, () -> ReadState.DATA.check(ReadState.HEADERS));
+        assertThrows(IllegalStateException.class, () -> ReadState.TRAILERS.check(ReadState.HEADERS));
+        assertThrows(IllegalStateException.class, () -> ReadState.END.check(ReadState.HEADERS));
+
+        assertThrows(IllegalStateException.class, () -> ReadState.TRAILERS.check(ReadState.DATA));
+        assertThrows(IllegalStateException.class, () -> ReadState.END.check(ReadState.DATA));
+
+        assertThrows(IllegalStateException.class, () -> ReadState.END.check(ReadState.TRAILERS));
+    }
+}


### PR DESCRIPTION
### Description

Allows transition from HEADERS to END in HTTP2 client stream. This is required for the new gRPC client. See issue #8693.