### PR TITLE
4.x: Methods to retrieve optional typed entity

### DIFF
--- a/http/media/media/src/main/java/io/helidon/http/media/ReadableEntity.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/ReadableEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.http.media;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 
 import io.helidon.common.GenericType;
 
@@ -30,6 +31,7 @@ public interface ReadableEntity {
     /**
      * Input stream to read bytes of the entity.
      * Cannot be combined with methods {@link #as(Class)} or {@link #as(io.helidon.common.GenericType)}
+     * If there is no entity, returns input stream on empty byte array.
      *
      * @return input stream to entity bytes
      */
@@ -42,11 +44,26 @@ public interface ReadableEntity {
      * @param type class of the entity
      * @param <T>  type of the entity
      * @return entity correctly typed
-     * @throws IllegalArgumentException     in case the entity type is not supported
-     * @throws java.io.UncheckedIOException in case I/O fails
+     * @throws IllegalArgumentException        in case the entity type is not supported
+     * @throws java.lang.IllegalStateException in case there is no entity
+     * @throws java.io.UncheckedIOException    in case I/O fails
      */
     default <T> T as(Class<T> type) {
         return as(GenericType.create(type));
+    }
+
+    /**
+     * Get the entity as a specific class (optional).
+     * The entity will use {@link MediaContext} to find correct media mapper.
+     *
+     * @param type class of the entity
+     * @param <T>  type of the entity
+     * @return entity correctly typed, or an empty optional if entity is not present
+     * @throws IllegalArgumentException     in case the entity type is not supported
+     * @throws java.io.UncheckedIOException in case I/O fails
+     */
+    default <T> Optional<T> asOptional(Class<T> type) {
+        return asOptional(GenericType.create(type));
     }
 
     /**
@@ -56,10 +73,23 @@ public interface ReadableEntity {
      * @param type generic type of the entity
      * @param <T>  type of the entity
      * @return entity correctly typed
+     * @throws IllegalArgumentException        in case the entity type is not supported
+     * @throws java.lang.IllegalStateException in case there is no entity
+     * @throws java.io.UncheckedIOException    in case I/O fails
+     */
+    <T> T as(GenericType<T> type);
+
+    /**
+     * Get the entity as a specific type (optional).
+     * The entity will use {@link MediaContext} to find correct media mapper.
+     *
+     * @param type generic type of the entity
+     * @param <T>  type of the entity
+     * @return entity correctly typed, or an empty optional if entity is not present
      * @throws IllegalArgumentException     in case the entity type is not supported
      * @throws java.io.UncheckedIOException in case I/O fails
      */
-    <T> T as(GenericType<T> type);
+    <T> Optional<T> asOptional(GenericType<T> type);
 
     /**
      * Whether an entity actually exists.

--- a/http/media/media/src/main/java/io/helidon/http/media/ReadableEntityBase.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/ReadableEntityBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -109,6 +110,14 @@ public abstract class ReadableEntityBase implements ReadableEntity {
     @Override
     public final <T> T as(GenericType<T> type) {
         return entityAs(type);
+    }
+
+    @Override
+    public <T> Optional<T> asOptional(GenericType<T> type) {
+        if (hasEntity()) {
+            return Optional.of(entityAs(type));
+        }
+        return Optional.empty();
     }
 
     @Override
@@ -258,6 +267,11 @@ public abstract class ReadableEntityBase implements ReadableEntity {
         @Override
         public <T> T as(GenericType<T> type) {
             throw new IllegalStateException("No entity");
+        }
+
+        @Override
+        public <T> Optional<T> asOptional(GenericType<T> type) {
+            return Optional.empty();
         }
 
         @Override

--- a/http/media/multipart/src/main/java/io/helidon/http/media/multipart/ReadablePartAbstract.java
+++ b/http/media/multipart/src/main/java/io/helidon/http/media/multipart/ReadablePartAbstract.java
@@ -18,6 +18,7 @@ package io.helidon.http.media.multipart;
 
 import java.util.Optional;
 
+import io.helidon.common.GenericType;
 import io.helidon.http.ContentDisposition;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
@@ -74,6 +75,13 @@ abstract class ReadablePartAbstract implements ReadablePart {
     @Override
     public boolean hasEntity() {
         return true;
+    }
+
+
+    @Override
+    public <T> Optional<T> asOptional(GenericType<T> type) {
+        // there is always an entity (see #hasEntity())
+        return Optional.of(as(type));
     }
 
     protected abstract void finish();

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/EntityTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/EntityTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests;
+
+import io.helidon.common.GenericType;
+import io.helidon.http.Status;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/*
+Test that methods on entity work as expected.
+ */
+@ServerTest
+class EntityTest {
+    private final Http1Client client;
+
+    EntityTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        LogConfig.configureRuntime();
+
+        rules.get("/noContent", EntityTest::noContent)
+                .get("/content", EntityTest::content);
+    }
+
+    @Test
+    void testContentAsClassContent() {
+        try (Http1ClientResponse response = client.get("/content")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().as(String.class), is("OK"));
+        }
+    }
+
+    @Test
+    void testContentAsClassContentOptional() {
+        try (Http1ClientResponse response = client.get("/content")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().asOptional(String.class), optionalValue(is("OK")));
+        }
+    }
+
+    @Test
+    void testContentAsGenericTypeContent() {
+        try (Http1ClientResponse response = client.get("/content")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().as(GenericType.STRING), is("OK"));
+        }
+    }
+
+    @Test
+    void testContentAsGenericTypeContentOptional() {
+        try (Http1ClientResponse response = client.get("/content")
+                .request()) {
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().asOptional(GenericType.STRING), optionalValue(is("OK")));
+        }
+    }
+
+    @Test
+    void testContentAsClassNoContent() {
+        try (Http1ClientResponse response = client.get("/noContent")
+                .request()) {
+
+            assertThat(response.status(), is(Status.NO_CONTENT_204));
+            assertThrows(IllegalStateException.class, () -> response.entity().as(String.class));
+        }
+    }
+
+    @Test
+    void testContentAsClassNoContentOptional() {
+        try (Http1ClientResponse response = client.get("/noContent")
+                .request()) {
+
+            assertThat(response.status(), is(Status.NO_CONTENT_204));
+            assertThat(response.entity().asOptional(String.class), optionalEmpty());
+        }
+    }
+
+    @Test
+    void testContentAsGenericTypeNoContent() {
+        try (Http1ClientResponse response = client.get("/noContent")
+                .request()) {
+
+            assertThat(response.status(), is(Status.NO_CONTENT_204));
+            assertThrows(IllegalStateException.class, () -> response.entity().as(GenericType.STRING));
+        }
+    }
+
+    @Test
+    void testContentAsGenericTypeNoContentOptional() {
+        try (Http1ClientResponse response = client.get("/noContent")
+                .request()) {
+
+            assertThat(response.status(), is(Status.NO_CONTENT_204));
+            assertThat(response.entity().asOptional(GenericType.STRING), optionalEmpty());
+        }
+    }
+
+    private static void content(ServerRequest req, ServerResponse res) {
+        res.status(Status.OK_200).send("OK");
+    }
+
+    private static void noContent(ServerRequest req, ServerResponse res) {
+        res.status(Status.NO_CONTENT_204).send();
+    }
+
+}
+


### PR DESCRIPTION
Resolves #8827 

Provide entity methods that return optional (empty if there is no entity)
Updated javadoc that was not aligned with behavior (behavior is correct) 
Added test

