### PR TITLE
Update max-prologue-length from 2048 to 4096 to align with 3.x

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConfigBlueprint.java
@@ -45,7 +45,7 @@ interface Http1ConfigBlueprint extends ProtocolConfig {
      * @return maximal size in bytes
      */
     @Option.Configured
-    @Option.DefaultInt(2048)
+    @Option.DefaultInt(4096)
     int maxPrologueLength();
 
     /**


### PR DESCRIPTION
### Description

Before:
```yaml
server:
  protocols:
    http_1_1:
      max-prologue-length: 2048 # old default
```

After:
```yaml
server:
  protocols:
    http_1_1:
      max-prologue-length: 4096 # new default
```

Fixes #9002

### Documentation

None

