### PR TITLE
4.x: Remove unused methods 'produce' and 'dispose' from PersistenceExtension.ReferenceCountingProducer

### DIFF
--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
@@ -27,7 +27,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -1644,34 +1643,6 @@ public final class PersistenceExtension implements Extension {
 
         private <T> T produce(Supplier<? extends T> supplier,
                               Consumer<? super T> disposer,
-                              Class<T> type,
-                              Annotation... qualifiers) {
-            return this.produce(supplier, disposer, Set.of(type), Set.copyOf(Arrays.asList(qualifiers)));
-        }
-
-        private <T> T produce(Supplier<? extends T> supplier,
-                              Consumer<? super T> disposer,
-                              TypeLiteral<T> type,
-                              Set<Annotation> qualifiers) {
-            return this.produce(supplier, disposer, Set.of(type.getType()), qualifiers);
-        }
-
-        private <T> T produce(Supplier<? extends T> supplier,
-                              Consumer<? super T> disposer,
-                              TypeLiteral<T> type,
-                              Annotation... qualifiers) {
-            return this.produce(supplier, disposer, Set.of(type.getType()), Set.copyOf(Arrays.asList(qualifiers)));
-        }
-
-        private <T> T produce(Supplier<? extends T> supplier,
-                              Consumer<? super T> disposer,
-                              Set<Type> types,
-                              Annotation... qualifiers) {
-            return this.produce(supplier, disposer, types, Set.copyOf(Arrays.asList(qualifiers)));
-        }
-
-        private <T> T produce(Supplier<? extends T> supplier,
-                              Consumer<? super T> disposer,
                               Set<Type> types,
                               Set<Annotation> qualifiers) {
             Objects.requireNonNull(supplier, "supplier");
@@ -1688,22 +1659,6 @@ public final class PersistenceExtension implements Extension {
 
         private <T> void dispose(Class<T> type, Set<Annotation> qualifiers) {
             this.dispose(Set.of(type), qualifiers);
-        }
-
-        private <T> void dispose(Class<T> type, Annotation... qualifiers) {
-            this.dispose(Set.of(type), Set.copyOf(Arrays.asList(qualifiers)));
-        }
-
-        private <T> void dispose(TypeLiteral<T> type, Set<Annotation> qualifiers) {
-            this.dispose(Set.of(type.getType()), qualifiers);
-        }
-
-        private <T> void dispose(TypeLiteral<T> type, Annotation... qualifiers) {
-            this.dispose(Set.of(type.getType()), Set.copyOf(Arrays.asList(qualifiers)));
-        }
-
-        private <T> void dispose(Set<Type> types, Annotation... qualifiers) {
-            this.dispose(types, Set.copyOf(Arrays.asList(qualifiers)));
         }
 
         private <T> void dispose(Set<Type> types, Set<Annotation> qualifiers) {


### PR DESCRIPTION
### Description

I've found some unused overloaded methods `produce` and `dispose` in `PersistenceExtension.ReferenceCountingProducer`. 
<img width="409" alt="Screenshot 2024-06-11 at 21 07 54" src="https://github.com/helidon-io/helidon/assets/4740207/e737fb60-f150-4c52-b88b-4205460f907a">

<img width="409" alt="Screenshot 2024-06-11 at 21 07 07" src="https://github.com/helidon-io/helidon/assets/4740207/906b07f4-e232-4434-81ea-6489abe752f9">


I think, that they can be deleted. Am I wrong? 

These methods are private and the cleaning won't break any code.

These methods were added in [this PR](https://github.com/helidon-io/helidon/commit/af9aeb539f15574d825b8510a1f0de7a566a8d1f#diff-eb8e146fefccc9a72c7533156f995619951b426f8d05cac263277dcba191872aR1535).