### PR TITLE
4.x: Update Dockerfiles to use jdk-no-fee-term instead of openjdk

### DIFF
--- a/archetypes/archetypes/src/main/archetype/common/files/Dockerfile.jlink.mustache
+++ b/archetypes/archetypes/src/main/archetype/common/files/Dockerfile.jlink.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 WORKDIR /usr/share
 

--- a/archetypes/archetypes/src/main/archetype/common/files/Dockerfile.mustache
+++ b/archetypes/archetypes/src/main/archetype/common/files/Dockerfile.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -31,7 +31,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/employee-app/Dockerfile
+++ b/examples/employee-app/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -42,7 +42,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/integrations/cdi/datasource-hikaricp/Dockerfile
+++ b/examples/integrations/cdi/datasource-hikaricp/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -41,7 +41,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/messaging/docker/kafka/Dockerfile.kafka
+++ b/examples/messaging/docker/kafka/Dockerfile.kafka
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 
 ENV VERSION=2.7.0
 ENV SCALA_VERSION=2.13

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -41,7 +41,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -42,7 +42,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -41,7 +41,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -42,7 +42,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share

--- a/examples/translator-app/backend/Dockerfile
+++ b/examples/translator-app/backend/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -42,7 +42,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/translator-app/frontend/Dockerfile
+++ b/examples/translator-app/frontend/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -42,7 +42,7 @@ RUN mvn package -Dmaven.test.skip
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/webserver/opentracing/Dockerfile
+++ b/examples/webserver/opentracing/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 # Install maven
 WORKDIR /usr/share
@@ -42,7 +42,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/lra/coordinator/server/Dockerfile
+++ b/lra/coordinator/server/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM container-registry.oracle.com/java/openjdk:21 as build
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21 as build
 
 WORKDIR /usr/share
 
@@ -41,7 +41,7 @@ RUN wget -q -O helidon_repo.zip https://github.com/${HELIDON_REPOSITORY}/archive
 RUN mvn install -pl :helidon-lra-coordinator-server -am -DskipTests && \
     echo "Helidon LRA Coordinator build successfully finished"
 
-FROM container-registry.oracle.com/java/openjdk:21
+FROM container-registry.oracle.com/java/jdk-no-fee-term:21
 WORKDIR /helidon
 
 COPY --from=build /helidon/lra/coordinator/server/target/helidon-lra-coordinator-server.jar ./


### PR DESCRIPTION
### Description

Update Dockerfiles to use `jdk-no-fee-term` JDK instead of `openjdk`.  Related to #5209.  Reasons why:

1. `openjdk` stops getting updates after the next version of the JDK is released. `jdk-no-fee-term` gets updates until one year after the next LTS version (so much longer)
2. Like the `openjdk` repo, no login is needed. So user experience should not be impacted.

Tip: if for some reason you run into authentication errors with `container-registry.oracle.com` (even when accessing repositories that should not require authentication) it might be caused by cached expired credentials mucking up the works. Try this:
```
docker logout container-registry.oracle.com
rm ~/.docker/config.json
```

### Documentation

No change