### PR TITLE
Get annotation processing going with Eclipse Compiler for Java

### DIFF
--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptContextImpl.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptContextImpl.java
@@ -145,7 +145,7 @@ class AptContextImpl extends CodegenContextBase implements AptContext {
             try (InputStream in = resource.openInputStream()) {
                 return Optional.of(ModuleInfoSourceParser.parse(in));
             }
-        } catch (IOException ignored) {
+        } catch (Exception ignored) {
             // it is not in sources, let's see if it got generated
         }
         // generated

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptTypeInfoFactory.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptTypeInfoFactory.java
@@ -255,7 +255,13 @@ public final class AptTypeInfoFactory extends TypeInfoFactoryBase {
                 .throwsChecked(thrownChecked)
                 .parameterArguments(params)
                 .originatingElement(v);
-        AptTypeFactory.createTypeName(v.getEnclosingElement()).ifPresent(builder::enclosingType);
+
+        // To be failure-tolerant, as the ECJ may not provide an enclosing element for a VariableElement.
+        Element enclosingElement = v.getEnclosingElement();
+        if (enclosingElement != null) {
+            AptTypeFactory.createTypeName(enclosingElement).ifPresent(builder::enclosingType);
+        }
+
         Optional.ofNullable(defaultValue).ifPresent(builder::defaultValue);
 
         return mapElement(ctx, builder.build());

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/FilerTextResourceImpl.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/FilerTextResourceImpl.java
@@ -76,7 +76,11 @@ class FilerTextResourceImpl implements FilerTextResource {
     public void write() {
         if (modified) {
             if (originalResource != null) {
-                originalResource.delete();
+                try {
+                    originalResource.delete();
+                } catch (Exception ignored) {
+                    // The resource cannot be deleted, e.g. because ECJ has not implemented this method.
+                }
             }
             try {
                 FileObject newResource = filer.createResource(StandardLocation.CLASS_OUTPUT,

--- a/config/metadata/processor/src/main/java/io/helidon/config/metadata/processor/ConfigMetadataHandler.java
+++ b/config/metadata/processor/src/main/java/io/helidon/config/metadata/processor/ConfigMetadataHandler.java
@@ -18,6 +18,9 @@ package io.helidon.config.metadata.processor;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -49,7 +52,7 @@ import static io.helidon.config.metadata.processor.UsedTypes.META_CONFIGURED;
 /*
  * This class is separated so javac correctly reports possible errors.
  */
-class  ConfigMetadataHandler {
+class ConfigMetadataHandler {
     /*
      * Configuration metadata file location.
      */
@@ -94,8 +97,7 @@ class  ConfigMetadataHandler {
             return doProcess(roundEnv);
         } catch (Exception e) {
             messager.printMessage(Diagnostic.Kind.ERROR, "Failed to process config metadata annotation processor. "
-                    + toMessage(e));
-            e.printStackTrace();
+                    + stackTraceAsString(e));
             return false;
         }
     }
@@ -210,7 +212,21 @@ class  ConfigMetadataHandler {
         }
     }
 
-    private String toMessage(Exception e) {
-        return e.getClass().getName() + ": " + e.getMessage();
+    @Retention(RetentionPolicy.CLASS)
+    private @interface SuppressFBWarnings {
+
+        String[] value() default {};
+
+        String justification() default "";
+    }
+
+    @SuppressFBWarnings(
+            value = "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE",
+            justification = "During compile time this isn't a problem.")
+    private static String stackTraceAsString(Throwable e) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        return sw.toString();
     }
 }


### PR DESCRIPTION
### Problem

I'm writing a HTTP feature for Helidon (related to #8897) and want to work with Eclipse IDE, but the Helidon annotation processors throw exceptions because the *Eclipse Compiler for Java* (ECJ) behaves slightly different compared to *javac*.

### Solution

Some changes were necessary to get the annotation processing going:
- Due to the implementation of [IdeFilerImpl:236](https://github.com/eclipse-jdt/eclipse.jdt.core/blob/7e0c89e8e422ceb8334eaaa84066fcad32ad6bf4/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/filer/IdeFilerImpl.java#L236) there is no handling for `javax.tools.StandardLocation.SOURCE_PATH` implemented and therefore the search for `module-info.java` fails with a thrown `IllegalArgumentException`. Ignoring this exception when compiling with the ECJ is fine.
- There is also a case where the ECJ cannot resolve a type name and the `Element` parameter is null. Returning an empty `Optional` enables the caller to fall back.
- Due to the implementation of [IdeInputFileObject:50](https://github.com/eclipse-jdt/eclipse.jdt.core/blob/e56c823649b351a74f287ec1479c9004ef6ed11f/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/filer/IdeInputFileObject.java#L50) the deletion of a `FileObject` throws an `IllegalStateException`. Ignoring any exception when compiling with the ECJ should be fine.

I have successfully tested the changes suggested by myself in a recent Eclipse IDE (`Version: 2024-06 (4.32.0)`) on my local computer.