### PR TITLE
4.x: Capitalized received message in io.helidon.examples.webserver.websocket.MessageBoardEndpoint (#8725)

### DIFF
--- a/examples/webserver/websocket/src/main/java/io/helidon/examples/webserver/websocket/MessageBoardEndpoint.java
+++ b/examples/webserver/websocket/src/main/java/io/helidon/examples/webserver/websocket/MessageBoardEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public class MessageBoardEndpoint implements WsListener {
     @Override
     public void onMessage(WsSession session, String text, boolean last) {
         // Send all messages in the queue
-        if (text.equals("send")) {
+        if (text.equals("SEND")) {
             while (!messageQueue.isEmpty()) {
                 session.send(messageQueue.pop(), last);
             }

--- a/examples/webserver/websocket/src/test/java/io/helidon/examples/webserver/websocket/MessageBoardTest.java
+++ b/examples/webserver/websocket/src/test/java/io/helidon/examples/webserver/websocket/MessageBoardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class MessageBoardTest {
 
             @Override
             public void onOpen(WsSession session) {
-                session.send("send", false);
+                session.send("SEND", false);
             }
         });
 


### PR DESCRIPTION
Fixes #8725 

### Description
It can be capitalized or `equalsIgnoreCase` can be used.