### PR TITLE
4.x: Service registry OCI integration update

### DIFF
--- a/docs/src/main/asciidoc/config/io_helidon_integrations_oci_sdk_runtime_OciConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_integrations_oci_sdk_runtime_OciConfig.adoc
@@ -45,7 +45,7 @@ This is a standalone configuration type, prefix from configuration root: `oci`
 |key |type |default value |description
 
 |`auth-strategies` |string[&#93; (auto, config, config-file, instance-principals, resource-principal) |{nbsp} |The list of authentication strategies that will be attempted by
- com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider when one is
+ com.oracle.bmc.auth.BasicAuthenticationDetailsProvider when one is
  called for. This is only used if authStrategy() is not present.
 
 - `auto` - if present in the list, or if no value

--- a/integrations/oci/authentication/README.md
+++ b/integrations/oci/authentication/README.md
@@ -2,7 +2,7 @@
 
 OCI provides a few authentication methods that can be used when connecting to services.
 Available methods depend on where your client runs.
-Each method is represented through an `AbstractAuthenticationDetailsProvider` implementation
+Each method is represented through an `BasicAuthenticationDetailsProvider` implementation
 
 Helidon supports the following Authentication Methods:
 

--- a/integrations/oci/authentication/instance/src/main/java/io/helidon/integrations/oci/authentication/instance/AuthenticationMethodInstancePrincipal.java
+++ b/integrations/oci/authentication/instance/src/main/java/io/helidon/integrations/oci/authentication/instance/AuthenticationMethodInstancePrincipal.java
@@ -26,7 +26,7 @@ import io.helidon.integrations.oci.OciConfig;
 import io.helidon.integrations.oci.spi.OciAuthenticationMethod;
 import io.helidon.service.registry.Service;
 
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider.InstancePrincipalsAuthenticationDetailsProviderBuilder;
 
 /**
@@ -39,7 +39,7 @@ class AuthenticationMethodInstancePrincipal implements OciAuthenticationMethod {
     private static final System.Logger LOGGER = System.getLogger(AuthenticationMethodInstancePrincipal.class.getName());
     private static final String METHOD = "instance-principal";
 
-    private final LazyValue<Optional<AbstractAuthenticationDetailsProvider>> provider;
+    private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
     AuthenticationMethodInstancePrincipal(OciConfig config,
                                           InstancePrincipalsAuthenticationDetailsProviderBuilder builder) {
@@ -52,11 +52,11 @@ class AuthenticationMethodInstancePrincipal implements OciAuthenticationMethod {
     }
 
     @Override
-    public Optional<AbstractAuthenticationDetailsProvider> provider() {
+    public Optional<BasicAuthenticationDetailsProvider> provider() {
         return provider.get();
     }
 
-    private static LazyValue<Optional<AbstractAuthenticationDetailsProvider>>
+    private static LazyValue<Optional<BasicAuthenticationDetailsProvider>>
     createProvider(OciConfig config,
                    InstancePrincipalsAuthenticationDetailsProviderBuilder builder) {
         return LazyValue.create(() -> {

--- a/integrations/oci/authentication/instance/src/main/java/io/helidon/integrations/oci/authentication/instance/InstancePrincipalBuilderProvider.java
+++ b/integrations/oci/authentication/instance/src/main/java/io/helidon/integrations/oci/authentication/instance/InstancePrincipalBuilderProvider.java
@@ -42,6 +42,11 @@ class InstancePrincipalBuilderProvider implements Supplier<InstancePrincipalsAut
         var builder = InstancePrincipalsAuthenticationDetailsProvider.builder()
                 .timeoutForEachRetry((int) config.authenticationTimeout().toMillis());
 
+        config.imdsDetectRetries()
+                .ifPresent(builder::detectEndpointRetries);
+        config.federationEndpoint()
+                .map(URI::toString)
+                .ifPresent(builder::federationEndpoint);
         config.imdsBaseUri()
                 .map(URI::toString)
                 .ifPresent(builder::metadataBaseUrl);

--- a/integrations/oci/authentication/oke-workload/src/main/java/io/helidon/integrations/oci/authentication/okeworkload/AuthenticationMethodOkeWorkload.java
+++ b/integrations/oci/authentication/oke-workload/src/main/java/io/helidon/integrations/oci/authentication/okeworkload/AuthenticationMethodOkeWorkload.java
@@ -29,7 +29,7 @@ import io.helidon.integrations.oci.OciConfig;
 import io.helidon.integrations.oci.spi.OciAuthenticationMethod;
 import io.helidon.service.registry.Service;
 
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.okeworkloadidentity.OkeWorkloadIdentityAuthenticationDetailsProvider;
 
 /**
@@ -51,7 +51,7 @@ class AuthenticationMethodOkeWorkload implements OciAuthenticationMethod {
     private static final String SERVICE_ACCOUNT_CERT_PATH_DEFAULT = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
     private static final String SERVICE_ACCOUNT_CERT_PATH_ENV = "OCI_KUBERNETES_SERVICE_ACCOUNT_CERT_PATH";
 
-    private final LazyValue<Optional<AbstractAuthenticationDetailsProvider>> provider;
+    private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
     AuthenticationMethodOkeWorkload(OciConfig config) {
         provider = createProvider(config);
@@ -63,11 +63,11 @@ class AuthenticationMethodOkeWorkload implements OciAuthenticationMethod {
     }
 
     @Override
-    public Optional<AbstractAuthenticationDetailsProvider> provider() {
+    public Optional<BasicAuthenticationDetailsProvider> provider() {
         return provider.get();
     }
 
-    private static LazyValue<Optional<AbstractAuthenticationDetailsProvider>> createProvider(OciConfig config) {
+    private static LazyValue<Optional<BasicAuthenticationDetailsProvider>> createProvider(OciConfig config) {
         return LazyValue.create(() -> {
             if (available()) {
                 return Optional.of(OkeWorkloadIdentityAuthenticationDetailsProvider.builder()

--- a/integrations/oci/authentication/oke-workload/src/main/java/io/helidon/integrations/oci/authentication/okeworkload/OkeWorkloadBuilderProvider.java
+++ b/integrations/oci/authentication/oke-workload/src/main/java/io/helidon/integrations/oci/authentication/okeworkload/OkeWorkloadBuilderProvider.java
@@ -42,6 +42,11 @@ class OkeWorkloadBuilderProvider implements Supplier<OkeWorkloadIdentityAuthenti
         var builder = OkeWorkloadIdentityAuthenticationDetailsProvider.builder()
                 .timeoutForEachRetry((int) config.authenticationTimeout().toMillis());
 
+        config.imdsDetectRetries()
+                .ifPresent(builder::detectEndpointRetries);
+        config.federationEndpoint()
+                .map(URI::toString)
+                .ifPresent(builder::federationEndpoint);
         config.imdsBaseUri()
                 .map(URI::toString)
                 .ifPresent(builder::metadataBaseUrl);

--- a/integrations/oci/authentication/resource/src/main/java/io/helidon/integrations/oci/authentication/resource/AuthenticationMethodResourcePrincipal.java
+++ b/integrations/oci/authentication/resource/src/main/java/io/helidon/integrations/oci/authentication/resource/AuthenticationMethodResourcePrincipal.java
@@ -25,7 +25,7 @@ import io.helidon.common.Weighted;
 import io.helidon.integrations.oci.spi.OciAuthenticationMethod;
 import io.helidon.service.registry.Service;
 
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider.ResourcePrincipalAuthenticationDetailsProviderBuilder;
 
 /**
@@ -40,7 +40,7 @@ class AuthenticationMethodResourcePrincipal implements OciAuthenticationMethod {
 
 
 
-    private final LazyValue<Optional<AbstractAuthenticationDetailsProvider>> provider;
+    private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
     AuthenticationMethodResourcePrincipal(ResourcePrincipalAuthenticationDetailsProviderBuilder builder) {
         provider = createProvider(builder);
@@ -52,11 +52,11 @@ class AuthenticationMethodResourcePrincipal implements OciAuthenticationMethod {
     }
 
     @Override
-    public Optional<AbstractAuthenticationDetailsProvider> provider() {
+    public Optional<BasicAuthenticationDetailsProvider> provider() {
         return provider.get();
     }
 
-    private static LazyValue<Optional<AbstractAuthenticationDetailsProvider>>
+    private static LazyValue<Optional<BasicAuthenticationDetailsProvider>>
     createProvider(ResourcePrincipalAuthenticationDetailsProviderBuilder builder) {
 
         return LazyValue.create(() -> {

--- a/integrations/oci/authentication/resource/src/main/java/io/helidon/integrations/oci/authentication/resource/ResourcePrincipalBuilderProvider.java
+++ b/integrations/oci/authentication/resource/src/main/java/io/helidon/integrations/oci/authentication/resource/ResourcePrincipalBuilderProvider.java
@@ -42,6 +42,11 @@ class ResourcePrincipalBuilderProvider implements Supplier<ResourcePrincipalAuth
         var builder = ResourcePrincipalAuthenticationDetailsProvider.builder()
                 .timeoutForEachRetry((int) config.authenticationTimeout().toMillis());
 
+        config.imdsDetectRetries()
+                .ifPresent(builder::detectEndpointRetries);
+        config.federationEndpoint()
+                .map(URI::toString)
+                .ifPresent(builder::federationEndpoint);
         config.imdsBaseUri()
                 .map(URI::toString)
                 .ifPresent(builder::metadataBaseUrl);

--- a/integrations/oci/oci/README.md
+++ b/integrations/oci/oci/README.md
@@ -31,7 +31,7 @@ This module provides a few services that can be used by other modules.
 
 ## Authentication Details Provider
 
-Any service can have a dependency on `com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider`, and it can be
+Any service can have a dependency on `com.oracle.bmc.auth.BasicAuthenticationDetailsProvider`, and it can be
 looked up using Service Registry lookup methods.
 
 The provider is looked up by using instances of `io.helidon.integrations.oci.spi.OciAuthenticationMethod`. The first service instance to provide an authentication provider is used, and no other service instance is called.
@@ -47,7 +47,7 @@ The following out-of-the-box implementations exist:
 | Instance Principal | 60     | Principal of the compute instance                             | 
 
 To create a custom instance of authentication details provider, just create a new service for service registry
-with default or higher weight that provides an instance of the `AbstractAuthenticationDetailsProvider` 
+with default or higher weight that provides an instance of the `BasicAuthenticationDetailsProvider` 
 (ServiceRegistry requires setup of annotation processors, see this module's pom file).
 
 ## Authentication Details Provider Builders

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/AdpProvider.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/AdpProvider.java
@@ -26,23 +26,23 @@ import io.helidon.common.config.ConfigException;
 import io.helidon.integrations.oci.spi.OciAuthenticationMethod;
 import io.helidon.service.registry.Service;
 
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 
 @Service.Provider
-@Service.ExternalContracts(AbstractAuthenticationDetailsProvider.class)
-class AdpProvider implements Supplier<Optional<AbstractAuthenticationDetailsProvider>> {
+@Service.ExternalContracts(BasicAuthenticationDetailsProvider.class)
+class AdpProvider implements Supplier<Optional<BasicAuthenticationDetailsProvider>> {
 
-    private final LazyValue<Optional<AbstractAuthenticationDetailsProvider>> provider;
+    private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
     AdpProvider(OciConfig ociConfig, List<OciAuthenticationMethod> atnDetailsProviders) {
         String chosenAtnMethod = ociConfig.authenticationMethod();
-        LazyValue<Optional<AbstractAuthenticationDetailsProvider>> providerLazyValue = null;
+        LazyValue<Optional<BasicAuthenticationDetailsProvider>> providerLazyValue = null;
 
         if (OciConfigBlueprint.AUTHENTICATION_METHOD_AUTO.equals(chosenAtnMethod)) {
             // auto, chose from existing
             providerLazyValue = LazyValue.create(() -> {
                 for (OciAuthenticationMethod atnDetailsProvider : atnDetailsProviders) {
-                    Optional<AbstractAuthenticationDetailsProvider> provider = atnDetailsProvider.provider();
+                    Optional<BasicAuthenticationDetailsProvider> provider = atnDetailsProvider.provider();
                     if (provider.isPresent()) {
                         return provider;
                     }
@@ -71,11 +71,11 @@ class AdpProvider implements Supplier<Optional<AbstractAuthenticationDetailsProv
     }
 
     @Override
-    public Optional<AbstractAuthenticationDetailsProvider> get() {
+    public Optional<BasicAuthenticationDetailsProvider> get() {
         return provider.get();
     }
 
-    private Optional<AbstractAuthenticationDetailsProvider> toProvider(OciAuthenticationMethod atnDetailsProvider,
+    private Optional<BasicAuthenticationDetailsProvider> toProvider(OciAuthenticationMethod atnDetailsProvider,
                                                                        String chosenMethod) {
         return Optional.of(atnDetailsProvider.provider()
                                    .orElseThrow(() -> new ConfigException(

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/AuthenticationMethodConfig.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/AuthenticationMethodConfig.java
@@ -27,7 +27,7 @@ import io.helidon.integrations.oci.spi.OciAuthenticationMethod;
 import io.helidon.service.registry.Service;
 
 import com.oracle.bmc.Region;
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimplePrivateKeySupplier;
 
@@ -41,7 +41,7 @@ class AuthenticationMethodConfig implements OciAuthenticationMethod {
 
     private static final System.Logger LOGGER = System.getLogger(AuthenticationMethodConfig.class.getName());
 
-    private final LazyValue<Optional<AbstractAuthenticationDetailsProvider>> provider;
+    private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
     AuthenticationMethodConfig(OciConfig config) {
         provider = config.configMethodConfig()
@@ -63,11 +63,11 @@ class AuthenticationMethodConfig implements OciAuthenticationMethod {
     }
 
     @Override
-    public Optional<AbstractAuthenticationDetailsProvider> provider() {
+    public Optional<BasicAuthenticationDetailsProvider> provider() {
         return provider.get();
     }
 
-    private static AbstractAuthenticationDetailsProvider createProvider(ConfigMethodConfigBlueprint config) {
+    private static BasicAuthenticationDetailsProvider createProvider(ConfigMethodConfigBlueprint config) {
         Region region = Region.fromRegionCodeOrId(config.region());
 
         var builder = SimpleAuthenticationDetailsProvider.builder();

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/AuthenticationMethodConfigFile.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/AuthenticationMethodConfigFile.java
@@ -26,7 +26,7 @@ import io.helidon.integrations.oci.spi.OciAuthenticationMethod;
 import io.helidon.service.registry.Service;
 
 import com.oracle.bmc.ConfigFileReader;
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 
 /**
@@ -37,7 +37,7 @@ import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 class AuthenticationMethodConfigFile implements OciAuthenticationMethod {
     static final String METHOD = "config-file";
 
-    private final LazyValue<Optional<AbstractAuthenticationDetailsProvider>> provider;
+    private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
     AuthenticationMethodConfigFile(Supplier<Optional<ConfigFileReader.ConfigFile>> configFile) {
         provider = createProvider(configFile);
@@ -49,11 +49,11 @@ class AuthenticationMethodConfigFile implements OciAuthenticationMethod {
     }
 
     @Override
-    public Optional<AbstractAuthenticationDetailsProvider> provider() {
+    public Optional<BasicAuthenticationDetailsProvider> provider() {
         return provider.get();
     }
 
-    private static LazyValue<Optional<AbstractAuthenticationDetailsProvider>>
+    private static LazyValue<Optional<BasicAuthenticationDetailsProvider>>
     createProvider(Supplier<Optional<ConfigFileReader.ConfigFile>> configFileSupplier) {
 
         return LazyValue.create(() -> configFileSupplier.get()

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/AuthenticationMethodSessionToken.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/AuthenticationMethodSessionToken.java
@@ -28,7 +28,7 @@ import io.helidon.integrations.oci.spi.OciAuthenticationMethod;
 import io.helidon.service.registry.Service;
 
 import com.oracle.bmc.ConfigFileReader;
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SessionTokenAuthenticationDetailsProvider.SessionTokenAuthenticationDetailsProviderBuilder;
 
 /**
@@ -42,7 +42,7 @@ class AuthenticationMethodSessionToken implements OciAuthenticationMethod {
 
     private static final System.Logger LOGGER = System.getLogger(AuthenticationMethodSessionToken.class.getName());
 
-    private final LazyValue<Optional<AbstractAuthenticationDetailsProvider>> provider;
+    private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
     AuthenticationMethodSessionToken(OciConfig config,
                                      Supplier<Optional<ConfigFileReader.ConfigFile>> configFileSupplier,
@@ -56,11 +56,11 @@ class AuthenticationMethodSessionToken implements OciAuthenticationMethod {
     }
 
     @Override
-    public Optional<AbstractAuthenticationDetailsProvider> provider() {
+    public Optional<BasicAuthenticationDetailsProvider> provider() {
         return provider.get();
     }
 
-    private static Optional<AbstractAuthenticationDetailsProvider>
+    private static Optional<BasicAuthenticationDetailsProvider>
     createProvider(OciConfig config,
                    Supplier<Optional<ConfigFileReader.ConfigFile>> configFileSupplier,
                    Supplier<SessionTokenAuthenticationDetailsProviderBuilder> builder) {

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigBlueprint.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigBlueprint.java
@@ -137,6 +137,13 @@ interface OciConfigBlueprint {
     Optional<URI> imdsBaseUri();
 
     /**
+     * Customize the number of retries to contact IMDS service.
+     *
+     * @return number of retries, each provider has its own defaults
+     */
+    Optional<Integer> imdsDetectRetries();
+
+    /**
      * Timeout of authentication operations, where applicable.
      * This is a timeout for each operation (if there are retries, each timeout will be this duration).
      * Defaults to 10 seconds.
@@ -146,6 +153,13 @@ interface OciConfigBlueprint {
     @Option.Configured
     @Option.Default("PT10S")
     Duration authenticationTimeout();
+
+    /**
+     * Customization of federation endpoint for authentication providers.
+     *
+     * @return custom federation endpoint URI
+     */
+    Optional<URI> federationEndpoint();
 
     /**
      * Get the config used to update the builder.

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/RegionProviderAuthenticationMethod.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/RegionProviderAuthenticationMethod.java
@@ -26,7 +26,7 @@ import io.helidon.integrations.oci.spi.OciRegion;
 import io.helidon.service.registry.Service;
 
 import com.oracle.bmc.Region;
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.RegionProvider;
 
 /**
@@ -38,7 +38,7 @@ import com.oracle.bmc.auth.RegionProvider;
 class RegionProviderAuthenticationMethod implements OciRegion {
     private final LazyValue<Optional<Region>> region;
 
-    RegionProviderAuthenticationMethod(Supplier<Optional<AbstractAuthenticationDetailsProvider>> atnProvider) {
+    RegionProviderAuthenticationMethod(Supplier<Optional<BasicAuthenticationDetailsProvider>> atnProvider) {
 
         this.region = LazyValue.create(() -> {
             var provider = atnProvider.get();

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/spi/OciAuthenticationMethod.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/spi/OciAuthenticationMethod.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import io.helidon.service.registry.Service;
 
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 
 /**
  * An OCI Authentication Details Provider service contract.
@@ -45,10 +45,10 @@ public interface OciAuthenticationMethod {
     String method();
 
     /**
-     * Provide an instance of the {@link com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider} to be used
+     * Provide an instance of the {@link com.oracle.bmc.auth.BasicAuthenticationDetailsProvider} to be used
      * by other services.
      *
      * @return authentication details provider, or empty if nothing can be provided
      */
-    Optional<AbstractAuthenticationDetailsProvider> provider();
+    Optional<BasicAuthenticationDetailsProvider> provider();
 }

