### PR TITLE
4.0.11: Moves client protocol ID caching from HttpClientRequest to WebClien

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.util.Optional;
 
 import io.helidon.common.configurable.LruCache;
 import io.helidon.common.socket.HelidonSocket;
-import io.helidon.common.tls.Tls;
 import io.helidon.http.Method;
 import io.helidon.webclient.spi.HttpClientSpi;
 
@@ -35,7 +34,7 @@ import io.helidon.webclient.spi.HttpClientSpi;
 public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, HttpClientResponse> {
     private static final System.Logger LOGGER = System.getLogger(HttpClientRequest.class.getName());
 
-    private final LruCache<EndpointKey, HttpClientSpi> clientSpiCache = LruCache.create();
+    private final LruCache<LoomClient.EndpointKey, HttpClientSpi> clientSpiCache;
     private final WebClient webClient;
     private final Map<String, LoomClient.ProtocolSpi> clients;
     private final List<LoomClient.ProtocolSpi> tcpProtocols;
@@ -50,13 +49,15 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
                       Map<String, LoomClient.ProtocolSpi> protocolsToClients,
                       List<LoomClient.ProtocolSpi> protocols,
                       List<LoomClient.ProtocolSpi> tcpProtocols,
-                      List<String> tcpProtocolIds) {
+                      List<String> tcpProtocolIds,
+                      LruCache<LoomClient.EndpointKey, HttpClientSpi> clientSpiCache) {
         super(clientConfig, webClient.cookieManager(), "any", method, clientUri, clientConfig.properties());
         this.webClient = webClient;
         this.clients = protocolsToClients;
         this.protocols = protocols;
         this.tcpProtocols = tcpProtocols;
         this.tcpProtocolIds = tcpProtocolIds;
+        this.clientSpiCache = clientSpiCache;
     }
 
     /**
@@ -99,10 +100,10 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
             return httpClientSpi.spi().clientRequest(this, resolvedUri);
         }
 
-        EndpointKey endpointKey = new EndpointKey(resolvedUri.scheme(),
-                                                  resolvedUri.authority(),
-                                                  tls(),
-                                                  proxy());
+        LoomClient.EndpointKey endpointKey = new LoomClient.EndpointKey(resolvedUri.scheme(),
+                                                                        resolvedUri.authority(),
+                                                                        tls(),
+                                                                        proxy());
         Optional<HttpClientSpi> spi = clientSpiCache.get(endpointKey);
         if (spi.isPresent()) {
             /*
@@ -187,12 +188,5 @@ public class HttpClientRequest extends ClientRequestBase<HttpClientRequest, Http
 
         throw new IllegalArgumentException("Cannot handle request to " + resolvedUri + ", did not discover any HTTP version "
                                                    + "willing to handle it. HTTP versions supported: " + clients.keySet());
-    }
-
-    private record EndpointKey(String scheme, // http/https
-                               String authority, // myserver:80
-                               Tls tlsConfig, // TLS configuration (may be disabled, never null)
-                               Proxy proxy) { // proxy, never null
-
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/LoomClient.java
@@ -27,6 +27,8 @@ import java.util.concurrent.Executors;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
+import io.helidon.common.configurable.LruCache;
+import io.helidon.common.tls.Tls;
 import io.helidon.http.Method;
 import io.helidon.inject.configdriven.api.ConfigDriven;
 import io.helidon.webclient.spi.ClientProtocolProvider;
@@ -43,11 +45,10 @@ import jakarta.inject.Inject;
 @SuppressWarnings("rawtypes")
 @ConfigDriven(WebClientConfigBlueprint.class)
 class LoomClient implements WebClient {
-    static final LazyValue<ExecutorService> EXECUTOR = LazyValue.create(() -> {
-        return Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
-                                                          .name("helidon-client-", 0)
-                                                          .factory());
-    });
+    static final LazyValue<ExecutorService> EXECUTOR =
+            LazyValue.create(() -> Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
+                                                                            .name("helidon-client-", 0)
+                                                                            .factory()));
     private static final List<HttpClientSpiProvider> PROVIDERS =
             HelidonServiceLoader.create(ServiceLoader.load(HttpClientSpiProvider.class))
                     .asList();
@@ -68,6 +69,7 @@ class LoomClient implements WebClient {
     private final ProtocolConfigs protocolConfigs;
     private final List<String> tcpProtocolIds;
     private final WebClientCookieManager cookieManager;
+    private final LruCache<EndpointKey, HttpClientSpi> clientSpiLruCache = LruCache.create();
 
     /**
      * Construct this instance from a subclass of builder.
@@ -148,7 +150,8 @@ class LoomClient implements WebClient {
                                      clientSpiByProtocol,
                                      protocols,
                                      tcpProtocols,
-                                     tcpProtocolIds);
+                                     tcpProtocolIds,
+                                     clientSpiLruCache);
     }
 
     @Override
@@ -187,5 +190,11 @@ class LoomClient implements WebClient {
     }
 
     record ProtocolSpi(String id, HttpClientSpi spi) {
+    }
+
+    record EndpointKey(String scheme, // http/https
+                       String authority, // myserver:80
+                       Tls tlsConfig, // TLS configuration (may be disabled, never null)
+                       Proxy proxy) { // proxy, never null
     }
 }

--- a/webserver/tests/mtls/src/test/java/io/helidon/webserver/tests/mtls/MtlsTest.java
+++ b/webserver/tests/mtls/src/test/java/io/helidon/webserver/tests/mtls/MtlsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,21 +143,22 @@ class MtlsTest {
 
     @Test
     void testTlsReload() {
-        WebClient client = client();
-        ClientResponseTyped<String> response = client.method(Method.GET)
+        WebClient client1 = client();
+        ClientResponseTyped<String> response = client1.method(Method.GET)
                 .uri("/serverCert")
                 .request(String.class);
 
         assertThat(response.status(), is(Status.OK_200));
         assertThat(response.entity(), is("X.509:CN=Helidon-Test-Server|X.509:CN=Helidon-Test-CA"));
 
-        response = client.method(Method.GET)
+        response = client1.method(Method.GET)
                 .uri("/reload")
                 .request(String.class);
 
         assertThat(response.status(), is(Status.OK_200));
 
-        response = client.method(Method.GET)
+        WebClient client2  = client();      // for caching in HttpClientRequest
+        response = client2.method(Method.GET)
                 .uri("/serverCert")
                 .request(String.class);
 


### PR DESCRIPTION

### Description

Backport of #8933 

Moves client protocol ID caching from HttpClientRequest to WebClient level for proper sharing. See issue https://github.com/helidon-io/helidon/issues/8930.

### Documentation

None
