### PR TITLE
4.0.11: Skips content encoding of empty entities. 

### DIFF
--- a/webserver/tests/webserver/pom.xml
+++ b/webserver/tests/webserver/pom.xml
@@ -63,5 +63,10 @@
             <artifactId>helidon-logging-jul</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.http.encoding</groupId>
+            <artifactId>helidon-http-encoding-gzip</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingEmptyTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingEmptyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.tests;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class ContentEncodingEmptyTest {
+
+    private final Http1Client client;
+
+    ContentEncodingEmptyTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        LogConfig.configureRuntime();
+        rules.post("/hello", (req, res) -> {
+            res.status(Status.NO_CONTENT_204);
+            res.send();     // empty entity
+        });
+    }
+
+    @Test
+    void gzipEncodeEmptyEntity() {
+        Http1ClientResponse res = client.post("hello")
+                .header(HeaderNames.CONTENT_TYPE, "application/json")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .request();
+        assertThat(res.status().code(), is(204));
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,14 +197,15 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     }
 
     /**
-     * Entity bytes encoded using content encoding.
+     * Entity bytes encoded using content encoding. Does not attempt encoding
+     * if entity is empty.
      *
      * @param configuredEntity plain bytes
      * @return encoded bytes
      */
     protected byte[] entityBytes(byte[] configuredEntity) {
         byte[] entity = configuredEntity;
-        if (contentEncodingContext.contentEncodingEnabled()) {
+        if (contentEncodingContext.contentEncodingEnabled() && entity.length > 0) {
             ContentEncoder encoder = contentEncodingContext.encoder(requestHeaders);
             // we want to preserve optimization here, let's create a new byte array
             ByteArrayOutputStream baos = new ByteArrayOutputStream(entity.length);


### PR DESCRIPTION
### Description

Backport of #9000 to 4.0.11

Skips content encoding of empty entities. Attempting to encode an empty entity with an encoder such as GZIP will result in a non-empty entity (a GZIP preamble) which is problematic --especially when a 204 is returned by a handler. See issue #8998.