### PR TITLE
4.x: Upgrade microprofile rest client to 3.0.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -115,7 +115,7 @@
         <version.lib.microprofile-reactive-messaging-api>3.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>3.0</version.lib.microprofile-reactive-streams-operators-api>
         <version.lib.microprofile-reactive-streams-operators-core>3.0</version.lib.microprofile-reactive-streams-operators-core>
-        <version.lib.microprofile-rest-client>3.0</version.lib.microprofile-rest-client>
+        <version.lib.microprofile-rest-client>3.0.1</version.lib.microprofile-rest-client>
         <version.lib.microprofile-telemetry-tck>1.0</version.lib.microprofile-telemetry-tck>
         <version.lib.microprofile-tracing>3.0</version.lib.microprofile-tracing>
         <version.lib.microprofile-lra-api>2.0</version.lib.microprofile-lra-api>


### PR DESCRIPTION
### Description

Upgrade microprofile rest client from [3.0 to 3.0.1](https://github.com/eclipse/microprofile-rest-client/compare/3.0...3.0.1)

Fixes #8729

### Documentation

No impact. A new version of the spec was not released as part of 3.0.1 as it did not include any updates to the specification/APIs.