### PR TITLE
[4.x] Cannot read config from environment with environment modules variables

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpEnvironmentVariablesSource.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpEnvironmentVariablesSource.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import io.helidon.common.configurable.LruCache;
+import io.helidon.config.PropertiesFilter;
 
 import jakarta.annotation.Priority;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -41,7 +42,7 @@ class MpEnvironmentVariablesSource implements ConfigSource {
     }
 
     MpEnvironmentVariablesSource(int cacheSize) {
-        this.env = Map.copyOf(System.getenv());
+        this.env = Map.copyOf(PropertiesFilter.create(System.getProperties()).filter(System.getenv()));
         this.cache = LruCache.<String, Cached>builder().capacity(cacheSize).build();
     }
 

--- a/config/config/src/main/java/io/helidon/config/EnvironmentVariables.java
+++ b/config/config/src/main/java/io/helidon/config/EnvironmentVariables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ public final class EnvironmentVariables {
      * @return An unmodifiable copy of {@link System#getenv()} including aliases.
      */
     public static Map<String, String> expand() {
-        return expand(System.getenv());
+        return expand(PropertiesFilter.create(System.getProperties()).filter(System.getenv()));
     }
 
     /**

--- a/config/config/src/main/java/io/helidon/config/PropertiesFilter.java
+++ b/config/config/src/main/java/io/helidon/config/PropertiesFilter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Filter properties with provided and default filter pattern.
+ */
+public class PropertiesFilter {
+    /**
+     * Key filter system property.
+     */
+    static final String KEY_FILTER_PROPERTY = "io.helidon.config.env-filter.key";
+    /**
+     * Value filter system property.
+     */
+    static final String VALUE_FILTER_PROPERTY = "io.helidon.config.env-filter.value";
+    /**
+     * Use default filter system property.
+     */
+    static final String USE_DEFAULT_FILTER_PROPERTY = "io.helidon.config.env-filter.use-default";
+    /**
+     * Regex separator property.
+     */
+    static final String SEPARATOR_FILTER_PROPERTY = "io.helidon.config.env-filter.separator";
+    private static final String REGEX_BASH_FUNC = "BASH_FUNC_(.*?)%%";
+    private static final Pattern PATTERN_BASH_FUNC = Pattern.compile(REGEX_BASH_FUNC);
+    private static final List<Pattern> DEFAULT_KEY_PATTERNS = List.of(PATTERN_BASH_FUNC);
+    private final List<Pattern> keyFilters;
+    private final List<Pattern> valueFilters;
+
+    private PropertiesFilter(List<String> keyFilters, List<String> valueFilters, boolean useDefault) {
+        this.keyFilters = convert(keyFilters);
+        this.valueFilters = convert(valueFilters);
+        if (useDefault) {
+            this.keyFilters.addAll(DEFAULT_KEY_PATTERNS);
+        }
+    }
+
+    /**
+     * Create a {@link PropertiesFilter} instance.
+     *
+     * @param properties System Properties
+     * @return a {@link PropertiesFilter} instance
+     */
+    public static PropertiesFilter create(Properties properties) {
+        Objects.requireNonNull(properties, "properties are null");
+        List<String> keyFilters = parseFilterProperty(KEY_FILTER_PROPERTY, properties);
+        List<String> valueFilters = parseFilterProperty(VALUE_FILTER_PROPERTY, properties);
+        boolean useDefault = Boolean.parseBoolean(properties.getProperty(USE_DEFAULT_FILTER_PROPERTY, "true"));
+        return new PropertiesFilter(keyFilters, valueFilters, useDefault);
+    }
+
+    /**
+     * Filter provided properties with this filter.
+     *
+     * @param properties to be filtered
+     * @return  the filtered properties
+     */
+    public Map<String, String> filter(Map<String, String> properties) {
+        return properties.entrySet().stream()
+                .filter(entry -> matches(keyFilters, entry.getKey()))
+                .filter(entry -> matches(valueFilters, entry.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static List<String> parseFilterProperty(String property, Properties properties) {
+        String separator = properties.getProperty(SEPARATOR_FILTER_PROPERTY, ",");
+        String resolved = properties.getProperty(property);
+        if (resolved == null) {
+            return List.of();
+        }
+        return Arrays.asList(resolved.split(separator));
+    }
+
+    private List<Pattern> convert(List<String> list) {
+        return list.stream()
+                .map(Pattern::compile)
+                .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    private boolean matches(List<Pattern> patterns, String value) {
+        return patterns.stream()
+                .noneMatch(matcher -> matcher.matcher(value).matches());
+    }
+}

--- a/config/config/src/test/java/io/helidon/config/PropertiesFilterTest.java
+++ b/config/config/src/test/java/io/helidon/config/PropertiesFilterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.PropertiesFilter.KEY_FILTER_PROPERTY;
+import static io.helidon.config.PropertiesFilter.USE_DEFAULT_FILTER_PROPERTY;
+import static io.helidon.config.PropertiesFilter.VALUE_FILTER_PROPERTY;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+public class PropertiesFilterTest {
+
+    @BeforeEach
+    void clearProperties() {
+        clear();
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        clear();
+    }
+    private static void clear() {
+        System.clearProperty(KEY_FILTER_PROPERTY);
+        System.clearProperty(VALUE_FILTER_PROPERTY);
+        System.clearProperty(USE_DEFAULT_FILTER_PROPERTY);
+    }
+
+    @Test
+    void testDefaultFilter() {
+        PropertiesFilter filter = PropertiesFilter.create(System.getProperties());
+        Map<String, String> filtered = filter.filter(Map.of("foo", "bar",
+                                                            "BASH_FUNC_%%", "bash function"));
+        assertThat(filtered.size(), is(1));
+        assertThat(filtered.keySet(), contains("foo"));
+    }
+
+    @Test
+    void testWithoutDefaultFilter() {
+        System.setProperty(USE_DEFAULT_FILTER_PROPERTY, "false");
+        PropertiesFilter filter = PropertiesFilter.create(System.getProperties());
+
+        Map<String, String> result = filter.filter(Map.of("foo", "bar",
+                "BASH_FUNC_foo%%", "bash function"));
+        assertThat(result.size(), is(2));
+        assertThat(result.keySet(), contains("foo", "BASH_FUNC_foo%%"));
+    }
+
+    @Test
+    void testFilter() {
+        System.setProperty(KEY_FILTER_PROPERTY, "foo.(.*?),(.*?).foo.(.*?)");
+        System.setProperty(VALUE_FILTER_PROPERTY, "bar.(.*?)");
+        PropertiesFilter filter = PropertiesFilter.create(System.getProperties());
+
+        Map<String, String> result = filter.filter(Map.of("foo", "bar",
+                                                          "foo.bar", "foo.bar",
+                                                          "bar.foo.bar", "bar.foo.bar",
+                                                          "bar.foo", "bar.foo",
+                                                          "BASH_FUNC_foo%%", "bash function"));
+        assertThat(result.size(), is(1));
+        assertThat(result.keySet(), contains("foo"));
+    }
+}


### PR DESCRIPTION
### Description

Cannot read config from environment with environment modules variables. Forward port of issue #6829 to Helidon 4.

