### PR TITLE
1.x: upgrade owasp dependency check to 10.0.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -88,7 +88,7 @@
         <version.lib.mysql-connector-java>8.0.29</version.lib.mysql-connector-java>
         <version.lib.narayana>5.9.3.Final</version.lib.narayana>
         <version.lib.netty>4.1.108.Final</version.lib.netty>
-        <version.lib.oci-java-sdk-objectstorage>2.66.0</version.lib.oci-java-sdk-objectstorage>
+        <version.lib.oci-java-sdk-objectstorage>2.73.0</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>19.3.0.0</version.lib.ojdbc8>
         <version.lib.opentracing>0.32.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -292,5 +292,52 @@
    <cve>CVE-2023-4759</cve>
 </suppress>
 
+<!--
+    False Positives. These CVEs are against the Brave web browser, not brave-opentracing.
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2022-47932</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2022-47933</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2022-47934</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2021-22929</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2022-30334</cve>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: brave-opentracing-1.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.opentracing\.brave/brave\-opentracing@.*$</packageUrl>
+   <cve>CVE-2023-28360</cve>
+</suppress>
+
+
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.plugin.spotbugs>3.1.12</version.plugin.spotbugs>
         <version.plugin.surefire.provider.junit>1.0.3</version.plugin.surefire.provider.junit>
         <version.plugin.surefire>2.19.1</version.plugin.surefire>
-        <version.plugin.dependency-check>9.1.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>10.0.2</version.plugin.dependency-check>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>
@@ -524,7 +524,7 @@
                     <configuration>
                         <skip>${dependency-check.skip}</skip>
                         <skipTestScope>true</skipTestScope>
-                        <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
+                        <failBuildOnCVSS>0</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <excludes>
                             <!-- Exclude stuff we do not deploy -->


### PR DESCRIPTION
### Description

* Upgrades owasp dependency check plugin to 10.0.2. This is required due to a change in the NVD API
* Replaces deprecated failBuildOnAnyVulnerability property with failBuildOnCVSS with a value of 0
* Upgrades OCI SDK to 2.73.0
* Suppress brave false positives

### Documentation

No impact