### PR TITLE
Makes SocketContext available to a WsSession

### DIFF
--- a/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusConnection.java
+++ b/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.concurrent.Semaphore;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.socket.SocketContext;
 import io.helidon.http.DateTime;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.spi.ServerConnection;
@@ -128,6 +129,11 @@ class TyrusConnection implements ServerConnection, WsSession {
     @Override
     public Optional<String> subProtocol() {
         return Optional.empty();
+    }
+
+    @Override
+    public SocketContext socketContext() {
+        return ctx;
     }
 
     @Override

--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/ClientWsConnection.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/ClientWsConnection.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.socket.SocketContext;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.websocket.ClientWsFrame;
 import io.helidon.websocket.ServerWsFrame;
@@ -167,6 +168,11 @@ public class ClientWsConnection implements WsSession, Runnable {
     @Override
     public Optional<String> subProtocol() {
         return Optional.ofNullable(subProtocol);
+    }
+
+    @Override
+    public SocketContext socketContext() {
+        return helidonSocket;
     }
 
     private ClientWsConnection send(ClientWsFrame frame) {

--- a/webserver/tests/websocket/src/main/java/io/helidon/webserver/tests/websocket/EchoService.java
+++ b/webserver/tests/websocket/src/main/java/io/helidon/webserver/tests/websocket/EchoService.java
@@ -40,6 +40,9 @@ class EchoService implements WsListener {
         if (subProtocol != null && !subProtocol.equals(p)) {
             throw new InternalError("Invalid sub-protocol in session");
         }
+        if (session.socketContext().remotePeer() == null) {
+            throw new InternalError("Unable to access remote peer info");
+        }
     }
 
     @Override

--- a/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketClientTest.java
+++ b/webserver/tests/websocket/src/test/java/io/helidon/webserver/tests/websocket/WebSocketClientTest.java
@@ -88,6 +88,9 @@ public class WebSocketClientTest {
 
             @Override
             public void onOpen(WsSession session) {
+                if (session.socketContext().remotePeer() == null) {
+                    throw new InternalError("Unable to access remote peer info");
+                }
                 for (String s : text) {
                     session.send(s, false);
                 }

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Semaphore;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.socket.SocketContext;
 import io.helidon.http.DateTime;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
@@ -198,6 +199,11 @@ public class WsConnection implements ServerConnection, WsSession {
     @Override
     public Optional<String> subProtocol() {
         return upgradeHeaders.first(WsUpgrader.PROTOCOL);
+    }
+
+    @Override
+    public SocketContext socketContext() {
+        return ctx;
     }
 
     @Override

--- a/websocket/src/main/java/io/helidon/websocket/WsSession.java
+++ b/websocket/src/main/java/io/helidon/websocket/WsSession.java
@@ -87,7 +87,7 @@ public interface WsSession {
     /**
      * The underlying socket context.
      *
-     * @return connection context
+     * @return socket context
      */
     SocketContext socketContext();
 }

--- a/websocket/src/main/java/io/helidon/websocket/WsSession.java
+++ b/websocket/src/main/java/io/helidon/websocket/WsSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.websocket;
 import java.util.Optional;
 
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.socket.SocketContext;
 
 /**
  * WebSocket session.
@@ -82,4 +83,11 @@ public interface WsSession {
     default Optional<String> subProtocol() {
         return Optional.empty();
     }
+
+    /**
+     * The underlying socket context.
+     *
+     * @return connection context
+     */
+    SocketContext socketContext();
 }


### PR DESCRIPTION
### Description

Makes SocketContext available to a WsSession to access peer and socket information. Adds new method to existing interface (not intended to be implemented by developers). See issue #8856.

