### PR TITLE
3.x: Upgrade owasp dependency check plugin to 10.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.plugin.source>3.3.0</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>9.0.9</version.plugin.dependency-check>
+        <version.plugin.dependency-check>10.0.2</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
@@ -565,7 +565,7 @@
                     <configuration>
                         <skip>${dependency-check.skip}</skip>
                         <skipTestScope>true</skipTestScope>
-                        <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
+                        <failBuildOnCVSS>0</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
 			# If provide improves rate limits
 			<nvdApiKey>${nvd-api-key}</nvdApiKey>


### PR DESCRIPTION
### Description

* Upgrades owasp dependency check plugin to 10.0.2. This is required due to a change in the NVD API
* Replaces deprecated failBuildOnAnyVulnerability property with failBuildOnCVSS with a value of 0

### Documentation

No impact