### PR TITLE
4.1: Return correct status on too long prologue

### DIFF
--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ConfiguredLimitsTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ConfiguredLimitsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ class ConfiguredLimitsTest {
             } else {
                 assertThat("Initial line of size " + size + " should have failed",
                            response.status(),
-                           is(Status.BAD_REQUEST_400));
+                           is(Status.REQUEST_URI_TOO_LONG_414));
             }
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
@@ -24,6 +24,7 @@ import io.helidon.http.DirectHandler;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.RequestException;
+import io.helidon.http.Status;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.http.DirectTransportRequest;
 
@@ -160,8 +161,9 @@ public final class Http1Prologue {
         if (eol == maxLength) {
             // exceeded maximal length, we do not want to parse it anyway
             throw RequestException.builder()
-                    .message("Prologue size exceeded")
+                    .message("Request URI too long.")
                     .type(DirectHandler.EventType.BAD_REQUEST)
+                    .status(Status.REQUEST_URI_TOO_LONG_414)
                     .build();
         }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http1;
+
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.common.buffers.DataReader;
+import io.helidon.http.DirectHandler;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.http.RequestException;
+import io.helidon.http.Status;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Http1PrologueTest {
+    @Test
+    void testOk() {
+        DataReader reader = new DataReader(() -> "GET / HTTP/1.1\r\n".getBytes(StandardCharsets.US_ASCII));
+        Http1Prologue p = new Http1Prologue(reader, 100, false);
+
+        HttpPrologue prologue = p.readPrologue();
+        assertThat(prologue.method(), is(Method.GET));
+        assertThat(prologue.uriPath().path(), is("/"));
+        assertThat(prologue.protocol(), is("HTTP"));
+        assertThat(prologue.protocolVersion(), is("1.1"));
+    }
+
+    @Test
+    void testUriTooLong() {
+        // make sure this regression does not happen again
+        DataReader reader = new DataReader(() -> "GET /01234567890123456789012 HTTP/1.1\r\n".getBytes(StandardCharsets.US_ASCII));
+        Http1Prologue p = new Http1Prologue(reader, 20, false);
+
+        RequestException e = assertThrows(RequestException.class, p::readPrologue);
+
+        assertThat(e.status(), is(Status.REQUEST_URI_TOO_LONG_414));
+        assertThat(e.eventType(), is(DirectHandler.EventType.BAD_REQUEST));
+    }
+}


### PR DESCRIPTION
A regression in 4.1 introduced with SWAR parsing of request.
Now correctly returning the status code that should be returned when prologue is too long + added a test.