### PR TITLE
4.x: Helidon Webclient (4.0.10) is not routing the requests through proxy configured using Proxy Builder. #9022

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <version.lib.junit-platform>1.9.3</version.lib.junit-platform>
         <version.lib.kafka-junit5>3.2.3</version.lib.kafka-junit5>
         <version.lib.mockito>2.23.4</version.lib.mockito>
+        <version.lib.mockserver>5.15.0</version.lib.mockserver>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.2.10</version.lib.rxjava>
@@ -1033,6 +1034,11 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${version.lib.mockito}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mock-server</groupId>
+                <artifactId>mockserver-netty-no-dependencies</artifactId>
+                <version>${version.lib.mockserver}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jgit</groupId>

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -59,6 +59,10 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
      */
     public static final Header USER_AGENT_HEADER = HeaderValues.create(HeaderNames.USER_AGENT,
                                                                        "Helidon " + Version.VERSION);
+    /**
+     * Proxy connection header.
+     */
+    public static final Header PROXY_CONNECTION = HeaderValues.create("Proxy-Connection", "keep-alive");
     private static final Map<String, AtomicLong> COUNTERS = new ConcurrentHashMap<>();
     private static final Set<String> SUPPORTED_SCHEMES = Set.of("https", "http");
 
@@ -253,7 +257,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
 
     @Override
     public R request() {
-        headers.setIfAbsent(USER_AGENT_HEADER);
+        additionalHeaders();
         return validateAndSubmit(BufferData.EMPTY_BYTES);
     }
 
@@ -262,15 +266,22 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         if (!(entity instanceof byte[] bytes && bytes.length == 0)) {
             rejectHeadWithEntity();
         }
-        headers.setIfAbsent(USER_AGENT_HEADER);
+        additionalHeaders();
         return validateAndSubmit(entity);
     }
 
     @Override
     public final R outputStream(OutputStreamHandler outputStreamConsumer) {
         rejectHeadWithEntity();
-        headers.setIfAbsent(USER_AGENT_HEADER);
+        additionalHeaders();
         return doOutputStream(outputStreamConsumer);
+    }
+
+    /**
+     * Append additional headers before sending the request.
+     */
+    protected void additionalHeaders() {
+        headers.setIfAbsent(USER_AGENT_HEADER);
     }
 
     /**

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,7 @@ public class Proxy {
     private final Optional<char[]> password;
     private final ProxySelector systemProxySelector;
     private final Optional<Header> proxyAuthHeader;
+    private final boolean forceHttpConnect;
 
     private Proxy(Proxy.Builder builder) {
         this.host = builder.host();
@@ -102,6 +103,7 @@ public class Proxy {
         this.port = builder.port();
         this.username = builder.username();
         this.password = builder.password();
+        this.forceHttpConnect = builder.forceHttpConnect();
 
         if (type == ProxyType.SYSTEM) {
             this.noProxy = inetSocketAddress -> true;
@@ -451,7 +453,8 @@ public class Proxy {
     private static Socket connectToProxy(WebClient webClient,
                                          InetSocketAddress proxyAddress,
                                          InetSocketAddress targetAddress,
-                                         Proxy proxy) {
+                                         Proxy proxy,
+                                         boolean tls) {
 
         WebClientConfig clientConfig = webClient.prototype();
         TcpClientConnection connection = TcpClientConnection.create(webClient,
@@ -469,26 +472,26 @@ public class Proxy {
                                                                     it -> {
                                                                     })
                 .connect();
-
-        HttpClientRequest request = webClient.method(Method.CONNECT)
-                .followRedirects(false) // do not follow redirects for proxy connect itself
-                .connection(connection)
-                .uri("http://" + proxyAddress.getHostName() + ":" + proxyAddress.getPort())
-                .protocolId("http/1.1") // MUST be 1.1, if not available, proxy connection will fail
-                .header(HeaderNames.HOST, targetAddress.getHostName() + ":" + targetAddress.getPort())
-                .accept(MediaTypes.WILDCARD);
-        if (clientConfig.keepAlive()) {
-            request.header(HeaderValues.CONNECTION_KEEP_ALIVE)
-                .header(PROXY_CONNECTION);
+        if (proxy.forceHttpConnect || tls || proxy.username.isPresent()) {
+            HttpClientRequest request = webClient.method(Method.CONNECT)
+                    .followRedirects(false) // do not follow redirects for proxy connect itself
+                    .connection(connection)
+                    .uri("http://" + proxyAddress.getHostName() + ":" + proxyAddress.getPort())
+                    .protocolId("http/1.1") // MUST be 1.1, if not available, proxy connection will fail
+                    .header(HeaderNames.HOST, targetAddress.getHostName() + ":" + targetAddress.getPort())
+                    .accept(MediaTypes.WILDCARD);
+            if (clientConfig.keepAlive()) {
+                request.header(HeaderValues.CONNECTION_KEEP_ALIVE)
+                    .header(PROXY_CONNECTION);
+            }
+            proxy.proxyAuthHeader.ifPresent(request::header);
+            // we cannot close the response, as that would close the connection
+            HttpClientResponse response = request.request();
+            if (response.status().family() != Status.Family.SUCCESSFUL) {
+                response.close();
+                throw new IllegalStateException("Proxy sent wrong HTTP response code: " + response.status());
+            }
         }
-        proxy.proxyAuthHeader.ifPresent(request::header);
-        // we cannot close the response, as that would close the connection
-        HttpClientResponse response = request.request();
-        if (response.status().family() != Status.Family.SUCCESSFUL) {
-            response.close();
-            throw new IllegalStateException("Proxy sent wrong HTTP response code: " + response.status());
-        }
-
         return connection.socket();
     }
 
@@ -562,7 +565,8 @@ public class Proxy {
                         .map(proxyAddress -> connectToProxy(webClient,
                                                             proxyAddress,
                                                             targetAddress,
-                                                            proxy))
+                                                            proxy,
+                                                            tls))
                         .orElseGet(() -> NONE.connect(webClient, proxy, targetAddress, socketOptions, tls));
             }
         };
@@ -587,6 +591,7 @@ public class Proxy {
         private int port = 80;
         private String username;
         private char[] password;
+        private boolean forceHttpConnect = false;
 
         private Builder() {
         }
@@ -632,6 +637,11 @@ public class Proxy {
          *     <td>Proxy password</td>
          * </tr>
          * <tr>
+         *     <td>httpConnect</td>
+         *     <td>{@code false}</td>
+         *     <td>Specify whether the HTTP client will always execute HTTP CONNECT.</td>
+         * </tr>
+         * <tr>
          *     <td>no-proxy</td>
          *     <td>{@code no default}</td>
          *     <td>Contains list of the hosts which should be excluded from using proxy</td>
@@ -664,6 +674,19 @@ public class Proxy {
         @ConfiguredOption("HTTP")
         public Builder type(ProxyType type) {
             this.type = Objects.requireNonNull(type);
+            return this;
+        }
+
+        /**
+         * Forces HTTP CONNECT with the proxy server.
+         * Otherwise it will not execute HTTP CONNECT for HTTP protocol.
+         *
+         * @param forceHttpConnect HTTP CONNECT
+         * @return updated builder instance
+         */
+        @ConfiguredOption
+        public Builder forceHttpConnect(boolean forceHttpConnect) {
+            this.forceHttpConnect = forceHttpConnect;
             return this;
         }
 
