### PR TITLE
4.x: cleanup helidon-bom and helidon-all

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -294,10 +294,6 @@
             <artifactId>helidon-metrics-system-meters</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics-provider-tests</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.metrics.providers</groupId>
             <artifactId>helidon-metrics-providers-micrometer</artifactId>
         </dependency>
@@ -1029,10 +1025,6 @@
         <dependency>
             <groupId>io.helidon.inject</groupId>
             <artifactId>helidon-inject-processor</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.inject</groupId>
-            <artifactId>helidon-inject-maven-plugin</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.inject</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -381,11 +381,6 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.helidon.metrics</groupId>
-                <artifactId>helidon-metrics-provider-tests</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.helidon.metrics.providers</groupId>
                 <artifactId>helidon-metrics-providers-micrometer</artifactId>
                 <version>${helidon.version}</version>
@@ -663,12 +658,6 @@
                 <!-- to add TracerResolver support -->
                 <groupId>io.helidon.tracing</groupId>
                 <artifactId>helidon-tracing-tracer-resolver</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <!-- for testing all providers -->
-                <groupId>io.helidon.tracing</groupId>
-                <artifactId>helidon-tracing-provider-tests</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
@@ -1355,11 +1344,6 @@
             <dependency>
                 <groupId>io.helidon.inject</groupId>
                 <artifactId>helidon-inject-processor</artifactId>
-                <version>${helidon.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.inject</groupId>
-                <artifactId>helidon-inject-maven-plugin</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>

--- a/inject/tests/resources-inject/pom.xml
+++ b/inject/tests/resources-inject/pom.xml
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>io.helidon.inject</groupId>
             <artifactId>helidon-inject-maven-plugin</artifactId>
+            <version>${helidon.version}</version>
             <scope>provided</scope> <!-- reactor dependency ordering only -->
             <optional>true</optional>
         </dependency>

--- a/inject/tests/tck-jsr330/pom.xml
+++ b/inject/tests/tck-jsr330/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>io.helidon.inject</groupId>
             <artifactId>helidon-inject-maven-plugin</artifactId>
+            <version>${helidon.version}</version>
             <scope>provided</scope> <!-- reactor ordering only -->
             <optional>true</optional>
         </dependency>

--- a/metrics/providers/pom.xml
+++ b/metrics/providers/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics-provider-tests</artifactId>
+            <version>${helidon.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tracing/providers/pom.xml
+++ b/tracing/providers/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>io.helidon.tracing</groupId>
             <artifactId>helidon-tracing-provider-tests</artifactId>
+            <version>${helidon.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
### Description

Remove dependencies from `helidon-all` and `helidon-bom` that we do not deploy.

### Documentation

No impact