### PR TITLE
4.x Adopt MP Telemetry 1.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -116,7 +116,7 @@
         <version.lib.microprofile-reactive-streams-operators-api>3.0</version.lib.microprofile-reactive-streams-operators-api>
         <version.lib.microprofile-reactive-streams-operators-core>3.0</version.lib.microprofile-reactive-streams-operators-core>
         <version.lib.microprofile-rest-client>3.0.1</version.lib.microprofile-rest-client>
-        <version.lib.microprofile-telemetry-tck>1.0</version.lib.microprofile-telemetry-tck>
+        <version.lib.microprofile-telemetry-tck>1.1</version.lib.microprofile-telemetry-tck>
         <version.lib.microprofile-tracing>3.0</version.lib.microprofile-tracing>
         <version.lib.microprofile-lra-api>2.0</version.lib.microprofile-lra-api>
         <version.lib.microstream>08.01.01-MS-GA</version.lib.microstream>
@@ -138,10 +138,10 @@
         <version.lib.okio>3.4.0</version.lib.okio>
         <!-- Force upgrade okhttp3 for CVE-2023-0833 -->
         <version.lib.okhttp3>4.11.0</version.lib.okhttp3>
-        <version.lib.opentelemetry.semconv>1.22.0-alpha</version.lib.opentelemetry.semconv>
-        <version.lib.opentelemetry-sdk-extension-autoconfigure>1.22.0-alpha</version.lib.opentelemetry-sdk-extension-autoconfigure>
-        <version.lib.opentelemetry.opentracing.shim>1.22.0-alpha</version.lib.opentelemetry.opentracing.shim>
-        <version.lib.opentelemetry>1.22.0</version.lib.opentelemetry>
+        <version.lib.opentelemetry.semconv>1.29.0-alpha</version.lib.opentelemetry.semconv>
+        <version.lib.opentelemetry-sdk-extension-autoconfigure>1.29.0</version.lib.opentelemetry-sdk-extension-autoconfigure>
+        <version.lib.opentelemetry.opentracing.shim>1.29.0</version.lib.opentelemetry.opentracing.shim>
+        <version.lib.opentelemetry>1.29.0</version.lib.opentelemetry>
         <version.lib.opentracing>0.33.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>

--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -22,6 +22,8 @@
 :keywords: helidon, telemetry, microprofile, micro-profile
 :microprofile-bundle: true
 :rootdir: {docdir}/..
+:mp-telemetry-version: 1.1
+:otel-version: 1.29.0
 
 include::{rootdir}/includes/mp.adoc[]
 
@@ -50,7 +52,24 @@ include::{rootdir}/includes/dependencies.adoc[]
 
 link:https://opentelemetry.io/[OpenTelemetry] comprises a collection of APIs, SDKs, integration tools, and other software components intended to facilitate the generation and control of telemetry data, including traces, metrics, and logs. In an environment where distributed tracing is enabled via OpenTelemetry (which combines OpenTracing and OpenCensus), this specification establishes the necessary behaviors for MicroProfile applications to participate seamlessly.
 
-MicroProfile Telemetry 1.0 allows for the exportation of the data it collects to Jaeger or Zipkin and to other systems using a variety of exporters.
+MicroProfile Telemetry {mp-telemetry-version} allows for the exportation of the data it collects to Jaeger or Zipkin and to other systems using a variety of exporters.
+
+[NOTE]
+.Change in Span Names for REST Requests
+====
+Earlier releases of Helidon 4 implemented MicroProfile Telemetry 1.0 which was based on OpenTelemetry semantic conventions 1.22.0-alpha.
+
+MicroProfile Telemetry {mp-telemetry-version} is based on OpenTelemetry {otel-version}, and in that release the semantic convention for the REST span name is now
+[source]
+----
+{http-method-name} {http-request-route}
+----
+The HTTP method name part is new (see https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name).
+
+Although span names are often used only for display in monitoring tools, this is a backward-incompatible change. By default, Helidon {helidon-version} conforms to the new semantic convention so as to comply with MicroProfile Telemetry {mp-telemetry-version}.
+
+If you need to use the previous span naming format, set `mp.telemetry.span.name-includes-method` to `false` in `META-INF/microprofile-config.properties`. This option is deprecated for removal in a future major release of Helidon, and for that reason Helidon logs a warning if you choose this option.
+====
 
 In a distributed tracing system, *traces* are used to capture a series of requests and are composed of multiple *spans* that represent individual operations within those requests. Each *span* includes a name, timestamps, and metadata that provide insights into the corresponding operation.
 
