### PR TITLE
4.x Associate tracer-level tags with Jaeger process level (instead of span level)

### DIFF
--- a/tracing/providers/jaeger/pom.xml
+++ b/tracing/providers/jaeger/pom.xml
@@ -32,6 +32,11 @@
         Integration with Jaeger tracing
     </description>
 
+    <properties>
+        <!-- The default for the following is 5000 ms. Reducing it speeds up tests significantly. -->
+        <otel.bsp.schedule.delay>100</otel.bsp.schedule.delay>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
@@ -154,12 +159,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- Separate the baggage prop test to avoid interference with other tests -->
+                <!-- Separate some of the tests to avoid interference with other tests -->
                 <executions>
                     <execution>
                         <id>default-test</id>
                         <configuration>
-                            <excludes>**/JaegerBaggagePropagationTest.java</excludes>
+                            <excludes>**/JaegerBaggagePropagationTest.java,**/JaegerTracerBuilderTest.java</excludes>
                         </configuration>
                     </execution>
                     <execution>
@@ -174,6 +179,20 @@
                                 </configurationParameters>
                             </properties>
                             <includes>**/JaegerBaggagePropagationTest.java</includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>trace-level-attribute-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <properties>
+                                <configurationParameters>
+                                    junit.jupiter.extensions.autodetection.enabled = true
+                                </configurationParameters>
+                            </properties>
+                            <includes>**/JaegerTracerBuilderTest.java</includes>
                         </configuration>
                     </execution>
                 </executions>

--- a/tracing/providers/jaeger/pom.xml
+++ b/tracing/providers/jaeger/pom.xml
@@ -32,11 +32,6 @@
         Integration with Jaeger tracing
     </description>
 
-    <properties>
-        <!-- The default for the following is 5000 ms. Reducing it speeds up tests significantly. -->
-        <otel.bsp.schedule.delay>100</otel.bsp.schedule.delay>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
@@ -182,7 +177,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>trace-level-attribute-test</id>
+                        <id>tracer-builder-tests</id>
                         <goals>
                             <goal>test</goal>
                         </goals>

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -18,6 +18,7 @@ package io.helidon.tracing.providers.jaeger;
 
 import java.lang.System.Logger.Level;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +38,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
@@ -46,6 +48,7 @@ import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
@@ -179,6 +182,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     private int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
     private int maxExportBatchSize = DEFAULT_MAX_EXPORT_BATCH_SIZE;
     private SpanProcessorType spanProcessorType = SpanProcessorType.BATCH;