@@ -740,6 +763,10 @@ public class Proxy {
 
         ProxyType type() {
             return type;
+        }
+
+        boolean forceHttpConnect() {
+            return forceHttpConnect;
         }
 
         String host() {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -679,7 +679,8 @@ public class Proxy {
 
         /**
          * Forces HTTP CONNECT with the proxy server.
-         * Otherwise it will not execute HTTP CONNECT for HTTP protocol.
+         * Otherwise it will not execute HTTP CONNECT when the request is
+         * plain HTTP with no authentication.
          *
          * @param forceHttpConnect HTTP CONNECT
          * @return updated builder instance

--- a/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/Proxy.java
@@ -58,8 +58,6 @@ import io.helidon.http.Status;
 public class Proxy {
     private static final System.Logger LOGGER = System.getLogger(Proxy.class.getName());
     private static final Tls NO_TLS = Tls.builder().enabled(false).build();
-    private static final Header PROXY_CONNECTION =
-            HeaderValues.create("Proxy-Connection", "keep-alive");
 
     /**
      * No proxy instance.
@@ -482,7 +480,7 @@ public class Proxy {
                     .accept(MediaTypes.WILDCARD);
             if (clientConfig.keepAlive()) {
                 request.header(HeaderValues.CONNECTION_KEEP_ALIVE)
-                    .header(PROXY_CONNECTION);
+                    .header(ClientRequestBase.PROXY_CONNECTION);
             }
             proxy.proxyAuthHeader.ifPresent(request::header);
             // we cannot close the response, as that would close the connection

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.Proxy.ProxyType;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
 
@@ -177,6 +178,14 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
     @Override
     protected MediaContext mediaContext() {
         return super.mediaContext();
+    }
+
+    @Override
+    protected void additionalHeaders() {
+        super.additionalHeaders();
+        if (proxy() != null && proxy().type() != ProxyType.NONE) {
+            header(PROXY_CONNECTION);
+        }
     }
 
     Http1ClientImpl http1Client() {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -183,7 +183,7 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
     @Override
     protected void additionalHeaders() {
         super.additionalHeaders();
-        if (proxy() != null && proxy().type() != ProxyType.NONE) {
+        if (proxy().type() != ProxyType.NONE) {
             header(PROXY_CONNECTION);
         }
     }

--- a/webclient/tests/http1/pom.xml
+++ b/webclient/tests/http1/pom.xml
@@ -67,5 +67,10 @@
             <artifactId>vertx-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpMockProxyTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpMockProxyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.tests;
+
+import static io.helidon.http.Method.GET;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpForward.forward;
+import static org.mockserver.model.HttpRequest.request;
+
+import io.helidon.http.Status;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpForward.Scheme;
+
+@ServerTest
+class HttpMockProxyTest {
+
+    private static final int PROXY_PORT = 1080;
+    private final WebClient webClient;
+    private final int serverPort;
+    private ClientAndServer mockServer;
+
+    HttpMockProxyTest(WebServer server) {
+        this.serverPort = server.port();
+        this.webClient = WebClient.builder()
+                .baseUri("http://localhost:" + serverPort)
+                .proxy(Proxy.builder().host("localhost").port(PROXY_PORT).build())
+                .build();
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder router) {
+        router.route(GET, "/get", Routes::get);
+    }
+
+    @BeforeEach
+    public void before() {
+        mockServer = startClientAndServer(PROXY_PORT);
+        mockServer.when(request()).forward(forward().withScheme(Scheme.HTTP).withHost("localhost").withPort(serverPort)); 
+    }
+
+    @AfterEach
+    public void after() {
+        mockServer.stop();
+    }
+
+    @Test
+    public void issue9022() {
+        try (HttpClientResponse response = webClient.get("/get").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            String entity = response.entity().as(String.class);
+            assertThat(entity, is("Hello"));
+        }
+    }
+
+    private static class Routes {
+        private static String get() {
+            return "Hello";
+        }
+    }
+}

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,37 +128,37 @@ class HttpProxyTest {
 
     @Test
     void testNoProxyTypeButHasHost1() {
-        Proxy proxy = Proxy.builder().host(PROXY_HOST).port(proxyPort).build();
+        Proxy proxy = Proxy.builder().forceHttpConnect(true).host(PROXY_HOST).port(proxyPort).build();
         successVerify(proxy, clientHttp1);
     }
 
     @Test
     void testNoProxyTypeButHasHost2() {
-        Proxy proxy = Proxy.builder().host(PROXY_HOST).port(proxyPort).build();
+        Proxy proxy = Proxy.builder().forceHttpConnect(true).host(PROXY_HOST).port(proxyPort).build();
         successVerify(proxy, clientHttp2);
     }
 
     @Test
     void testProxyNoneTypeButHasHost1() {
-        Proxy proxy = Proxy.builder().type(ProxyType.NONE).host(PROXY_HOST).port(proxyPort).build();
+        Proxy proxy = Proxy.builder().forceHttpConnect(true).type(ProxyType.NONE).host(PROXY_HOST).port(proxyPort).build();
         successVerify(proxy, clientHttp1);
     }
 
     @Test
     void testProxyNoneTypeButHasHost2() {
-        Proxy proxy = Proxy.builder().type(ProxyType.NONE).host(PROXY_HOST).port(proxyPort).build();
+        Proxy proxy = Proxy.builder().forceHttpConnect(true).type(ProxyType.NONE).host(PROXY_HOST).port(proxyPort).build();
         successVerify(proxy, clientHttp2);
     }
 
     @Test
     void testSimpleProxy1() {
-        Proxy proxy = Proxy.builder().type(ProxyType.HTTP).host(PROXY_HOST).port(proxyPort).build();
+        Proxy proxy = Proxy.builder().forceHttpConnect(true).type(ProxyType.HTTP).host(PROXY_HOST).port(proxyPort).build();
         successVerify(proxy, clientHttp1);
     }
 
     @Test
     void testSimpleProxy2() {
-        Proxy proxy = Proxy.builder().type(ProxyType.HTTP).host(PROXY_HOST).port(proxyPort).build();
+        Proxy proxy = Proxy.builder().forceHttpConnect(true).type(ProxyType.HTTP).host(PROXY_HOST).port(proxyPort).build();
         successVerify(proxy, clientHttp2);
     }
 

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpsProxyTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpsProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.Keys;
 import io.helidon.common.tls.Tls;
 import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientRequest;
+import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.HttpClient;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.Proxy;
@@ -44,6 +46,8 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.http.Method.GET;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ServerTest
 class HttpsProxyTest {
@@ -182,10 +186,17 @@ class HttpsProxyTest {
     }
 
     private void successVerify(Proxy proxy, HttpClient<?> client) {
-        try (HttpClientResponse response = client.get("/get").proxy(proxy).request()) {
+        ClientRequest<?> request = client.get("/get").proxy(proxy);
+        try (HttpClientResponse response = request.request()) {
             assertThat(response.status(), is(Status.OK_200));
             String entity = response.entity().as(String.class);
             assertThat(entity, is("Hello"));
+        }
+        boolean proxyConnection = request.headers().contains(ClientRequestBase.PROXY_CONNECTION);
+        if (client == clientHttp1) {
+            assertTrue(proxyConnection, "HTTP1 requires Proxy-Connection header");
+        } else {
+            assertFalse(proxyConnection, "HTTP2 does not allow Proxy-Connection header");
         }
     }
 


### PR DESCRIPTION
### Description
https://github.com/helidon-io/helidon/issues/9022

It will do HTTP CONNECT if any of these is true:
- You explicitly set in a flag.
- It is TLS
- It uses proxy authentication

### Documentation
None