### PR TITLE
4.x: Use Hamcrest assertions instead of JUnit in dbclient/mongodb  (#1749)

### DIFF
--- a/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/StatementParsersTest.java
+++ b/dbclient/mongodb/src/test/java/io/helidon/dbclient/mongodb/StatementParsersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import io.helidon.dbclient.mongodb.StatementParsers.NamedParser;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit test for {@link StatementParsers}.
@@ -44,7 +45,7 @@ public class StatementParsersTest {
                 .replace("$idmax", String.valueOf(mapping.get("idmax")));
         NamedParser parser = new NamedParser(stmtIn, mapping);
         String stmtOut = parser.convert();
-        assertEquals(stmtExp, stmtOut);
+        assertThat(stmtOut, is(stmtExp));
     }
 
 }


### PR DESCRIPTION
### Description
Part of #1749 