### PR TITLE
4.x: Force hibernate to use no-op bytecode provider with native-image

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -930,6 +930,11 @@
                 <version>${version.lib.graalvm}</version>
             </dependency>
             <dependency>
+                <groupId>org.graalvm.nativeimage</groupId>
+                <artifactId>svm</artifactId>
+                <version>${version.lib.graalvm}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.graphql-java</groupId>
                 <artifactId>graphql-java</artifactId>
                 <version>${version.lib.graphql-java}</version>

--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Compile-scoped dependencies. -->
         <dependency>

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/BytecodeProvider.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/BytecodeProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.cdi.hibernate;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.hibernate.bytecode.spi.ReflectionOptimizer;
+import org.hibernate.property.access.spi.PropertyAccess;
+
+/**
+ * Reflection optimizer of the no-op Bytecode provider cannot be disabled
+ * with properties and throw an exception, so it has to return {@code null}.
+ * After Hibernate version 6.5, this substitution is not required anymore.
+ */
+@TargetClass(className = "org.hibernate.bytecode.internal.none.BytecodeProviderImpl",
+        onlyWith = BytecodeProvider.SubstituteOnlyIfPresent.class)
+final class BytecodeProvider {
+
+    private BytecodeProvider() {
+    }
+
+    @Substitute
+    @SuppressWarnings("NullAway")
+    public ReflectionOptimizer getReflectionOptimizer(Class<?> clazz, Map<String, PropertyAccess> propertyAccessMap) {
+        return null;
+    }
+
+    static class SubstituteOnlyIfPresent implements Predicate<String> {
+
+        @Override
+        public boolean test(String type) {
+            try {
+                Class<?> clazz = Class.forName(type, false, getClass().getClassLoader());
+                clazz.getDeclaredMethod("getReflectionOptimizer", Class.class, Map.class);
+                return true;
+            } catch (ClassNotFoundException | NoClassDefFoundError | NoSuchMethodException ex) {
+                return false;
+            }
+        }
+    }
+}

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/BytecodeProviderInitiator.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/BytecodeProviderInitiator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.cdi.hibernate;
+
+import java.util.function.Predicate;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.hibernate.bytecode.spi.BytecodeProvider;
+
+/**
+ * In native image, we force the usage of the no-op bytecode provider so no bytecode
+ * operation happen during runtime.
+ */
+@TargetClass(className = "org.hibernate.bytecode.internal.BytecodeProviderInitiator",
+        onlyWith = BytecodeProviderInitiator.SubstituteOnlyIfPresent.class)
+final class BytecodeProviderInitiator {
+
+    private BytecodeProviderInitiator() {
+    }
+
+    @Substitute
+    public static BytecodeProvider buildBytecodeProvider(String providerName) {
+        return new org.hibernate.bytecode.internal.none.BytecodeProviderImpl();
+    }
+
+    static class SubstituteOnlyIfPresent implements Predicate<String> {
+
+        @Override
+        public boolean test(String type) {
+            try {
+                Class<?> clazz = Class.forName(type, false, getClass().getClassLoader());
+                clazz.getDeclaredMethod("buildBytecodeProvider", String.class);
+                return true;
+            } catch (ClassNotFoundException | NoClassDefFoundError | NoSuchMethodException ex) {
+                return false;
+            }
+        }
+    }
+}

--- a/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ module io.helidon.integrations.cdi.hibernate {
     requires transitive jakarta.inject;
     requires jakarta.persistence;
     requires transitive jakarta.transaction;
+    requires org.graalvm.nativeimage;
     requires transitive org.hibernate.orm.core;
 
     requires static io.helidon.common.features.api;

--- a/integrations/cdi/hibernate-cdi/src/main/resources/META-INF/helidon/native-image/reflection-config.json
+++ b/integrations/cdi/hibernate-cdi/src/main/resources/META-INF/helidon/native-image/reflection-config.json
@@ -102,6 +102,13 @@
         "org.hibernate.hql.internal.ast.tree.ConstructorNode",
         "org.hibernate.hql.internal.ast.tree.LiteralNode",
         "org.hibernate.hql.internal.ast.tree.BinaryArithmeticOperatorNode",
+        "org.hibernate.query.hql.spi.DotIdentifierConsumer[]",
+        "org.hibernate.query.hql.spi.SqmCreationProcessingState[]",
+        "org.hibernate.query.sqm.spi.ParameterDeclarationContext[]",
+        "org.hibernate.query.sqm.sql.FromClauseIndex[]",
+        "org.hibernate.sql.ast.tree.select.QueryPart[]",
+        "org.hibernate.sql.ast.spi.SqlAstProcessingState[]",
+        "org.hibernate.sql.results.jdbc.spi.JdbcValuesSourceProcessingState[]",
         "antlr.CommonToken"
     ],
     "exclude": [


### PR DESCRIPTION
### Description

Solves the runtime hibernate bytecode provider issue with native image, and register additional classes to reflection config.

fix #8096

### Documentation

no impact
