### PR TITLE
Fix typo in example code

### DIFF
--- a/docs/se/metrics/micrometer.adoc
+++ b/docs/se/metrics/micrometer.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ public class MyService implements Service {
 
     private final Counter requestCounter;
 
-    public MyService(MicrometerMeterRegistry registry) {
+    public MyService(MeterRegistry registry) {
         requestCounter = registry.counter("allRequests"); // <1>
     }
 


### PR DESCRIPTION
### Description
Resolves #8940

The Helidon `MicrometerSupport#registry` method actually returns `MeterRegistry`, not `MicrometerMeterRegistry`.

This PR changes the doc to reflect that.

The doc in 4.x does not have this typo.

### Documentation
This is a doc bug fix.