### PR TITLE
4.x: fix `getOrdinal` for system property and environment variable config sources 

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpEnvironmentVariablesSource.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpEnvironmentVariablesSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,9 @@ import java.util.regex.Pattern;
 import jakarta.annotation.Priority;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
-@Priority(300)
+@Priority(MpEnvironmentVariablesSource.MY_DEFAULT_ORDINAL)
 class MpEnvironmentVariablesSource implements ConfigSource {
+    static final int MY_DEFAULT_ORDINAL = 300;
     private static final Pattern DISALLOWED_CHARS = Pattern.compile("[^a-zA-Z0-9_]");
     private static final String UNDERSCORE = "_";
 
@@ -68,6 +69,16 @@ class MpEnvironmentVariablesSource implements ConfigSource {
             result = env.get(rule3);
             return new Cached(result);
         }).value;
+    }
+
+    @Override
+    public int getOrdinal() {
+        String configOrdinal = getValue(CONFIG_ORDINAL);
+        if (configOrdinal == null) {
+            return MY_DEFAULT_ORDINAL;
+        } else {
+            return ConfigSource.super.getOrdinal();
+        }
     }
 
     @Override

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpSystemPropertiesSource.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpSystemPropertiesSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,9 @@ import java.util.Set;
 import jakarta.annotation.Priority;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
-@Priority(400)
+@Priority(MpSystemPropertiesSource.MY_DEFAULT_ORDINAL)
 class MpSystemPropertiesSource implements ConfigSource {
+    static final int MY_DEFAULT_ORDINAL = 400;
     private final Properties props;
 
     MpSystemPropertiesSource() {
@@ -55,6 +56,16 @@ class MpSystemPropertiesSource implements ConfigSource {
     @Override
     public String getName() {
         return "System Properties";
+    }
+
+    @Override
+    public int getOrdinal() {
+        String configOrdinal = getValue(CONFIG_ORDINAL);
+        if (configOrdinal == null) {
+            return MY_DEFAULT_ORDINAL;
+        } else {
+            return ConfigSource.super.getOrdinal();
+        }
     }
 
     @Override

--- a/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigSourcesTest.java
+++ b/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigSourcesTest.java
@@ -110,6 +110,18 @@ public class MpConfigSourcesTest {
     }
 
     @Test
+    void testSystemPropertiesConfigSourceDefaultOrdinal() {
+        org.eclipse.microprofile.config.spi.ConfigSource configSource = MpConfigSources.systemProperties();
+        assertThat(configSource.getOrdinal(), is(400));
+    }
+
+    @Test
+    void testEnvironmentVariablesConfigSourceDefaultOrdinal() {
+        org.eclipse.microprofile.config.spi.ConfigSource configSource = MpConfigSources.environmentVariables();
+        assertThat(configSource.getOrdinal(), is(300));
+    }
+
+    @Test
     void testPropertiesMetaConfigProvider() {
         typeChecks("properties", """
                 another1.key=another1.value


### PR DESCRIPTION
### Description

`ConfigSource.getOrdinal()` was returning 100 for the system property and environment variable config sources when the special property `config_ordinal` was not set in the config source (instead of the correct value of 400 and 300).

This PR corrects that and adds tests.

See MP Config Spec: https://download.eclipse.org/microprofile/microprofile-config-3.0/microprofile-config-spec-3.0.html#default_configsources

Fixes #8737 

### Documentation

No impact