### PR TITLE
4.0.11: Skip test if InstancePrincipal UT if Imds is available

### DIFF
--- a/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/TestInstancePrincipalsAuthenticationDetailsProvider.java
+++ b/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/TestInstancePrincipalsAuthenticationDetailsProvider.java
@@ -15,13 +15,8 @@
  */
 package io.helidon.integrations.oci.sdk.cdi;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.nio.file.Path;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
-import com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider;
 import jakarta.ws.rs.ProcessingException;
 import org.apache.http.client.config.RequestConfig;
 import org.junit.jupiter.api.Test;
@@ -29,11 +24,9 @@ import org.junit.jupiter.api.Test;
 import static com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider.builder;
 import static com.oracle.bmc.http.client.jersey3.ApacheClientProperties.REQUEST_CONFIG;
 import static com.oracle.bmc.http.client.StandardClientProperties.CONNECT_TIMEOUT;
-import static java.nio.file.Files.createTempFile;
-import static java.nio.file.Files.deleteIfExists;
-import static java.nio.file.Files.newBufferedWriter;
-import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static io.helidon.integrations.oci.sdk.cdi.Utils.imdsAvailable;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class TestInstancePrincipalsAuthenticationDetailsProvider {
@@ -47,6 +40,8 @@ class TestInstancePrincipalsAuthenticationDetailsProvider {
         // Don't run in the pipeline/Github Actions; there's no point. See comments below.
         String ci = System.getenv("CI");
         assumeTrue(ci == null || ci.isBlank());
+        // skip if imds is available
+        assumeFalse(imdsAvailable());
 
         assertThrows(ProcessingException.class, () -> builder()
                      // (There does not seem to be a way to avoid this taking multiple seconds, no matter what timeout
@@ -74,5 +69,4 @@ class TestInstancePrincipalsAuthenticationDetailsProvider {
                      .timeoutForEachRetry(1) // milliseconds; no visible effect
                      .build()); // takes multiple seconds
     }
-
 }

--- a/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/TestProcessProviderInjectionPoint.java
+++ b/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/TestProcessProviderInjectionPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package io.helidon.integrations.oci.sdk.cdi;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.InetAddress;
 
 import io.helidon.microprofile.config.ConfigCdiExtension;
 import io.helidon.microprofile.testing.junit5.AddBean;
@@ -33,6 +32,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.integrations.oci.sdk.cdi.Utils.imdsAvailable;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -84,16 +84,6 @@ class TestProcessProviderInjectionPoint {
             return false;
         }
     }
-
-    private static final boolean imdsAvailable() {
-        try {
-            return InetAddress.getByName(System.getProperty("oci.imds.hostname", "169.254.169.254"))
-                .isReachable(Integer.getInteger("oci.imds.timeout", 100).intValue());
-        } catch (final IOException ignored) {
-            return false;
-        }
-    }
-
 
     /*
      * Inner and nested classes.

--- a/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/TestSpike.java
+++ b/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/TestSpike.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package io.helidon.integrations.oci.sdk.cdi;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.InetAddress;
 
 import io.helidon.microprofile.config.ConfigCdiExtension;
 import io.helidon.microprofile.testing.junit5.AddBean;
@@ -45,6 +44,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.integrations.oci.sdk.cdi.Utils.imdsAvailable;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -112,16 +112,6 @@ class TestSpike {
             return false;
         }
     }
-
-    private static final boolean imdsAvailable() {
-        try {
-            return InetAddress.getByName(System.getProperty("oci.imds.hostname", "169.254.169.254"))
-                .isReachable(Integer.getInteger("oci.imds.timeout", 100).intValue());
-        } catch (final IOException ignored) {
-            return false;
-        }
-    }
-
 
     /*
      * Inner and nested classes.

--- a/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/Utils.java
+++ b/integrations/oci/sdk/cdi/src/test/java/io/helidon/integrations/oci/sdk/cdi/Utils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.sdk.cdi;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+class Utils {
+
+    static final boolean imdsAvailable() {
+        try {
+            return InetAddress.getByName(System.getProperty("oci.imds.hostname", "169.254.169.254"))
+                    .isReachable(Integer.getInteger("oci.imds.timeout", 100).intValue());
+        } catch (final IOException ignored) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Description

Backport of #8985 to 4.0.11

TestInstancePrincipalsAuthenticationDetailsProvider is a negative test that validates a failure will take place if authentication is done on an environment with no Imds avaialable like an OCI instance, hence this will fail if the test is executed on an environment where Imds is available.

### Documentation

No impact