### PR TITLE
Fix problems with tracing data propagation

### DIFF
--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerDataPropagationProvider.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerDataPropagationProvider.java
@@ -33,6 +33,9 @@ public class JaegerDataPropagationProvider extends OpenTelemetryDataPropagationP
         return new JaegerContext(super.data());
     }
 
+    /**
+     * Jaeger context.
+     */
     public static class JaegerContext extends OpenTelemetryDataPropagationProvider.OpenTelemetryContext {
         JaegerContext(OpenTelemetryContext delegate) {
             super(delegate.tracer(), delegate.span());

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryDataPropagationProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryDataPropagationProvider.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.opentelemetry;
+
+import io.helidon.common.context.Contexts;
+import io.helidon.common.context.spi.DataPropagationProvider;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.Tracer;
+
+/**
+ * A data propagation provider for OpenTelemetry which makes sure active spans are properly propagated
+ * across threads managed by {@link io.helidon.common.context.ContextAwareExecutorService}.
+ */
+public class OpenTelemetryDataPropagationProvider
+        implements DataPropagationProvider<OpenTelemetryDataPropagationProvider.OpenTelemetryContext> {
+
+    private static final System.Logger LOGGER = System.getLogger(OpenTelemetryDataPropagationProvider.class.getName());
+
+    @Override
+    public OpenTelemetryContext data() {
+        return Contexts.context().map(context -> context.get(Span.class).map(span -> {
+            Tracer tracer = context.get(Tracer.class).orElseGet(OpenTelemetryTracerProvider::globalTracer);
+            return new OpenTelemetryContext(tracer, span);
+        }).orElse(null)).orElse(null);
+    }
+
+    @Override
+    public void clearData(OpenTelemetryContext context) {
+        if (context != null && context.scope != null) {
+            try {
+                context.scope.close();
+            } catch (Exception e) {
+                LOGGER.log(System.Logger.Level.TRACE, "Cannot close tracing span", e);
+            }
+        }
+    }
+
+    @Override
+    public void propagateData(OpenTelemetryContext context) {
+        if (context != null) {
+            context.scope = context.span.activate();
+        }
+    }
+
+    /**
+     * OpenTelementry context.
+     */
+    public static class OpenTelemetryContext {
+        private final Span span;
+        private final Tracer tracer;
+        private Scope scope;
+
+        protected OpenTelemetryContext(Tracer tracer, Span span) {
+            this.tracer = tracer;
+            this.span = span;
+        }
+
+        /**
+         * Return the current scope.
+         *
+         * @return current scope, null if the span in this context is not active
+         */
+        public Scope scope() {
+            return scope;
+        }
+
+        /**
+         * Return the tracer.
+         *
+         * @return tracer from the context
+         */
+        public Tracer tracer() {
+            return tracer;
+        }
+
+        /**
+         * Return the span.
+         *
+         * @return span from the context
+         */
+        public Span span() {
+            return span;
+        }
+    }
+}

--- a/tracing/providers/opentelemetry/src/main/java/module-info.java
+++ b/tracing/providers/opentelemetry/src/main/java/module-info.java
@@ -37,4 +37,7 @@ module io.helidon.tracing.providers.opentelemetry {
     provides io.helidon.tracing.spi.TracerProvider
             with io.helidon.tracing.providers.opentelemetry.OpenTelemetryTracerProvider;
 
+    provides io.helidon.common.context.spi.DataPropagationProvider
+            with io.helidon.tracing.providers.opentelemetry.OpenTelemetryDataPropagationProvider;
+
 }

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestDataPropagation.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestDataPropagation.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.opentelemetry;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.common.testing.junit5.OptionalMatcher;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.Tracer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class TestDataPropagation {
+
+    private final OpenTelemetryDataPropagationProvider provider = new OpenTelemetryDataPropagationProvider();
+    private final ExecutorService executor = Contexts.wrap(Executors.newVirtualThreadPerTaskExecutor());
+
+    @Test
+    void testSyncPropagation() {
+        Context context = Context.create();
+        Tracer tracer = OpenTelemetryTracer.builder()
+                .serviceName("test-prop")
+                .build();
+        context.register(tracer);
+        Span span = tracer.spanBuilder("test-span").start();
+        context.register(span);
+
+        try (Scope scope = span.activate()) {
+            context.register(scope);
+            Contexts.runInContext(context, () -> {
+                OpenTelemetryDataPropagationProvider.OpenTelemetryContext data = provider.data();
+                assertThat("Scope before prop ", data.scope(), is(nullValue()));
+
+                provider.propagateData(data);
+                assertThat("Scope during prop has been closed", data.scope().isClosed(), is(false));
+
+                provider.clearData(data);
+                assertThat("Scope after prop has been closed", data.scope().isClosed(), is(true));
+            });
+        }
+    }
+
+    @Test
+    void testAsyncPropagation() {
+        Context context = Context.create();
+        Tracer tracer = Tracer.global();
+        context.register(tracer);
+        Span span = tracer.spanBuilder("test-async-span").start();
+        context.register(span);
+        SpanContext spanContext = span.context();
+        AtomicReference<Optional<Span>> asyncSpanRef = new AtomicReference<>();
+        try (Scope scope = span.activate()) {
+            context.register(scope);
+            Contexts.runInContext(context, () ->
+            {
+                try {
+                    asyncSpanRef.set(executor.submit(() -> {
+                        return Span.current();
+                    }).get(5, TimeUnit.SECONDS));
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        Optional<SpanContext> asyncSpanContext = asyncSpanRef.get().map(Span::context);
+        assertThat("Span ID",
+                   asyncSpanContext.map(SpanContext::spanId),
+                   OptionalMatcher.optionalValue(is(spanContext.spanId())));
+    }
+}

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,6 +216,8 @@ public class TracingObserver implements Observer, RuntimeType.Api<TracingObserve
                     .start();
 
             context.register(span.context());
+            context.register(span);
+            context.register(tracer);
             context.register(TracingConfig.class, span.context());
 
             /*


### PR DESCRIPTION
### Description
Resolves #8722 

Several problems:
1. The OpenTelemetry tracing provider library lacked an implementation of `DataPropagationProvider`. As a result, OTel-based tracing information was never propagated via context.
2. The `TracingObserver` registered only the `SpanContext` in the context, not also the `Span` and `Tracer`. The existing Jaeger data propagation provider and the new one for OTel need to retrieve the `Span` from the context so we can re-establish that span as the active span during a `runInContext`.
3. The original Jaeger data propagation provider `propagateData` method  incorrectly used the current span rather than the span captured in the `JaegerContext` object earlier. The analogous code in the new `OpenTelemetryDataPropagationProvider` uses the saved context instead and the analogous Jaeger type now extends that OTel implementation.

Because Jaeger relies on OTel, the Jaeger and the OTel propagation providers are virtually identical. This PR makes the Jaeger one a subclass of the new OTel one to avoid duplicating the code. 

### Documentation
Bug fix; no doc impact.
