### PR TITLE
4.x: Pin GitHub runner to macos-13 (not latest) to ensure x86 to workaround protoc issue

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,6 @@
 # Notes
 # - cannot run on Windows, as we use shell scripts
-# - removed macos-latest from most jobs to speed up the process
+# - removed macos from most jobs to speed up the process
 
 name: "Validate"
 
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-latest ]
+        os: [ ubuntu-20.04, macos-13 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-latest]
+        os: [ ubuntu-20.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

### Description

Pin MacOS runner version to `macos-13` to:
1. Make pipelines predeictable
2. Workaround issue #8714

### Documentation

No impact