### PR TITLE
4.x: Remove unused constructor parameter from io.helidon.faulttolerance.AsyncImpl

### DIFF
--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Async.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Async.java
@@ -45,7 +45,7 @@ public interface Async extends RuntimeType.Api<AsyncConfig> {
      * @return a default async instance
      */
     static Async create(AsyncConfig config) {
-        return new AsyncImpl(config, true);
+        return new AsyncImpl(config);
     }
 
     /**

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/AsyncImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/AsyncImpl.java
@@ -32,7 +32,7 @@ class AsyncImpl implements Async {
     private final CompletableFuture<Async> onStart;
     private final AsyncConfig config;
 
-    AsyncImpl(AsyncConfig config, boolean internal) {
+    AsyncImpl(AsyncConfig config) {
         this.executor = config.executor().orElseGet(() -> FaultTolerance.executor().get());
         this.onStart = config.onStart().orElseGet(CompletableFuture::new);
         this.config = config;


### PR DESCRIPTION
### Description
I've found the unused constructor parameter in `io.helidon.faulttolerance.AsyncImpl`. It can be safely removed.