### PR TITLE
4.x: Fix example to use the configured values.

### DIFF
--- a/examples/webserver/tls/src/main/java/io/helidon/examples/webserver/tls/Main.java
+++ b/examples/webserver/tls/src/main/java/io/helidon/examples/webserver/tls/Main.java
@@ -45,11 +45,12 @@ public final class Main {
         Config config = Config.create();
 
         WebServerConfig.Builder builder1 = WebServer.builder();
-        setupConfigBased(builder1, config);
+        setupConfigBased(builder1, config.get("config-based"));
         WebServer server1 = builder1.build().start();
         System.out.println("Started config based WebServer on https://localhost:" + server1.port());
 
-        WebServerConfig.Builder builder2 = WebServer.builder();
+        WebServerConfig.Builder builder2 = WebServer.builder()
+                .config(config.get("builder-based")); // we want port to be configurable always
         setupBuilderBased(builder2);
         WebServer server2 = builder2.build().start();
         System.out.println("Started builder based WebServer on http://localhost:" + server2.port());
@@ -69,7 +70,8 @@ public final class Main {
     }
 
     static void setupConfigBased(WebServerConfig.Builder server, Config config) {
-        server.config(config).routing(Main::routing);
+        server.config(config)
+                .routing(Main::routing);
     }
 
     static void routing(HttpRouting.Builder routing) {


### PR DESCRIPTION
### Description
The example did not use expected configuration (test was unfortunately using a different config instance than runtime)