### PR TITLE
4.0.11: Archetype: fix database app-type typo (#8963)

### DIFF
--- a/archetypes/archetypes/src/main/archetype/se/se.xml
+++ b/archetypes/archetypes/src/main/archetype/se/se.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
                 </option>
                 <option value="database"
                         name="Database"
-                        description="Helidon SE application that uses a database with JPA">
+                        description="Helidon SE application that uses a database with the DB Client API">
                     <exec src="database/database-se.xml"/>
                 </option>
                 <option value="custom"


### PR DESCRIPTION

### Description

Backport of #8963 to 4.0.11

fix #8962