@@ -335,5 +354,5 @@ This example is available at the link:{helidon-github-tree-url}/examples/micropr
 
 == Reference
 
-* link:https://download.eclipse.org/microprofile/microprofile-telemetry-1.0/tracing/microprofile-telemetry-tracing-spec-1.0.pdf[MicroProfile Telemetry Specification]
+* link:https://download.eclipse.org/microprofile/microprofile-telemetry-{mp-telemetry-version}/tracing/microprofile-telemetry-tracing-spec-{mp-telemetry-version}.pdf[MicroProfile Telemetry Specification]
 * link:https://opentelemetry.io/docs/[OpenTelemetry Documentation]

--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -54,7 +54,7 @@ link:https://opentelemetry.io/[OpenTelemetry] comprises a collection of APIs, SD
 
 MicroProfile Telemetry {mp-telemetry-version} allows for the exportation of the data it collects to Jaeger or Zipkin and to other systems using a variety of exporters.
 
-// TODO In 5.x remove the following note.
+// @Deprecated(forRemoval = true) In 5.x remove the following note.
 [NOTE]
 .Span Names for REST Requests
 ====
@@ -78,6 +78,7 @@ Therefore, Helidon {helidon-version} by default conforms to the _older_ semantic
 
 The ability to use the older format is deprecated, and you should plan for its removal in a future major release of Helidon. For that reason Helidon logs a warning message if you use the older REST span naming convention.
 ====
+// end of text to be removed in 5.x
 
 In a distributed tracing system, *traces* are used to capture a series of requests and are composed of multiple *spans* that represent individual operations within those requests. Each *span* includes a name, timestamps, and metadata that provide insights into the corresponding operation.
 

--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -54,21 +54,29 @@ link:https://opentelemetry.io/[OpenTelemetry] comprises a collection of APIs, SD
 
 MicroProfile Telemetry {mp-telemetry-version} allows for the exportation of the data it collects to Jaeger or Zipkin and to other systems using a variety of exporters.
 
+// TODO In 5.x remove the following note.
 [NOTE]
-.Change in Span Names for REST Requests
+.Span Names for REST Requests
 ====
+If possible, assign the following config setting in your application's `META-INF/microprofile-config.properties` file:
+[source,properties]
+----
+mp.telemetry.span.name-includes-method = true
+----
 Earlier releases of Helidon 4 implemented MicroProfile Telemetry 1.0 which was based on OpenTelemetry semantic conventions 1.22.0-alpha.
 
-MicroProfile Telemetry {mp-telemetry-version} is based on OpenTelemetry {otel-version}, and in that release the semantic convention for the REST span name is now
+MicroProfile Telemetry {mp-telemetry-version} is based on OpenTelemetry {otel-version}, and in that release the semantic convention for the REST span name now includes the HTTPmethod name, as shown in the format below.
 [source]
 ----
 {http-method-name} {http-request-route}
 ----
-The HTTP method name part is new (see https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name).
+(see https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name)
 
-Although span names are often used only for display in monitoring tools, this is a backward-incompatible change. By default, Helidon {helidon-version} conforms to the new semantic convention so as to comply with MicroProfile Telemetry {mp-telemetry-version}.
+Although span names are often used only for display in monitoring tools, this is a backward-incompatible change.
 
-If you need to use the previous span naming format, set `mp.telemetry.span.name-includes-method` to `false` in `META-INF/microprofile-config.properties`. This option is deprecated for removal in a future major release of Helidon, and for that reason Helidon logs a warning if you choose this option.
+Therefore, Helidon {helidon-version} by default conforms to the _older_ semantic convention to preserve backward compatibility with earlier 4.x releases. Only if you set the property as shown above will Helidon {helidon-version} use the new span naming format.
+
+The ability to use the older format is deprecated, and you should plan for its removal in a future major release of Helidon. For that reason Helidon logs a warning message if you use the older REST span naming convention.
 ====
 
 In a distributed tracing system, *traces* are used to capture a series of requests and are composed of multiple *spans* that represent individual operations within those requests. Each *span* includes a name, timestamps, and metadata that provide insights into the corresponding operation.

