### PR TITLE
4.x pr merge workflow concurrency

### DIFF
--- a/.github/workflows/pr-merge.yaml
+++ b/.github/workflows/pr-merge.yaml
@@ -17,6 +17,5 @@ jobs:
   validate:
     uses: ./.github/workflows/validate.yml
   snapshot:
-    # Run validation then deploy snapshot release
     needs: validate
     uses: ./.github/workflows/snapshotrelease.yaml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ env:
   MAVEN_HTTP_ARGS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3'
 
 concurrency:
-  group: validate-${{ github.ref }}
+  group: Validate-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ env:
   MAVEN_HTTP_ARGS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 -Dmaven.wagon.http.retryHandler.count=3'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: validate-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Description

Fix concurrency issue with pr-merge workflow by hardcoding validate's workflow name. This is because  github.workflow  is inherited from calling workflows and can result in errors like:

```

Canceling since a deadlock for concurrency group 'Post PR Merge-refs/heads/main' was detected between 'top level workflow' and 'validate'

```

