### PR TITLE
[4.x] Server TLS - Add path key description

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ mvn validate  -Pcopyright
 $ mvn verify  -Pspotbugs
 ```
 
-**Documentatonn**
+**Documentation**
 
 ```bash
 # At the root of the project

--- a/docs/src/main/asciidoc/mp/server.adoc
+++ b/docs/src/main/asciidoc/mp/server.adoc
@@ -183,14 +183,18 @@ server:
         passphrase: "password"
         trust-store: true
         resource:
-          resource-path: "keystore.p12"
+          # load from classpath
+          resource-path: "keystore.p12" # <1>
     #Keystore with private key and server certificate
     private-key:
       keystore:
         passphrase: "password"
         resource:
-          resource-path: "keystore.p12"
+          # load from file system
+          path: "/path/to/keystore.p12" # <2>
 ----
+<1> File loaded from the classpath.
+<2> File loaded from the file system.
 
 === Configuring additional ports [[conf-additional-ports]]
 

--- a/docs/src/main/asciidoc/se/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver.adoc
@@ -129,14 +129,19 @@ server:
         passphrase: "password"
         trust-store: true
         resource:
-          resource-path: "keystore.p12"
+          # load from classpath
+          resource-path: "keystore.p12" # <1>
     # Keystore with private key and server certificate
     private-key:
       keystore:
         passphrase: "password"
         resource:
-          resource-path: "keystore.p12"
+          # load from file system
+          path: "/path/to/keystore.p12" # <2>
 ----
+<1> File loaded from classpath
+<2> File loaded from file system
+
 Then, in your application code, load the configuration from that file.
 
 [source,java]

--- a/docs/src/main/asciidoc/se/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver.adoc
@@ -139,8 +139,8 @@ server:
           # load from file system
           path: "/path/to/keystore.p12" # <2>
 ----
-<1> File loaded from classpath
-<2> File loaded from file system
+<1> File loaded from classpath.
+<2> File loaded from file system.
 
 Then, in your application code, load the configuration from that file.
 


### PR DESCRIPTION
### Description

fix #8926

Add description for keystore `path` resource key.

### Documentation

Updated into this PR.