--- a/microprofile/telemetry/etc/spotbugs/exclude.xml
+++ b/microprofile/telemetry/etc/spotbugs/exclude.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <!-- False positive similar to https://github.com/spotbugs/spotbugs/issues/1877 -->
+        <Class name="io.helidon.microprofile.telemetry.HelidonTelemetryContainerFilter"/>
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern = "VA_FORMAT_STRING_USES_NEWLINE"/>
+    </Match>
+</FindBugsFilter>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <!-- The default for the following is 5000 ms. Reducing it speeds up tests significantly. -->
         <otel.bsp.schedule.delay>100</otel.bsp.schedule.delay>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
     </properties>
 
     <dependencies>

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryClientFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryClientFilter.java
@@ -24,6 +24,8 @@ import io.helidon.tracing.HeaderProvider;
 import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.context.Context;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
@@ -82,6 +84,11 @@ class HelidonTelemetryClientFilter implements ClientRequestFilter, ClientRespons
                         .ifPresent(builder::parent))
                 .start();
 
+        Baggage.fromContext(Context.current())
+                .forEach((key, baggageEntry) ->
+                                 helidonSpan.baggage().set(key,
+                                                           baggageEntry.getValue(),
+                                                           baggageEntry.getMetadata().getValue()));
         Scope helidonScope = helidonSpan.activate();
 
         clientRequestContext.setProperty(SPAN_SCOPE, helidonScope);

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryClientFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryClientFilter.java
@@ -17,6 +17,7 @@ package io.helidon.microprofile.telemetry;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import io.helidon.tracing.HeaderConsumer;
 import io.helidon.tracing.HeaderProvider;
@@ -29,12 +30,14 @@ import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 
 import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_METHOD;
 import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_SCHEME;
 import static io.helidon.microprofile.telemetry.HelidonTelemetryConstants.HTTP_STATUS_CODE;
-
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_PORT;
 
 /**
  * Filter to process Client request and Client response. Starts a new {@link io.opentelemetry.api.trace.Span} on request and
@@ -46,6 +49,9 @@ class HelidonTelemetryClientFilter implements ClientRequestFilter, ClientRespons
     private static final String HTTP_URL = "http.url";
     private static final String SPAN_SCOPE = Scope.class.getName();
     private static final String SPAN = Span.class.getName();
+    private static final Set<Response.Status.Family> ERROR_STATUS_FAMILIES = Set.of(
+            Response.Status.Family.CLIENT_ERROR,
+            Response.Status.Family.SERVER_ERROR);
 
     private final io.helidon.tracing.Tracer helidonTracer;
 
@@ -69,6 +75,8 @@ class HelidonTelemetryClientFilter implements ClientRequestFilter, ClientRespons
                 .tag(HTTP_METHOD, clientRequestContext.getMethod())
                 .tag(HTTP_SCHEME, clientRequestContext.getUri().getScheme())
                 .tag(HTTP_URL, clientRequestContext.getUri().toString())
+                .tag(NET_PEER_NAME.getKey(), clientRequestContext.getUri().getHost())
+                .tag(NET_PEER_PORT.getKey(), clientRequestContext.getUri().getPort())
                 .update(builder -> Span.current()
                         .map(Span::context)
                         .ifPresent(builder::parent))
@@ -100,6 +108,13 @@ class HelidonTelemetryClientFilter implements ClientRequestFilter, ClientRespons
         scope.close();
 
         span.tag(HTTP_STATUS_CODE, clientResponseContext.getStatus());
+
+        // OpenTelemetry semantic conventions dictate what the span status should be.
+        // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+        if (ERROR_STATUS_FAMILIES.contains(clientResponseContext.getStatusInfo().getFamily())) {
+            span.status(Span.Status.ERROR);
+        }
+
         span.end();
 
         clientRequestContext.removeProperty(SPAN);

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -89,7 +89,7 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         this.helidonTracer = helidonTracer;
         isAgentPresent = HelidonOpenTelemetry.AgentDetector.isAgentPresent(MpConfig.toHelidonConfig(mpConfig));
 
-        // TODO In 5.x remove the following.
+        // @Deprecated(forRemoval = true) In 5.x remove the following.
         mpConfig.getOptionalValue(SPAN_NAME_FULL_URL, Boolean.class).ifPresent(e -> spanNameFullUrl = e);
         Optional<Boolean> includeMethodConfig = mpConfig.getOptionalValue(SPAN_NAME_INCLUDES_METHOD, Boolean.class);
         restSpanNameIncludesMethod = includeMethodConfig.orElse(false);
@@ -104,6 +104,7 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
                                migrate to the current conventions.""",
                                SPAN_NAME_INCLUDES_METHOD));
         }
+        // end of code to remove in 5.x.
     }
 
     @Override
@@ -178,7 +179,13 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
     }
 
     private String spanName(ContainerRequestContext requestContext, String route) {
-        // TODO IN 5.x remove the option of excluding the HTTP method from the REST span name.
+        // @Deprecated(forRemoval = true) In 5.x remove the option of excluding the HTTP method from the REST span name.
+        // Starting in 5.x this method should be:
+        // return requestContext.getMethod() + " " + (
+        //          spanNameFullUrl
+        //              ? requestContext.getUriInfo().getAbsolutePath().toString()
+        //              : route);
+        //
         // According to recent OpenTelemetry semantic conventions for spans, the span name for a REST endpoint should be
         //
         // http-method-name low-cardinality-path

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -75,10 +75,11 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
     /*
      MP Telemetry 1.1 adopts OpenTelemetry 1.29 semantic conventions which require the route to be in the REST span name.
      Because Helidon adopts MP Telemetry 1.1 in a dot release (4.1), this would be a backward-incompatible change. This setting,
-     controllable via config, allows users to preserve the earlier behavior. The default is to adopt the new behavior.
+     controllable via config, defaults to the older behavior that is backward-compatible with Helidon 4.0.x but allows users to
+     select the newer, spec-compliant behavior that is backward-incompatible with Helidon 4.0.x. The default is to use the
+     old behavior.
      */
     private final boolean restSpanNameIncludesMethod;
