### PR TITLE
4.x: Native image fixes (required for Java 22)

### DIFF
--- a/common/features/features/src/main/resources/META-INF/native-image/io.helidon.common.features/helidon-common-features/native-image.properties
+++ b/common/features/features/src/main/resources/META-INF/native-image/io.helidon.common.features/helidon-common-features/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,5 @@
 # limitations under the License.
 #
 
-handlers=io.helidon.logging.jul.HelidonConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
-
-# Global logging level. Can be overridden by specific loggers
-.level=INFO
-io.helidon.level=INFO
+# Needed at build time, as we validate all used features are usable with native-image
+Args=--initialize-at-build-time=io.helidon.common.features

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/logging/common/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-common/native-image.properties
+++ b/logging/common/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-common/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-handlers=io.helidon.logging.jul.HelidonConsoleHandler
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
-
-# Global logging level. Can be overridden by specific loggers
-.level=INFO
-io.helidon.level=INFO
+# Logging is used from our native image extension, as we need to correctly initialize it both at build time
+# and at run time
+Args=--initialize-at-build-time=io.helidon.logging


### PR DESCRIPTION
- initialize features at build time (used to discover features that do not support AOT)
- initialize logging at build time (used explicitly to be able to log) Fixed a few problems in Quickstart that I used to test this

Resolves #8726 