### PR TITLE
4.x: Add tests for building native-image for quickstart examples

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Maven build
         run: etc/scripts/github-build.sh
   examples:
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       matrix:
         os: [ ubuntu-20.04, macos-14 ]
@@ -101,11 +101,20 @@ jobs:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: 21
+          distribution: graalvm-community
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
+          cache: maven
       - name: Maven build
         run: |
           mvn -B -e "-Dmaven.test.skip=true" $MAVEN_HTTP_ARGS -DskipTests -Ppipeline install 
           cd examples
           mvn -B verify
+      - name: Test quickstarts native image
+        run: etc/scripts/test-quickstarts.sh
   mp-tck:
     timeout-minutes: 60
     name: "MicroProfile TCKs"

--- a/etc/scripts/test-quickstarts.sh
+++ b/etc/scripts/test-quickstarts.sh
@@ -1,0 +1,47 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Path to this script
+[ -h "${0}" ] && readonly SCRIPT_PATH="$(readlink "${0}")" || readonly SCRIPT_PATH="${0}"
+
+# Load pipeline environment setup and define WS_DIR
+. $(dirname -- "${SCRIPT_PATH}")/includes/pipeline-env.sh "${SCRIPT_PATH}" '../..'
+
+# Setup error handling using default settings (defined in includes/error_handlers.sh)
+error_trap_setup
+
+if [ -z "${GRAALVM_HOME}" ]; then
+    echo "ERROR: GRAALVM_HOME is not set";
+    exit 1
+fi
+
+if [ ! -x "${GRAALVM_HOME}/bin/native-image" ]; then
+    echo "ERROR: ${GRAALVM_HOME}/bin/native-image does not exist or is not executable";
+    exit 1
+fi
+
+mvn ${MAVEN_ARGS} --version
+
+${GRAALVM_HOME}/bin/native-image --version;
+
+# Build quickstart native-image executable and run jar file
+readonly quickstarts="helidon-quickstart-mp helidon-quickstart-se"
+for quickstart in ${quickstarts}; do
+  cd "${WS_DIR}"/examples/quickstarts/"${quickstart}"
+  mvn ${MAVEN_ARGS} -e clean install -Pnative-image -DskipTests
+  ./target/"${quickstart}" -Dexit.on.started=!
+done


### PR DESCRIPTION
### Description

This PR adds a new job that builds and tests native image executable for the quickstart examples.

fix #7831

### Documentation

no impact