--- a/integrations/oci/oci/src/main/java/module-info.java
+++ b/integrations/oci/oci/src/main/java/module-info.java
@@ -17,7 +17,7 @@
 /**
  * OCI integration module using Helidon Service Registry.
  * This core module provides services for {@link com.oracle.bmc.Region} and
- * {@link com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider}.
+ * {@link com.oracle.bmc.auth.BasicAuthenticationDetailsProvider}.
  * <p>
  * The module does not require {@link io.helidon.common.config.Config} service to be available, as it is considered
  * a prerequisite for possible config sources.

--- a/integrations/oci/oci/src/test/java/io/helidon/integrations/oci/OciIntegrationTest.java
+++ b/integrations/oci/oci/src/test/java/io/helidon/integrations/oci/OciIntegrationTest.java
@@ -26,7 +26,7 @@ import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
 
 import com.oracle.bmc.Region;
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import org.junit.jupiter.api.AfterEach;
@@ -79,7 +79,7 @@ class OciIntegrationTest {
         assertThat(method.provider(), optionalEmpty());
 
         assertThat(registry.first(Region.class), is(Optional.empty()));
-        assertThat(registry.first(AbstractAuthenticationDetailsProvider.class), is(Optional.empty()));
+        assertThat(registry.first(BasicAuthenticationDetailsProvider.class), is(Optional.empty()));
     }
 
     @Test
@@ -124,7 +124,7 @@ class OciIntegrationTest {
         assertThat(method.method(), is(AuthenticationMethodConfigFile.METHOD));
         assertThat(method.provider(), optionalEmpty());
 
-        AbstractAuthenticationDetailsProvider provider = registry.get(AbstractAuthenticationDetailsProvider.class);
+        BasicAuthenticationDetailsProvider provider = registry.get(BasicAuthenticationDetailsProvider.class);
 
         assertThat(provider, instanceOf(SimpleAuthenticationDetailsProvider.class));
         SimpleAuthenticationDetailsProvider auth = (SimpleAuthenticationDetailsProvider) provider;
@@ -159,7 +159,7 @@ class OciIntegrationTest {
         assertThat(method.method(), is(AuthenticationMethodConfigFile.METHOD));
         assertThat(method.provider(), not(Optional.empty()));
 
-        AbstractAuthenticationDetailsProvider provider = registry.get(AbstractAuthenticationDetailsProvider.class);
+        BasicAuthenticationDetailsProvider provider = registry.get(BasicAuthenticationDetailsProvider.class);
 
         assertThat(provider, instanceOf(ConfigFileAuthenticationDetailsProvider.class));
         ConfigFileAuthenticationDetailsProvider auth = (ConfigFileAuthenticationDetailsProvider) provider;

--- a/integrations/oci/tests/authentication/src/test/java/io/helidon/integrations/oci/AuthenticationDetailsProvidersTest.java
+++ b/integrations/oci/tests/authentication/src/test/java/io/helidon/integrations/oci/AuthenticationDetailsProvidersTest.java
@@ -27,7 +27,7 @@ import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
 
 import com.oracle.bmc.Region;
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import org.junit.jupiter.api.AfterEach;
@@ -95,7 +95,7 @@ class AuthenticationDetailsProvidersTest {
         assertThat(atnMethod.provider(), optionalEmpty());
 
         assertThat(registry.first(Region.class), is(Optional.empty()));
-        assertThat(registry.first(AbstractAuthenticationDetailsProvider.class), is(Optional.empty()));
+        assertThat(registry.first(BasicAuthenticationDetailsProvider.class), is(Optional.empty()));
     }
 
     @Test
@@ -148,7 +148,7 @@ class AuthenticationDetailsProvidersTest {
         assertThat(atnMethod.method(), is("resource-principal"));
         assertThat(atnMethod.provider(), optionalEmpty());
 
-        AbstractAuthenticationDetailsProvider provider = registry.get(AbstractAuthenticationDetailsProvider.class);
+        BasicAuthenticationDetailsProvider provider = registry.get(BasicAuthenticationDetailsProvider.class);
 
         assertThat(provider, instanceOf(SimpleAuthenticationDetailsProvider.class));
         SimpleAuthenticationDetailsProvider auth = (SimpleAuthenticationDetailsProvider) provider;
@@ -191,7 +191,7 @@ class AuthenticationDetailsProvidersTest {
         assertThat(atnMethod.method(), is("resource-principal"));
         assertThat(atnMethod.provider(), optionalEmpty());
 
-        AbstractAuthenticationDetailsProvider provider = registry.get(AbstractAuthenticationDetailsProvider.class);
+        BasicAuthenticationDetailsProvider provider = registry.get(BasicAuthenticationDetailsProvider.class);
 
         assertThat(provider, instanceOf(ConfigFileAuthenticationDetailsProvider.class));
         ConfigFileAuthenticationDetailsProvider auth = (ConfigFileAuthenticationDetailsProvider) provider;


### PR DESCRIPTION
Additional configuration for metadata based authentication details providers:
- federation endpoint
- detect endpoint retries

Use `BasicAuthenticationDetailsProvider` instead of `Abstract`, as that is required by OCI APIs.
