### PR TITLE
3.x: Upgrade glassgraph to 4.8.165

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.lib.jmh>1.23</version.lib.jmh>
         <version.lib.wiremock>2.26.3</version.lib.wiremock>
         <version.lib.commons-lang3>3.10</version.lib.commons-lang3>
-        <version.lib.classgraph>4.8.87</version.lib.classgraph>
+        <version.lib.classgraph>4.8.165</version.lib.classgraph>
         <!--
         !Version statement! - end
         -->


### PR DESCRIPTION
### Description

Upgrade glassgraph to 4.8.165

This matches what is used in 4.x

### Documentation

No impact