### PR TITLE
4.0.11: Properly handle disabled metrics in MP

### DIFF
--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -123,6 +123,7 @@
                                 <exclude>**/HelloWorldAsyncResponseTest.java</exclude>
                                 <exclude>**/TestMetricsOnOwnSocket.java</exclude>
                                 <exclude>**/TestDisabledMetrics.java</exclude>
+                                <exclude>**/TestSelectivelyDisabledMetrics.java</exclude>
                                 <exclude>**/TestConfigProcessing.java</exclude>
                             </excludes>
                             <systemPropertyVariables>
@@ -160,6 +161,17 @@
                                 <exclude>**/HelloWorldTest.java</exclude>
                                 <exclude>**/HelloWorldAsyncResponseWithRestRequestTest.java</exclude>
                             </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-selectively-disabled-metrics</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestSelectivelyDisabledMetric.java</include>
+                            </includes>
                         </configuration>
                     </execution>
                     <execution>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonCounter.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,12 @@ class HelidonCounter extends MetricImpl<io.helidon.metrics.api.Counter> implemen
                                  io.helidon.metrics.api.Counter delegate) {
         return new HelidonCounter(scope,
                                   metadata,
+                                  delegate);
+    }
+
+    static HelidonCounter create(io.helidon.metrics.api.Counter delegate) {
+        return new HelidonCounter(resolvedScope(delegate),
+                                  Registry.metadata(delegate),
                                   delegate);
     }
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonGauge.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,12 @@ abstract class HelidonGauge<N extends Number> extends MetricImpl<io.helidon.metr
                                                      io.helidon.metrics.api.Gauge<N> delegate) {
         return new HelidonGauge.DelegateBased<>(scope,
                                                 metadata,
+                                                delegate);
+    }
+
+    static <N extends Number> HelidonGauge<N> create(io.helidon.metrics.api.Gauge<N> delegate) {
+        return new HelidonGauge.DelegateBased<>(resolvedScope(delegate),
+                                                Registry.metadata(delegate),
                                                 delegate);
     }
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonHistogram.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonHistogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,12 @@ final class HelidonHistogram extends MetricImpl<DistributionSummary> implements 
                                    io.helidon.metrics.api.DistributionSummary delegate) {
         return new HelidonHistogram(scope,
                                     metadata,
+                                    delegate);
+    }
+
+    static HelidonHistogram create(io.helidon.metrics.api.DistributionSummary delegate) {
+        return new HelidonHistogram(resolvedScope(delegate),
+                                    Registry.metadata(delegate),
                                     delegate);
     }
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonTimer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,13 @@ final class HelidonTimer extends MetricImpl<io.helidon.metrics.api.Timer> implem
         return new HelidonTimer(meterRegistry,
                                 scope,
                                 metadata,
+                                delegate);
+    }
+
+    static HelidonTimer create(MeterRegistry meterRegistry, io.helidon.metrics.api.Timer delegate) {
+        return new HelidonTimer(meterRegistry,
+                                resolvedScope(delegate),
+                                Registry.metadata(delegate),
                                 delegate);
     }
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricImpl.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,10 @@ abstract class MetricImpl<M extends Meter> extends AbstractMetric<M> implements 
      */
     protected static Iterable<io.helidon.metrics.api.Tag> allTags(String scope, Tag[] tags) {
         return toHelidonTags(SystemTagsManager.instance().withScopeTag(iterableEntries(tags), scope));
+    }
+
+    static String resolvedScope(Meter delegate) {
+        return SystemTagsManager.instance().effectiveScope(delegate.scope()).orElse(Meter.Scope.DEFAULT);
     }
 
     /**

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/Registry.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/Registry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,15 @@ class Registry implements MetricRegistry {
 
     static Registry create(String scope, MeterRegistry meterRegistry) {
         return new Registry(scope, meterRegistry);
+    }
+
+    static Metadata metadata(Meter meter) {
+
+        MetadataBuilder builder = Metadata.builder().withName(meter.id().name());
+        meter.baseUnit().ifPresent(builder::withUnit);
+        meter.description().ifPresent(builder::withDescription);
+
+        return builder.build();
     }
 
     protected static String sanitizeUnit(String unit) {
@@ -431,14 +440,16 @@ class Registry implements MetricRegistry {
 
             HelidonMetric<?> newMetric = metric(collector, existingInfo == null ? newMetadata : existingInfo.metadata, meter);
 
-            // Now update the data structures.
-            InfoPerName info = infoByName.computeIfAbsent(newMetricID.getName(),
-                                                          n -> InfoPerName.create(newMetadata, newMetricID));
+            // Now update the data structures if the meter is enabled.
+            if (meterRegistry.isMeterEnabled(meter.id().name(), meter.id().tagsMap(), meter.scope())) {
+                InfoPerName info = infoByName.computeIfAbsent(newMetricID.getName(),
+                                                              n -> InfoPerName.create(newMetadata, newMetricID));
 
-            // Inside info, metric IDs are stored in a set, so adding the first ID again does no harm.
-            info.add(newMetricID);
-            metricsById.put(newMetricID, newMetric);
-            metricsByDelegate.put(meter, newMetric);
+                // Inside info, metric IDs are stored in a set, so adding the first ID again does no harm.
+                info.add(newMetricID);
+                metricsById.put(newMetricID, newMetric);
+                metricsByDelegate.put(meter, newMetric);
+            }
 
             collector.collect().log(LOGGER);
 
@@ -573,21 +584,16 @@ class Registry implements MetricRegistry {
         }
     }
 
-    private static Metadata metadata(Meter meter) {
-
-        MetadataBuilder builder = Metadata.builder().withName(meter.id().name());
-        meter.baseUnit().ifPresent(builder::withUnit);
-        meter.description().ifPresent(builder::withDescription);
-
-        return builder.build();
-    }
-
     private static Map<String, String> tagsWithoutSystemOrScopeTags(Iterable<io.helidon.metrics.api.Tag> tags) {
         Map<String, String> result = new TreeMap<>();
 
         SystemTagsManager.instance().withoutSystemOrScopeTags(tags).forEach(t -> result.put(t.key(), t.value()));
 
         return result;
+    }
+
+    private boolean isMeterEnabled(Meter meter) {
+        return meterRegistry.isMeterEnabled(meter.id().name(), meter.id().tagsMap(), meter.scope());
     }
 
     private static Tag[] tags(Map<String, String> tags) {
@@ -605,9 +611,7 @@ class Registry implements MetricRegistry {
     }
 
     private HelidonCounter createCounter(io.helidon.metrics.api.Counter.Builder counterBuilder) {
-        io.helidon.metrics.api.Counter delegate = meterRegistry.getOrCreate(counterBuilder);
-        HelidonCounter result = (HelidonCounter) metricsByDelegate.get(delegate);
-        return result;
+        return createMeter(counterBuilder, HelidonCounter::create);
     }
 
     @SuppressWarnings("unchecked")
@@ -634,17 +638,15 @@ class Registry implements MetricRegistry {
 
     @SuppressWarnings("unchecked")
     private <N extends Number> HelidonGauge<N> createGauge(io.helidon.metrics.api.Gauge.Builder<N> gBuilder) {
-        io.helidon.metrics.api.Gauge<?> delegate = meterRegistry.getOrCreate(gBuilder);
-        return (HelidonGauge<N>) metricsByDelegate.get(delegate);
+        return createMeter(gBuilder, HelidonGauge::create);
     }
 
     @SuppressWarnings("unchecked")
     private <T> HelidonGauge<Long> createFunctionalCounter(io.helidon.metrics.api.FunctionalCounter.Builder<T> fcBuilder) {
-        io.helidon.metrics.api.Gauge<?> delegate = meterRegistry
-                .getOrCreate(io.helidon.metrics.api.Gauge.builder(fcBuilder.name(),
-                                                                  () -> fcBuilder.fn()
-                                                                          .apply(fcBuilder.stateObject())));
-        return (HelidonGauge<Long>) metricsByDelegate.get(delegate);
+        return createMeter(io.helidon.metrics.api.Gauge.builder(fcBuilder.name(),
+                                                                () -> fcBuilder.fn()
+                                                                        .apply(fcBuilder.stateObject())),
+                           HelidonGauge::create);
     }
 
     private HelidonHistogram createHistogram(Metadata metadata, Tag... tags) {
@@ -657,8 +659,7 @@ class Registry implements MetricRegistry {
     }
 
     private HelidonHistogram createHistogram(io.helidon.metrics.api.DistributionSummary.Builder sBuilder) {
-        io.helidon.metrics.api.DistributionSummary delegate = meterRegistry.getOrCreate(sBuilder);
-        return (HelidonHistogram) metricsByDelegate.get(delegate);
+        return createMeter(sBuilder, HelidonHistogram::create);
     }
 
     private HelidonTimer createTimer(Metadata metadata, Tag... tags) {
@@ -670,8 +671,19 @@ class Registry implements MetricRegistry {
     }
 
     private HelidonTimer createTimer(io.helidon.metrics.api.Timer.Builder tBuilder) {
-        io.helidon.metrics.api.Timer delegate = meterRegistry.getOrCreate(tBuilder);
-        return (HelidonTimer) metricsByDelegate.get(delegate);
+        return createMeter(tBuilder, d -> HelidonTimer.create(meterRegistry, d));
+    }
+
+    private <HM extends HelidonMetric<M>,
+            M extends Meter,
+            B extends Meter.Builder<B, M>> HM createMeter(B builder,
+                                                          Function<M, HM> factory) {
+        M delegate = meterRegistry.getOrCreate(builder);
+        // Disabled metrics are not in the data structures supporting our registry, so we cannot find those via metricsByDelegate.
+        // Instead just create a new wrapper around the delegate.
+        return isMeterEnabled(delegate)
+                ? (HM) metricsByDelegate.get(delegate)
+                : factory.apply(delegate);
     }
 
     private boolean removeMatchingWithResult(MetricFilter filter) {

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestSelectivelyDisabledMetric.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestSelectivelyDisabledMetric.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import io.helidon.metrics.api.Meter;
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfigBlock;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@HelidonTest
+@AddBean(CountedBean.class)
+@AddConfigBlock("""
+        metrics.scoping.scopes.0.name=application
+        metrics.scoping.scopes.0.filter.exclude=.*oome.*"""
+)
+class TestSelectivelyDisabledMetric {
+
+    @Test
+    void testDisabledCounter() {
+        RegistryFactory rf = RegistryFactory.getInstance();
+        Registry reg = rf.registry(Meter.Scope.APPLICATION);
+
+        MetricID metricID = new MetricID(CountedBean.DOOMED_COUNTER);
+        Counter counter = reg.getCounter(metricID);
+        assertThat("Disabled counter looked up", counter, is(nullValue()));
+
+        counter = reg.counter(metricID);
+        counter.inc();
+        assertThat("Disabled (no-op) counter after increment", counter.getCount(), is(0L));
+    }
+}


### PR DESCRIPTION
### Description

Backport of #8908 to 4.0.11

Resolves #8906

In Helidon 3.x, if the metrics configuration disabled a metric then Helidon created a no-op metric and registered it in the registry.

For Helidon 4.x, after discussion and in conformance with common practice, Helidon SE no longer registers a disabled meter in the meter registry or stores it in the related data structures. It simply returns a no-op meter when one is looked up or registered.

Helidon MP metrics needs additional data structures beyond the SE meter registry. When code invokes the MP metrics API to get a metric, MP metrics consults those MP data structures. If the requested metric does not exist, the MP code delegates to the SE code to register a meter and then via an "on-create" callback updates its data structures and returns an MP metric wrapper around the new SE meter.

In this processing, though, the MP code did not check whether the created SE meter was a no-op or not and this led to the MP data structures being out of sync with the SE meter registry and led to the error reported in the issue.

The key change in the PR is that Helidon MP metrics is now sensitive to whether a searched-for metric is disabled or not. If enabled, it uses the old code path which always worked for that case. If disabled, it now bypasses the attempt to look-up the SE delegate and returns a Helidon MP wrapper around the disabled SE meter delegate.

To accomplish this, each Helidon MP metric type (HelidonCounter, etc.) add a new static create factory method which accepts the corresponding Helidon Meter type (Counter, etc.) as a delegate. Those methods delegate to some new common code which encapsulates the decision-making about whether the delegate is configured to be enabled or not.

One new test makes sure that selectively disabled metrics are handled correctly.

### Documentation

Bug fix; no doc impact