### PR TITLE
Update metrics config default for `rest-request-enabled` and add doc text explaining SE vs. MP defaults for some values

### DIFF
--- a/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
@@ -59,8 +59,8 @@ This is a standalone configuration type, prefix from configuration root: `metric
 |`permit-all` |boolean |`true` |Whether to allow anybody to access the endpoint.
 
  Whether to permit access to metrics endpoint to anybody, defaults to `true`
- See roles()
-|`rest-request-enabled` |boolean |{nbsp} |Whether automatic REST request metrics should be measured.
+ @see #roles()
+|`rest-request-enabled` |boolean |`false` |Whether automatic REST request metrics should be measured.
 
  True/false
 |`roles` |string[&#93; |`observe` |Hints for role names the user is expected to be in.

--- a/docs/src/main/asciidoc/includes/metrics/metrics-config.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-config.adoc
@@ -29,8 +29,33 @@ To control how the Helidon metrics subsystem behaves, add a `metrics` section to
 ifdef::mp-flavor[your `META-INF/microprofile-config.properties` file.]
 ifdef::se-flavor[your configuration file, such as `application.yaml`.]
 
+Certain default configuration values depend on the fact that you are using Helidon {flavor-uc} as described in the <<flavor-specific-defaults,second table below>>.
+
 include::{rootdir}/config/io_helidon_webserver_observe_metrics_MetricsObserver.adoc[tag=config,leveloffset=+1]
 
+// It seems we need an explicit open block for the website rendering to create the anchor properly. I tried adding the anchor to the table (without the block) but that didn't work on the live site.
+[#flavor-specific-defaults]
+--
+.Default Values Specific to Helidon {flavor-uc}
+[%autowidth]
+|====
+|Key | Default Value
+
+| `app-tag-name`
+a| ifdef::se-flavor[`app`]
+ifdef::mp-flavor[`mp_app`]
+
+| `scoping.tag-name`
+a| ifdef::se-flavor[`scope`]
+ifdef::mp-flavor[`mp_scope`]
+
+| `scoping.default`
+// Use two ifdefs even though the value is the same because without that the resulting formatting can look different vs. the preceding cells.
+a| ifdef::se-flavor[`application`]
+ifdef::mp-flavor[`application`]
+
+|====
+--
 // end::config-intro[]
 
 // tag::config-examples[]

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -195,6 +195,7 @@ interface MetricsConfigBlueprint {
      * @return true/false
      */
     @Option.Configured
+    @Option.DefaultBoolean(false)
     boolean restRequestEnabled();
 
     /**


### PR DESCRIPTION
### Description
Resolves #8805 

The `MetricsConfigBlueprint` did not specify a default value for `rest-request-enabled` because the default is `false` which is how the JVM initializes the builder's boolean for that setting.

But the generated config `.adoc` file did not specify `false` so I just added an explicit default value for that setting.

There are some default values which actually vary between SE and MP. This PR adds a table describing those and a bit of text referring to the table in the metrics page Config section.


### Documentation

This PR updates the doc.