-
 
     @jakarta.ws.rs.core.Context
     private ResourceInfo resourceInfo;
@@ -97,11 +98,11 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
             spanNameWarningLogged.set(true);
             LOGGER.log(System.Logger.Level.WARNING,
                        String.format("""
-                               Current OpenTelemetry semantic conventions require the HTTP method to be part of REST span
+                               Current OpenTelemetry semantic conventions include the HTTP method as part of REST span
                                names. Your configuration does not set mp.%s to true, so your service uses the legacy span name
                                format which excludes the HTTP method. This feature is deprecated and marked for removal in a
-                               future major release of Helidon. Consider adding this setting to your configuration to
-                               migrate to the current conventions.""",
+                               future major release of Helidon. Consider adding a setting of mp.%1$s to 'true' in your
+                               configuration to migrate to the current conventions.""",
                                SPAN_NAME_INCLUDES_METHOD));
         }
         // end of code to remove in 5.x.

--- a/microprofile/telemetry/src/main/java/module-info.java
+++ b/microprofile/telemetry/src/main/java/module-info.java
@@ -48,6 +48,7 @@ module io.helidon.microprofile.telemetry {
     requires jakarta.inject;
     requires microprofile.config.api;
     requires opentelemetry.instrumentation.annotations;
+    requires io.opentelemetry.semconv;
 
     requires static io.helidon.common.features.api;
 

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
@@ -18,6 +18,8 @@ package io.helidon.microprofile.telemetry;
 import java.util.List;
 import java.util.stream.Stream;
 
+import io.helidon.microprofile.testing.junit5.AddConfig;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -58,12 +60,12 @@ class WithSpanTest extends WithSpanTestBase {
 
     @ParameterizedTest()
     @MethodSource()
-    void testDefaultAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
+    void testDefaultAppSpanNameFromPathWithMethodName(SpanPathTestInfo spanPathTestInfo) {
         testSpanNameFromPath(spanPathTestInfo);
     }
 
-    static Stream<SpanPathTestInfo> testDefaultAppSpanNameFromPath() {
-        return Stream.of(new SpanPathTestInfo("traced", "/traced"),
-                         new SpanPathTestInfo("traced/sub/data", "/traced/sub/{name}"));
+    static Stream<SpanPathTestInfo> testDefaultAppSpanNameFromPathWithMethodName() {
+        return Stream.of(new SpanPathTestInfo("traced", "GET /traced"),
+                         new SpanPathTestInfo("traced/sub/data", "GET /traced/sub/{name}"));
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanTest.java
@@ -18,8 +18,6 @@ package io.helidon.microprofile.telemetry;
 import java.util.List;
 import java.util.stream.Stream;
 
-import io.helidon.microprofile.testing.junit5.AddConfig;
-
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -60,12 +58,12 @@ class WithSpanTest extends WithSpanTestBase {
 
     @ParameterizedTest()
     @MethodSource()
-    void testDefaultAppSpanNameFromPathWithMethodName(SpanPathTestInfo spanPathTestInfo) {
+    void testDefaultAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
         testSpanNameFromPath(spanPathTestInfo);
     }
 
-    static Stream<SpanPathTestInfo> testDefaultAppSpanNameFromPathWithMethodName() {
-        return Stream.of(new SpanPathTestInfo("traced", "GET /traced"),
-                         new SpanPathTestInfo("traced/sub/data", "GET /traced/sub/{name}"));
+    static Stream<SpanPathTestInfo> testDefaultAppSpanNameFromPath() {
+        return Stream.of(new SpanPathTestInfo("traced", "/traced"),
+                         new SpanPathTestInfo("traced/sub/data", "/traced/sub/{name}"));
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanUsingLegacySpanNameTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanUsingLegacySpanNameTest.java
@@ -17,23 +17,23 @@ package io.helidon.microprofile.telemetry;
 
 import java.util.stream.Stream;
 
-import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@AddBean(App.class)
-@AddBean(AppTracedResource.class)
-class WithSpanWithExplicitAppTest extends WithSpanTestBase {
+@AddConfig(key = HelidonTelemetryContainerFilter.SPAN_NAME_INCLUDES_METHOD,
+           value = "false")
+class WithSpanUsingLegacySpanNameTest extends WithSpanTestBase {
 
     @ParameterizedTest()
     @MethodSource()
-    void testExplicitAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
+    void testDefaultAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
         testSpanNameFromPath(spanPathTestInfo);
     }
 
-    static Stream<SpanPathTestInfo> testExplicitAppSpanNameFromPath() {
-        return Stream.of(new SpanPathTestInfo("topapp/apptraced", "GET /topapp/apptraced"),
-                         new SpanPathTestInfo("topapp/apptraced/sub/data", "GET /topapp/apptraced/sub/{name}"));
+    static Stream<SpanPathTestInfo> testDefaultAppSpanNameFromPath() {
+        return Stream.of(new SpanPathTestInfo("traced", "/traced"),
+                         new SpanPathTestInfo("traced/sub/data", "/traced/sub/{name}"));
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppTest.java
@@ -18,6 +18,7 @@ package io.helidon.microprofile.telemetry;
 import java.util.stream.Stream;
 
 import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,7 +34,7 @@ class WithSpanWithExplicitAppTest extends WithSpanTestBase {
     }
 
     static Stream<SpanPathTestInfo> testExplicitAppSpanNameFromPath() {
-        return Stream.of(new SpanPathTestInfo("topapp/apptraced", "GET /topapp/apptraced"),
-                         new SpanPathTestInfo("topapp/apptraced/sub/data", "GET /topapp/apptraced/sub/{name}"));
+        return Stream.of(new SpanPathTestInfo("topapp/apptraced", "/topapp/apptraced"),
+                         new SpanPathTestInfo("topapp/apptraced/sub/data", "/topapp/apptraced/sub/{name}"));
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppUsingLegacyNamingTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppUsingLegacyNamingTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @AddBean(App.class)
 @AddBean(AppTracedResource.class)
-@AddConfig(key = HelidonTelemetryContainerFilter.SPAN_NAME_INCLUDES_METHOD, value = "false")
 class WithSpanWithExplicitAppUsingLegacyNamingTest extends WithSpanTestBase {
 
         @ParameterizedTest()

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppUsingLegacyNamingTest.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/WithSpanWithExplicitAppUsingLegacyNamingTest.java
@@ -18,22 +18,24 @@ package io.helidon.microprofile.telemetry;
 import java.util.stream.Stream;
 
 import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @AddBean(App.class)
 @AddBean(AppTracedResource.class)
-class WithSpanWithExplicitAppTest extends WithSpanTestBase {
+@AddConfig(key = HelidonTelemetryContainerFilter.SPAN_NAME_INCLUDES_METHOD, value = "false")
+class WithSpanWithExplicitAppUsingLegacyNamingTest extends WithSpanTestBase {
 
-    @ParameterizedTest()
-    @MethodSource()
-    void testExplicitAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
-        testSpanNameFromPath(spanPathTestInfo);
-    }
+        @ParameterizedTest()
+        @MethodSource()
+        void testExplicitAppSpanNameFromPath(SpanPathTestInfo spanPathTestInfo) {
+            testSpanNameFromPath(spanPathTestInfo);
+        }
 
-    static Stream<SpanPathTestInfo> testExplicitAppSpanNameFromPath() {
-        return Stream.of(new SpanPathTestInfo("topapp/apptraced", "GET /topapp/apptraced"),
-                         new SpanPathTestInfo("topapp/apptraced/sub/data", "GET /topapp/apptraced/sub/{name}"));
-    }
+        static Stream<SpanPathTestInfo> testExplicitAppSpanNameFromPath() {
+            return Stream.of(new SpanPathTestInfo("topapp/apptraced", "/topapp/apptraced"),
+                             new SpanPathTestInfo("topapp/apptraced/sub/data", "/topapp/apptraced/sub/{name}"));
+        }
 }

--- a/microprofile/tests/tck/tck-telemetry/pom.xml
+++ b/microprofile/tests/tck/tck-telemetry/pom.xml
@@ -83,6 +83,14 @@
                         --add-opens=java.base/java.lang=ALL-UNNAMED
                         --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
                     </argLine>
+                    <systemPropertyVariables>
+                        <!--
+                            The TCK expects the current REST span names (which include the HTTP method name). But for backward
+                            compatibility Helidon 4.x defaults to use the previous REST span name format which excludes the
+                            HTTP method name. So override that default for running the TCK.
+                        -->
+                        <mp.telemetry.span.name-includes-method>true</mp.telemetry.span.name-includes-method>
+                    </systemPropertyVariables>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/tck-suite.xml</suiteXmlFile>
                     </suiteXmlFiles>

--- a/microprofile/tests/tck/tck-telemetry/pom.xml
+++ b/microprofile/tests/tck/tck-telemetry/pom.xml
@@ -83,6 +83,10 @@
                         --add-opens=java.base/java.lang=ALL-UNNAMED
                         --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
                     </argLine>
+                    <!--
+                       @Deprecated(forRemoval = true) Remove the  systemPropertyVariable setting for name-includes-method
+                       in 5.x. The property will no longer be supported.
+                    -->
                     <systemPropertyVariables>
                         <!--
                             The TCK expects the current REST span names (which include the HTTP method name). But for backward

--- a/microprofile/tests/tck/tck-telemetry/pom.xml
+++ b/microprofile/tests/tck/tck-telemetry/pom.xml
@@ -36,11 +36,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.testng</groupId>
-            <artifactId>arquillian-testng-container</artifactId>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.jboss.arquillian.testng</groupId>-->
+<!--            <artifactId>arquillian-testng-container</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
@@ -71,14 +71,9 @@
             <artifactId>helidon-microprofile-server</artifactId>
             <scope>test</scope>
         </dependency>
-         <dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.logging</groupId>
-            <artifactId>helidon-logging-jul</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microprofile/tests/tck/tck-telemetry/pom.xml
+++ b/microprofile/tests/tck/tck-telemetry/pom.xml
@@ -36,11 +36,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.jboss.arquillian.testng</groupId>-->
-<!--            <artifactId>arquillian-testng-container</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>

--- a/microprofile/tests/tck/tck-telemetry/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-telemetry/src/test/tck-suite.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <!--
 
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,7 +19,16 @@
 
 <suite name="microprofile-telemetry-tracing-TCK" verbose="2" configfailurepolicy="continue">
 
-    <test name="microprofile-telemetry-tracing TCK">
+    <test name="microprofile-telemetry-tracing TCK" verbose="10">
+        <groups>
+            <run>
+<!--                <exclude name="optional-tests"></exclude>-->
+                <!--
+                    We do not have Jakarta Concurrency, which the optional TCK async tests use. So skip those tests.
+                -->
+<!--                <exclude name="optional-jaxrs-tests"></exclude>-->
+            </run>
+        </groups>
         <packages>
             <package name="org.eclipse.microprofile.telemetry.tracing.tck.*"/>
         </packages>

--- a/microprofile/tests/tck/tck-telemetry/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-telemetry/src/test/tck-suite.xml
@@ -22,11 +22,10 @@
     <test name="microprofile-telemetry-tracing TCK" verbose="10">
         <groups>
             <run>
-<!--                <exclude name="optional-tests"></exclude>-->
                 <!--
-                    We do not have Jakarta Concurrency, which the optional TCK async tests use. So skip those tests.
+                    Helidon does not use Jakarta Concurrency, which the optional 1.1 TCK async tests use. Skip those tests.
                 -->
-<!--                <exclude name="optional-jaxrs-tests"></exclude>-->
+                <exclude name="optional-jaxrs-tests"></exclude>
             </run>
         </groups>
         <packages>

--- a/microprofile/tracing/src/main/java/io/helidon/microprofile/tracing/TracingCdiExtension.java
+++ b/microprofile/tracing/src/main/java/io/helidon/microprofile/tracing/TracingCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import io.helidon.tracing.TracerBuilder;
 import io.helidon.tracing.config.TracingConfig;
 import io.helidon.webserver.observe.tracing.TracingObserver;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
@@ -36,6 +37,7 @@ import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.DeploymentException;
@@ -65,7 +67,7 @@ public class TracingCdiExtension implements Extension {
     // must be higher priority than security, so tracer is ready when IDCS and OIDC uses webclient
     // the client is used in security configuration
     private void setupTracer(@Observes @Priority(PLATFORM_BEFORE) @RuntimeStart Config rootConfig,
-                             BeanManager bm) {
+                             BeanManager bm, Instance<OpenTelemetry> openTelemetryInstance) {
 
         String serviceName = bm.getExtension(JaxRsCdiExtension.class).serviceName();
         config = rootConfig.get("tracing");
@@ -91,8 +93,10 @@ public class TracingCdiExtension implements Extension {
             registeredTracer = tracer.unwrap(Tracer.class);
         } catch (Exception e) {
             try {
-                io.opentelemetry.api.trace.Tracer otelTracer = tracer.unwrap(io.opentelemetry.api.trace.Tracer.class);
-                registeredTracer = OpenTracingShim.createTracerShim(otelTracer);
+                if (openTelemetryInstance.isUnsatisfied()) {
+                    throw new RuntimeException("Unable to create an OpenTelemetry instance to create a tracer");
+                }
+                registeredTracer = OpenTracingShim.createTracerShim(openTelemetryInstance.get());
             } catch (Exception ex) {
                 throw new DeploymentException("MicroProfile tracing requires an OpenTracing or OpenTelemetry based tracer", ex);
             }

--- a/tracing/providers/jaeger/src/main/resources/META-INF/native-image/io.helidon.tracing.providers/helidon-tracing-providers-jaeger/reflect-config.json
+++ b/tracing/providers/jaeger/src/main/resources/META-INF/native-image/io.helidon.tracing.providers/helidon-tracing-providers-jaeger/reflect-config.json
@@ -7,5 +7,11 @@
                 "parameterTypes": []
             }
         ]
+    },
+    {
+        "condition": {
+            "typeReachable": "io.opentelemetry.sdk.OpenTelemetrySdk"
+        },
+        "name": "io.opentelemetry.sdk.common.export.RetryPolicy"
     }
 ]

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/MutableOpenTelemetryBaggage.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/MutableOpenTelemetryBaggage.java
@@ -89,9 +89,13 @@ class MutableOpenTelemetryBaggage implements Baggage, WritableBaggage {
     }
 
     void baggage(String key, String value) {
+        baggage(key, value, "");
+    }
+
+    void baggage(String key, String value, String metadata) {
         Objects.requireNonNull(key, "baggage key cannot be null");
         Objects.requireNonNull(value, "baggage value cannot be null");
-        values.put(key, new HBaggageEntry(value, new HBaggageEntryMetadata("")));
+        values.put(key, new HBaggageEntry(value, new HBaggageEntryMetadata(metadata)));
     }
 
     @Override
@@ -115,7 +119,12 @@ class MutableOpenTelemetryBaggage implements Baggage, WritableBaggage {
 
     @Override
     public WritableBaggage set(String key, String value) {
-        baggage(key, value);
+        return set(key, value, "");
+    }
+
+    @Override
+    public WritableBaggage set(String key, String value, String metadata) {
+        baggage(key, value, metadata);
         return this;
     }
 

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanBuilder.java
@@ -99,7 +99,8 @@ class OpenTelemetrySpanBuilder implements Span.Builder<OpenTelemetrySpanBuilder>
         io.opentelemetry.api.trace.Span span = spanBuilder.startSpan();
         OpenTelemetrySpan result = new OpenTelemetrySpan(span, spanListeners);
         if (parentBaggage != null) {
-            parentBaggage.forEach((key, baggageEntry) -> result.baggage().set(key, baggageEntry.getValue()));
+            parentBaggage.forEach((key, baggageEntry) -> result.baggage()
+                    .set(key, baggageEntry.getValue(), baggageEntry.getMetadata().getValue()));
         }
         HelidonOpenTelemetry.invokeListeners(spanListeners, LOGGER, listener -> listener.started(result.limited()));
 

--- a/tracing/tracing/src/main/java/io/helidon/tracing/WritableBaggage.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/WritableBaggage.java
@@ -28,4 +28,16 @@ public interface WritableBaggage extends Baggage {
      * @return the baggage instance (for chained invocation)
      */
     WritableBaggage set(String key, String value);
+
+    /**
+     * Adds a new or overrides an existing setting for the specified key using the provided value and baggage metadata.
+     *
+     * @param key name of the entry to add or update
+     * @param value value to assign to the entry
+     * @param metadata metadata to assign to the entry
+     * @return the baggage instance (for chained invocation)
+     */
+    default WritableBaggage set(String key, String value, String metadata) {
+        return set(key, value);
+    }
 }


### PR DESCRIPTION
### Description
Resolves #8728 

Major changes by component:

* Dependencies
   * MP Tel to 1.1
   * OTel to 1.29.0
   * OTel semantic conventions to 1.29.0-alpha.
* MP telemetry
   * Helidon now adds additional tags to spans (`HTTP_ROUTE`, `NET_PEER_NAME`, `NET_PEER_PORT`) as required by MP Telemetry 1.1.
   * Helidon now sets the span status in accordance with the OpenTelemetry semantic conventions. See https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status.
   * The more recent OTel semantic conventions require the HTTP method to be in the span name for REST spans. https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name This is a backward-incompatible change from MP Telemetry 1.0 and, therefore, earlier releases of Helidon 4.0.x. 
      
      For backward compatibility with earlier releases of 4.0.x, Helidon _does not_ by default include the HTTP method in REST span names. In this case Helidon displays a warning during start-up that the behavior is deprecated.
      
      Users can choose the newer, spec-compliant but backward-incompatible behavior by setting the Helidon-specific `mp.telemetry.span.name-includes-method` config property to `true`. 
      
      The PR includes a new unit test which exercises the config setting.
   * Using 
       ```
       @Inject 
       private Span span;
       ```
      was apparently always intended to provide access to the span that is current _at the time of use_, not the current span at the time of injection. This is now checked in the TCK and Helidon now conforms. 
* Helidon telemetry TCK driver
   * The new TCK contains optional tests that rely on Jakarta concurrency and work only if the MP implementation under test uses that.  Helidon does not so we skip those tests.
* OpenTelemetry tracing provider
   * OTel supports baggage metadata for each baggage entry. The MP Telemetry TCK now tests for that. To support that the Helidon tracing `WritableBaggage` API now supports a `set(key, value, metadataString)` method which defaults to `this.set(key, value, "")` The OTel tracing provider now deals with baggage metadata; the other providers ignore metadata.

### Documentation
This PR adds a note to the MP telemetry page about the REST span naming incompatibility and the config option to use the newer format.