### PR TITLE
MP Metrics 5.1 support

### DIFF
--- a/config/metadata-processor/src/main/java/io/helidon/config/metadata/processor/TypeHandlerBase.java
+++ b/config/metadata-processor/src/main/java/io/helidon/config/metadata/processor/TypeHandlerBase.java
@@ -197,7 +197,7 @@ abstract class TypeHandlerBase {
     }
 
     List<ConfiguredOptionData.AllowedValue> allowedValuesEnum(ConfiguredOptionData data, TypeElement typeElement) {
-        if (data.allowedValues().isEmpty()) {
+        if (!data.allowedValues().isEmpty()) {
             // this was already processed due to an explicit type defined in the annotation
             // or allowed values explicitly configured in annotation
             return data.allowedValues();

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -110,7 +110,7 @@
         <version.lib.microprofile-graphql>2.0</version.lib.microprofile-graphql>
         <version.lib.microprofile-health>4.0.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>2.1</version.lib.microprofile-jwt>
-        <version.lib.microprofile-metrics-api>5.0.1</version.lib.microprofile-metrics-api>
+        <version.lib.microprofile-metrics-api>5.1.1</version.lib.microprofile-metrics-api>
         <version.lib.microprofile-openapi-api>3.1.1</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-reactive-messaging-api>3.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>3.0</version.lib.microprofile-reactive-streams-operators-api>

--- a/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
@@ -53,8 +53,7 @@ This is a standalone configuration type, prefix from configuration root: `metric
 |`enabled` |boolean |`true` |Whether metrics functionality is enabled.
 
  If metrics are configured to be enabled
-|[.line-through]#`gc-time-type`# |
-|`GcTimeType.COUNTER` |*Deprecated* Whether the `gc.time` meter should be registered as a gauge (vs. a counter).
+|[.line-through]#`gc-time-type`# |GcTimeType (GAUGE, COUNTER) |`GcTimeType.COUNTER` |*Deprecated* Whether the `gc.time` meter should be registered as a gauge (vs. a counter).
  The `gc.time` meter is inspired by the MicroProfile Metrics spec, in which the meter was originally checked to
  be a counter but starting in 5.1 was checked be a gauge. For the duration of Helidon 4.x users can choose which
  type of meter Helidon registers for `gc.time`.

--- a/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
@@ -53,13 +53,19 @@ This is a standalone configuration type, prefix from configuration root: `metric
 |`enabled` |boolean |`true` |Whether metrics functionality is enabled.
 
  If metrics are configured to be enabled
+|[.line-through]#`gc-time-type`# |xref:{rootdir}/config/io_helidon_metrics_api_MetricsConfigBlueprint_GcTimeType.adoc[GcTimeType] |`GcTimeType.COUNTER` |*Deprecated* Whether the `gc.time` meter should be registered as a gauge (vs. a counter).
+ The `gc.time` meter is inspired by the MicroProfile Metrics spec, in which the meter was originally checked to
+ be a counter but starting in 5.1 was checked be a gauge. For the duration of Helidon 4.x users can choose which
+ type of meter Helidon registers for `gc.time`.
+ The type of meter to use for registering `gc.time`
+ @deprecated Provided for backward compatibility only; no replacement
 |`key-performance-indicators` |xref:{rootdir}/config/io_helidon_metrics_api_KeyPerformanceIndicatorMetricsConfig.adoc[KeyPerformanceIndicatorMetricsConfig] |{nbsp} |Key performance indicator metrics settings.
 
  Key performance indicator metrics settings
 |`permit-all` |boolean |`true` |Whether to allow anybody to access the endpoint.
 
  Whether to permit access to metrics endpoint to anybody, defaults to `true`
- @see #roles()
+ See roles()
 |`rest-request-enabled` |boolean |`false` |Whether automatic REST request metrics should be measured.
 
  True/false

--- a/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
@@ -53,7 +53,7 @@ This is a standalone configuration type, prefix from configuration root: `metric
 |`enabled` |boolean |`true` |Whether metrics functionality is enabled.
 
  If metrics are configured to be enabled
-|[.line-through]#`gc-time-type`# |xref:{rootdir}/config/io_helidon_metrics_api_MetricsConfigBlueprint_GcTimeType.adoc[GcTimeType] |`GcTimeType.COUNTER` |*Deprecated* Whether the `gc.time` meter should be registered as a gauge (vs. a counter).
+|[.line-through]#`gc-time-type`# |xref:{rootdir}/config/io_helidon_metrics_api_GcTimeType.adoc[GcTimeType] |`GcTimeType.COUNTER` |*Deprecated* Whether the `gc.time` meter should be registered as a gauge (vs. a counter).
  The `gc.time` meter is inspired by the MicroProfile Metrics spec, in which the meter was originally checked to
  be a counter but starting in 5.1 was checked be a gauge. For the duration of Helidon 4.x users can choose which
  type of meter Helidon registers for `gc.time`.

--- a/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
+++ b/docs/src/main/asciidoc/config/io_helidon_metrics_api_MetricsConfig.adoc
@@ -53,7 +53,8 @@ This is a standalone configuration type, prefix from configuration root: `metric
 |`enabled` |boolean |`true` |Whether metrics functionality is enabled.
 
  If metrics are configured to be enabled
-|[.line-through]#`gc-time-type`# |xref:{rootdir}/config/io_helidon_metrics_api_GcTimeType.adoc[GcTimeType] |`GcTimeType.COUNTER` |*Deprecated* Whether the `gc.time` meter should be registered as a gauge (vs. a counter).
+|[.line-through]#`gc-time-type`# |
+|`GcTimeType.COUNTER` |*Deprecated* Whether the `gc.time` meter should be registered as a gauge (vs. a counter).
  The `gc.time` meter is inspired by the MicroProfile Metrics spec, in which the meter was originally checked to
  be a counter but starting in 5.1 was checked be a gauge. For the duration of Helidon 4.x users can choose which
  type of meter Helidon registers for `gc.time`.

--- a/docs/src/main/asciidoc/includes/metrics/metrics-config.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-config.adoc
@@ -56,6 +56,26 @@ ifdef::mp-flavor[`application`]
 
 |====
 --
+
+[[controlling-gc-time]]
+=== Controlling the {metric_uc} Type for `gc.time`
+To date Helidon 4 releases have implemented the system-provided {metric} `gc.time` as a counter.
+In fact, a gauge is more suitable for the approximate time the JVM has spent doing garbage
+ifdef::se-flavor[collection.]
+ifdef::mp-flavor[]
+collection, and beginning with MicroProfile Metrics 5.1 the TCK relies on `gc.time` being a gauge.
+endif::mp-flavor[]
+
+Helidon {helidon-version} continues to use a counter by default to preserve backward compatibility, but you can choose to use a gauge by setting the configuration property `metrics.gc-time-type` to `gauge`.
+You can also set the config property to `counter` which is the default.
+
+Why should you care?
+In fact, this distinction might not make a difference for many users.
+But for others the differences between the programmatic APIs for `Counter` and `Gauge` would affect application code that works directly with the `gc-time`
+{metric}. Further, the difference in output--particularly in the OpenMetrics/Prometheus format--might affect their application or downstream monitoring tools.
+
+The ability to choose the {metric} type for `gc.time` is deprecated and is planned for removal in a future major release of Helidon at which time Helidon will always use a gauge.
+
 // end::config-intro[]
 
 // tag::config-examples[]

--- a/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
@@ -37,6 +37,21 @@ endif::[]
 
 Metrics is one of the Helidon observability features.
 
+// TODO - Remove the following note starting in Helidon 5.
+[NOTE]
+.Recommended Configuration Setting
+====
+Beginning with Helidon 4.1, strongly consider assigning the config setting
+[source,properties]
+----
+metrics.gc-time-type = gauge
+----
+ifdef::mp-flavor[]
+so your service complies with the MicroProfile Metrics 5.1 specification.
+endif::mp-flavor[]
+See the <<controlling-gc-time,longer discussion below>> in the  Configuration section.
+====
+
 // end::overview[]
 
 // tag::usage-body[]

--- a/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
@@ -37,7 +37,7 @@ endif::[]
 
 Metrics is one of the Helidon observability features.
 
-// TODO - Remove the following note starting in Helidon 5.
+// @Deprecated(forRemoval = true) Remove the following note starting in Helidon 5.
 [NOTE]
 .Recommended Configuration Setting
 ====

--- a/metrics/api/src/main/java/io/helidon/metrics/api/DistributionSummary.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/DistributionSummary.java
@@ -134,5 +134,12 @@ public interface DistributionSummary extends Meter {
          * @return distribution statistics config, if set; empty otherwise
          */
         Optional<DistributionStatisticsConfig.Builder> distributionStatisticsConfig();
+
+        /**
+         * Returns whether to publsh percentile histogram.
+         *
+         * @return true/false
+         */
+        Optional<Boolean> publishPercentileHistogram();
     }
 }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/DistributionSummary.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/DistributionSummary.java
@@ -114,6 +114,14 @@ public interface DistributionSummary extends Meter {
         Builder distributionStatisticsConfig(DistributionStatisticsConfig.Builder distributionStatisticsConfigBuilder);
 
         /**
+         * Sets whether to publish a percentile histogram.
+         *
+         * @param value true/false
+         * @return updated builder
+         */
+        Builder publishPercentileHistogram(boolean value);
+
+        /**
          * Returns the scale set on the builder.
          *
          * @return the scale

--- a/metrics/api/src/main/java/io/helidon/metrics/api/GcTimeType.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/GcTimeType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.api;
+
+/**
+ * Choices for the meter type for the {@code gc.time} meter.
+ */
+@Deprecated(since = "4.1", forRemoval = true)
+public enum GcTimeType {
+    /**
+     * Implement the meter as a gauge. This is backward-incompatible with Helidon 4.0.x releases but complies with
+     * MicroProfile 5.1.
+     */
+    GAUGE,
+
+    /**
+     * Implement the meter as a counter. This is backward-compatible with Helidon 4.0.x releases but does not comply with
+     * MicroProfile 5.1.
+     */
+    COUNTER
+}

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -60,8 +60,22 @@ interface MetricsConfigBlueprint {
      */
     String KEY_PERFORMANCE_INDICATORS_CONFIG_KEY = "key-performance-indicators";
 
+    /**
+     * Choices for the meter type for the {@code gc.time} meter.
+     */
     @Deprecated(since = "4.1", forRemoval = true)
-    enum GcTimeType { GAUGE, COUNTER }
+    enum GcTimeType {
+        /**
+         * Implement the meter as a gauge. This is backward-incompatible with Helidon 4.0.x releases but complies with
+         * MicroProfile 5.1.
+         */
+        GAUGE,
+
+        /**
+         * Implement the meter as a counter. This is backward-compatible with Helidon 4.0.x releases but does not comply with
+         * MicorProfile 5.1.
+         */
+        COUNTER }
 
     @Prototype.FactoryMethod
     static List<Tag> createTags(Config globalTagExpression) {

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -73,7 +73,7 @@ interface MetricsConfigBlueprint {
 
         /**
          * Implement the meter as a counter. This is backward-compatible with Helidon 4.0.x releases but does not comply with
-         * MicorProfile 5.1.
+         * MicroProfile 5.1.
          */
         COUNTER }
 

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -60,6 +60,9 @@ interface MetricsConfigBlueprint {
      */
     String KEY_PERFORMANCE_INDICATORS_CONFIG_KEY = "key-performance-indicators";
 
+    @Deprecated(since = "4.1", forRemoval = true)
+    enum GcTimeType { GAUGE, COUNTER }
+
     @Prototype.FactoryMethod
     static List<Tag> createTags(Config globalTagExpression) {
         return createTags(globalTagExpression.asString().get());
@@ -205,6 +208,19 @@ interface MetricsConfigBlueprint {
      */
     @Option.Redundant
     Config config();
+
+    /**
+     * Whether the {@code gc.time} meter should be registered as a gauge (vs. a counter).
+     * The {@code gc.time} meter is inspired by the MicroProfile Metrics spec, in which the meter was originally checked to
+     * be a counter but starting in 5.1 was checked be a gauge. For the duration of Helidon 4.x users can choose which
+     * type of meter Helidon registers for {@code gc.time}.
+     * @return the type of meter to use for registering {@code gc.time}
+     * @deprecated Provided for backward compatibility only; no replacement
+     */
+    @Deprecated(since = "4.1", forRemoval = true)
+    @Option.Configured
+    @Option.Default("COUNTER")
+    GcTimeType gcTimeType();
 
     /**
      * Reports whether the specified scope is enabled, according to any scope configuration that

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -60,23 +60,6 @@ interface MetricsConfigBlueprint {
      */
     String KEY_PERFORMANCE_INDICATORS_CONFIG_KEY = "key-performance-indicators";
 
-    /**
-     * Choices for the meter type for the {@code gc.time} meter.
-     */
-    @Deprecated(since = "4.1", forRemoval = true)
-    enum GcTimeType {
-        /**
-         * Implement the meter as a gauge. This is backward-incompatible with Helidon 4.0.x releases but complies with
-         * MicroProfile 5.1.
-         */
-        GAUGE,
-
-        /**
-         * Implement the meter as a counter. This is backward-compatible with Helidon 4.0.x releases but does not comply with
-         * MicroProfile 5.1.
-         */
-        COUNTER }
-
     @Prototype.FactoryMethod
     static List<Tag> createTags(Config globalTagExpression) {
         return createTags(globalTagExpression.asString().get());

--- a/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMeter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMeter.java
@@ -393,6 +393,12 @@ class NoOpMeter implements Meter, NoOpWrapper {
             public Optional<io.helidon.metrics.api.DistributionStatisticsConfig.Builder> distributionStatisticsConfig() {
                 return Optional.ofNullable(distributionStatisticsConfigBuilder);
             }
+
+            @Override
+            public Optional<Boolean> publishPercentileHistogram() {
+                return Optional.ofNullable(publishPercentileHistogram);
+            }
+
         }
     }
 
@@ -635,7 +641,7 @@ class NoOpMeter implements Meter, NoOpWrapper {
             private Duration[] buckets;
             private Duration min;
             private Duration max;
-            private boolean publishPercentileHistogram;
+            private Boolean publishPercentileHistogram;
 
             private Builder(String name) {
                 super(name, Type.TIMER);
@@ -695,6 +701,11 @@ class NoOpMeter implements Meter, NoOpWrapper {
             @Override
             public Optional<Duration> maximumExpectedValue() {
                 return Optional.ofNullable(max);
+            }
+
+            @Override
+            public Optional<Boolean> publishPercentileHistogram() {
+                return Optional.ofNullable(publishPercentileHistogram);
             }
 
         }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMeter.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMeter.java
@@ -354,6 +354,7 @@ class NoOpMeter implements Meter, NoOpWrapper {
 
             private io.helidon.metrics.api.DistributionStatisticsConfig.Builder distributionStatisticsConfigBuilder;
             private Double scale;
+            private boolean publishPercentileHistogram;
 
             private Builder(String name) {
                 super(name, Type.DISTRIBUTION_SUMMARY);
@@ -374,6 +375,12 @@ class NoOpMeter implements Meter, NoOpWrapper {
             public Builder distributionStatisticsConfig(
                     io.helidon.metrics.api.DistributionStatisticsConfig.Builder distributionStatisticsConfigBuilder) {
                 this.distributionStatisticsConfigBuilder = distributionStatisticsConfigBuilder;
+                return identity();
+            }
+
+            @Override
+            public io.helidon.metrics.api.DistributionSummary.Builder publishPercentileHistogram(boolean value) {
+                this.publishPercentileHistogram = value;
                 return identity();
             }
 
@@ -628,6 +635,7 @@ class NoOpMeter implements Meter, NoOpWrapper {
             private Duration[] buckets;
             private Duration min;
             private Duration max;
+            private boolean publishPercentileHistogram;
 
             private Builder(String name) {
                 super(name, Type.TIMER);
@@ -659,6 +667,12 @@ class NoOpMeter implements Meter, NoOpWrapper {
             @Override
             public Builder maximumExpectedValue(Duration max) {
                 this.max = max;
+                return identity();
+            }
+
+            @Override
+            public io.helidon.metrics.api.Timer.Builder publishPercentileHistogram(boolean value) {
+                publishPercentileHistogram = value;
                 return identity();
             }
 

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Timer.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Timer.java
@@ -261,5 +261,12 @@ public interface Timer extends Meter, HistogramSupport {
          * @return maximum expected value if set; empty otherwise
          */
         Optional<Duration> maximumExpectedValue();
+
+        /**
+         * Returns the setting for publishing percentile histogram.
+         *
+         * @return whether to publish percentile histogram
+         */
+        Optional<Boolean> publishPercentileHistogram();
     }
 }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/Timer.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/Timer.java
@@ -227,6 +227,14 @@ public interface Timer extends Meter, HistogramSupport {
         Builder maximumExpectedValue(Duration max);
 
         /**
+         * Prepares the timer to publish a percentile histogram.
+         *
+         * @param value whether to publish a percentile histogram
+         * @return updated builder
+         */
+        Builder publishPercentileHistogram(boolean value);
+
+        /**
          * Returns the percentiles set in the builder, if any.
          *
          * @return percentiles

--- a/metrics/api/src/test/java/io/helidon/metrics/api/TestGcTimeTypeChoice.java
+++ b/metrics/api/src/test/java/io/helidon/metrics/api/TestGcTimeTypeChoice.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.api;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigMappingException;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Deprecated(since = "4.1", forRemoval = true)
+class TestGcTimeTypeChoice {
+
+    @Test
+    void checkDefaultIsCounterForBackwardCompatibility() {
+        Config config = Config.just(ConfigSources.create(Map.of()));
+        MetricsConfig metricsConfig = MetricsConfig.create(config);
+        assertThat("Defaulted gc.time type", metricsConfig.gcTimeType(), is(MetricsConfigBlueprint.GcTimeType.COUNTER));
+    }
+
+    @Test
+    void checkExplicitCounter() {
+        Config config = Config.just(ConfigSources.create(Map.of("gc-time-type", "counter")));
+        MetricsConfig metricsConfig = MetricsConfig.create(config);
+        assertThat("Explicit gc.time type as counter",
+                   metricsConfig.gcTimeType(),
+                   is(MetricsConfigBlueprint.GcTimeType.COUNTER));
+    }
+
+    @Test
+    void checkGauge() {
+        Config config = Config.just(ConfigSources.create(Map.of("gc-time-type", "gauge")));
+        MetricsConfig metricsConfig = MetricsConfig.create(config);
+        assertThat("Explicit gc.time type as gauge",
+                   metricsConfig.gcTimeType(),
+                   is(MetricsConfigBlueprint.GcTimeType.GAUGE));
+    }
+
+    @Test
+    void checkInvalidSetting() {
+        Config config = Config.just(ConfigSources.create(Map.of("gc-time-type", "bad")));
+        assertThrows(ConfigMappingException.class, () ->MetricsConfig.create(config));
+    }
+}

--- a/metrics/api/src/test/java/io/helidon/metrics/api/TestGcTimeTypeChoice.java
+++ b/metrics/api/src/test/java/io/helidon/metrics/api/TestGcTimeTypeChoice.java
@@ -34,7 +34,7 @@ class TestGcTimeTypeChoice {
     void checkDefaultIsCounterForBackwardCompatibility() {
         Config config = Config.just(ConfigSources.create(Map.of()));
         MetricsConfig metricsConfig = MetricsConfig.create(config);
-        assertThat("Defaulted gc.time type", metricsConfig.gcTimeType(), is(MetricsConfigBlueprint.GcTimeType.COUNTER));
+        assertThat("Defaulted gc.time type", metricsConfig.gcTimeType(), is(GcTimeType.COUNTER));
     }
 
     @Test
@@ -43,7 +43,7 @@ class TestGcTimeTypeChoice {
         MetricsConfig metricsConfig = MetricsConfig.create(config);
         assertThat("Explicit gc.time type as counter",
                    metricsConfig.gcTimeType(),
-                   is(MetricsConfigBlueprint.GcTimeType.COUNTER));
+                   is(GcTimeType.COUNTER));
     }
 
     @Test
@@ -52,7 +52,7 @@ class TestGcTimeTypeChoice {
         MetricsConfig metricsConfig = MetricsConfig.create(config);
         assertThat("Explicit gc.time type as gauge",
                    metricsConfig.gcTimeType(),
-                   is(MetricsConfigBlueprint.GcTimeType.GAUGE));
+                   is(GcTimeType.GAUGE));
     }
 
     @Test

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MDistributionSummary.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MDistributionSummary.java
@@ -127,6 +127,7 @@ class MDistributionSummary extends MMeter<io.micrometer.core.instrument.Distribu
 
         private Double scale;
         private DistributionStatisticsConfig.Builder distributionStatisticsConfigBuilder;
+        private Boolean publishPercentileHistogram;
 
         private Builder(String name, DistributionStatisticsConfig.Builder configBuilder) {
             this(name, configBuilder.build());
@@ -206,6 +207,7 @@ class MDistributionSummary extends MMeter<io.micrometer.core.instrument.Distribu
         @Override
         public DistributionSummary.Builder publishPercentileHistogram(boolean value) {
             delegate().publishPercentileHistogram(value);
+            publishPercentileHistogram = value;
             return identity();
         }
 
@@ -217,6 +219,11 @@ class MDistributionSummary extends MMeter<io.micrometer.core.instrument.Distribu
         @Override
         public Optional<DistributionStatisticsConfig.Builder> distributionStatisticsConfig() {
             return Optional.ofNullable(distributionStatisticsConfigBuilder);
+        }
+
+        @Override
+        public Optional<Boolean> publishPercentileHistogram() {
+            return Optional.ofNullable(publishPercentileHistogram);
         }
 
         protected Builder from(DistributionSummary.Builder other) {

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MTimer.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MTimer.java
@@ -254,6 +254,12 @@ class MTimer extends MMeter<io.micrometer.core.instrument.Timer> implements io.h
         }
 
         @Override
+        public Timer.Builder publishPercentileHistogram(boolean value) {
+            delegate().publishPercentileHistogram(value);
+            return identity();
+        }
+
+        @Override
         public Iterable<Double> percentiles() {
             return Util.iterable(percentiles);
         }

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MTimer.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,6 +195,7 @@ class MTimer extends MMeter<io.micrometer.core.instrument.Timer> implements io.h
         private Duration[] buckets;
         private Duration min;
         private Duration max;
+        private Boolean publishPercentileHistogram;
 
         private Builder(String name) {
             super(name, io.micrometer.core.instrument.Timer.builder(name));
@@ -254,7 +255,7 @@ class MTimer extends MMeter<io.micrometer.core.instrument.Timer> implements io.h
         }
 
         @Override
-        public Timer.Builder publishPercentileHistogram(boolean value) {
+        public Builder publishPercentileHistogram(boolean value) {
             delegate().publishPercentileHistogram(value);
             return identity();
         }
@@ -277,6 +278,11 @@ class MTimer extends MMeter<io.micrometer.core.instrument.Timer> implements io.h
         @Override
         public Optional<Duration> maximumExpectedValue() {
             return Optional.ofNullable(max);
+        }
+
+        @Override
+        public Optional<Boolean> publishPercentileHistogram() {
+            return Optional.ofNullable(publishPercentileHistogram);
         }
 
         @Override

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactory.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactory.java
@@ -248,7 +248,7 @@ class MicrometerMetricsFactory implements MetricsFactory {
 
     @Override
     public DistributionStatisticsConfig.Builder distributionStatisticsConfigBuilder() {
-        return MDistributionStatisticsConfig.builder();
+        return MDistributionStatisticsConfig.Unconnected.builder();
     }
 
     @Override

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
     static Set<String> meterNameSuffixes(Meter.Type meterType) {
         return switch (meterType) {
             case COUNTER -> Set.of("_total");
-            case DISTRIBUTION_SUMMARY, LONG_TASK_TIMER, TIMER -> Set.of("_count", "_sum", "_max");
+            case DISTRIBUTION_SUMMARY, LONG_TASK_TIMER, TIMER -> Set.of("_count", "_sum", "_max", "_bucket");
             case GAUGE, OTHER -> Set.of();
         };
     }

--- a/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
+++ b/metrics/system-meters/src/main/java/io/helidon/metrics/systemmeters/SystemMetersProvider.java
@@ -240,7 +240,8 @@ public class SystemMetersProvider implements MetersProvider {
                           GarbageCollectorMXBean::getCollectionCount,
                           Tag.create("name", poolName));
             // Express the GC time in seconds.
-            // TODO - Starting in Helidon 5 always register a gauge.
+            // @Deprecated(forRemoval = true) - Starting in Helidon 5 always register a gauge instead of checking which
+            // type of meter to register.
             if (isGcTimeGauge()) {
                 registerGauge(result,
                               GC_TIME,

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/DistributionCustomizations.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/DistributionCustomizations.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import java.lang.reflect.Array;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.helidon.common.Errors;
+import io.helidon.common.LazyValue;
+import io.helidon.metrics.api.DistributionStatisticsConfig;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.Timer;
+
+import org.eclipse.microprofile.config.Config;
+
+/**
+ * Internal logic for handling config-based customization of percentiles and buckets.
+ * <p>
+ * MicroProfile Metrics 5.1 permits users to configure percentile and bucket settings for timers and histograms in
+ * {@code META-INF/microprofile-config.properties}. This class encapsulates the processing to apply those defaults.
+ * <p>
+ * The general format of the config value is a semicolon-separated list of {@code nameExpression=values}
+ * where each {@code values} is a comma-separated list of values. The {@code nameExpression} can be:
+ *     <ul>
+ *         <li>exact metric name</li>
+ *         <li>metric name prefix followed by {@code *}</li>
+ *         <li>{@code *}</li>
+ *         <li>nothing.</li>
+ *     </ul>
+ * <p>
+ *     Further, Micrometer provides a default set of histogram buckets which users can choose to apply to meters following the
+ *     same {@code nameExpression} pattern.
+ * </p>
+ * </p>
+ */
+class DistributionCustomizations {
+
+    private static final System.Logger LOGGER = System.getLogger(DistributionCustomizations.class.getName());
+
+    private static final double DEFAULT_SUMMARY_MIN = 0.05d;
+    private static final double DEFAULT_SUMMARY_MAX = 10000d;
+    private static final Duration DEFAULT_TIMER_MIN = Duration.ofMillis(5);
+    private static final Duration DEFAULT_TIMER_MAX = Duration.ofSeconds(10);
+
+    private static DistributionCustomizations instance;
+    private final List<Percentiles> percentileCustomizations;
+    private final List<SummaryBuckets> summaryBucketCustomizations;
+    private final List<TimerBuckets> timerBucketCustomizations;
+    private final List<SingleValuedCustomization<Boolean>> summaryBucketDefaultCustomizations;
+
+    private DistributionCustomizations(Config mpConfig) {
+
+        percentileCustomizations = collect(mpConfig, "mp.metrics.distribution.percentiles", Percentiles::new);
+
+        summaryBucketCustomizations = collect(mpConfig, "mp.metrics.distribution.histogram.buckets", SummaryBuckets::new);
+
+        timerBucketCustomizations = collect(mpConfig, "mp.metrics.distribution.timer.buckets", TimerBuckets::new);
+
+        summaryBucketDefaultCustomizations = collect(mpConfig,
+                                                     "mp.metrics.distribution.percentiles-histogram.enabled",
+                                                     expression -> new SingleValuedCustomization<>(expression,
+                                                                                                   Boolean::parseBoolean));
+    }
+
+    static void init(Config mpConfig) {
+        instance = new DistributionCustomizations(mpConfig);
+    }
+
+    static DistributionSummary.Builder apply(DistributionSummary.Builder builder) {
+        DistributionStatisticsConfig.Builder statsBuilder = builder.distributionStatisticsConfig()
+                .orElseGet(() -> {
+                    DistributionStatisticsConfig.Builder newBuilder = DistributionStatisticsConfig.builder();
+                    builder.distributionStatisticsConfig(newBuilder);
+                    return newBuilder;
+                });
+        instance.percentileCustomizations.stream()
+                .filter(p -> p.matches(builder.name()))
+                .forEach(p -> statsBuilder.percentiles(p.percentiles()));
+
+        AtomicBoolean matched = new AtomicBoolean();
+        instance.summaryBucketCustomizations.stream()
+                .filter(b -> b.matches(builder.name()))
+                .forEach(b -> {
+                    matched.set(true);
+                    statsBuilder.buckets(b.buckets());
+                });
+
+        if (!matched.get()) {
+            instance.summaryBucketDefaultCustomizations.stream()
+                    .filter(def -> def.matches(builder.name()))
+                    .map(SingleValuedCustomization::value)
+                    .reduce((a, b) -> b) // Always take the latest match.
+                    .ifPresent(def -> {
+                        builder.publishPercentileHistogram(def);
+                        statsBuilder.minimumExpectedValue(DEFAULT_SUMMARY_MIN)
+                                .maximumExpectedValue(DEFAULT_SUMMARY_MAX);
+
+                    });
+        }
+
+        return builder;
+    }
+
+    static Timer.Builder apply(Timer.Builder builder) {
+        instance.percentileCustomizations.stream()
+                .filter(p -> p.matches(builder.name()))
+                .forEach(p -> builder.percentiles(p.percentiles()));
+
+        AtomicBoolean matched = new AtomicBoolean();
+        instance.timerBucketCustomizations.stream()
+                .filter(b -> b.matches(builder.name()))
+                .forEach(b -> {
+                    matched.set(true);
+                    builder.buckets(b.buckets());
+                });
+
+        if (!matched.get()) {
+            instance.summaryBucketDefaultCustomizations.stream()
+                    .filter(def -> def.matches(builder.name()))
+                    .map(SingleValuedCustomization::value)
+                    .reduce((a, b) -> b) // Always take the latest match.
+                    .ifPresent(def -> {
+                        builder.publishPercentileHistogram(def);
+                        builder.minimumExpectedValue(DEFAULT_TIMER_MIN)
+                                .maximumExpectedValue(DEFAULT_TIMER_MAX);
+                    });
+        }
+
+        return builder;
+    }
+
+    private static <U extends Customization> List<U> collect(Config mpConfig,
+                                                             String configKey,
+                                                             Function<String, U> factory) {
+        return mpConfig.getOptionalValue(configKey, String.class)
+                .stream()
+                .flatMap(s -> Arrays.stream(s.split(";")))
+                .map(factory)
+                .toList();
+    }
+
+    private static double[] doubles(Double[] doubles) {
+        double[] result = new double[doubles.length];
+        for (int i = 0; i < doubles.length; i++) {
+            result[i] = doubles[i];
+        }
+        return result;
+    }
+
+    abstract static class Customization {
+        private final String namePrefix;
+        private final boolean hasTrailingWildcard;
+        private final String valuesExpression;
+
+        protected Customization(String nameExpressionAndValues) {
+            int eq = nameExpressionAndValues.indexOf('=');
+            if (eq <= 0) {
+                valuesExpression = "";
+                namePrefix = "";
+                hasTrailingWildcard = false;
+                return;
+            }
+            String namePrefixMaybeWithWildcard = nameExpressionAndValues.substring(0, eq);
+            hasTrailingWildcard = namePrefixMaybeWithWildcard.endsWith("*");
+            namePrefix = namePrefixMaybeWithWildcard.substring(0, hasTrailingWildcard ? eq - 1 : eq);
+            valuesExpression = nameExpressionAndValues.substring(eq + 1);
+        }
+
+        protected String namePrefix() {
+            return namePrefix;
+        }
+
+        protected boolean hasTrailingWildcard() {
+            return hasTrailingWildcard;
+        }
+
+        protected String valuesExpression() {
+            return valuesExpression;
+        }
+
+        protected boolean matches(String metricName) {
+            return hasTrailingWildcard() ? metricName.startsWith(namePrefix())
+                    : metricName.equals(namePrefix());
+        }
+    }
+
+    static class SingleValuedCustomization<T> extends Customization {
+
+        private final T value;
+
+        protected SingleValuedCustomization(String nameAndValuesExpression, Function<String, T> valueParser) {
+            super(nameAndValuesExpression);
+            value = valueParser.apply(valuesExpression());
+        }
+
+        protected T value() {
+            return value;
+        }
+    }
+
+    abstract static class MultiValuedCustomization<T extends Comparable<T>> extends Customization {
+
+        private final T[] values;
+
+        protected MultiValuedCustomization(String nameExpressionAndValues,
+                                           Class<T> type,
+                                           Function<String, T> valueParser,
+                                           Consumer<T> valueChecker) {
+            super(nameExpressionAndValues);
+            if (valuesExpression().isBlank()) {
+                values = (T[]) Array.newInstance(type, 0);
+                return;
+            }
+            values = values(valuesExpression(), type, valueParser, valueChecker);
+        }
+
+        protected T[] values() {
+            return values;
+        }
+
+        private T[] values(String valuesString,
+                           Class<T> type,
+                           Function<String, T> valueParser,
+                           Consumer<T> valueChecker) {
+            String[] valueStrings = valuesString.split(",");
+            T[] result = (T[]) Array.newInstance(type, valueStrings.length);
+            int next = 0;
+            T prev = null;
+            boolean valuesInOrder = true;
+            LazyValue<Errors.Collector> collector = LazyValue.create(Errors::collector);
+            for (String valueString : valueStrings) {
+                if (!valueString.isBlank()) {
+                    T value;
+                    try {
+                        value = valueParser.apply(valueString);
+                    } catch (Exception ex) {
+                        // The spec says to ignore invalid values but we'll warn about it.
+                        collector.get().warn("ignoring invalid value: " + ex.getMessage());
+                        continue;
+                    }
+                    valuesInOrder &= prev != null && prev.compareTo(value) < 0;
+                    try {
+                        valueChecker.accept(value);
+                    } catch (Exception ex) {
+                        collector.get().warn("ignoring value for "
+                                                     + namePrefix()
+                                                     + (hasTrailingWildcard() ? "*" : ": ")
+                                                     + ex.getMessage());
+                        continue;
+                    }
+                    result[next++] = value;
+                    prev = value;
+                }
+            }
+            if (!valuesInOrder) {
+                collector.get().warn("Values for "
+                                             + namePrefix()
+                                             + (hasTrailingWildcard() ? "*" : "")
+                                             + "should be in strictly increasing order but are not: "
+                                             + Arrays.toString(valueStrings));
+            }
+
+            if (collector.isLoaded()) {
+                collector.get().collect().log(LOGGER);
+            }
+            return Arrays.copyOf(result, next);
+        }
+    }
+
+    static class Percentiles extends MultiValuedCustomization<Double> {
+
+        private final double[] values;
+
+        private Percentiles(String nameExpressionAndValues) {
+            super(nameExpressionAndValues, Double.class, Double::parseDouble, d -> {
+                if (d < 0.0d || d > 1.0d) {
+                    throw new IllegalArgumentException("Value " + d + " not in required range [0.0, 1.0]");
+                }
+            });
+            values = doubles(values());
+        }
+
+        double[] percentiles() {
+            return values;
+        }
+    }
+
+    static class SummaryBuckets extends MultiValuedCustomization<Double> {
+
+        private final double[] values;
+
+        private SummaryBuckets(String nameExpressionAndValues) {
+            super(nameExpressionAndValues, Double.class, Double::parseDouble, d -> {
+                if (d <= 0) {
+                    throw new IllegalArgumentException("Value must be > 0 but " + d + " is not");
+                }
+            });
+            values = doubles(values());
+        }
+
+        double[] buckets() {
+            return values;
+        }
+    }
+
+    static class TimerBuckets extends MultiValuedCustomization<Duration> {
+
+        private TimerBuckets(String nameExpressionAndValues) {
+            super(nameExpressionAndValues, Duration.class, TimerBuckets::parseTimerBucketExpression, d -> {
+            });
+        }
+
+        protected Duration[] buckets() {
+            return values();
+        }
+
+        private static Duration parseTimerBucketExpression(String expr) {
+            TimeUnit timeUnit;
+            int suffixSize = 1;
+            String lcExpr = expr.toLowerCase(Locale.ROOT);
+            if (lcExpr.endsWith("ms")) {
+                timeUnit = TimeUnit.MILLISECONDS;
+                suffixSize = 2;
+            } else if (lcExpr.endsWith("s")) {
+                timeUnit = TimeUnit.SECONDS;
+            } else if (lcExpr.endsWith("m")) {
+                timeUnit = TimeUnit.MINUTES;
+            } else if (lcExpr.endsWith("h")) {
+                timeUnit = TimeUnit.HOURS;
+            } else {
+                timeUnit = TimeUnit.MILLISECONDS;
+                suffixSize = 0;
+            }
+            int amount = Integer.parseInt(expr.substring(0, expr.length() - suffixSize));
+            return Duration.of(amount, timeUnit.toChronoUnit());
+        }
+    }
+
+}

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonHistogram.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonHistogram.java
@@ -42,11 +42,12 @@ final class HelidonHistogram extends MetricImpl<DistributionSummary> implements 
     static HelidonHistogram create(MeterRegistry meterRegistry, String scope, Metadata metadata, Tag... tags) {
         return create(scope,
                       metadata,
-                      meterRegistry.getOrCreate(DistributionSummary.builder(metadata.getName())
-                                                        .scope(scope)
-                                                        .description(metadata.getDescription())
-                                                        .baseUnit(sanitizeUnit(metadata.getUnit()))
-                                                        .tags(allTags(scope, tags))));
+                      meterRegistry.getOrCreate(DistributionCustomizations
+                                                        .apply(DistributionSummary.builder(metadata.getName())
+                                                                       .scope(scope)
+                                                                       .description(metadata.getDescription())
+                                                                       .baseUnit(sanitizeUnit(metadata.getUnit()))
+                                                                       .tags(allTags(scope, tags)))));
     }
 
     static HelidonHistogram create(String scope,

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonSnapshot.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,13 @@ class HelidonSnapshot extends Snapshot {
         return StreamSupport.stream(delegate.percentileValues().spliterator(), false)
                 .map(pv -> new PercentileValue(pv.percentile(), pv.value()))
                 .toArray(PercentileValue[]::new);
+    }
+
+    @Override
+    public HistogramBucket[] bucketValues() {
+        return StreamSupport.stream(delegate.histogramCounts().spliterator(), false)
+                .map(bucket -> new HistogramBucket(bucket.boundary(), (long) bucket.count()))
+                .toArray(HistogramBucket[]::new);
     }
 
     @Override

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonTimer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/HelidonTimer.java
@@ -51,10 +51,11 @@ final class HelidonTimer extends MetricImpl<io.helidon.metrics.api.Timer> implem
         return create(meterRegistry,
                       scope,
                       metadata,
-                      meterRegistry.getOrCreate(io.helidon.metrics.api.Timer.builder(metadata.getName())
-                                                        .description(metadata.getDescription())
-                                                        .baseUnit(sanitizeUnit(metadata.getUnit()))
-                                                        .tags(allTags(scope, tags))));
+                      meterRegistry.getOrCreate(DistributionCustomizations
+                                                        .apply(io.helidon.metrics.api.Timer.builder(metadata.getName())
+                                                                       .description(metadata.getDescription())
+                                                                       .baseUnit(sanitizeUnit(metadata.getUnit()))
+                                                                       .tags(allTags(scope, tags)))));
     }
 
     static HelidonTimer create(MeterRegistry meterRegistry,

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/Registry.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/Registry.java
@@ -405,7 +405,7 @@ class Registry implements MetricRegistry {
 
         Errors.Collector collector = Errors.collector();
 
-        MetricID newMetricID = metricIDWithoutSystemTags(collector, meter.id());
+        MetricID newMetricID = metricIDWithoutSystemTags(meter.id());
 
         lock.lock();
 
@@ -659,7 +659,7 @@ class Registry implements MetricRegistry {
     }
 
     private HelidonHistogram createHistogram(io.helidon.metrics.api.DistributionSummary.Builder sBuilder) {
-        return createMeter(sBuilder, HelidonHistogram::create);
+        return createMeter(DistributionCustomizations.apply(sBuilder), HelidonHistogram::create);
     }
 
     private HelidonTimer createTimer(Metadata metadata, Tag... tags) {
@@ -671,7 +671,7 @@ class Registry implements MetricRegistry {
     }
 
     private HelidonTimer createTimer(io.helidon.metrics.api.Timer.Builder tBuilder) {
-        return createMeter(tBuilder, d -> HelidonTimer.create(meterRegistry, d));
+        return createMeter(DistributionCustomizations.apply(tBuilder), d -> HelidonTimer.create(meterRegistry, d));
     }
 
     private <HM extends HelidonMetric<M>,
@@ -738,6 +738,11 @@ class Registry implements MetricRegistry {
         if (!reservedTagNamesUsed.isEmpty()) {
             collector.fatal(reservedTagNamesUsed, "illegal use of reserved tag names");
         }
+        return new MetricID(meterId.name(), tags(tagsWithoutScope));
+    }
+
+    private MetricID metricIDWithoutSystemTags(Meter.Id meterId) {
+        Map<String, String> tagsWithoutScope = tagsWithoutSystemOrScopeTags(meterId.tags());
         return new MetricID(meterId.name(), tags(tagsWithoutScope));
     }
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
@@ -22,7 +22,6 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.Annotated;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.MetricRegistry.Type;
 import org.eclipse.microprofile.metrics.annotation.RegistryScope;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
 
@@ -40,6 +39,7 @@ final class RegistryProducer {
 
     @Produces
     @Default
+    @RegistryScope
     public static org.eclipse.microprofile.metrics.MetricRegistry getScopedRegistry(InjectionPoint injectionPoint) {
         Annotated annotated = (injectionPoint == null) ? null : injectionPoint.getAnnotated();
         RegistryScope scope = (annotated == null) ? null : annotated.getAnnotation(RegistryScope.class);
@@ -52,23 +52,23 @@ final class RegistryProducer {
         return getApplicationRegistry();
     }
 
-    // TODO Once RegistryScope becomes a qualifier, use it instead of RegistryType.
+    // TODO Remove if MP Metrics ever removes @RegistryType.
     @Produces
-    @RegistryType(type = Type.APPLICATION)
+    @RegistryType(type = MetricRegistry.Type.APPLICATION)
     public static org.eclipse.microprofile.metrics.MetricRegistry getApplicationRegistry() {
         return RegistryFactory.getInstance().getRegistry(MetricRegistry.APPLICATION_SCOPE);
     }
 
+    // TODO Remove if MP Metrics ever removes @RegistryType.
     @Produces
-    // TODO Once RegistryScope becomes a qualifier, use it instead of RegistryType.
-    @RegistryType(type = Type.BASE)
+    @RegistryType(type = MetricRegistry.Type.BASE)
     public static org.eclipse.microprofile.metrics.MetricRegistry getBaseRegistry() {
         return RegistryFactory.getInstance().getRegistry(MetricRegistry.BASE_SCOPE);
     }
 
-    // TODO Once RegistryScope becomes a qualifier, use it instead of RegistryType.
+    // TODO Remove if MP Metrics ever removes @RegistryType.
     @Produces
-    @RegistryType(type = Type.VENDOR)
+    @RegistryType(type = MetricRegistry.Type.VENDOR)
     public static org.eclipse.microprofile.metrics.MetricRegistry getVendorRegistry() {
         return RegistryFactory.getInstance().getRegistry(MetricRegistry.VENDOR_SCOPE);
     }

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
-import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -63,14 +63,12 @@ public class HelloWorldAsyncResponseTest {
     @Inject
     MetricRegistry registry;
 
-    // TODO change to RegistryScope once MP makes it a qualifier
     @Inject
-    @RegistryType(type = MetricRegistry.Type.BASE)
+    @RegistryScope(scope = MetricRegistry.BASE_SCOPE)
     private MetricRegistry syntheticTimerRegistry;
 
-    // TODO change to RegistryScope once MP makes it a qualifier
     @Inject
-    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    @RegistryScope(scope = MetricRegistry.VENDOR_SCOPE)
     private MetricRegistry vendorRegistry;
 
     @Disabled

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldResource.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 /**
@@ -102,9 +102,8 @@ public class HelloWorldResource {
     @Inject
     MetricRegistry metricRegistry;
 
-    // TODO change to RegistryScope once MP makes it a qualifier
     @Inject
-    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    @RegistryScope(scope = MetricRegistry.VENDOR_SCOPE)
     private MetricRegistry vendorRegistry;
 
     public HelloWorldResource() {

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldRestEndpointSimpleTimerDisabledTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldRestEndpointSimpleTimerDisabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import io.helidon.microprofile.testing.junit5.HelidonTest;
 
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -41,9 +41,8 @@ public class HelloWorldRestEndpointSimpleTimerDisabledTest {
         MetricsMpServiceTest.cleanUpSyntheticSimpleTimerRegistry();
     }
 
-    // TODO change to RegistryScope once MP makes it a qualifier
     @Inject
-    @RegistryType(type = MetricRegistry.Type.BASE)
+    @RegistryScope(scope = MetricRegistry.BASE_SCOPE)
     MetricRegistry syntheticTimerRegistry;
 
     boolean isSyntheticSimpleTimerPresent() {

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsMpServiceTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsMpServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
 import org.junit.jupiter.api.AfterAll;
 
 /**
@@ -48,9 +48,8 @@ public class MetricsMpServiceTest {
     @Inject
     private MetricRegistry registry;
 
-    // TODO change to RegistryScope once MP makes it a qualifier
     @Inject
-    @RegistryType(type = MetricRegistry.Type.BASE)
+    @RegistryScope(scope = MetricRegistry.BASE_SCOPE)
     private MetricRegistry baseRegistry;
 
     MetricRegistry syntheticTimerTimerRegistry() {

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDistributionCustomizations.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDistributionCustomizations.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Timer;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.greaterThan;
+
+@HelidonTest
+@AddConfig(key = "mp.metrics.distribution.percentiles-histogram.enabled",
+           value = "alpha.*=true;alpha.nope=false")
+class TestDistributionCustomizations {
+
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    @Test
+    void checkDefaultedSummaryWithNoCustomization() {
+        Histogram histogram = metricRegistry.histogram("alpha.useDefaults");
+        /*
+         Micrometer provides the buckets automatically. Just make sure there are some.
+         */
+        assertThat("alpha.useDefaults",
+                   histogram.getSnapshot().bucketValues(),
+                   arrayWithSize(greaterThan(0)));
+
+        Timer timer = metricRegistry.timer("alpha.timer");
+        assertThat("alpha.timer",
+                   timer.getSnapshot().bucketValues(),
+                   arrayWithSize(greaterThan(0)));
+    }
+
+    @Test
+    void checkNoDefaultDueToExclusion() {
+        Histogram histogram = metricRegistry.histogram("alpha.nope");
+        assertThat("alpha.nope",
+                   histogram.getSnapshot().bucketValues(),
+                   arrayWithSize(0));
+
+        metricRegistry.remove(new MetricID("alpha.nope"));
+
+        Timer timer = metricRegistry.timer("alpha.nope");
+        assertThat("alpha.nope",
+                   timer.getSnapshot().bucketValues(),
+                   arrayWithSize(0));
+
+        timer = metricRegistry.timer("beta.anything");
+        assertThat("beta.anything",
+                   timer.getSnapshot().bucketValues(),
+                   arrayWithSize(0));
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestGcTimeCounter.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestGcTimeCounter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import java.util.Map;
+
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+@HelidonTest
+@Deprecated(since = "4.1", forRemoval = true)
+@Disabled
+class TestGcTimeCounter {
+
+    @Inject
+    @RegistryScope(scope = MetricRegistry.BASE_SCOPE)
+    private MetricRegistry baseRegistry;
+
+    @Test
+    void checkForCounter() {
+
+        Map<MetricID, Metric> gcTimeMetrics =
+                baseRegistry.getMetrics((metricID, metric) -> metricID.getName().equals("gc.time"));
+
+        assertThat("gc.time metric IDs", gcTimeMetrics.keySet(), not(empty()));
+        assertThat("gc.time metric", gcTimeMetrics.values().stream().findFirst().orElseThrow(), instanceOf(Counter.class));
+    }
+
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestGcTimeGauge.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestGcTimeGauge.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import java.util.Map;
+
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+@HelidonTest
+@AddConfig(key = "mp.metrics.gc-time-type", value = "gauge")
+@Deprecated(since = "4.1", forRemoval = true)
+class TestGcTimeGauge {
+
+    @Inject
+    @RegistryScope(scope = MetricRegistry.BASE_SCOPE)
+    private MetricRegistry baseRegistry;
+
+    @Test
+    void checkForGauge() {
+
+        Map<MetricID, Metric> gcTimeMetrics =
+                baseRegistry.getMetrics((metricID, metric) -> metricID.getName().equals("gc.time"));
+
+        assertThat("gc.time metric IDs", gcTimeMetrics.keySet(), not(empty()));
+        assertThat("gc.time metric", gcTimeMetrics.values().stream().findFirst().orElseThrow(), instanceOf(Gauge.class));
+    }
+}

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -131,6 +131,10 @@
                     <systemPropertyVariables>
                         <context.root/> <!-- Suppress the TCK's default of /optionalTCK -->
                         <metrics.rest-request.enabled>true</metrics.rest-request.enabled> <!-- off by default -->
+                        <!-- TODO - remove setting of gc-time-type for Helidon 5
+                         This is required starting in 4.1 to use a gauge instead of the backward-compatible counter
+                         for gc.time. -->
+                        <metrics.gc-time-type>gauge</metrics.gc-time-type>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -131,7 +131,7 @@
                     <systemPropertyVariables>
                         <context.root/> <!-- Suppress the TCK's default of /optionalTCK -->
                         <metrics.rest-request.enabled>true</metrics.rest-request.enabled> <!-- off by default -->
-                        <!-- TODO - remove setting of gc-time-type for Helidon 5
+                        <!-- @Deprecated(forRemoval = true) - remove setting of gc-time-type for Helidon 5
                          This is required starting in 4.1 to use a gauge instead of the backward-compatible counter
                          for gc.time. -->
                         <metrics.gc-time-type>gauge</metrics.gc-time-type>


### PR DESCRIPTION
### Description
Resolves #8004

### Notable changes
1. Metrics config setting `gc-time-type` (new feature)
   
   The MP Metrics 5.1 TCK fixes a problem in a TCK test which used to check for the `gc.time` being a counter; the spec always said it is a gauge. In the 5.1 TCK the test now checks for a gauge by examining the Prometheus output to verify that metric, and the format is different for counters and gauges. 
   
   Helidon implements `gc.time` in SE as a system-provided meter. To maintain backward compatibility with Helidon 4.0.x while also passing the MP Metrics 5.1 TCK, Helidon adds `metrics.gc-time-type` which defaults to `counter` (the old behavior) but can also be set to `gauge` to pass the TCK or for user services to comply with MP Metrics 5.1.
   
   The setting is marked as deprecated; Helidon 5 should remove the option entirely, always using a gauge.
2. Default percentile precision (bug fix)
   
   Micrometer allows users to set the precision with which percentiles are computed. Since 4.0.0 Helidon has defaulted the precision to 3, but the code imposed this default in the `MDistributionStatisticsConfig#build` method which could incorrectly overwrite a user-assigned value. The PR moves the default assignment to the builder's constructor so a user setting will overwrite the default instead of the other way around.
3. `MDistributionStatisticsConfig` delegation (bug fix)
   
   Most of our metrics implementation classes have a delegate which points to the corresponding Micrometer object. Although
Micrometer does have a `DistributionStatisticConfig.Builder` type it is hidden inside the Micrometer `DistributionSummary.Builder` and we cannot access it. Instead, callers indirectly update the Micrometer `DistributionStatisticConfig.Builder` by invoking methods on the `DistributionSummary.Buider` which delegates to its hidden config.
   
   As a result, our `MDistributionStatisticsConfig` and its `Builder` classes cannot actually make use of normal Micrometer delegates. To satisfy the Helidon metrics API these types now keep a copy of the relevant values (min. and max. expected values and percentile and bucket boundary settings) that are also stored in their Micrometer counterparts.
   
   Our `MDistributionStatisticsConfig.Builder` type now delegates to the corresponding `DistributionSummary.Builder` because  that is where the setter methods are for the Micrometer distribution summary config settings.
   
   Relatedly, there are some cases in which we need a `MDistributionStatisticsConfig` or `Builder` but there is no corresponding Micrometer counterpart. For those, the PR adds the `MDistributionStatisticsConfig.Unconnected` inner class and its builder.
4. Prometheus output (bug fix)
   
   To create Prometheus output, Helidon's Micrometer-based provider leverages Micrometer's own ability to prepare Prometheus exposition format from a Micrometer Prometheus meter registry. For multi-valued meters such as timers and distribution summaries (histograms), the Micrometer Prometheus meter registry stores multiple "sub-meters" with suffixes such as `_total`, `_count`, `_sum`, and `_bucket`. To extract that data efficiently for our Prometheus output we compute all the meter and sub-meter names we might want and pass those to the Micrometer Prometheus meter registry. This calculation had incorrectly omitted the `_bucket` sub-meters for distribution summaries.
5. Expose a way to set whether to publish percentile histograms
   
   Micrometer, and an optional part of the MP Metrics spec 5.1, allow users to indicate whether or not to publish percentile histograms. The original Helidon metrics API did not expose this, and the optional section of the spec relies on it.
   
   This change affected the `Timer` and `DistributionSummary` builder types and their implementations.
6. Configuring percentiles and buckets (new MP-only feature)
   
   MP Metrics 5.1 allows users to configure the percentiles and/or bucket boundaries to be used for timers and distribution summaries, formatted as a semi-colon-separated list of `meter-name-expression=values-list` where `values-list` is a comma-separated list of values. The MP Metrics spec [configuration section](https://download.eclipse.org/microprofile/microprofile-metrics-5.1.1/microprofile-metrics-spec-5.1.1.html#histogram-timer-config) has details. The new Helidon class `DistributionCustomizations` encapsulates the required config processing and exposes a simple internal API to apply defaults as needed to builders for timers and distribution summaries.
   
   The previously-existing places in the MP-only Helidon `Registry` class where timer and distr. summary builders are created (also in `HelidonHistogram` and `HelidonTimers`) now also apply any matching configured defaults to those builders when the builder is created.
   
   This PR adds support for this only for MP, not also SE. The MP Metrics spec is unlikely to evolve further. MP is emphasizing OTel more and more and the MP Telemetry spec relies on OTel config settings rather than adding lots of its own config settings. It did not seem prudent to add this MP Metrics-specific feature to SE at this time.
   
   The spec contains an [optional portion](https://download.eclipse.org/microprofile/microprofile-metrics-5.1.1/microprofile-metrics-spec-5.1.1.html#_optional_enabling_a_default_set_of_histogram_buckets_for_histograms_and_timers) which this PR also implements (again, MP only).
7. `MetricsCdiExtension` config property handling (bug fix)
      
   Certain config settings in the `mp.metrics` namespace need to be reflected in the SE config space so SE metrics behaves correctly. In moving from Helidon 3.x to 4.0, the `metrics` `appName` key changed to `app-name` The code in the MP metrics extension which handles the mapping of MP to SE config was not changed accordingly. At this point we need to keep the existing 4.x SE config key so this code in the extension now allows for differing key names in the two config spaces.
8. `RegistryProducer` (spec change)
   
   MP Metrics 5.0 deprecated the `RegistryType` concept (fixed values of base, vendor, and application) and the `RegistryType` annotation in favor of `RegistryScope` (base, vendor, and application are predefined scopes but users can add their own). In 5.0, though, the `RegistryScope` annotation was not marked as a qualifier. That has now changed so our provider code now responds accordingly, while continuing to support the deprecated `RegistryType` annotation.
9. TCK driver (compatibility)
   
   To pass the TCK, our TCK driver needs to specify the new `metrics.gc-time-type` property as `gauge`. The `pom.xml` now sets that as a Java system property in the surefire plug-in set-up so it is visible to config.
10. `dependencies/pom.xml`
    
    Now declares our dependency on MP metrics 5.1.1.

### Documentation
The PR includes doc changes:
1. Metrics config doc (SE and MP) for choosing how Helidon implements `gc.time`.
2. Updates to the generated `MetricsConfig` `.adoc` file.
