### PR TITLE
Improvements to gRPC server-side support

### DIFF
--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcHeadersUtil.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcHeadersUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.grpc;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.http.WritableHeaders;
+
+import io.grpc.InternalMetadata;
+import io.grpc.Metadata;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+class GrpcHeadersUtil {
+
+    private static final byte[] BINARY_SUFFIX = Metadata.BINARY_HEADER_SUFFIX.getBytes(US_ASCII);
+
+    private GrpcHeadersUtil() {
+    }
+
+    static void updateHeaders(WritableHeaders<?> writable, Metadata headers) {
+        byte[][] byteHeaders = InternalMetadata.serialize(headers);
+        for (int i = 0; i < byteHeaders.length; i += 2) {
+            byte[] key = byteHeaders[i];
+            byte[] value = byteHeaders[i + 1];
+            if (endsWith(key, BINARY_SUFFIX)) {
+                writable.add(HeaderNames.create(new String(key, US_ASCII)),
+                             InternalMetadata.BASE64_ENCODING_OMIT_PADDING.encode(value));
+            } else {
+                writable.add(HeaderNames.create(new String(key, US_ASCII)),
+                             new String(value, US_ASCII));
+            }
+        }
+    }
+
+    private static boolean endsWith(byte[] buffer, byte[] suffix) {
+        int from = buffer.length - suffix.length;
+        if (from >= 0) {
+            for (int i = from; i < buffer.length; i++) {
+                if (buffer[i] != suffix[i - from]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package io.helidon.webserver.grpc;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Header;
@@ -26,7 +27,6 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.WritableHeaders;
-import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameTypes;
@@ -45,12 +45,17 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.Status;
 
+import static io.helidon.http.http2.Http2Flag.DataFlags;
+import static io.helidon.http.http2.Http2Flag.END_OF_HEADERS;
+import static io.helidon.http.http2.Http2Flag.END_OF_STREAM;
+import static io.helidon.http.http2.Http2Flag.HeaderFlags;
 import static java.lang.System.Logger.Level.ERROR;
 
 class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProtocolHandler {
     private static final System.Logger LOGGER = System.getLogger(GrpcProtocolHandler.class.getName());
     private static final Header GRPC_CONTENT_TYPE = HeaderValues.createCached(HeaderNames.CONTENT_TYPE, "application/grpc");
     private static final Header GRPC_ENCODING_IDENTITY = HeaderValues.createCached("grpc-encoding", "identity");
+    private static final DataFlags DATA_FLAGS_ZERO = DataFlags.create(0);
 
     private final HttpPrologue prologue;
     private final Http2Headers headers;
@@ -63,11 +68,10 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private final StreamFlowControl flowControl;
     private Http2StreamState currentStreamState;
     private ServerCall.Listener<REQ> listener;
-    private ServerCall<REQ, RES> serverCall;
 
-    private long length;
-    private boolean isCompressed;
-    private BufferData entityBytes = null;
+    private BufferData entityBytes;
+    private final AtomicInteger numMessages = new AtomicInteger();
+    private final LinkedBlockingQueue<REQ> listenerQueue = new LinkedBlockingQueue<>();
 
     GrpcProtocolHandler(HttpPrologue prologue,
                         Http2Headers headers,
@@ -78,7 +82,6 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                         StreamFlowControl flowControl,
                         Http2StreamState currentStreamState,
                         Grpc<REQ, RES> route) {
-
         this.prologue = prologue;
         this.headers = headers;
         this.streamWriter = streamWriter;
@@ -93,7 +96,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     @Override
     public void init() {
         try {
-            serverCall = createServerCall();
+            ServerCall<REQ, RES> serverCall = createServerCall();
             ServerCallHandler<REQ, RES> callHandler = route.callHandler();
             listener = callHandler.startCall(serverCall, toMetadata(headers));
             listener.onReady();
@@ -101,7 +104,10 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
             LOGGER.log(ERROR, "Failed to initialize grpc protocol handler", e);
             throw e;
         }
+    }
 
+    private void addNumMessages(int n) {
+        numMessages.getAndAdd(n);
     }
 
     @Override
@@ -116,32 +122,35 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
     @Override
     public void windowUpdate(Http2WindowUpdate update) {
-
     }
 
     @Override
     public void data(Http2FrameHeader header, BufferData data) {
         try {
             while (data.available() > 0) {
-                // Start of the chunk
+                // start of new chunk?
                 if (entityBytes == null) {
                     // fixme compression support
-                    isCompressed = (data.read() == 1);
-                    length = data.readUnsignedInt32();
+                    boolean isCompressed = (data.read() == 1);
+                    long length = data.readUnsignedInt32();
                     entityBytes = BufferData.create((int) length);
                 }
 
-                // Append to chunk in progress
+                // append data to current chunk
                 entityBytes.write(data);
 
-                // Whole chunk
+                // is chunk complete?
                 if (entityBytes.capacity() == 0) {
                     byte[] bytes = new byte[entityBytes.available()];
                     entityBytes.read(bytes);
-                    listener.onMessage(route.method().parseRequest(new ByteArrayInputStream(bytes)));
+                    REQ request = route.method().parseRequest(new ByteArrayInputStream(bytes));
+                    listenerQueue.add(request);
+                    flushQueue();
                     entityBytes = null;
                 }
             }
+
+            // if EOS then half close
             if (header.flags(Http2FrameTypes.DATA).endOfStream()) {
                 listener.onHalfClose();
                 currentStreamState = Http2StreamState.HALF_CLOSED_LOCAL;
@@ -151,45 +160,56 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         }
     }
 
+    private void flushQueue() {
+        if (listener != null) {
+            while (!listenerQueue.isEmpty() && numMessages.getAndDecrement() > 0) {
+                listener.onMessage(listenerQueue.poll());
+            }
+        }
+    }
+
     private ServerCall<REQ, RES> createServerCall() {
         return new ServerCall<>() {
             @Override
             public void request(int numMessages) {
-                //System.out.println("request: " + numMessages);
+                addNumMessages(numMessages);
+                flushQueue();
             }
 
             @Override
             public void sendHeaders(Metadata headers) {
-                // todo ignoring headers, just sending required response headers
+                // prepare response haaders
                 WritableHeaders<?> writable = WritableHeaders.create();
+                GrpcHeadersUtil.updateHeaders(writable, headers);
                 writable.set(GRPC_CONTENT_TYPE);
                 writable.set(GRPC_ENCODING_IDENTITY);
 
+                // write headers frame
                 Http2Headers http2Headers = Http2Headers.create(writable);
                 http2Headers.status(io.helidon.http.Status.OK_200);
                 streamWriter.writeHeaders(http2Headers,
                                           streamId,
-                                          Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                          HeaderFlags.create(END_OF_HEADERS),
                                           flowControl.outbound());
             }
 
             @Override
             public void sendMessage(RES message) {
                 try (InputStream inputStream = route.method().streamResponse(message)) {
+                    // prepare buffer for writing
                     byte[] bytes = inputStream.readAllBytes();
                     BufferData bufferData = BufferData.create(5 + bytes.length);
                     bufferData.write(0);
                     bufferData.writeUnsignedInt32(bytes.length);
                     bufferData.write(bytes);
 
-                    // todo flags based on method type
-                    // end flag should be sent when last message is sent (or just rst stream if we cannot determine this)
-
+                    // create data frame, EOS sent in close with trailers
                     Http2FrameHeader header = Http2FrameHeader.create(bufferData.available(),
                             Http2FrameTypes.DATA,
-                            Http2Flag.DataFlags.create(0),
+                            DATA_FLAGS_ZERO,
                             streamId);
 
+                    // write data frame
                     streamWriter.writeData(new Http2FrameData(header, bufferData), flowControl.outbound());
                 } catch (Exception e) {
                     LOGGER.log(ERROR, "Failed to respond to grpc request: " + route.method(), e);
@@ -198,19 +218,20 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
             @Override
             public void close(Status status, Metadata trailers) {
-                // todo ignoring trailers
+                // prepare trailers
                 WritableHeaders<?> writable = WritableHeaders.create();
-
+                GrpcHeadersUtil.updateHeaders(writable, trailers);
                 writable.set(HeaderValues.create(GrpcStatus.STATUS_NAME, status.getCode().value()));
                 String description = status.getDescription();
                 if (description != null) {
                     writable.set(HeaderValues.create(GrpcStatus.MESSAGE_NAME, description));
                 }
 
+                // write headers frame with trailers and EOS
                 Http2Headers http2Headers = Http2Headers.create(writable);
                 streamWriter.writeHeaders(http2Headers,
                                           streamId,
-                                          Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                          HeaderFlags.create(END_OF_HEADERS | END_OF_STREAM),
                                           flowControl.outbound());
                 currentStreamState = Http2StreamState.HALF_CLOSED_LOCAL;
             }
@@ -229,36 +250,5 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
     private Metadata toMetadata(Http2Headers headers) {
         return null;
-    }
-
-    private static final class BufferDataInputStream extends InputStream {
-        private final BufferData data;
-
-        private BufferDataInputStream(BufferData data) {
-            this.data = data;
-        }
-
-        @Override
-        public int read() throws IOException {
-            if (data.available() > 0) {
-                return data.read();
-            } else {
-                return -1;
-            }
-        }
-
-        @Override
-        public int read(byte[] b, int off, int len) throws IOException {
-            if (data.available() > 0) {
-                return data.read(b, off, len);
-            } else {
-                return -1;
-            }
-        }
-
-        @Override
-        public void close() throws IOException {
-            data.skip(data.available());
-        }
     }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -98,7 +98,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         try {
             ServerCall<REQ, RES> serverCall = createServerCall();
             ServerCallHandler<REQ, RES> callHandler = route.callHandler();
-            listener = callHandler.startCall(serverCall, toMetadata(headers));
+            listener = callHandler.startCall(serverCall, GrpcHeadersUtil.toMetadata(headers));
             listener.onReady();
         } catch (Throwable e) {
             LOGGER.log(ERROR, "Failed to initialize grpc protocol handler", e);
@@ -246,9 +246,5 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                 return route.method();
             }
         };
-    }
-
-    private Metadata toMetadata(Http2Headers headers) {
-        return null;
     }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
@@ -54,7 +55,6 @@ import io.grpc.ServerCallHandler;
 import io.grpc.Status;
 
 import static io.helidon.http.HeaderNames.CONTENT_TYPE;
-import static io.helidon.http.HeaderNames.create;
 import static io.helidon.http.http2.Http2Flag.DataFlags;
 import static io.helidon.http.http2.Http2Flag.END_OF_HEADERS;
 import static io.helidon.http.http2.Http2Flag.END_OF_STREAM;
@@ -64,8 +64,8 @@ import static java.lang.System.Logger.Level.ERROR;
 class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProtocolHandler {
     private static final System.Logger LOGGER = System.getLogger(GrpcProtocolHandler.class.getName());
 
-    private static final HeaderName GRPC_ENCODING = create("grpc-encoding");
-    private static final HeaderName GRPC_ACCEPT_ENCODING = create("grpc-accept-encoding");
+    private static final HeaderName GRPC_ENCODING = HeaderNames.create("grpc-encoding");
+    private static final HeaderName GRPC_ACCEPT_ENCODING = HeaderNames.create("grpc-accept-encoding");
     private static final Header GRPC_CONTENT_TYPE = HeaderValues.createCached(CONTENT_TYPE, "application/grpc");
     private static final Header GRPC_ENCODING_IDENTITY = HeaderValues.createCached(GRPC_ENCODING, "identity");
 
@@ -81,15 +81,13 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private final Http2Settings serverSettings;
     private final Http2Settings clientSettings;
     private final Grpc<REQ, RES> route;
-
-    private final StreamFlowControl flowControl;
-    private Http2StreamState currentStreamState;
-    private ServerCall.Listener<REQ> listener;
-
-    private BufferData entityBytes;
     private final AtomicInteger numMessages = new AtomicInteger();
     private final LinkedBlockingQueue<REQ> listenerQueue = new LinkedBlockingQueue<>();
+    private final StreamFlowControl flowControl;
 
+    private Http2StreamState currentStreamState;
+    private ServerCall.Listener<REQ> listener;
+    private BufferData entityBytes;
     private Compressor compressor;
     private Decompressor decompressor;
 

--- a/webserver/grpc/src/main/java/module-info.java
+++ b/webserver/grpc/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module io.helidon.webserver.grpc {
     requires io.helidon.builder.api;
     requires io.helidon.webserver.http2;
     requires java.logging;
+    requires com.google.common;
 
     requires static io.helidon.common.features.api;
 

--- a/webserver/grpc/src/main/java/module-info.java
+++ b/webserver/grpc/src/main/java/module-info.java
@@ -35,7 +35,6 @@ module io.helidon.webserver.grpc {
     requires io.helidon.builder.api;
     requires io.helidon.webserver.http2;
     requires java.logging;
-    requires com.google.common;
 
     requires static io.helidon.common.features.api;
 

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/BaseStringServiceTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/BaseStringServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,9 +52,7 @@ abstract class BaseStringServiceTest {
 
     @BeforeEach
     void beforeEach() {
-        channel = ManagedChannelBuilder.forAddress("localhost", port)
-                .usePlaintext()
-                .build();
+        channel = channel(port);
         blockingStub = StringServiceGrpc.newBlockingStub(channel);
         stub = StringServiceGrpc.newStub(channel);
     }
@@ -70,6 +68,12 @@ abstract class BaseStringServiceTest {
         if (!channel.isTerminated()) {
             System.err.println("Channel is not terminated!!!");
         }
+    }
+
+    ManagedChannel channel(int port) {
+        return ManagedChannelBuilder.forAddress("localhost", port)
+                .usePlaintext()
+                .build();
     }
 
     @RepeatedTest(20)

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GzipStringServiceTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GzipStringServiceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.grpc;
+
+import io.grpc.CompressorRegistry;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+/**
+ * Same as base class but uses {@link CompressorRegistry#getDefaultInstance()} to
+ * enable GZIP compression for data frames.
+ */
+@ServerTest
+class GzipStringServiceTest extends BaseStringServiceTest {
+
+    GzipStringServiceTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new StringService()));
+    }
+
+    @Override
+    ManagedChannel channel(int port) {
+        return ManagedChannelBuilder.forAddress("localhost", port)
+                .usePlaintext()
+                .compressorRegistry(CompressorRegistry.getDefaultInstance())    // gzip by default
+                .build();
+    }
+}

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GzipStringServiceTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GzipStringServiceTest.java
@@ -16,14 +16,24 @@
 
 package io.helidon.webserver.tests.grpc;
 
-import io.grpc.CompressorRegistry;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
+import javax.annotation.Nullable;
+
 import io.helidon.webserver.Router;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.grpc.GrpcRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.CompressorRegistry;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
 
 /**
  * Same as base class but uses {@link CompressorRegistry#getDefaultInstance()} to
@@ -46,6 +56,76 @@ class GzipStringServiceTest extends BaseStringServiceTest {
         return ManagedChannelBuilder.forAddress("localhost", port)
                 .usePlaintext()
                 .compressorRegistry(CompressorRegistry.getDefaultInstance())    // gzip by default
+                .intercept(new GzipVerifierInterceptor())
                 .build();
+    }
+
+    /**
+     * Verifies response is encoded using GZIP so negotiation was successful.
+     */
+    static class GzipVerifierInterceptor implements ClientInterceptor {
+
+        private static final Metadata.Key<String> GRPC_ENCODING = Metadata.Key.of("grpc-encoding",
+                Metadata.ASCII_STRING_MARSHALLER);
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+                                                                   CallOptions callOptions, Channel next) {
+            ClientCall<ReqT, RespT> nextCall = next.newCall(method, callOptions);
+            return new ClientCall<>() {
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                    Listener<RespT> verifierListener = new Listener<>() {
+                        @Override
+                        public void onHeaders(Metadata headers) {
+                            // verify that GZIP is in use
+                            String encoding = headers.get(GRPC_ENCODING);
+                            if (encoding == null || !encoding.contains("gzip")) {
+                                throw new RuntimeException("GZIP encoding has not been used");
+                            }
+
+                            // proceed forwarding normal call
+                            responseListener.onHeaders(headers);
+                        }
+
+                        @Override
+                        public void onMessage(RespT message) {
+                            responseListener.onMessage(message);
+                        }
+
+                        @Override
+                        public void onClose(Status status, Metadata trailers) {
+                            responseListener.onClose(status, trailers);
+                        }
+
+                        @Override
+                        public void onReady() {
+                            responseListener.onReady();
+                        }
+                    };
+                    nextCall.start(verifierListener, headers);
+                }
+
+                @Override
+                public void request(int numMessages) {
+                    nextCall.request(numMessages);
+                }
+
+                @Override
+                public void cancel(@Nullable String message, @Nullable Throwable cause) {
+                    nextCall.cancel(message, cause);
+                }
+
+                @Override
+                public void halfClose() {
+                    nextCall.halfClose();
+                }
+
+                @Override
+                public void sendMessage(ReqT message) {
+                    nextCall.sendMessage(message);
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
### Description

Several improvements to `GrpcProtocolHandler`: 

- support for flow control/back-pressure, data can now be queued if listener is not able to process it fast enough
- better handling for headers/trailers between gRPC and HTTP/2
- support for compression and codec negotiation
- additional tests
