### PR TITLE
4.x: Add uses io.helidon.dbclient.jdbc.spi.JdbcConnectionPoolProvider to io.helidon.dbclient.jdbc module (#8237)

### DIFF
--- a/dbclient/jdbc/src/main/java/module-info.java
+++ b/dbclient/jdbc/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ module io.helidon.dbclient.jdbc {
     exports io.helidon.dbclient.jdbc.spi;
 
     uses io.helidon.dbclient.jdbc.JdbcClientProvider;
+    uses io.helidon.dbclient.jdbc.spi.JdbcConnectionPoolProvider;
 
     provides io.helidon.dbclient.spi.DbClientProvider
             with io.helidon.dbclient.jdbc.JdbcClientProvider;


### PR DESCRIPTION
Fixes #8237 

### Description
IDE also says, that `uses` should be used

<img width="1584" alt="Screenshot 2024-06-06 at 10 48 54" src="https://github.com/helidon-io/helidon/assets/4740207/991a9ae4-b60e-42db-863c-1e55bfba9d7e">


