### PR TITLE
4.x: Replace deprecated method Header.value() on Header.get()

### DIFF
--- a/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/HttpHeaderMatcher.java
+++ b/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/HttpHeaderMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,7 +217,7 @@ public final class HttpHeaderMatcher {
             if (httpHeaders.contains(name)) {
                 Header headerValue = httpHeaders.get(name);
                 if (headerValue.allValues().size() == 1) {
-                    return valuesMatcher.matches(headerValue.value());
+                    return valuesMatcher.matches(headerValue.get());
                 }
                 return false;
             }

--- a/examples/security/basic-auth-with-static-content/src/test/java/io/helidon/examples/security/basicauth/BasicExampleTest.java
+++ b/examples/security/basic-auth-with-static-content/src/test/java/io/helidon/examples/security/basicauth/BasicExampleTest.java
@@ -132,7 +132,7 @@ public abstract class BasicExampleTest {
         try (Http1ClientResponse response = client.get().uri(uri).request()) {
 
             assertThat(response.status(), is(Status.UNAUTHORIZED_401));
-            String header = response.headers().get(HeaderNames.WWW_AUTHENTICATE).value();
+            String header = response.headers().get(HeaderNames.WWW_AUTHENTICATE).get();
 
             assertThat(header.toLowerCase(), containsString("basic"));
             assertThat(header, containsString("helidon"));

--- a/examples/webserver/echo/src/main/java/io/helidon/examples/webserver/echo/EchoClient.java
+++ b/examples/webserver/echo/src/main/java/io/helidon/examples/webserver/echo/EchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class EchoClient {
 
             Headers headers = response.headers();
             for (Header header : headers) {
-                System.out.println("Header: " + header.name() + "=" + header.value());
+                System.out.println("Header: " + header.name() + "=" + header.get());
             }
             System.out.println("Entity:");
             System.out.println(response.as(String.class));

--- a/http/encoding/encoding/src/main/java/io/helidon/http/encoding/ContentEncodingSupportImpl.java
+++ b/http/encoding/encoding/src/main/java/io/helidon/http/encoding/ContentEncodingSupportImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ class ContentEncodingSupportImpl implements ContentEncodingContext {
             return ContentEncoder.NO_OP;
         }
 
-        String acceptEncoding = headers.get(HeaderNames.ACCEPT_ENCODING).value();
+        String acceptEncoding = headers.get(HeaderNames.ACCEPT_ENCODING).get();
         /*
             Accept-Encoding: gzip
             Accept-Encoding: gzip, compress, br

--- a/http/http/src/main/java/io/helidon/http/ClientResponseHeadersImpl.java
+++ b/http/http/src/main/java/io/helidon/http/ClientResponseHeadersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ class ClientResponseHeadersImpl implements ClientResponseHeaders {
     public Optional<HttpMediaType> contentType() {
         if (parserMode == ParserMode.RELAXED) {
             return contains(HeaderNameEnum.CONTENT_TYPE)
-                    ? Optional.of(HttpMediaType.create(get(HeaderNameEnum.CONTENT_TYPE).value(), parserMode))
+                    ? Optional.of(HttpMediaType.create(get(HeaderNameEnum.CONTENT_TYPE).get(), parserMode))
                     : Optional.empty();
         }
         return headers.contentType();

--- a/http/http/src/main/java/io/helidon/http/ServerRequestHeaders.java
+++ b/http/http/src/main/java/io/helidon/http/ServerRequestHeaders.java
@@ -78,7 +78,7 @@ public interface ServerRequestHeaders extends Headers {
     default Optional<ZonedDateTime> ifModifiedSince() {
         if (contains(HeaderNames.IF_MODIFIED_SINCE)) {
             return Optional.of(get(HeaderNames.IF_MODIFIED_SINCE))
-                    .map(Header::value)
+                    .map(Header::get)
                     .map(DateTime::parse);
         }
 
@@ -95,7 +95,7 @@ public interface ServerRequestHeaders extends Headers {
     default Optional<ZonedDateTime> ifUnmodifiedSince() {
         if (contains(HeaderNames.IF_UNMODIFIED_SINCE)) {
             return Optional.of(get(HeaderNames.IF_UNMODIFIED_SINCE))
-                    .map(Header::value)
+                    .map(Header::get)
                     .map(DateTime::parse);
         }
         return Optional.empty();
@@ -189,7 +189,7 @@ public interface ServerRequestHeaders extends Headers {
     default Optional<ZonedDateTime> acceptDatetime() {
         if (contains(HeaderNames.ACCEPT_DATETIME)) {
             return Optional.of(get(HeaderNames.ACCEPT_DATETIME))
-                    .map(Header::value)
+                    .map(Header::get)
                     .map(DateTime::parse);
         }
         return Optional.empty();
@@ -203,7 +203,7 @@ public interface ServerRequestHeaders extends Headers {
     default Optional<ZonedDateTime> date() {
         if (contains(HeaderNames.DATE)) {
             return Optional.of(get(HeaderNames.DATE))
-                    .map(Header::value)
+                    .map(Header::get)
                     .map(DateTime::parse);
         }
         return Optional.empty();
@@ -221,7 +221,7 @@ public interface ServerRequestHeaders extends Headers {
     default Optional<URI> referer() {
         if (contains(HeaderNames.REFERER)) {
             return Optional.of(get(HeaderNames.REFERER))
-                    .map(Header::value)
+                    .map(Header::get)
                     .map(URI::create);
         }
         return Optional.empty();

--- a/http/http/src/main/java/io/helidon/http/ServerRequestHeadersImpl.java
+++ b/http/http/src/main/java/io/helidon/http/ServerRequestHeadersImpl.java
@@ -77,7 +77,7 @@ class ServerRequestHeadersImpl implements ServerRequestHeaders {
         List<HttpMediaType> acceptedTypes;
 
         List<String> acceptValues = all(HeaderNames.ACCEPT, List::of);
-        if (acceptValues.size() == 1 && HUC_ACCEPT_DEFAULT.value().equals(acceptValues.get(0))) {
+        if (acceptValues.size() == 1 && HUC_ACCEPT_DEFAULT.get().equals(acceptValues.get(0))) {
             acceptedTypes = HUC_ACCEPT_DEFAULT_TYPES;
         } else {
             acceptedTypes = new ArrayList<>(5);

--- a/http/http/src/test/java/io/helidon/http/ContentDispositionTest.java
+++ b/http/http/src/test/java/io/helidon/http/ContentDispositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,7 +224,7 @@ class ContentDispositionTest {
                 .filename("file.txt")
                 .size(300)
                 .build();
-        assertThat(cd.value(), is(equalTo(template)));
+        assertThat(cd.get(), is(equalTo(template)));
     }
 
     @Test

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -453,7 +453,7 @@ public class Http2Headers {
         }
 
         for (Header header : headers) {
-            String value = header.value();
+            String value = header.get();
             boolean shouldIndex = !header.changing();
             boolean neverIndex = header.sensitive();
 
@@ -649,7 +649,7 @@ public class Http2Headers {
 
         headers.remove(HeaderNames.HOST, it -> {
             if (!pseudoHeaders.hasAuthority()) {
-                pseudoHeaders.authority(it.value());
+                pseudoHeaders.authority(it.get());
             }
         });
 
@@ -689,7 +689,7 @@ public class Http2Headers {
     private static void removeFromHeadersAddToPseudo(WritableHeaders<?> headers,
                                                      Consumer<String> valueConsumer,
                                                      HeaderName pseudoHeader) {
-        headers.remove(pseudoHeader, it -> valueConsumer.accept(it.value()));
+        headers.remove(pseudoHeader, it -> valueConsumer.accept(it.get()));
     }
 
     private void writeHeader(Http2HuffmanEncoder huffman, DynamicTable table,

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ class Http2HeadersTest {
         DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
         Headers requestHeaders = headers(hexEncoded, dynamicTable).httpHeaders();
 
-        assertThat(requestHeaders.get(HeaderNames.create("custom-key")).value(), is("custom-header"));
+        assertThat(requestHeaders.get(HeaderNames.create("custom-key")).get(), is("custom-header"));
     }
 
     BufferData data(String hexEncoded) {
@@ -76,7 +76,7 @@ class Http2HeadersTest {
         DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
         Headers requestHeaders = headers(hexEncoded, dynamicTable).httpHeaders();
 
-        assertThat(requestHeaders.get(HeaderNames.create("password")).value(), is("secret"));
+        assertThat(requestHeaders.get(HeaderNames.create("password")).get(), is("secret"));
         assertThat("Dynamic table should be empty", dynamicTable.currentTableSize(), is(0));
     }
 
@@ -124,7 +124,7 @@ class Http2HeadersTest {
         assertThat(http2Headers.scheme(), is("http"));
         assertThat(http2Headers.path(), is("/"));
         assertThat(http2Headers.authority(), is("www.example.com"));
-        assertThat(requestHeaders.get(HeaderNames.create("cache-control")).value(), is("no-cache"));
+        assertThat(requestHeaders.get(HeaderNames.create("cache-control")).get(), is("no-cache"));
 
         assertThat("Dynamic table should not be empty", dynamicTable.currentTableSize(), not(0));
 
@@ -145,7 +145,7 @@ class Http2HeadersTest {
         assertThat(http2Headers.scheme(), is("https"));
         assertThat(http2Headers.path(), is("/index.html"));
         assertThat(http2Headers.authority(), is("www.example.com"));
-        assertThat(requestHeaders.get(CUSTOM_HEADER_NAME).value(), is("custom-value"));
+        assertThat(requestHeaders.get(CUSTOM_HEADER_NAME).get(), is("custom-value"));
 
         assertThat("Dynamic table should not be empty", dynamicTable.currentTableSize(), not(0));
 
@@ -214,7 +214,7 @@ class Http2HeadersTest {
         assertThat(http2Headers.scheme(), is("http"));
         assertThat(http2Headers.path(), is("/"));
         assertThat(http2Headers.authority(), is("www.example.com"));
-        assertThat(requestHeaders.get(HeaderNames.create("cache-control")).value(), is("no-cache"));
+        assertThat(requestHeaders.get(HeaderNames.create("cache-control")).get(), is("no-cache"));
 
         assertThat("Dynamic table should not be empty", dynamicTable.currentTableSize(), not(0));
 
@@ -235,7 +235,7 @@ class Http2HeadersTest {
         assertThat(http2Headers.scheme(), is("https"));
         assertThat(http2Headers.path(), is("/index.html"));
         assertThat(http2Headers.authority(), is("www.example.com"));
-        assertThat(requestHeaders.get(CUSTOM_HEADER_NAME).value(), is("custom-value"));
+        assertThat(requestHeaders.get(CUSTOM_HEADER_NAME).get(), is("custom-value"));
 
         assertThat("Dynamic table should not be empty", dynamicTable.currentTableSize(), not(0));
 

--- a/http/media/multipart/src/main/java/io/helidon/http/media/multipart/ReadablePartAbstract.java
+++ b/http/media/multipart/src/main/java/io/helidon/http/media/multipart/ReadablePartAbstract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ abstract class ReadablePartAbstract implements ReadablePart {
 
     private void contentDisposition() {
         if (headers.contains(HeaderNames.CONTENT_DISPOSITION)) {
-            this.contentDisposition = ContentDisposition.parse(headers.get(HeaderNames.CONTENT_DISPOSITION).value());
+            this.contentDisposition = ContentDisposition.parse(headers.get(HeaderNames.CONTENT_DISPOSITION).get());
         } else {
             this.contentDisposition = ContentDisposition.empty();
         }

--- a/integrations/common/rest/src/test/java/io/helidon/integrations/common/rest/RestApiTest.java
+++ b/integrations/common/rest/src/test/java/io/helidon/integrations/common/rest/RestApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ class RestApiTest {
             ServerRequestHeaders headers = req.headers();
             if (headers.size() > 0) {
                 JsonObjectBuilder headersBuilder = JSON.createObjectBuilder();
-                headers.forEach(header -> headersBuilder.add(header.name(), header.value()));
+                headers.forEach(header -> headersBuilder.add(header.name(), header.get()));
                 objectBuilder.add("headers", headersBuilder);
             }
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -250,7 +250,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         ContentDecoder decoder;
 
         if (encodingSupport.contentDecodingEnabled() && responseHeaders.contains(HeaderNames.CONTENT_ENCODING)) {
-            String contentEncoding = responseHeaders.get(HeaderNames.CONTENT_ENCODING).value();
+            String contentEncoding = responseHeaders.get(HeaderNames.CONTENT_ENCODING).get();
             if (encodingSupport.contentDecodingSupported(contentEncoding)) {
                 decoder = encodingSupport.decoder(contentEncoding);
             } else {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
         if (originalRequest().followRedirects()
                 && RedirectionProcessor.redirectionStatusCode(responseStatus)) {
             checkRedirectHeaders(responseHeaders);
-            URI newUri = URI.create(responseHeaders.get(HeaderNames.LOCATION).value());
+            URI newUri = URI.create(responseHeaders.get(HeaderNames.LOCATION).get());
             ClientUri redirectUri = ClientUri.create(newUri);
             if (newUri.getHost() == null) {
                 UriInfo resolvedUri = cos.lastRequest.resolvedUri();
@@ -440,7 +440,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
         }
 
         private void redirect(Status lastStatus, WritableHeaders<?> headerValues) {
-            String redirectedUri = headerValues.get(HeaderNames.LOCATION).value();
+            String redirectedUri = headerValues.get(HeaderNames.LOCATION).get();
             ClientUri lastUri = originalRequest.uri();
             Method method;
             boolean sendEntity;
@@ -492,7 +492,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                             method = Method.GET;
                             sendEntity = false;
                         }
-                        redirectedUri = response.headers().get(HeaderNames.LOCATION).value();
+                        redirectedUri = response.headers().get(HeaderNames.LOCATION).get();
                     }
                 } else {
                     if (!sendEntity) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
@@ -56,7 +56,7 @@ class RedirectionProcessor {
                                                             + " header present in the response! "
                                                             + "It is not clear where to redirect.");
                 }
-                String redirectedUri = clientResponse.headers().get(HeaderNames.LOCATION).value();
+                String redirectedUri = clientResponse.headers().get(HeaderNames.LOCATION).get();
                 URI newUri = URI.create(redirectedUri);
                 ClientUri redirectUri = ClientUri.create(newUri);
 

--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsClientImpl.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsClientImpl.java
@@ -142,14 +142,14 @@ class WsClientImpl implements WsClient {
                                                     + responseHeaders);
             }
             ClientConnection connection = upgradeResponse.connection();
-            String secWsAccept = responseHeaders.get(HEADER_WS_ACCEPT).value();
+            String secWsAccept = responseHeaders.get(HEADER_WS_ACCEPT).get();
             if (!hash(connection.helidonSocket(), secWsKey).equals(secWsAccept)) {
                 throw new WsClientException("Failed to upgrade to WebSocket, expected valid secWsKey. Headers: "
                                                     + responseHeaders);
             }
             // we are upgraded, let's switch to web socket
             if (headers.contains(HEADER_WS_PROTOCOL)) {
-                session = new ClientWsConnection(connection, listener, headers.get(HEADER_WS_PROTOCOL).value());
+                session = new ClientWsConnection(connection, listener, headers.get(HEADER_WS_PROTOCOL).get());
             } else {
                 session = new ClientWsConnection(connection, listener);
             }

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/AbstractCorsTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/AbstractCorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,11 +178,11 @@ abstract class AbstractCorsTest extends CorsRouting {
 
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers()
-                               .get(ACCESS_CONTROL_ALLOW_ORIGIN).value(), is(fooOrigin()));
+                               .get(ACCESS_CONTROL_ALLOW_ORIGIN).get(), is(fooOrigin()));
             assertThat(response.headers()
-                               .get(ACCESS_CONTROL_ALLOW_CREDENTIALS).value(), is("true"));
+                               .get(ACCESS_CONTROL_ALLOW_CREDENTIALS).get(), is("true"));
             assertThat(response.headers()
-                               .get(ACCESS_CONTROL_ALLOW_METHODS).value(), is("PUT"));
+                               .get(ACCESS_CONTROL_ALLOW_METHODS).get(), is("PUT"));
             assertThat(response.headers()
                                .get(ACCESS_CONTROL_ALLOW_HEADERS).values(), containsString(fooHeader()));
             assertThat(response.headers(), noHeader(ACCESS_CONTROL_MAX_AGE));
@@ -204,8 +204,8 @@ abstract class AbstractCorsTest extends CorsRouting {
             assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
             assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
             assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
-            assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).value(), containsString("X-foo"));
-            assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).value(), containsString("X-bar"));
+            assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).get(), containsString("X-foo"));
+            assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).get(), containsString("X-bar"));
             assertThat(response.headers(), noHeader(ACCESS_CONTROL_MAX_AGE));
         }
     }
@@ -226,8 +226,8 @@ abstract class AbstractCorsTest extends CorsRouting {
             assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
             assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
             assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
-            assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).value(), containsString("X-foo"));
-            assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).value(), containsString("X-bar"));
+            assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).get(), containsString("X-foo"));
+            assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).get(), containsString("X-bar"));
             assertThat(response.headers(), noHeader(ACCESS_CONTROL_MAX_AGE));
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
@@ -182,7 +182,7 @@ abstract class Http1ServerRequest implements RoutingRequest {
 
     @Override
     public String authority() {
-        return headers.get(HeaderNames.HOST).value();
+        return headers.get(HeaderNames.HOST).get();
     }
 
     @Override

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgrader.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgrader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ public class WsUpgrader implements Http1Upgrader {
     public ServerConnection upgrade(ConnectionContext ctx, HttpPrologue prologue, WritableHeaders<?> headers) {
         String wsKey;
         if (headers.contains(WS_KEY)) {
-            wsKey = headers.get(WS_KEY).value();
+            wsKey = headers.get(WS_KEY).get();
         } else {
             // this header is required
             return null;
@@ -132,7 +132,7 @@ public class WsUpgrader implements Http1Upgrader {
         // protocol version
         String version;
         if (headers.contains(WS_VERSION)) {
-            version = headers.get(WS_VERSION).value();
+            version = headers.get(WS_VERSION).get();
         } else {
             version = SUPPORTED_VERSION;
         }
@@ -156,7 +156,7 @@ public class WsUpgrader implements Http1Upgrader {
 
         if (!anyOrigin()) {
             if (headers.contains(HeaderNames.ORIGIN)) {
-                String origin = headers.get(HeaderNames.ORIGIN).value();
+                String origin = headers.get(HeaderNames.ORIGIN).get();
                 if (!origins().contains(origin)) {
                     throw RequestException.builder()
                             .message("Invalid Origin")


### PR DESCRIPTION
### Description

There is a deprecated method `value()` in `Header.java`. This method can be replaced on `get()`.
<img width="647" alt="Screenshot 2024-06-11 at 21 47 09" src="https://github.com/helidon-io/helidon/assets/4740207/016f2d1d-aec5-42b6-b3f8-3099b433aa70">


