### PR TITLE
Retrieve the correct requested URI info path value, indpt of the routing path used to locate the handler

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
@@ -238,7 +238,7 @@ class Http2ServerRequest implements RoutingRequest {
                 .orElse(DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT)
                 .uriInfo(remotePeer().address().toString(),
                          localPeer().address().toString(),
-                         prologue.uriPath().path(),
+                         path.absolute().path(),
                          headers,
                          query(),
                          isSecure());

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
@@ -238,7 +238,7 @@ class Http2ServerRequest implements RoutingRequest {
                 .orElse(DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT)
                 .uriInfo(remotePeer().address().toString(),
                          localPeer().address().toString(),
-                         path.path(),
+                         prologue.uriPath().path(),
                          headers,
                          query(),
                          isSecure());

--- a/webserver/tests/pom.xml
+++ b/webserver/tests/pom.xml
@@ -41,6 +41,7 @@
         <module>imperative</module>
         <module>mtls</module>
         <module>observe</module>
+        <module>requested-uri-path-gh8818</module>
         <module>resource-limits</module>
         <module>sse</module>
         <module>static-content</module>

--- a/webserver/tests/requested-uri-path-gh8818/pom.xml
+++ b/webserver/tests/requested-uri-path-gh8818/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.webserver.tests</groupId>
+        <artifactId>helidon-webserver-tests-project</artifactId>
+        <version>4.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-webserver-tests-requested-uri-path-gh8818</artifactId>
+    <name>Helidon WebServer Tests Requested URI Path GH 8818</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-static-content</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/webserver/tests/requested-uri-path-gh8818/src/main/java/io/helidon/webserver/tests/gh2631/Gh8818.java
+++ b/webserver/tests/requested-uri-path-gh8818/src/main/java/io/helidon/webserver/tests/gh2631/Gh8818.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.gh2631;
+
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+public class Gh8818 {
+
+    static final String ENDPOINT_PATH = "/greet";
+
+    public static void main(String[] args) {
+        startServer();
+    }
+
+    static WebServer startServer() {
+        return WebServer.builder()
+                .routing(Gh8818::routing)
+                .build()
+                .start();
+    }
+
+    static void routing(HttpRouting.Builder routing) {
+        LogConfig.configureRuntime();
+
+        routing.register(ENDPOINT_PATH, new TestResource());
+    }
+
+    private static class TestResource implements HttpService {
+
+        @Override
+        public void routing(HttpRules httpRules) {
+            httpRules.get("/", this::getDefaultMessageHandler);
+        }
+
+        private void getDefaultMessageHandler(ServerRequest serverRequest,
+                                              ServerResponse serverResponse) {
+            serverResponse.send(serverRequest.requestedUri().path().path());
+        }
+    }
+}

--- a/webserver/tests/requested-uri-path-gh8818/src/main/resources/logging.properties
+++ b/webserver/tests/requested-uri-path-gh8818/src/main/resources/logging.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%4$s %3$s: %5$s%6$s%n
+
+.level=INFO

--- a/webserver/tests/requested-uri-path-gh8818/src/test/java/io/helidon/webserver/tests/gh2631/Gh8818Test.java
+++ b/webserver/tests/requested-uri-path-gh8818/src/test/java/io/helidon/webserver/tests/gh2631/Gh8818Test.java
@@ -16,16 +16,10 @@
 
 package io.helidon.webserver.tests.gh2631;
 
-import io.helidon.http.Status;
-import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.http1.Http1Client;
-import io.helidon.webclient.http1.Http1ClientResponse;
-import io.helidon.webserver.WebServer;
-import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
-import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 

--- a/webserver/tests/requested-uri-path-gh8818/src/test/java/io/helidon/webserver/tests/gh2631/Gh8818Test.java
+++ b/webserver/tests/requested-uri-path-gh8818/src/test/java/io/helidon/webserver/tests/gh2631/Gh8818Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/tests/requested-uri-path-gh8818/src/test/java/io/helidon/webserver/tests/gh2631/Gh8818Test.java
+++ b/webserver/tests/requested-uri-path-gh8818/src/test/java/io/helidon/webserver/tests/gh2631/Gh8818Test.java
@@ -22,7 +22,9 @@ import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
@@ -32,17 +34,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @ServerTest
 class Gh8818Test {
-    private final Http1Client client;
 
-    Gh8818Test(WebServer server) {
-        this.client = Http1Client.builder()
-                               .baseUri("http://localhost:" + server.port())
-                               .build();
+    private Http1Client client;
+
+    Gh8818Test(Http1Client client) {
+        this.client = client;
     }
 
-    @SetUpServer
-    static void setup(WebServerConfig.Builder builder) {
-        builder.routing(Gh8818::routing);
+   @SetUpRoute
+    static void setupRoute(HttpRouting.Builder routing) {
+        Gh8818.routing(routing);
     }
 
     @Test

--- a/webserver/tests/requested-uri-path-gh8818/src/test/java/io/helidon/webserver/tests/gh2631/Gh8818Test.java
+++ b/webserver/tests/requested-uri-path-gh8818/src/test/java/io/helidon/webserver/tests/gh2631/Gh8818Test.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.gh2631;
+
+import io.helidon.http.Status;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class Gh8818Test {
+    private final Http1Client client;
+
+    Gh8818Test(WebServer server) {
+        this.client = Http1Client.builder()
+                               .baseUri("http://localhost:" + server.port())
+                               .build();
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder builder) {
+        builder.routing(Gh8818::routing);
+    }
+
+    @Test
+    void checkForFullPath() {
+        String requestedPath = get(Gh8818.ENDPOINT_PATH);
+        assertThat("Requested path", requestedPath, is(Gh8818.ENDPOINT_PATH));
+    }
+
+    private String get(String path) {
+        return client.get()
+                .path(path)
+                .requestEntity(String.class);
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
@@ -225,7 +225,7 @@ abstract class Http1ServerRequest implements RoutingRequest {
                 .orElse(DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT)
                 .uriInfo(remotePeer().address().toString(),
                          localPeer().address().toString(),
-                         path.path(),
+                         prologue.uriPath().path(),
                          headers,
                          query(),
                          isSecure());

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
@@ -225,7 +225,7 @@ abstract class Http1ServerRequest implements RoutingRequest {
                 .orElse(DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT)
                 .uriInfo(remotePeer().address().toString(),
                          localPeer().address().toString(),
-                         prologue.uriPath().path(),
+                         path.absolute().path(),
                          headers,
                          query(),
                          isSecure());


### PR DESCRIPTION
### Description
Resolves #8818 

The requested URI info logic used to fetch its path value from the incoming request `path()` return value. This is incorrect; that path is relative to the routing path which selected the handler, and that value has nothing to do with the path the client originally used in its outgoing request (which is what the requested URI feature is intended to reveal).

This PR changes the way the path is derived for the requested URI info to use the path from the prologue which reflects the entire path, not just the portion used in routing within the server.

It also adds a webserver test that makes sure that the path in the requested URI info is correct.

----

TL;DR - This bug escaped our attention until now because in 4.0.0 the server always invoked some CORS code, whether CORS was enabled or not. Part of that logic retrieved each request's requested URI info. That data is lazily created and cached. The routing that sends requests to CORS has no path prefix, so the `serverRequest.path()` value during the CORS-triggered handling just happened to include the entire path. 

Later, when a user handler retrieved the requested URI info from the request, even though at that moment the `request.path()` value was relative to the routing, the cached requested URI info with the original CORS-triggered value was returned.

Beginning in 4.0.1 the server stopped invoking CORS logic unless CORS was enabled. Beginning then, the requested URI information retrieved from a user handler that used path-based routing would be incorrect, omitting the part of the path used in the routing rule.

### Documentation
Bug fix; no doc update.