+    private final List<SpanExporter> adHocExporters = new ArrayList<>(); // primarily for testing
 
 
     /**
@@ -512,17 +516,25 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
                         : Sampler.alwaysOff();
             };
 
-            Resource serviceName = Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, this.serviceName));
+            AttributesBuilder attributesBuilder = Attributes.builder()
+                    .put(ResourceAttributes.SERVICE_NAME, serviceName);
+            tags.forEach(attributesBuilder::put);
+            Resource otelResource = Resource.create(attributesBuilder.build());
+
+            SdkTracerProviderBuilder sdkTracerProviderBuilder = SdkTracerProvider.builder()
+                    .setSampler(sampler)
+                    .setResource(otelResource)
+                    .addSpanProcessor(spanProcessor(exporter));
+            adHocExporters.stream()
+                    .map(this::spanProcessor)
+                    .forEach(sdkTracerProviderBuilder::addSpanProcessor);
+
             OpenTelemetry ot = OpenTelemetrySdk.builder()
-                    .setTracerProvider(SdkTracerProvider.builder()
-                                               .addSpanProcessor(spanProcessor(exporter))
-                                               .setSampler(sampler)
-                                               .setResource(serviceName)
-                                               .build())
+                    .setTracerProvider(sdkTracerProviderBuilder.build())
                     .setPropagators(ContextPropagators.create(TextMapPropagator.composite(createPropagators())))
                     .build();
 
-            result = HelidonOpenTelemetry.create(ot, ot.getTracer(this.serviceName), tags);
+            result = HelidonOpenTelemetry.create(ot, ot.getTracer(this.serviceName), Map.of());
 
             if (global) {
                 GlobalOpenTelemetry.set(ot);
@@ -602,6 +614,12 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         return propagationFormats.stream()
                 .map(JaegerTracerBuilder::mapFormatToPropagator)
                 .toList();
+    }
+
+    // Primarily for testing
+    JaegerTracerBuilder exporter(SpanExporter spanExporter) {
+        adHocExporters.add(spanExporter);
+        return this;
     }
 
     private SpanProcessor spanProcessor(SpanExporter exporter) {

--- a/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/TestSpanExporter.java
+++ b/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/TestSpanExporter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.jaeger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.helidon.common.testing.junit5.MatcherWithRetry;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+import static org.hamcrest.Matchers.iterableWithSize;
+
+// Partially inspired by the MP Telemetry TCK InMemorySpanExporter.
+public class TestSpanExporter implements SpanExporter {
+
+    private final List<SpanData> spanData = new CopyOnWriteArrayList<>();
+    private final System.Logger LOGGER = System.getLogger(TestSpanExporter.class.getName());
+
+    private final int RETRY_COUNT = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryCount", 120);
+    private final int RETRY_DELAY_MS = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryDelayMs", 500);
+
+
+    private enum State {READY, STOPPED}
+
+    private State state = State.READY;
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> collection) {
+        if (state == State.STOPPED) {
+            return CompletableResultCode.ofFailure();
+        }
+        spanData.addAll(collection);
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        state = State.STOPPED;
+        spanData.clear();
+        return CompletableResultCode.ofSuccess();
+    }
+
+    List<SpanData> spanData(int expectedCount) {
+        long startTime = 0;
+        if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+            startTime = System.currentTimeMillis();
+        }
+        var result = MatcherWithRetry.assertThatWithRetry("Expected span count",
+                                             () -> new ArrayList<>(spanData),
+                                             iterableWithSize(expectedCount),
+                                             RETRY_COUNT,
+                                             RETRY_DELAY_MS);
+        if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+            LOGGER.log(System.Logger.Level.DEBUG, "spanData waited "
+                    + (System.currentTimeMillis() - startTime)
+                    + " ms for expected spans to arrive.");
+        }
+        return result;
+    }
+
+    void clear() {
+        spanData.clear();
+    }
+}

--- a/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/TestSpanExporterProvider.java
+++ b/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/TestSpanExporterProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.jaeger;
+
+import io.helidon.common.LazyValue;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+public class TestSpanExporterProvider implements ConfigurableSpanExporterProvider {
+
+    private static final LazyValue<TestSpanExporter> SPAN_EXPORTER = LazyValue.create(TestSpanExporter::new);
+
+    public TestSpanExporterProvider() {
+        System.err.println("provider ctor");
+    }
+
+    @Override
+    public SpanExporter createExporter(ConfigProperties configProperties) {
+        return SPAN_EXPORTER.get();
+    }
+
+    @Override
+    public String getName() {
+        return "in-memory";
+    }
+
+    static TestSpanExporter exporter() {
+        if (SPAN_EXPORTER.isLoaded()) {
+            return SPAN_EXPORTER.get();
+        }
+        throw new IllegalStateException("Attempt to retrieve TestSpanExporter before it has been created");
+    }
+}


### PR DESCRIPTION
### Description
Resolves #8763 

The basics of the PR are the same as in the 3.x PR #7027 except that this PR also adds a test (which involves adding a test in-memory span processor which the test can query.) I added the unit test before fixing the code and the test failed  pre-fix, passed post-fix.

Because of how the Jaeger code sets up the `OpenTelemetry` instance, the PR also adds a non-public method to `JaegerTracerBuilder` allowing the caller to add span exporters programmatically so the test can add the in-memory collector.

I also manually started up `jaeger-all-in-one` locally and then ran the new unit test. The Jaeger UI now properly shows the tracer-level tag at the process level (not the span level).

### Documentation
Bug fix; no doc impact.
