### PR TITLE
4.x: Remove unnecessary field length from ContentLengthInputStream

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -304,7 +304,6 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
 
     static class ContentLengthInputStream extends InputStream {
         private final DataReader reader;
-        private final long length;
         private final Runnable entityProcessedRunnable;
         private final HelidonSocket socket;
 
@@ -319,7 +318,6 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                                  long length) {
             this.socket = socket;
             this.reader = reader;
-            this.length = length;
             this.remainingLength = length;
             // we can only get the response at the time of completion, as the instance is created after this constructor
             // returns


### PR DESCRIPTION
### Description
I've found the unnecessary field `length` in `ContentLengthInputStream`. There is the field `remainingLength` and it's used.
