### PR TITLE
4.x: SSE mediaType comes null after first consumed event

### DIFF
--- a/webclient/sse/src/main/java/io/helidon/webclient/sse/SseSourceHandlerProvider.java
+++ b/webclient/sse/src/main/java/io/helidon/webclient/sse/SseSourceHandlerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class SseSourceHandlerProvider implements SourceHandlerProvider<SseEvent>
                         sseBuilder.data(data.toString());
                         source.onEvent(sseBuilder.build());
                         data.setLength(0);
-                        sseBuilder = SseEvent.builder();
+                        sseBuilder = SseEvent.builder().mediaContext(mediaContext);
                         emit = false;
                     }
                     continue;


### PR DESCRIPTION
### Description
Events with media type are throwing exception after the first is sent. The reason is that there is one workflow that creates a new builder and forgets about the mediaType.

```
2024.06.28 15:09:45 INFO io.helidon.ai.integration.Main !thread!: Response is: 
Exception in thread "main" java.lang.IllegalStateException: Media context has not been set on this event
	at io.helidon.http.sse.SseEvent.data(SseEvent.java:125)
	at io.helidon.http.sse.SseEvent.data(SseEvent.java:153)
	at io.helidon.ai.openai.OpenAIStreamingChatModel$1.onEvent(OpenAIStreamingChatModel.java:71)
	at io.helidon.ai.openai.OpenAIStreamingChatModel$1.onEvent(OpenAIStreamingChatModel.java:68)
	at io.helidon.webclient.sse.SseSourceHandlerProvider.handle(SseSourceHandlerProvider.java:72)
	at io.helidon.webclient.http1.Http1ClientResponseImpl.source(Http1ClientResponseImpl.java:173)
	at io.helidon.ai.openai.OpenAIStreamingChatModel.call(OpenAIStreamingChatModel.java:68)
	at io.helidon.ai.integration.Main.openAIStreamingChatModel(Main.java:86)
	at io.helidon.ai.integration.Main.main(Main.java:58)
```

### Documentation

N/A
