### PR TITLE
4.0.10: Reorder checking of delegate vs. wrapper in OTel tracer unwrap (

### DIFF
--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracer.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracer.java
@@ -96,12 +96,13 @@ class OpenTelemetryTracer implements Tracer {
 
     @Override
     public <T> T unwrap(Class<T> tracerClass) {
-        if (tracerClass.isInstance(this)) {
-            return tracerClass.cast(this);
-        }
         if (tracerClass.isAssignableFrom(delegate.getClass())) {
             return tracerClass.cast(delegate);
         }
+        if (tracerClass.isInstance(this)) {
+            return tracerClass.cast(this);
+        }
+
         throw new IllegalArgumentException("Cannot provide an instance of " + tracerClass.getName()
                                                    + ", telemetry tracer is: " + delegate.getClass().getName());
     }

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestUnwrap.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestUnwrap.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.trace.Tracer;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 class TestUnwrap {
@@ -32,6 +33,14 @@ class TestUnwrap {
         assertThat("Tracer unwrapped",
                    tracer.unwrap(Tracer.class),
                    instanceOf(Tracer.class));
+
+        assertThat("Delegate unwrapped",
+                   tracer.unwrap(io.opentelemetry.api.trace.Tracer.class),
+                   instanceOf(io.opentelemetry.api.trace.Tracer.class));
+
+        assertThat("Object.toString()",
+                   tracer.unwrap(Object.class).toString(),
+                   containsString("io.opentelemetry"));
     }
 
     @Test


### PR DESCRIPTION

Backport of #8855 to 4.0.10

### Description

Resolves #8854

A recent PR added the ability to unwrap the OTel tracer as the Helidon Tracer wrapper (to the pre-existing ability to unwrap the OTel delegate tracer) by checking the wrapper first, then the delegate.

This broke previous behavior where users used unwrap(Object.class).toString() to display delegate information.

This PR reorders the checking in the OTel Tracer wrapper to restore the earlier behavior for unwrapping as Object while still adding the ability to unwrap as the wrapper (which was the purpose of this part of the earlier PR).

The PR also adds tests to make sure the older behavior works again.

### Documentation

Bug fix; no doc impact.

