### PR TITLE
Update UriEncoding.decode to expose a decodeQuery method

### DIFF
--- a/common/uri/src/main/java/io/helidon/common/uri/UriQueryImpl.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriQueryImpl.java
@@ -31,7 +31,7 @@ import io.helidon.common.mapper.MapperManager;
 import io.helidon.common.mapper.OptionalValue;
 import io.helidon.common.mapper.Value;
 
-import static io.helidon.common.uri.UriEncoding.decodeUri;
+import static io.helidon.common.uri.UriEncoding.decodeQuery;
 
 // must be lazily populated to prevent perf overhead when queries are ignored
 final class UriQueryImpl implements UriQuery {
@@ -215,11 +215,11 @@ final class UriQueryImpl implements UriQuery {
     private void addDecoded(Map<String, List<String>> newQueryParams, String next) {
         int eq = next.indexOf('=');
         if (eq == -1) {
-            newQueryParams.putIfAbsent(decodeUri(next), new LinkedList<>());
+            newQueryParams.putIfAbsent(decodeQuery(next), new LinkedList<>());
         } else {
             String name = next.substring(0, eq);
             String value = next.substring(eq + 1);
-            newQueryParams.computeIfAbsent(decodeUri(name), it -> new LinkedList<>()).add(decodeUri(value));
+            newQueryParams.computeIfAbsent(decodeQuery(name), it -> new LinkedList<>()).add(decodeQuery(value));
         }
     }
 

--- a/common/uri/src/test/java/io/helidon/common/uri/UriEncodingTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriEncodingTest.java
@@ -30,4 +30,9 @@ class UriEncodingTest {
         assertThat(decodeUri("+hello+world+"), is(" hello world "));
         assertThat(decodeUri("[+]hello[+]world[+]"), is("[+]hello[+]world[+]"));
     }
+
+    @Test
+    void testIPv6Literal() {
+        assertThat(decodeUri("http://[fe80::1%lo0]:8080"), is("http://[fe80::1%lo0]:8080"));
+    }
 }

--- a/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriQueryTest.java
@@ -16,7 +16,6 @@
 
 package io.helidon.common.uri;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
 
@@ -41,9 +40,15 @@ class UriQueryTest {
     }
 
     @Test
-    void testEncoded() throws UnsupportedEncodingException {
+    void testEncoded() {
         UriQuery uriQuery = UriQuery.create("a=" + URLEncoder.encode("1&b=2", US_ASCII));
         assertThat(uriQuery.get("a"), is("1&b=2"));
+    }
+
+    @Test
+    void testEncodedWithinBrackets() {
+        UriQuery uriQuery = UriQuery.create("msg=[Hello%20World]");
+        assertThat(uriQuery.get("msg"), is("[Hello World]"));
     }
 
     @Test


### PR DESCRIPTION
### Description

- UriEncoding.decodeQuery does not ignore %s within []
- UriEncoding.decodeUri ignores %s within [] to support IPv6 literal (E.g. http://[fe80::1%lo0]:8080)

See https://tools.ietf.org/html/rfc6874#section-2

Fixes #8993

### Documentation

None
