### PR TITLE
4.x: Fixed configuration metadata of blueprints that are configured and provide a service

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/Types.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/Types.java
@@ -43,6 +43,7 @@ final class Types {
     static final TypeName PROTOTYPE_ANNOTATED = TypeName.create("io.helidon.builder.api.Prototype.Annotated");
     static final TypeName PROTOTYPE_FACTORY = TypeName.create("io.helidon.builder.api.Prototype.Factory");
     static final TypeName PROTOTYPE_CONFIGURED = TypeName.create("io.helidon.builder.api.Prototype.Configured");
+    static final TypeName PROTOTYPE_PROVIDES = TypeName.create("io.helidon.builder.api.Prototype.Provides");
     static final TypeName PROTOTYPE_BUILDER = TypeName.create("io.helidon.builder.api.Prototype.Builder");
     static final TypeName PROTOTYPE_CONFIGURED_BUILDER = TypeName.create("io.helidon.builder.api.Prototype.ConfiguredBuilder");
     static final TypeName PROTOTYPE_CUSTOM_METHODS = TypeName.create("io.helidon.builder.api.Prototype.CustomMethods");

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/ValidationTask.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/ValidationTask.java
@@ -42,7 +42,7 @@ abstract class ValidationTask {
         if (validatedType.interfaceTypeInfo()
                 .stream()
                 .noneMatch(it -> it.typeName().equals(implementedInterface))) {
-            errors.fatal(message);
+            errors.fatal(validatedType.typeName(), message);
         }
     }
 
@@ -71,7 +71,7 @@ abstract class ValidationTask {
                 })
                 .findFirst()
                 .isEmpty()) {
-            errors.fatal(validatedType.typeName().fqName(), message);
+            errors.fatal(validatedType.typeName(), message);
         }
     }
 
