### PR TITLE
Ensures endpoint LRU cache is properly shared in HttpClientRequest

### DIFF
--- a/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
+++ b/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,12 @@ import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Metrics;
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -81,6 +81,16 @@ public class ClientMainTest {
 
     @Test
     @Order(1)
+    public void testMetricsExample() {
+        String counterName = "example.metric.GET.localhost";
+        Counter counter = METRIC_REGISTRY.getOrCreate(Counter.builder(counterName));
+        assertThat("Counter " + counterName + " has not been 0", counter.count(), is(0L));
+        ClientMain.clientMetricsExample("http://localhost:" + server.port() + "/greet", Config.create());
+        assertThat("Counter " + counterName + " " + "has not been 1", counter.count(), is(1L));
+    }
+
+    @Test
+    @Order(2)
     public void testPerformRedirect() {
         WebClient client = client();
         String greeting = ClientMain.followRedirects(client);
@@ -88,22 +98,12 @@ public class ClientMainTest {
     }
 
     @Test
-    @Order(2)
+    @Order(3)
     public void testFileDownload() throws IOException {
         WebClient client = client();
         ClientMain.saveResponseToFile(client);
         assertThat(Files.exists(testFile), is(true));
         assertThat(Files.readString(testFile), is("{\"message\":\"Hello World!\"}"));
-    }
-
-    @Test
-    @Order(3)
-    public void testMetricsExample() {
-        String counterName = "example.metric.GET.localhost";
-        Counter counter = METRIC_REGISTRY.getOrCreate(Counter.builder(counterName));
-        assertThat("Counter " + counterName + " has not been 0", counter.count(), is(0L));
-        ClientMain.clientMetricsExample("http://localhost:" + server.port() + "/greet", Config.create());
-        assertThat("Counter " + counterName + " " + "has not been 1", counter.count(), is(1L));
     }
 
     @Test

--- a/webclient/api/pom.xml
+++ b/webclient/api/pom.xml
@@ -97,6 +97,11 @@
             <artifactId>helidon-common-testing-http-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientRequestTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/HttpClientRequestTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.api;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Optional;
+
+import io.helidon.common.socket.SocketOptions;
+import io.helidon.http.Method;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class HttpClientRequestTest {
+
+    @Test
+    void testCacheSharing() {
+        HttpClientRequest req1 = mockHttpClientRequest();
+        HttpClientRequest req2 = mockHttpClientRequest();
+        assertThat(req1.clientSpiLruCache(), is(sameInstance(req2.clientSpiLruCache())));
+    }
+
+    private HttpClientRequest mockHttpClientRequest() {
+        WebClient webClient = Mockito.mock(WebClient.class);
+        WebClientConfig webClientConfig = Mockito.mock(WebClientConfig.class);
+        Mockito.when(webClientConfig.readTimeout()).thenReturn(Optional.empty());
+        Mockito.when(webClientConfig.socketOptions()).thenReturn(Mockito.mock(SocketOptions.class));
+        ClientUri clientUri = ClientUri.create(URI.create("http://localhost"));
+        return new HttpClientRequest(webClient,
+                                     webClientConfig,
+                                     Method.GET,
+                                     clientUri,
+                                     Collections.emptyMap(),
+                                     Collections.emptyList(),
+                                     Collections.emptyList(),
+                                     Collections.emptyList());
+    }
+}

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HeadersClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HeadersClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import io.helidon.logging.common.LogConfig;
 import io.helidon.webclient.api.HttpClientRequest;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http1.Http1Client;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.Http2Settings;
@@ -150,6 +151,7 @@ class HeadersClientTest {
     @Test
     public void testInvalidTextContentTypeStrict() {
         try (HttpClientResponse res = CLIENT.method(Method.GET)
+                .protocolId(Http1Client.PROTOCOL_ID)
                 .path("/test/invalidTextContentType")
                 .request()) {
             assertThat(res.status(), is(Status.OK_200));
@@ -172,6 +174,7 @@ class HeadersClientTest {
                 .mediaTypeParserMode(ParserMode.RELAXED)
                 .build();
         try (HttpClientResponse res = client.method(Method.GET)
+                .protocolId(Http1Client.PROTOCOL_ID)
                 .path("/test/invalidTextContentType")
                 .request()) {
             assertThat(res.status(), is(Status.OK_200));


### PR DESCRIPTION
### Description

Ensures endpoint LRU cache is properly shared among instances of HttpClientRequest. Fixes issue #8930.

### Documentation

None
