### PR TITLE
@Provided -> @Provider typo fix

### DIFF
--- a/docs/src/main/asciidoc/mp/jaxrs/jaxrs-applications.adoc
+++ b/docs/src/main/asciidoc/mp/jaxrs/jaxrs-applications.adoc
@@ -63,7 +63,7 @@ If one or more `Application` subclasses are found, call the `getClasses` and `ge
 in each subclass using the collections in steps (2) and (3) only as defaults, i.e. if these methods
 both return empty sets.
 
-NOTE: Helidon treats `@Path` and `@Provided` as bean-defining annotations but, as stated above,
+NOTE: Helidon treats `@Path` and `@Provider` as bean-defining annotations but, as stated above,
 `Application` subclasses may require additional annotations depending on the discovery mode
 
 == Setting Application Path


### PR DESCRIPTION
### Description

IIUIC the note refers to https://jakarta.ee/specifications/platform/9/apidocs/jakarta/ws/rs/ext/provider as described in paragraph https://jakarta.ee/specifications/restful-ws/3.0/jakarta-restful-ws-spec-3.0#automatic_discovery