@@ -167,7 +167,8 @@ abstract class ValidationTask {
         public void validate(Errors.Collector errors) {
             // must be package local
             if (blueprint.accessModifier() == AccessModifier.PUBLIC) {
-                errors.fatal(blueprint.typeName(), blueprint.typeName().fqName() + " is defined as public, it must be package local");
+                errors.fatal(blueprint.typeName(), blueprint.typeName().fqName()
+                        + " is defined as public, it must be package local");
             }
 
             // if configured & provides, must have config key
@@ -177,7 +178,8 @@ abstract class ValidationTask {
                 String value = configured.stringValue().orElse("");
                 if (value.isEmpty()) {
                     // we have a @Configured and @Provides - this should have a configuration key!
-                    errors.fatal(blueprint.typeName(), blueprint.typeName().fqName() + " is marked as @Configured and @Provides, yet it does not"
+                    errors.fatal(blueprint.typeName(), blueprint.typeName().fqName()
+                            + " is marked as @Configured and @Provides, yet it does not"
                                          + " define a configuration key");
                 }
             }
@@ -289,8 +291,9 @@ abstract class ValidationTask {
             if (typeInfo.findAnnotation(annotation)
                     .stream()
                     .noneMatch(it -> it.value().map(expectedValue::equals).orElse(false))) {
-                errors.fatal("Type " + typeInfo.typeName()
-                        .fqName() + " must be annotated with " + annotation.fqName() + "(" + expectedValue + ")");
+                errors.fatal(typeInfo.typeName(),
+                             "Type " + typeInfo.typeName().fqName()
+                                     + " must be annotated with " + annotation.fqName() + "(" + expectedValue + ")");
             }
         }
     }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/ValidationTask.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/ValidationTask.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import io.helidon.codegen.ElementInfoPredicates;
 import io.helidon.common.Errors;
 import io.helidon.common.types.AccessModifier;
+import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
@@ -166,7 +167,19 @@ abstract class ValidationTask {
         public void validate(Errors.Collector errors) {
             // must be package local
             if (blueprint.accessModifier() == AccessModifier.PUBLIC) {
-                errors.fatal(blueprint.typeName().fqName() + " is defined as public, it must be package local");
+                errors.fatal(blueprint.typeName(), blueprint.typeName().fqName() + " is defined as public, it must be package local");
+            }
+
+            // if configured & provides, must have config key
+            if (blueprint.hasAnnotation(Types.PROTOTYPE_CONFIGURED)
+                && blueprint.hasAnnotation(Types.PROTOTYPE_PROVIDES)) {
+                Annotation configured = blueprint.annotation(Types.PROTOTYPE_CONFIGURED);
+                String value = configured.stringValue().orElse("");
+                if (value.isEmpty()) {
+                    // we have a @Configured and @Provides - this should have a configuration key!
+                    errors.fatal(blueprint.typeName(), blueprint.typeName().fqName() + " is marked as @Configured and @Provides, yet it does not"
+                                         + " define a configuration key");
+                }
             }
         }
 

--- a/builder/tests/codegen/src/test/java/io/helidon/builder/codegen/TypesTest.java
+++ b/builder/tests/codegen/src/test/java/io/helidon/builder/codegen/TypesTest.java
@@ -94,6 +94,7 @@ public class TypesTest {
         checkField(toCheck, checked, fields, "PROTOTYPE_ANNOTATED", Prototype.Annotated.class);
         checkField(toCheck, checked, fields, "PROTOTYPE_FACTORY", Prototype.Factory.class);
         checkField(toCheck, checked, fields, "PROTOTYPE_CONFIGURED", Prototype.Configured.class);
+        checkField(toCheck, checked, fields, "PROTOTYPE_PROVIDES", Prototype.Provides.class);
         checkField(toCheck, checked, fields, "PROTOTYPE_BUILDER", Prototype.Builder.class);
         checkField(toCheck, checked, fields, "PROTOTYPE_CONFIGURED_BUILDER", Prototype.ConfiguredBuilder.class);
         checkField(toCheck, checked, fields, "PROTOTYPE_CUSTOM_METHODS", Prototype.CustomMethods.class);

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_ListenerConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_ListenerConfig.adoc
@@ -110,7 +110,16 @@ Type: link:{javadoc-base-url}/io.helidon.webserver/io/helidon/webserver/Listener
  If configured to `0` (the default), server starts on a random port.
 
  Port to listen on (for the default socket)
-|`protocols` |io.helidon.webserver.spi.ProtocolConfig[&#93; (service provider interface) |{nbsp} |Configuration of protocols. This may be either protocol selectors, or protocol upgraders from HTTP/1.1.
+|`protocols` |io.helidon.webserver.spi.ProtocolConfig[&#93; (service provider interface)
+
+Such as:
+
+ - xref:{rootdir}/config/io_helidon_webserver_http2_Http2Config.adoc[http_2 (Http2Config)]
+ - xref:{rootdir}/config/io_helidon_webserver_grpc_GrpcConfig.adoc[grpc (GrpcConfig)]
+ - xref:{rootdir}/config/io_helidon_webserver_websocket_WsConfig.adoc[websocket (WsConfig)]
+ - xref:{rootdir}/config/io_helidon_webserver_http1_Http1Config.adoc[http_1_1 (Http1Config)]
+
+ |{nbsp} |Configuration of protocols. This may be either protocol selectors, or protocol upgraders from HTTP/1.1.
  As the order is not important (providers are ordered by weight by default), we can use a configuration as an object,
  such as:
  <pre>

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_WebServer.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_WebServer.adoc
@@ -126,7 +126,16 @@ Such as:
  If configured to `0` (the default), server starts on a random port.
 
  Port to listen on (for the default socket)
-|`protocols` |io.helidon.webserver.spi.ProtocolConfig[&#93; (service provider interface) |{nbsp} |Configuration of protocols. This may be either protocol selectors, or protocol upgraders from HTTP/1.1.
+|`protocols` |io.helidon.webserver.spi.ProtocolConfig[&#93; (service provider interface)
+
+Such as:
+
+ - xref:{rootdir}/config/io_helidon_webserver_http2_Http2Config.adoc[http_2 (Http2Config)]
+ - xref:{rootdir}/config/io_helidon_webserver_grpc_GrpcConfig.adoc[grpc (GrpcConfig)]
+ - xref:{rootdir}/config/io_helidon_webserver_websocket_WsConfig.adoc[websocket (WsConfig)]
+ - xref:{rootdir}/config/io_helidon_webserver_http1_Http1Config.adoc[http_1_1 (Http1Config)]
+
+ |{nbsp} |Configuration of protocols. This may be either protocol selectors, or protocol upgraders from HTTP/1.1.
  As the order is not important (providers are ordered by weight by default), we can use a configuration as an object,
  such as:
  <pre>

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_cors_CorsConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_cors_CorsConfig.adoc
@@ -66,7 +66,7 @@ This type provides the following service implementations:
 |`sockets` |string[&#93; |{nbsp} |List of sockets to register this feature on. If empty, it would get registered on all sockets.
 
  Socket names to register on, defaults to empty (all available sockets)
-|`weight` |double |`950.0` |Weight of the CORS feature. As it is used by other features, the default is quite high:
+|`weight` |double |`850.0` |Weight of the CORS feature. As it is used by other features, the default is quite high:
  CorsFeature.WEIGHT.
 
  Weight of the feature

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_cors_CorsFeature.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_cors_CorsFeature.adoc
@@ -66,7 +66,7 @@ This type provides the following service implementations:
 |`sockets` |string[&#93; |{nbsp} |List of sockets to register this feature on. If empty, it would get registered on all sockets.
 
  Socket names to register on, defaults to empty (all available sockets)
-|`weight` |double |`950.0` |Weight of the CORS feature. As it is used by other features, the default is quite high:
+|`weight` |double |`850.0` |Weight of the CORS feature. As it is used by other features, the default is quite high:
  CorsFeature.WEIGHT.
 
  Weight of the feature

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_grpc_GrpcConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_grpc_GrpcConfig.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -30,10 +30,16 @@ include::{rootdir}/includes/attributes.adoc[]
 Type: link:{javadoc-base-url}/io.helidon.webserver.grpc/io/helidon/webserver/grpc/GrpcConfig.html[io.helidon.webserver.grpc.GrpcConfig]
 
 
+[source,text]
+.Config key
+----
+grpc
+----
+
 
 This type provides the following service implementations:
 
-- `io.helidon.webserver.spi.ProtocolConfig`
+- `io.helidon.webserver.spi.ProtocolConfigProvider`
 
 
 == Configuration options

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_http1_Http1Config.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_http1_Http1Config.adoc
@@ -30,10 +30,16 @@ include::{rootdir}/includes/attributes.adoc[]
 Type: link:{javadoc-base-url}/io.helidon.webserver.http1/io/helidon/webserver/http1/Http1Config.html[io.helidon.webserver.http1.Http1Config]
 
 
+[source,text]
+.Config key
+----
+http_1_1
+----
+
 
 This type provides the following service implementations:
 
-- `io.helidon.webserver.spi.ProtocolConfig`
+- `io.helidon.webserver.spi.ProtocolConfigProvider`
 
 
 == Configuration options

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_http2_Http2Config.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_http2_Http2Config.adoc
@@ -30,10 +30,16 @@ include::{rootdir}/includes/attributes.adoc[]
 Type: link:{javadoc-base-url}/io.helidon.webserver.http2/io/helidon/webserver/http2/Http2Config.html[io.helidon.webserver.http2.Http2Config]
 
 
+[source,text]
+.Config key
+----
+http_2
+----
+
 
 This type provides the following service implementations:
 
-- `io.helidon.webserver.spi.ProtocolConfig`
+- `io.helidon.webserver.spi.ProtocolConfigProvider`
 
 
 == Configuration options

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_observe_ObserveFeature.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_observe_ObserveFeature.adoc
@@ -70,10 +70,10 @@ This type provides the following service implementations:
 
 Such as:
 
- - xref:{rootdir}/config/io_helidon_webserver_observe_log_LogObserver.adoc[LogObserver]
- - xref:{rootdir}/config/io_helidon_webserver_observe_tracing_TracingObserver.adoc[TracingObserver]
- - xref:{rootdir}/config/io_helidon_webserver_observe_config_ConfigObserver.adoc[ConfigObserver]
- - xref:{rootdir}/config/io_helidon_webserver_observe_info_InfoObserver.adoc[InfoObserver]
+ - xref:{rootdir}/config/io_helidon_webserver_observe_log_LogObserver.adoc[log (LogObserver)]
+ - xref:{rootdir}/config/io_helidon_webserver_observe_tracing_TracingObserver.adoc[tracing (TracingObserver)]
+ - xref:{rootdir}/config/io_helidon_webserver_observe_config_ConfigObserver.adoc[config (ConfigObserver)]
+ - xref:{rootdir}/config/io_helidon_webserver_observe_info_InfoObserver.adoc[info (InfoObserver)]
  - xref:{rootdir}/config/io_helidon_webserver_observe_metrics_MetricsObserver.adoc[metrics (MetricsObserver)]
  - xref:{rootdir}/config/io_helidon_webserver_observe_health_HealthObserver.adoc[health (HealthObserver)]
 

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_observe_config_ConfigObserver.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_observe_config_ConfigObserver.adoc
@@ -30,6 +30,12 @@ include::{rootdir}/includes/attributes.adoc[]
 Type: link:{javadoc-base-url}/io.helidon.webserver.observe.config/io/helidon/webserver/observe/config/ConfigObserver.html[io.helidon.webserver.observe.config.ConfigObserver]
 
 
+[source,text]
+.Config key
+----
+config
+----
+
 
 This type provides the following service implementations:
 

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_observe_info_InfoObserver.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_observe_info_InfoObserver.adoc
@@ -30,6 +30,12 @@ include::{rootdir}/includes/attributes.adoc[]
 Type: link:{javadoc-base-url}/io.helidon.webserver.observe.info/io/helidon/webserver/observe/info/InfoObserver.html[io.helidon.webserver.observe.info.InfoObserver]
 
 
+[source,text]
+.Config key
+----
+info
+----
+
 
 This type provides the following service implementations:
 

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_observe_log_LogObserver.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_observe_log_LogObserver.adoc
@@ -30,6 +30,12 @@ include::{rootdir}/includes/attributes.adoc[]
 Type: link:{javadoc-base-url}/io.helidon.webserver.observe.log/io/helidon/webserver/observe/log/LogObserver.html[io.helidon.webserver.observe.log.LogObserver]
 
 
+[source,text]
+.Config key
+----
+log
+----
+
 
 This type provides the following service implementations:
 

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_observe_tracing_TracingObserver.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_observe_tracing_TracingObserver.adoc
@@ -30,6 +30,12 @@ include::{rootdir}/includes/attributes.adoc[]
 Type: link:{javadoc-base-url}/io.helidon.webserver.observe.tracing/io/helidon/webserver/observe/tracing/TracingObserver.html[io.helidon.webserver.observe.tracing.TracingObserver]
 
 
+[source,text]
+.Config key
+----
+tracing
+----
+
 
 This type provides the following service implementations:
 

--- a/docs/src/main/asciidoc/config/io_helidon_webserver_websocket_WsConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_webserver_websocket_WsConfig.adoc
@@ -30,10 +30,16 @@ include::{rootdir}/includes/attributes.adoc[]
 Type: link:{javadoc-base-url}/io.helidon.webserver.websocket/io/helidon/webserver/websocket/WsConfig.html[io.helidon.webserver.websocket.WsConfig]
 
 
+[source,text]
+.Config key
+----
+websocket
+----
+
 
 This type provides the following service implementations:
 
-- `io.helidon.webserver.spi.ProtocolConfig`
+- `io.helidon.webserver.spi.ProtocolConfigProvider`
 
 
 == Configuration options

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -18,10 +18,11 @@ package io.helidon.webserver.grpc;
 
 import io.helidon.builder.api.Prototype;
 import io.helidon.webserver.spi.ProtocolConfig;
+import io.helidon.webserver.spi.ProtocolConfigProvider;
 
 @Prototype.Blueprint
-@Prototype.Configured
-@Prototype.Provides(ProtocolConfig.class)
+@Prototype.Configured(root = false, value = GrpcProtocolProvider.CONFIG_NAME)
+@Prototype.Provides(ProtocolConfigProvider.class)
 interface GrpcConfigBlueprint extends ProtocolConfig {
     /**
      * Protocol configuration type.

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConfigBlueprint.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConfigBlueprint.java
@@ -22,13 +22,14 @@ import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.http.RequestedUriDiscoveryContext;
 import io.helidon.webserver.spi.ProtocolConfig;
+import io.helidon.webserver.spi.ProtocolConfigProvider;
 
 /**
  * HTTP/2 server configuration.
  */
 @Prototype.Blueprint(decorator = Http2ConfigBlueprint.Http2ConfigDecorator.class)
-@Prototype.Configured
-@Prototype.Provides(ProtocolConfig.class)
+@Prototype.Configured(root = false, value = Http2ConnectionProvider.CONFIG_NAME)
+@Prototype.Provides(ProtocolConfigProvider.class)
 interface Http2ConfigBlueprint extends ProtocolConfig {
     /**
      * The size of the largest frame payload that the sender is willing to receive in bytes.

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserverConfigBlueprint.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserverConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.webserver.observe.ObserverConfigBase;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 
 @Prototype.Blueprint
-@Prototype.Configured
+@Prototype.Configured(root = false, value = "config")
 @Prototype.Provides(ObserveProvider.class)
 interface ConfigObserverConfigBlueprint extends ObserverConfigBase, Prototype.Factory<ConfigObserver> {
     @Option.Configured

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserverConfigBlueprint.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoObserverConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import io.helidon.webserver.observe.spi.ObserveProvider;
  * Info Observer configuration.
  */
 @Prototype.Blueprint
-@Prototype.Configured
+@Prototype.Configured(root = false, value = "info")
 @Prototype.Provides(ObserveProvider.class)
 interface InfoObserverConfigBlueprint extends ObserverConfigBase, Prototype.Factory<InfoObserver> {
     @Option.Configured

--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserverConfigBlueprint.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogObserverConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import io.helidon.webserver.observe.spi.ObserveProvider;
  * Log Observer configuration.
  */
 @Prototype.Blueprint
-@Prototype.Configured
+@Prototype.Configured(root = false, value = "log")
 @Prototype.Provides(ObserveProvider.class)
 interface LogObserverConfigBlueprint extends ObserverConfigBase, Prototype.Factory<LogObserver> {
     @Option.Configured

--- a/webserver/observe/tracing/pom.xml
+++ b/webserver/observe/tracing/pom.xml
@@ -51,6 +51,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-metadata</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserverConfigBlueprint.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/TracingObserverConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import io.helidon.webserver.observe.spi.ObserveProvider;
  * @see io.helidon.webserver.observe.tracing.TracingObserver#builder()
  */
 @Prototype.Blueprint(decorator = TracingObserverSupport.TracingObserverDecorator.class)
-@Prototype.Configured
+@Prototype.Configured(root = false, value = "tracing")
 @Prototype.Provides(ObserveProvider.class)
 interface TracingObserverConfigBlueprint extends ObserverConfigBase, Prototype.Factory<TracingObserver> {
     @Option.Default("tracing")
@@ -60,6 +60,7 @@ interface TracingObserverConfigBlueprint extends ObserverConfigBase, Prototype.F
      *
      * By default we disable both the SE-style paths ({@code /observe/health}) and the MP-style paths ({@code /health}).
      */
+
     /**
      * Path specific configuration of tracing.
      *

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConfigBlueprint.java
@@ -22,13 +22,14 @@ import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.http.RequestedUriDiscoveryContext;
 import io.helidon.webserver.spi.ProtocolConfig;
+import io.helidon.webserver.spi.ProtocolConfigProvider;
 
 /**
  * HTTP/1.1 server configuration.
  */
 @Prototype.Blueprint(decorator = Http1BuilderDecorator.class)
-@Prototype.Configured
-@Prototype.Provides(ProtocolConfig.class)
+@Prototype.Configured(root = false, value = Http1ConnectionProvider.CONFIG_NAME)
+@Prototype.Provides(ProtocolConfigProvider.class)
 interface Http1ConfigBlueprint extends ProtocolConfig {
     /**
      * Name of this configuration, in most cases the same as {@link #type()}.

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConfigBlueprint.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConfigBlueprint.java
@@ -21,13 +21,14 @@ import java.util.Set;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.webserver.spi.ProtocolConfig;
+import io.helidon.webserver.spi.ProtocolConfigProvider;
 
 /**
  * WebSocket protocol configuration.
  */
 @Prototype.Blueprint
-@Prototype.Configured
-@Prototype.Provides(ProtocolConfig.class)
+@Prototype.Configured(root = false, value = WsUpgradeProvider.CONFIG_NAME)
+@Prototype.Provides(ProtocolConfigProvider.class)
 interface WsConfigBlueprint extends ProtocolConfig {
     /**
      * WebSocket origins.


### PR DESCRIPTION
Updated generated documentation to latest state of code.

Resolves #8776 

There were two problems in the code:
1. The protocol config blueprints used wrong provides (must match the `@Option.Provider(ProtocolConfigProvider.class)` in listener config)
2. The protocol config blueprints lacked the configured key, and setting that it is not a root configuration

After fixing the above problems, the generated documentation correctly shows the configuration keys, and the listener config documentation now lists all available implementations.

In addition the same problem was with observe providers. Fixed all providers to add config key, re-generated the documentation.

Added validation that `@Provides` and `@Configured` must have a configuration key.