### PR TITLE
Use correct exception when retrying in FT

### DIFF
--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -59,6 +60,10 @@ class RetryImpl implements Retry {
                 return supplier.get();
             } catch (Throwable t) {
                 Throwable throwable = SupplierHelper.unwrapThrowable(t);
+                // if an ExecutionException, extract real cause
+                if (throwable instanceof ExecutionException) {
+                    throwable = throwable.getCause();
+                }
                 context.thrown.add(throwable);
                 if (errorChecker.shouldSkip(throwable)
                         || throwable instanceof InterruptedException) {     // no retry on interrupt

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/RetryBean.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/RetryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,8 +118,22 @@ class RetryBean {
             // fails twice
             future.completeExceptionally(new RuntimeException("Simulated error"));
         } else {
-            future.complete("Success");
+            future.complete("success");
         }
         return future;
+    }
+
+    @Asynchronous
+    @Retry(maxRetries = 2, retryOn = {CustomRuntimeException.class})
+    public CompletableFuture<String> retryOnCustomRuntimeException() {
+        if (invocations.incrementAndGet() <= 2) {
+            printStatus("RetryBean::retryOnCustomRuntimeException()", "failure");
+            return CompletableFuture.failedFuture(new CustomRuntimeException());
+        }
+        printStatus("RetryBean::retryOnCustomRuntimeException()", "success");
+        return CompletableFuture.completedFuture("success");
+    }
+
+    static class CustomRuntimeException extends RuntimeException {
     }
 }

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/RetryTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/RetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,16 @@ public class RetryTest extends FaultToleranceTest {
     @MethodSource("createBeans")
     public void testRetryCompletionStageWithEventualSuccess(RetryBean bean, String unused) {
         bean.reset();
-        assertCompleteOk(bean.retryWithUltimateSuccess(), "Success");
+        assertCompleteOk(bean.retryWithUltimateSuccess(), "success");
+        assertThat(bean.getInvocations(), is(3));
+    }
+
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("createBeans")
+    public void testRetryWithCustomRuntimeException(RetryBean bean, String unused) {
+        bean.reset();
+        assertThat(bean.getInvocations(), is(0));
+        assertCompleteOk(bean.retryOnCustomRuntimeException(), "success");
         assertThat(bean.getInvocations(), is(3));
     }
 }


### PR DESCRIPTION
### Description

Uses correct exception when retrying in FT. If wrapped in an ExecutorException, it needs to be unwrapped before retry logic is applied. Some new tests. See issue #8974.

