### PR TITLE
4.x: Add post pr merge workflow to support continuous snapshot deployments

### DIFF
--- a/.github/workflows/pr-merge.yaml
+++ b/.github/workflows/pr-merge.yaml
@@ -1,0 +1,22 @@
+#
+# Workflow that runs on any push to main.
+
+name: "Post PR Merge"
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'helidon-*.x'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    uses: ./.github/workflows/validate.yml
+  snapshot:
+    # Run validation then deploy snapshot release
+    needs: validate
+    uses: ./.github/workflows/snapshotrelease.yml

--- a/.github/workflows/snapshotrelease.yaml
+++ b/.github/workflows/snapshotrelease.yaml
@@ -6,6 +6,7 @@ name: "Snapshot Release"
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 env:
   JAVA_VERSION: '21'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,9 @@
 
 name: "Validate"
 
-on: [pull_request, push]
+on:
+  pull_request:
+  workflow_call:
 
 env:
   JAVA_VERSION: '21'


### PR DESCRIPTION
### Description

Adds a post-pr-merge workflow that:

1. Runs validate
2. Deploys a snapshot build

This means we will deploy a snapshot release to https://oss.sonatype.org/content/repositories/snapshots/io/helidon/ every time a PR is merged.


### Documentation

No impact