### PR TITLE
Correct the ordering of whenSent in doc snippet

### DIFF
--- a/docs/src/main/java/io/helidon/docs/se/guides/MetricsSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/guides/MetricsSnippets.java
@@ -174,8 +174,8 @@ class MetricsSnippets {
 
             private void getDefaultMessageHandler(ServerRequest request, ServerResponse response) {
                 Timer.Sample timerSample = Timer.start(); // <3>
-                sendResponse(response, "Here are some cards ...");
                 response.whenSent(() -> timerSample.stop(cardTimer)); // <4>
+                sendResponse(response, "Here are some cards ...");
             }
 
             private void sendResponse(ServerResponse response, String msg) {


### PR DESCRIPTION
### Description
Resolves #8875 

The doc snippet incorrectly registers the `whenSent` action _after_ sending the response. This (probably) would work in 3.x with the reactive non-blocking style but in 4.x, virtual threads, and blocking it no longer works when done this way.

This PR changes the snippet so it invokes `whenSent` _before_ sending the response.

I looked for and did not find other incorrect uses of `whenSent` in other snippets or in examples.

### Documentation
This is a doc bug.