### PR TITLE
4.x: Oci integration fixes

### DIFF
--- a/integrations/oci/oci/pom.xml
+++ b/integrations/oci/oci/pom.xml
@@ -44,13 +44,17 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.oracle.oci.sdk</groupId>
             <artifactId>oci-java-sdk-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml</artifactId>
-            <scope>test</scope>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.testing</groupId>

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/HelidonOci.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/HelidonOci.java
@@ -44,7 +44,7 @@ public final class HelidonOci {
         try {
             if (InetAddress.getByName(config.imdsBaseUri().map(URI::getHost).orElse(IMDS_HOSTNAME))
                     .isReachable((int) timeout.toMillis())) {
-                return RegionProviderSdk.regionFromImds(config) != null;
+                return RegionProviderSdk.regionFromImdsDirect(config) != null;
             }
             return false;
         } catch (IOException e) {

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigBlueprint.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigBlueprint.java
@@ -141,6 +141,7 @@ interface OciConfigBlueprint {
      *
      * @return number of retries, each provider has its own defaults
      */
+    @Option.Configured
     Optional<Integer> imdsDetectRetries();
 
     /**

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigSupport.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigSupport.java
@@ -16,6 +16,8 @@
 
 package io.helidon.integrations.oci;
 
+import java.net.URI;
+
 import io.helidon.builder.api.Prototype;
 import io.helidon.common.config.Config;
 
@@ -28,6 +30,8 @@ final class OciConfigSupport {
     // we do not use the constant, as it is marked as internal, and we only need the IP address anyway
     // see com.oracle.bmc.auth.AbstractFederationClientAuthenticationDetailsProviderBuilder.METADATA_SERVICE_BASE_URL
     static final String IMDS_HOSTNAME = "169.254.169.254";
+    @SuppressWarnings("HttpUrlsUsage") // this is a known endpoint available only on OCI instances
+    static final URI IMDS_URI = URI.create("http://" + IMDS_HOSTNAME + "/opc/v2/");
 
     private OciConfigSupport() {
     }

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/RegionProviderSdk.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/RegionProviderSdk.java
@@ -43,16 +43,22 @@ class RegionProviderSdk implements OciRegion {
      */
     static Region regionFromImds(OciConfig ociConfig) {
         if (HelidonOci.imdsAvailable(ociConfig)) {
-            Optional<URI> uri = ociConfig.imdsBaseUri();
-            return uri.map(URI::toString)
-                    .map(Region::getRegionFromImds)
-                    .orElseGet(() -> {
-                        Region.registerFromInstanceMetadataService();
-                        return Region.getRegionFromImds();
-                    });
-
+            return regionFromImdsDirect(ociConfig);
         }
         return null;
+    }
+
+    /**
+     * Only called when we know imds is available.
+     */
+    static Region regionFromImdsDirect(OciConfig ociConfig) {
+        Optional<URI> uri = ociConfig.imdsBaseUri();
+        return uri.map(URI::toString)
+                .map(Region::getRegionFromImds)
+                .orElseGet(() -> {
+                    Region.registerFromInstanceMetadataService();
+                    return Region.getRegionFromImds();
+                });
     }
 
     @Override

--- a/integrations/oci/oci/src/main/java/module-info.java
+++ b/integrations/oci/oci/src/main/java/module-info.java
@@ -49,6 +49,7 @@ module io.helidon.integrations.oci {
     requires io.helidon.service.registry;
     requires io.helidon.common.config;
     requires io.helidon.config;
+    requires io.helidon.webclient;
 
     requires oci.java.sdk.common;
     requires vavr;


### PR DESCRIPTION
Fixed missed configured option in OciConfig.
Using a custom webclient request to check if IMDS endpoint is valid (as the default that used Region discovery has hardcoded 7 retries and increasing delays between them).
Added config-yaml as a runtime dependency, as without it the OCI configuration does not work.