### PR TITLE
4.x: Updates to support latest dev release of GraalVM native image

### DIFF
--- a/common/configurable/src/main/resources/META-INF/native-image/io.helidon.common/helidon-common-configurable/native-image.properties
+++ b/common/configurable/src/main/resources/META-INF/native-image/io.helidon.common/helidon-common-configurable/native-image.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args=--initialize-at-build-time=io.helidon.common.configurable.LruCache \
+  --initialize-at-build-time=io.helidon.common.configurable.LruCacheConfig

--- a/integrations/graal/mp-native-image-extension/src/main/resources/META-INF/native-image/io.helidon.integrations.graal/helidon-mp-graal-native-image-extension/native-image.properties
+++ b/integrations/graal/mp-native-image-extension/src/main/resources/META-INF/native-image/io.helidon.integrations.graal/helidon-mp-graal-native-image-extension/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,7 +40,12 @@ Args=--features=io.helidon.integrations.graal.mp.nativeimage.extension.HelidonMp
      --initialize-at-build-time=jakarta.interceptor \
      --initialize-at-build-time=jakarta.annotation \
      --initialize-at-build-time=com.sun.beans.TypeResolver \
+     --initialize-at-build-time=com.sun.beans.WeakCache \
      --initialize-at-build-time=java.beans.PropertyDescriptor \
      --initialize-at-build-time=java.beans.MethodRef \
      --initialize-at-build-time=org.yaml.snakeyaml \
+     --initialize-at-build-time=org.jvnet.hk2 \
+     --initialize-at-build-time=java.lang.annotation.Annotation \
+     --initialize-at-build-time=io.helidon \
+     --initialize-at-build-time=org.eclipse.microprofile \
      --report-unsupported-elements-at-runtime

--- a/logging/jul/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-jul/native-image.properties
+++ b/logging/jul/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-jul/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args=--initialize-at-build-time=io.helidon.logging.jul.JulMdcPropagator

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/TenantAuthenticationHandler.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.helidon.common.Errors;
+import io.helidon.common.LazyValue;
 import io.helidon.common.parameters.Parameters;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -83,7 +84,7 @@ class TenantAuthenticationHandler {
     private static final System.Logger LOGGER = System.getLogger(TenantAuthenticationHandler.class.getName());
     private static final TokenHandler PARAM_HEADER_HANDLER = TokenHandler.forHeader(OidcConfig.PARAM_HEADER_NAME);
     private static final TokenHandler PARAM_ID_HEADER_HANDLER = TokenHandler.forHeader(OidcConfig.PARAM_ID_HEADER_NAME);
-    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final LazyValue<SecureRandom> RANDOM = LazyValue.create(SecureRandom::new);
 
     private final boolean optional;
     private final OidcConfig oidcConfig;
@@ -824,7 +825,7 @@ class TenantAuthenticationHandler {
         int rightLimit = 122; // letter 'z'
         int targetStringLength = 10;
 
-        return RANDOM.ints(leftLimit, rightLimit + 1)
+        return RANDOM.get().ints(leftLimit, rightLimit + 1)
                 .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
                 .limit(targetStringLength)
                 .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)


### PR DESCRIPTION
Updates to native image configuration to support latest release of GraalVM (tested with `OpenJDK Runtime Environment GraalVM CE 23-dev+23.1 (build 23+23-jvmci-b01)`).

There are a few changes that cause compilation failures, probably due to the change of "strict image heap" now being the default. In most cases the problems were caused by instances getting into the image heap that were not marked as `initialize-at-build-time`.

This PR fixes all the cases that were needed for our MP-1 integration test, and for a quickstart-mp (pipeline should find if there are other issues).