### PR TITLE
[4.x] LazyConfigSource is now queried when an unknown node is requested

### DIFF
--- a/config/config/src/main/java/io/helidon/config/ConfigSourcesRuntime.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSourcesRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,18 @@ final class ConfigSourcesRuntime {
     @Override
     public String toString() {
         return allSources.toString();
+    }
+
+    Optional<ConfigNode> lazyValue(String key) {
+        for (ConfigSourceRuntimeImpl source : allSources) {
+            if (source.isLazy()) {
+                Optional<ConfigNode> node = source.node(key);
+                if (node.isPresent()) {
+                    return node;
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     void changeListener(Consumer<Optional<ObjectNode>> changeListener) {

--- a/config/config/src/main/java/io/helidon/config/ConfigSourcesRuntime.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSourcesRuntime.java
@@ -76,6 +76,7 @@ final class ConfigSourcesRuntime {
     }
 
     Optional<ConfigNode> lazyValue(String key) {
+        // list of sources in `allSources` is final, there is no need to synchronize
         for (ConfigSourceRuntimeImpl source : allSources) {
             if (source.isLazy()) {
                 Optional<ConfigNode> node = source.node(key);

--- a/config/config/src/main/java/io/helidon/config/ProviderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ProviderImpl.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.helidon.config.spi.ConfigFilter;
+import io.helidon.config.spi.ConfigNode;
 import io.helidon.config.spi.ConfigNode.ObjectNode;
 
 /**
@@ -114,6 +115,10 @@ class ProviderImpl implements Config.Context {
     @Override
     public synchronized Config last() {
         return lastConfig;
+    }
+
+    synchronized Optional<ConfigNode> lazyValue(String string) {
+        return configSource.lazyValue(string);
     }
 
     void onChange(Consumer<ConfigDiff> listener) {

--- a/config/config/src/main/java/io/helidon/config/ProviderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ProviderImpl.java
@@ -117,7 +117,7 @@ class ProviderImpl implements Config.Context {
         return lastConfig;
     }
 
-    synchronized Optional<ConfigNode> lazyValue(String string) {
+    Optional<ConfigNode> lazyValue(String string) {
         return configSource.lazyValue(string);
     }
 

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -63,5 +63,6 @@
         <module>service-registry</module>
         <module>config-metadata-meta-api</module>
         <module>config-metadata-builder-api</module>
+        <module>test-lazy-source</module>
     </modules>
 </project>

--- a/config/tests/test-lazy-source/pom.xml
+++ b/config/tests/test-lazy-source/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.config.tests</groupId>
+        <artifactId>helidon-config-tests-project</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-config-tests-test-lazy-source</artifactId>
+    <name>Helidon Config Tests Lazy Source</name>
+
+    <description>
+        Integration tests of lazy config source.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/config/tests/test-lazy-source/src/test/java/io/helidon/config/tests/lazy/source/LazySourceTest.java
+++ b/config/tests/test-lazy-source/src/test/java/io/helidon/config/tests/lazy/source/LazySourceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.lazy.source;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.config.spi.ConfigSource;
+import io.helidon.config.spi.LazyConfigSource;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+public class LazySourceTest {
+    @Test
+    void testLazySource() {
+        Map<String, String> map = new HashMap<>();
+        map.put("tree.node2", "value2");
+
+        TestLazySource testLazySource = new TestLazySource(map);
+
+        Config config = Config.builder()
+                .addSource(testLazySource)
+                .addSource(ConfigSources.create(Map.of("tree.node1", "value1")))
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .build();
+
+        assertThat(config.get("tree.node1").as(String.class).get(), is("value1"));
+
+        // when using lazy config source, we defer the loading of the key until it is actually requested
+        assertThat("tree.node2 should exist", config.get("tree.node2").exists(), is(true));
+        assertThat(config.get("tree.node2").as(String.class).get(), is("value2"));
+        assertThat("tree.node3 should not exist", config.get("tree.node3").exists(), is(false));
+
+        // config tree is immutable once created - so we ignore values that appear in the source later in time,
+        // as we have already resolved that the node is not present
+        map.put("tree.node3", "value3");
+        assertThat("tree.node3 should not exist, as it was already cached as not existing",
+                   config.get("tree.node3").exists(),
+                   is(false));
+
+        // each node should have been requested from the config source, starting from root
+        assertThat(testLazySource.requestedNodes, containsInAnyOrder("", "tree", "tree.node1", "tree.node2", "tree.node3"));
+    }
+
+    private static class TestLazySource implements LazyConfigSource, ConfigSource {
+        private final List<String> requestedNodes = new ArrayList<>();
+        private final Map<String, String> values;
+
+        private TestLazySource(Map<String, String> values) {
+            this.values = values;
+        }
+
+        @Override
+        public Optional<ConfigNode> node(String key) {
+            requestedNodes.add(key);
+            return Optional.ofNullable(values.get(key))
+                    .map(ConfigNode.ValueNode::create);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Previously `LazyConfigSource` was invoked only for nodes that existed in other config sources. If a node was not known by the config system, it would always return an empty value, even if one of the lazy config sources could provide a value for it.

This PR introduces a change where we first check if the key exists in any lazy source before caching it as non-existent.
As usual with Helidon Config, changes in time are not reflected, as the config tree is considered a snapshot of configuration (even though the lazy config source may introduce a value later in time, it is still considered immutable, and changes must be handled through change API).

Resolves #8709 


### Documentation
We are currently missing documentation of `LazyConfigSource` and I did not add it as part of this PR.
