### PR TITLE
4.x: Upgrade to MP Config 3.1 and fix an issue with profile specific properties

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.helidon.config.ConfigSources;
 import io.helidon.config.mp.spi.MpConfigFilter;
 
 import org.eclipse.microprofile.config.Config;
@@ -343,7 +342,7 @@ class MpConfigImpl implements Config {
                         .map(it -> new ConfigValueImpl(propertyName, it, rawValue, source.getName(), source.getOrdinal()));
             } catch (NoSuchElementException e) {
                 // Property expression does not resolve
-                return Optional.empty();
+                return Optional.of(new ConfigValueImpl(propertyName, null, rawValue, source.getName(), source.getOrdinal()));
             }
         }
 

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
@@ -92,8 +92,6 @@ class MpConfigImpl implements Config {
         this.converters.putIfAbsent(String.class, value -> value);
         this.configProfile = profile;
 
-        dumpConfigSources(this.sources);
-
         this.valueResolving = getOptionalValue("mp.config.property.expressions.enabled", Boolean.class)
                 .or(() -> getOptionalValue("helidon.config.value-resolving.enabled", Boolean.class))
                 .orElse(true);
@@ -106,13 +104,6 @@ class MpConfigImpl implements Config {
             // do not do this first, as we would end up in using an uninitialized filter
             this.filters.add(it);
         });
-    }
-
-    private void dumpConfigSources(List<ConfigSource> sources) {
-        System.out.println("CCCC ConfigSources");
-        for (ConfigSource source : sources) {
-            System.out.println("     " + source.getOrdinal() + " " + source.getName());
-        }
     }
 
     @Override
@@ -128,8 +119,6 @@ class MpConfigImpl implements Config {
         ConfigValue profileValue = findConfigValue("%" + configProfile + "." + key)
                 .orElseGet(() -> new ConfigValueImpl(key, null, null, null, 0));
 
-        System.out.println("CCCCC " + "key=" + key + " value=" + value);
-        System.out.println("CCCCC " + "key=" + key + " profileValue=" + profileValue);
         return value.getSourceOrdinal() > profileValue.getSourceOrdinal() ? value : profileValue;
     }
 

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
@@ -109,14 +109,14 @@ class MpConfigImpl implements Config {
     public ConfigValue getConfigValue(String key) {
 
         ConfigValue value = findConfigValue(key)
-                .orElseGet(() -> new ConfigValueImpl(key, null, null, null, 0));
+                .orElse(new ConfigValueImpl(key, null, null, null, 0));
 
         if (configProfile == null) {
             return value;
         }
 
         ConfigValue profileValue = findConfigValue("%" + configProfile + "." + key)
-                .orElseGet(() -> new ConfigValueImpl(key, null, null, null, 0));
+                .orElse(value);
 
         return value.getSourceOrdinal() > profileValue.getSourceOrdinal() ? value : profileValue;
     }

--- a/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigReferenceTest.java
+++ b/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigReferenceTest.java
+++ b/config/config-mp/src/test/java/io/helidon/config/mp/MpConfigReferenceTest.java
@@ -20,13 +20,16 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MpConfigReferenceTest {
@@ -65,6 +68,15 @@ public class MpConfigReferenceTest {
         // since Config 2.0, missing references must throw an exception
         assertThrows(NoSuchElementException.class, () -> config.getValue("referencing4-1", String.class));
         assertThrows(NoSuchElementException.class, () -> config.getValue( "referencing4-2", String.class));
+
+        // MP Config 3.1 TCK requires well-formed ConfigValue when missing reference
+        ConfigValue configValue = config.getConfigValue("referencing4-1");
+        assertThat(configValue, notNullValue());
+        assertThat(configValue.getName(), is("referencing4-1"));
+        assertThat(configValue.getValue(), nullValue());
+        assertThat(configValue.getRawValue(), is("${missing}"));
+        assertThat(configValue.getSourceName(), endsWith("microprofile-config.properties"));
+        assertThat(configValue.getSourceOrdinal(), is(100));
     }
 
     @Test

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -103,8 +103,7 @@
         <version.lib.micronaut>3.8.7</version.lib.micronaut>
         <version.lib.micronaut.data>3.4.3</version.lib.micronaut.data>
         <version.lib.micronaut.sql>4.8.0</version.lib.micronaut.sql>
-        <!-- FIXME upgrade to 3.1 when it is released in Maven -->
-        <version.lib.microprofile-config>3.0.3</version.lib.microprofile-config>
+        <version.lib.microprofile-config>3.1</version.lib.microprofile-config>
         <!-- FIXME upgrade to 4.1 when it is released in Maven -->
         <version.lib.microprofile-fault-tolerance-api>4.0.2</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-graphql>2.0</version.lib.microprofile-graphql>

--- a/docs/src/main/asciidoc/includes/attributes.adoc
+++ b/docs/src/main/asciidoc/includes/attributes.adoc
@@ -43,7 +43,7 @@ endif::[]
 
 // microprofile specifications
 :version-lib-microprofile-lra-api: 2.0
-:version-lib-microprofile-config: 3.0.3
+:version-lib-microprofile-config: 3.1
 :version-lib-microprofile-fault-tolerance-api: 4.0.2
 :version-lib-microprofile-graphql: 2.0
 :version-lib-microprofile-health: 4.0

--- a/docs/src/main/asciidoc/mp/config/introduction.adoc
+++ b/docs/src/main/asciidoc/mp/config/introduction.adoc
@@ -243,4 +243,4 @@ Step-by-step guide about using {spec-name} in your Helidon MP application.
 == Reference
 
 * link:{microprofile-config-spec-url}[{spec-name} Specifications]
-* link:{microprofile-fault-tolerance-javadoc-url}[{spec-name} Javadocs]
+* link:{microprofile-config-javadoc-url}[{spec-name} Javadocs]


### PR DESCRIPTION
### Description

1. Upgrade MicroProfile Config to version 3.1
2. Fix an issue (#8738) with profile specific property precedence that was found by a new TCK test 
3. Return a well-formed `ConfigValue` even when value is an unresolved expression (required by new TCK tests)
4. Add unit tests for the above issues

Fixes #8724
Fixes #8738

### Documentation

Updated with new MP Config version.

### Compatibility

MP Config 3.1 is fully backwards compatible with MP Config 3.0. But the bug fixes in this PR do alter the behavior of our implementation which potentially could impact a small set of users if they were depending on the buggy behavior. For this reason we should do this upgrade in 4.1 instead of 4.0.9.