### PR TITLE
4.0.11: Upgrade oci-sdk to 3.43.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -127,7 +127,7 @@
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.108.Final</version.lib.netty>
-        <version.lib.oci>3.39.0</version.lib.oci>
+        <version.lib.oci>3.43.2</version.lib.oci>
         <version.lib.ojdbc.family>21</version.lib.ojdbc.family>
         <!--
             UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.


### PR DESCRIPTION
### Description

Upgrade oci-sdk to 3.43.2

### Documentation

No impact
