### PR TITLE
4.0.11: upgrade owasp dependency check plugin to 10.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>9.0.8</version.plugin.dependency-check>
+        <version.plugin.dependency-check>10.0.2</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
@@ -625,7 +625,7 @@
                     <configuration>
                         <skip>${dependency-check.skip}</skip>
                         <skipTestScope>true</skipTestScope>
-                        <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
+                        <failBuildOnCVSS>0</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <nvdApiKey>${nvd-api-key}</nvdApiKey>
                         <excludes>


### PR DESCRIPTION
### Description

* Upgrades owasp dependency check plugin to 10.0.2. This is required due to a change in the NVD API
* Replaces deprecated failBuildOnAnyVulnerability property with failBuildOnCVSS with a value of 0

### Documentation

No impact