### PR TITLE
4.x: Add todo for duplicates in CompositeArrayBufferData and CompositeListBufferData

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/CompositeArrayBufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/CompositeArrayBufferData.java
@@ -21,6 +21,10 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
+/* todo there are duplicated methods in CompositeArrayBufferData and CompositeListBufferData:
+ read(byte[] buffer, int position, int length), writeTo(ByteBuffer writeBuffer, int limit)
+ skip(int length), int indexOf(byte aByte), get(int index)
+ */
 class CompositeArrayBufferData extends ReadOnlyBufferData implements CompositeBufferData {
     private final BufferData[] data;
 


### PR DESCRIPTION
### Description
I've found, that there are many duplicated methods in `CompositeArrayBufferData` and `CompositeListBufferData`

For example `writeTo(ByteBuffer writeBuffer, int limit)`
<img width="1689" alt="Screenshot 2024-06-14 at 09 50 17" src="https://github.com/helidon-io/helidon/assets/4740207/bacdafff-9b49-4e9b-88f9-448d4b4c4010">

Maybe I should create the issue, but I'm not sure. The todo can be useful.
