### PR TITLE
Switched implementation of MpEnvironmentVariablesSource to use an LRU cache

### DIFF
--- a/config/config-mp/pom.xml
+++ b/config/config-mp/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-configurable</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>

--- a/config/config-mp/src/main/java/module-info.java
+++ b/config/config-mp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ module io.helidon.config.mp {
     requires io.helidon.common;
     requires io.helidon.config;
     requires jakarta.annotation;
+    requires io.helidon.common.configurable;
 
     requires static io.helidon.config.metadata;
 

--- a/config/config-mp/src/test/java/io/helidon/config/mp/MpEnvironmentVariablesSourceTest.java
+++ b/config/config-mp/src/test/java/io/helidon/config/mp/MpEnvironmentVariablesSourceTest.java
@@ -21,22 +21,20 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.is;
 
 class MpEnvironmentVariablesSourceTest {
 
+    private static final int MAX_GROWTH = 10;
+
     @Test
-    void testCacheMissGrowth() {
-        MpEnvironmentVariablesSource source = new MpEnvironmentVariablesSource();
+    void testCacheMaxGrowth() {
+        MpEnvironmentVariablesSource source = new MpEnvironmentVariablesSource(MAX_GROWTH);
         assertThat(source.cache().size(), is(0));
-        IntStream.range(0, 10).forEach(i -> {
+        IntStream.range(0, 5 * MAX_GROWTH).forEach(i -> {
             String random = UUID.randomUUID().toString().toLowerCase();
-            assertThat(source.cache().keySet(), not(contains(random)));
-            source.getValue(random);        // lookup miss, should not cache
-            assertThat(source.cache().keySet(), not(contains(random)));
+            source.getValue(random);        // should cache and discard oldest after MAX_GROWTH
         });
-        assertThat(source.cache().size(), is(0));
+        assertThat(source.cache().size(), is(MAX_GROWTH));
     }
 }

--- a/config/config-mp/src/test/java/io/helidon/config/mp/MpEnvironmentVariablesSourceTest.java
+++ b/config/config-mp/src/test/java/io/helidon/config/mp/MpEnvironmentVariablesSourceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.config.mp;
+
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.is;
+
+class MpEnvironmentVariablesSourceTest {
+
+    @Test
+    void testCacheMissGrowth() {
+        MpEnvironmentVariablesSource source = new MpEnvironmentVariablesSource();
+        assertThat(source.cache().size(), is(0));
+        IntStream.range(0, 10).forEach(i -> {
+            String random = UUID.randomUUID().toString().toLowerCase();
+            assertThat(source.cache().keySet(), not(contains(random)));
+            source.getValue(random);        // lookup miss, should not cache
+            assertThat(source.cache().keySet(), not(contains(random)));
+        });
+        assertThat(source.cache().size(), is(0));
+    }
+}


### PR DESCRIPTION
### Description

Switched implementation of `MpEnvironmentVariablesSource` to use an LRU cache and avoid an OOM. See issue #8767.
