### PR TITLE
4.x: Java 22 support. Upgrade ASM, byte-buddy, and eclipselink

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -58,6 +58,14 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate-enhance}</version>
+                    <!-- Force upgrade for Java 22 support. Should remove after Hibernate upgrade -->
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.bytebuddy</groupId>
+                            <artifactId>byte-buddy</artifactId>
+                            <version>${version.lib.bytebuddy}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -40,13 +40,13 @@
         <version.lib.animal-sniffer>1.18</version.lib.animal-sniffer>
         <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
-        <version.lib.bytebuddy>1.14.14</version.lib.bytebuddy>
+        <version.lib.bytebuddy>1.14.18</version.lib.bytebuddy>
         <version.lib.commons-codec>1.16.0</version.lib.commons-codec>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.1.6</version.lib.cron-utils>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.dropwizard.metrics>4.1.36</version.lib.dropwizard.metrics>
-        <version.lib.eclipselink>4.0.2</version.lib.eclipselink>
+        <version.lib.eclipselink>4.0.3</version.lib.eclipselink>
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>

--- a/microprofile/graphql/server/src/test/java/io/helidon/microprofile/graphql/server/SchemaGeneratorTest.java
+++ b/microprofile/graphql/server/src/test/java/io/helidon/microprofile/graphql/server/SchemaGeneratorTest.java
@@ -534,7 +534,7 @@ class SchemaGeneratorTest extends AbstractGraphQLTest {
 
     @Test
     public void testFormatting() {
-        assertFormat(FLOAT, "en-ZA", "¤ 000.00", 100.0d, "R 100,00");
+        assertFormat(FLOAT, "fr-FR", "¤ 000.00", 100.0d, "€ 100,00");
         assertFormat(FLOAT, "en-AU", "¤ 000.00", 100.0d, "$ 100.00");
         assertFormat(FLOAT, "en-AU", "000.00 'ml'", 125.12d, "125.12 ml");
         assertFormat(INT, "en-AU", "0 'years'", 52, "52 years");

--- a/microprofile/graphql/server/src/test/java/io/helidon/microprofile/graphql/server/SchemaGeneratorTest.java
+++ b/microprofile/graphql/server/src/test/java/io/helidon/microprofile/graphql/server/SchemaGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.arquillian>1.7.0.Final</version.lib.arquillian>
-        <version.lib.asm>9.5</version.lib.asm>
+        <version.lib.asm>9.7</version.lib.asm>
         <version.lib.checkstyle>10.12.5</version.lib.checkstyle>
         <version.lib.commons-io>2.11.0</version.lib.commons-io>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
@@ -693,6 +693,14 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate-enhance}</version>
+                    <!-- Force upgrade for Java 22 support. Should remove after Hibernate upgrade -->
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.bytebuddy</groupId>
+                            <artifactId>byte-buddy</artifactId>
+                            <version>${version.lib.bytebuddy}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
### Description

Upgrades the following to support Java 22:

- byte-buddy
- asm
- EclipseLink

Also updates a graphql test so that it works with both Java 21 and Java 22.

Note that this does not upgrade Hibernate which is a larger task.

With these changes all examples build with Java 22 except for the Micronaut Data and Microstream examples. So this works with Java 22 (when run in `examples` directory):

```
mvn clean install -pl '!integrations/micronaut/data,!integrations/microstream/greetings-se,!integrations/microstream/greetings-mp'
```

### Documentation

No impact
