### PR TITLE
4.x: Remove unnecessary fields from Http1ClientResponseImpl

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,8 +211,7 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
                     return null;
                 });
 
-        return new Http1ClientResponseImpl(clientConfig(),
-                                           http1Client().protocolConfig(),
+        return new Http1ClientResponseImpl(http1Client().protocolConfig(),
                                            serviceResponse.status(),
                                            serviceResponse.serviceRequest().headers(),
                                            serviceResponse.headers(),

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -29,7 +29,6 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
-import io.helidon.common.media.type.ParserMode;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.ClientResponseTrailers;


### PR DESCRIPTION
### Description
I've found some unnecessary fields in `Http1ClientResponseImpl`. It's not a public class and these fields can be removed without breaking compatibility.
<img width="763" alt="Screenshot 2024-07-07 at 17 11 36" src="https://github.com/helidon-io/helidon/assets/4740207/b4f94391-d453-4f73-b996-823af7b4a249">
