### PR TITLE
Refactor OCI metrics library a bit

### DIFF
--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -17,6 +17,7 @@ package io.helidon.integrations.oci.metrics.cdi;
 
 import io.helidon.config.Config;
 import io.helidon.integrations.oci.metrics.OciMetricsSupport;
+import io.helidon.integrations.oci.metrics.OciMetricsSupportFactory;
 import io.helidon.microprofile.server.RoutingBuilders;
 
 import com.oracle.bmc.monitoring.Monitoring;
@@ -38,9 +39,8 @@ import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 // This bean is added to handle injection on the ObserverMethod as it does not work on an Extension class.
 @Singleton
-public class OciMetricsBean {
+public class OciMetricsBean extends OciMetricsSupportFactory {
 
-    private Config ociMetricsConfig;
     private OciMetricsSupport ociMetricsSupport;
 
     /**
@@ -50,63 +50,23 @@ public class OciMetricsBean {
     public OciMetricsBean() {
     }
 
-    /**
-     * Returns the config key to use for retrieving OCI metrics settings from the root config.
-     *
-     * @return config key for OCI metrics settings
-     */
+    @Override
     protected String configKey() {
         return "ocimetrics";
     }
 
-    /**
-     * Returns the builder for constructing a new {@link io.helidon.integrations.oci.metrics.OciMetricsSupport} instance,
-     * initialized using the config retrieved using the {@link #configKey()} return value and the provided
-     * {@link com.oracle.bmc.monitoring.Monitoring} instance.
-     *
-     * @param rootConfig root {@link io.helidon.config.Config} node
-     * @param ociMetricsConfig config node for the OCI metrics settings
-     * @param monitoring monitoring implementation to be used in preparing the {@code OciMetricsSupport.Builder}.
-     * @return resulting builder
-     */
-    protected OciMetricsSupport.Builder ociMetricsSupportBuilder(Config rootConfig,
-                                                                 Config ociMetricsConfig,
-                                                                 Monitoring monitoring) {
-        return OciMetricsSupport.builder()
-                .config(ociMetricsConfig)
-                .monitoringClient(monitoring);
-    }
-
-    /**
-     * Returns the OCI metrics config settings previously retrieved from the config root.
-     *
-     * @return  OCI metrics config node
-     */
-    protected Config ociMetricsConfig() {
-        return ociMetricsConfig;
-    }
-
-    /**
-     * Activates OCI metrics support.
-     *
-     * @param rootConfig root config node
-     * @param ociMetricsConfig OCI metrics configuration
-     * @param builder builder for {@link io.helidon.integrations.oci.metrics.OciMetricsSupport}
-     */
+    @Override
     protected void activateOciMetricsSupport(Config rootConfig, Config ociMetricsConfig, OciMetricsSupport.Builder builder) {
-        ociMetricsSupport = builder.build();
+        this.ociMetricsSupport = builder.build();
         RoutingBuilders.create(ociMetricsConfig)
                 .routingBuilder()
                 .register(ociMetricsSupport);
     }
+
     // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
     void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object ignore,
                             Config rootConfig, Monitoring monitoringClient) {
-        ociMetricsConfig = rootConfig.get(configKey());
-        OciMetricsSupport.Builder builder = ociMetricsSupportBuilder(rootConfig, ociMetricsConfig, monitoringClient);
-        if (builder.enabled()) {
-            activateOciMetricsSupport(rootConfig, ociMetricsConfig, builder);
-        }
+        registerOciMetrics(rootConfig, monitoringClient);
     }
 
     // For testing

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,13 @@ import jakarta.enterprise.inject.spi.Extension;
  * OCI metrics integration CDI extension.
  */
 public class OciMetricsCdiExtension implements Extension {
+
+    /**
+     * For CDI use only.
+     */
+    @Deprecated
+    public OciMetricsCdiExtension() {
+    }
 
     // A new bean is added to handle the Observer Method as injection does not work here
     void addOciMetricsBean(@Observes BeforeBeanDiscovery event) {

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -302,6 +302,9 @@ public class OciMetricsSupport implements HttpService {
         private int batchSize = DEFAULT_BATCH_SIZE;
         private boolean enabled = true;
         private Monitoring monitoringClient;
+
+        private Builder() {
+        }
 
         @Override
         public OciMetricsSupport build() {

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupportFactory.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupportFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.oci.metrics;
+
+import io.helidon.config.Config;
+
+import com.oracle.bmc.monitoring.Monitoring;
+
+/**
+ * Holds information needed to create an instance of {@link io.helidon.integrations.oci.metrics.OciMetricsSupport}.
+ * <p>
+ * This class is intended as an abstract superclass for CDI beans responsible for initializing an
+ * {@code OciMetricsSupport} instance using config and the {@link com.oracle.bmc.monitoring.Monitoring} instance.
+ * Concrete implementations implement must, of course, implement the abstract methods and might override other methods
+ * as needed.
+ * <p>
+ * Callers typically invoke {@link #registerOciMetrics(io.helidon.config.Config, com.oracle.bmc.monitoring.Monitoring)}
+ * directly.
+ * </p>
+ */
+public abstract class OciMetricsSupportFactory {
+
+    private Config ociMetricsConfig;
+
+    /**
+     * Creates a new instance of the factory.
+     */
+    protected OciMetricsSupportFactory() {
+    }
+
+    /**
+     * Registers OCI metrics using the configuration and the provided monitoring client by preparing
+     * an {@link io.helidon.integrations.oci.metrics.OciMetricsSupport} instance and then calling back to the
+     * subclass to activate that instance with, for example, routing.
+     *
+     * @param rootConfig       root config node
+     * @param monitoringClient {@link Monitoring} instance to use in preparing the {@code OciMetricsSupport} instance
+     */
+    protected void registerOciMetrics(Config rootConfig, Monitoring monitoringClient) {
+        ociMetricsConfig = rootConfig.get(configKey());
+        OciMetricsSupport.Builder builder = ociMetricsSupportBuilder(rootConfig, ociMetricsConfig, monitoringClient);
+        if (builder.enabled()) {
+            activateOciMetricsSupport(rootConfig, ociMetricsConfig, builder);
+        }
+    }
+
+    /**
+     * Returns the builder for constructing a new {@link io.helidon.integrations.oci.metrics.OciMetricsSupport} instance,
+     * initialized using the config retrieved using the {@link #configKey()} return value and the provided
+     * {@link com.oracle.bmc.monitoring.Monitoring} instance.
+     *
+     * @param rootConfig       root {@link io.helidon.config.Config} node
+     * @param ociMetricsConfig config node for the OCI metrics settings
+     * @param monitoring       monitoring implementation to be used in preparing the {@code OciMetricsSupport.Builder}.
+     * @return resulting builder
+     */
+    protected OciMetricsSupport.Builder ociMetricsSupportBuilder(Config rootConfig,
+                                                                 Config ociMetricsConfig,
+                                                                 Monitoring monitoring) {
+        this.ociMetricsConfig = ociMetricsConfig;
+        return OciMetricsSupport.builder()
+                .config(ociMetricsConfig)
+                .monitoringClient(monitoring);
+    }
+
+    /**
+     * Returns the OCI metrics config node used to set up the {@code OciMetricsSupport} instance.
+     *
+     * @return config node controlling the OCI metrics support behavior
+     */
+    protected Config ociMetricsConfig() {
+        return ociMetricsConfig;
+    }
+
+    /**
+     * Returns the config key to use for retrieving OCI metrics settings from the root config.
+     *
+     * @return config key for OCI metrics settings
+     */
+    protected abstract String configKey();
+
+    /**
+     * Activates OCI metrics support.
+     *
+     * @param rootConfig       root config node
+     * @param ociMetricsConfig OCI metrics configuration
+     * @param builder          {@link io.helidon.integrations.oci.metrics.OciMetricsSupport.Builder} instance
+     */
+    protected abstract void activateOciMetricsSupport(Config rootConfig,
+                                                      Config ociMetricsConfig,
+                                                      OciMetricsSupport.Builder builder);
+}

--- a/integrations/oci/metrics/metrics/src/main/java/module-info.java
+++ b/integrations/oci/metrics/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
 module io.helidon.integrations.oci.metrics {
 
     requires io.helidon.http;
-    requires io.helidon.metrics.api;
     requires java.logging;
     requires oci.java.sdk.common;
 
@@ -29,6 +28,7 @@ module io.helidon.integrations.oci.metrics {
 
     requires transitive io.helidon.common;
     requires transitive io.helidon.config;
+    requires transitive io.helidon.metrics.api;
     requires transitive io.helidon.webserver;
     requires transitive oci.java.sdk.monitoring;
 


### PR DESCRIPTION
### Description
This PR refactors how the OCI metrics library code is organized just a bit so other implementations can extend common types without having to also include the OCI metrics library CDI module (which is helpful if the other implementation has its own CDI work to do).

### Documentation
No doc impact.