### PR TITLE
4.x - Archetype: fix Native image build for `quickstart` with `jackson`

### DIFF
--- a/archetypes/archetypes/src/main/archetype/common/docker.xml
+++ b/archetypes/archetypes/src/main/archetype/common/docker.xml
@@ -39,6 +39,12 @@
                                 <include>src/*/resources/META-INF/**/*.mustache</include>
                             </includes>
                         </templates>
+                        <files if="${flavor} == 'mp' &amp;&amp; ${media.json-lib} == 'jackson'">
+                            <directory>files</directory>
+                            <includes>
+                                <include>src/**/native-image/**/resource-config.json</include>
+                            </includes>
+                        </files>
                     </output>
                 </boolean>
                 <boolean id="jlink-image" name="JLink Support"

--- a/archetypes/archetypes/src/main/archetype/common/files/src/main/resources/META-INF/native-image/groupid/artifactid/native-image.properties.mustache
+++ b/archetypes/archetypes/src/main/archetype/common/files/src/main/resources/META-INF/native-image/groupid/artifactid/native-image.properties.mustache
@@ -1,1 +1,1 @@
-Args=--initialize-at-build-time={{package}}
+Args=--initialize-at-build-time={{package}}{{#initialize-at-build-time}},{{.}}{{/initialize-at-build-time}}

--- a/archetypes/archetypes/src/main/archetype/common/files/src/main/resources/META-INF/native-image/jakarta/xml/bind/jakarta.xml.bind-api/resource-config.json
+++ b/archetypes/archetypes/src/main/archetype/common/files/src/main/resources/META-INF/native-image/jakarta/xml/bind/jakarta.xml.bind-api/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "bundles": [
+    {
+      "name": "jakarta.xml.bind.Messages"
+    }
+  ]
+}

--- a/archetypes/archetypes/src/main/archetype/common/media.xml
+++ b/archetypes/archetypes/src/main/archetype/common/media.xml
@@ -72,6 +72,9 @@
                                                 <value key="artifactId">jakarta.xml.bind-api</value>
                                             </map>
                                         </list>
+                                        <list key="initialize-at-build-time" if="${flavor} == 'mp'">
+                                            <value>com.fasterxml.jackson.core</value>
+                                        </list>
                                         <list key="module-requires">
                                             <value>com.fasterxml.jackson.annotation</value>
                                             <value>com.fasterxml.jackson.core</value>


### PR DESCRIPTION
### Description

fix #8799

Add required native image properties and resource configuration for reflection.

### Documentation

No impact on documentation