### PR TITLE
Consider missing named parameters values in the parameters Map as null

### DIFF
--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientBuilderBase.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientBuilderBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ public abstract class DbClientBuilderBase<T extends DbClientBuilderBase<T>>
     private String url;
     private String username;
     private String password;
+    private boolean missingMapParametersAsNull;
     private DbStatements statements;
     private MapperManager mapperManager;
     private DbMapperManager dbMapperManager;
@@ -49,6 +50,7 @@ public abstract class DbClientBuilderBase<T extends DbClientBuilderBase<T>>
      */
     protected DbClientBuilderBase() {
         this.clientServices = new LinkedList<>();
+        this.missingMapParametersAsNull = false;
     }
 
     @Override
@@ -71,6 +73,7 @@ public abstract class DbClientBuilderBase<T extends DbClientBuilderBase<T>>
 
     @Override
     public T config(Config config) {
+        config.get("missing-map-parameters-as-null").as(Boolean.class).ifPresent(this::missingMapParametersAsNull);
         config.get("statements").map(DbStatements::create).ifPresent(this::statements);
         return identity();
     }
@@ -90,6 +93,12 @@ public abstract class DbClientBuilderBase<T extends DbClientBuilderBase<T>>
     @Override
     public T password(String password) {
         this.password = password;
+        return identity();
+    }
+
+    @Override
+    public T missingMapParametersAsNull(boolean missingMapParametersAsNull) {
+        this.missingMapParametersAsNull = missingMapParametersAsNull;
         return identity();
     }
 
@@ -183,6 +192,17 @@ public abstract class DbClientBuilderBase<T extends DbClientBuilderBase<T>>
      */
     public String password() {
         return password;
+    }
+
+    /**
+     * Configured missing values in named parameters {@link java.util.Map} handling.
+     *
+     * @return when set to {@code true}, named parameters value missing in the {@code Map} is considered
+     *         as {@code null}, when set to {@code false}, any parameter value missing in the {@code Map}
+     *         will cause an exception.
+     */
+    public boolean missingMapParametersAsNull() {
+        return missingMapParametersAsNull;
     }
 
     /**

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientBuilderBase.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientBuilderBase.java
@@ -50,7 +50,6 @@ public abstract class DbClientBuilderBase<T extends DbClientBuilderBase<T>>
      */
     protected DbClientBuilderBase() {
         this.clientServices = new LinkedList<>();
-        this.missingMapParametersAsNull = false;
     }
 
     @Override

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientContext.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ public class DbClientContext implements DbContext {
     private final DbMapperManager dbMapperManager;
     private final MapperManager mapperManager;
     private final List<DbClientService> clientServices;
+    private final boolean missingMapParametersAsNull;
     private final DbStatements statements;
     private final String dbType;
 
@@ -42,8 +43,14 @@ public class DbClientContext implements DbContext {
         this.dbMapperManager = builder.dbMapperManager;
         this.mapperManager = builder.mapperManager;
         this.clientServices = builder.clientServices;
+        this.missingMapParametersAsNull = builder.missingMapParametersAsNull;
         this.statements = builder.statements;
         this.dbType = builder.dbType;
+    }
+
+    @Override
+    public boolean missingMapParametersAsNull() {
+        return missingMapParametersAsNull;
     }
 
     @Override
@@ -107,6 +114,7 @@ public class DbClientContext implements DbContext {
         private DbMapperManager dbMapperManager;
         private MapperManager mapperManager;
         private List<DbClientService> clientServices = List.of();
+        private boolean missingMapParametersAsNull;
         private DbStatements statements;
         private String dbType;
 
@@ -114,6 +122,7 @@ public class DbClientContext implements DbContext {
          * Creates an instance of base builder for {@link DbClientContext}.
          */
         protected BuilderBase() {
+            this.missingMapParametersAsNull = false;
         }
 
         /**
@@ -146,6 +155,20 @@ public class DbClientContext implements DbContext {
          */
         public B clientServices(List<DbClientService> clientServices) {
             this.clientServices = clientServices;
+            return identity();
+        }
+
+        /**
+         * Missing values in named parameters {@link java.util.Map} are considered as null values.
+         * When set to {@code true}, named parameters value missing in the {@code Map} is considered
+         * as {@code null}. When set to {@code false}, any parameter value missing in the {@code Map}
+         * will cause an exception.
+         * @param missingMapParametersAsNull whether missing values in named parameters {@code Map}
+         *                                   are considered as null values
+         * @return updated builder instance
+         */
+        public B missingMapParametersAsNull(boolean missingMapParametersAsNull) {
+            this.missingMapParametersAsNull = missingMapParametersAsNull;
             return identity();
         }
 

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientContext.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientContext.java
@@ -122,7 +122,6 @@ public class DbClientContext implements DbContext {
          * Creates an instance of base builder for {@link DbClientContext}.
          */
         protected BuilderBase() {
-            this.missingMapParametersAsNull = false;
         }
 
         /**

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbContext.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,15 @@ import io.helidon.common.mapper.MapperManager;
  * Database context.
  */
 public interface DbContext {
+
+    /**
+     * Configured missing values in named parameters {@link java.util.Map} handling.
+     *
+     * @return when set to {@code true}, named parameters value missing in the {@code Map} is considered
+     *         as {@code null}, when set to {@code false}, any parameter value missing in the {@code Map}
+     *         will cause an exception.
+     */
+    boolean missingMapParametersAsNull();
 
     /**
      * Configured statements.

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbExecuteContext.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbExecuteContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,11 @@ public class DbExecuteContext implements DbContext {
      */
     public String statement() {
         return statement;
+    }
+
+    @Override
+    public boolean missingMapParametersAsNull() {
+        return clientContext.missingMapParametersAsNull();
     }
 
     @Override

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/spi/DbClientBuilder.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/spi/DbClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,17 @@ public interface DbClientBuilder<T extends DbClientBuilder<T>> extends Builder<T
      * @return database provider builder
      */
     T password(String password);
+
+    /**
+     * Missing values in named parameters {@link java.util.Map} are considered as null values.
+     * When set to {@code true}, named parameters value missing in the {@code Map} is considered
+     * as {@code null}. When set to {@code false}, any parameter value missing in the {@code Map}
+     * will cause an exception.
+     * @param missingMapParametersAsNull whether missing values in named parameters {@code Map}
+     *                                   are considered as null values
+     * @return updated builder instance
+     */
+    T missingMapParametersAsNull(boolean missingMapParametersAsNull);
 
     /**
      * Statements to use either from configuration

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcClient.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcClient.java
@@ -36,6 +36,7 @@ class JdbcClient extends DbClientBase implements DbClient {
      */
     JdbcClient(JdbcClientBuilder builder) {
         super(JdbcClientContext.jdbcBuilder()
+                .missingMapParametersAsNull(builder.missingMapParametersAsNull())
                 .statements(builder.statements())
                 .dbMapperManager(builder.dbMapperManager())
                 .mapperManager(builder.mapperManager())

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
@@ -152,7 +152,13 @@ public abstract class JdbcStatement<S extends DbStatement<S>> extends DbStatemen
                     setParameter(preparedStatement, i, value);
                     i++;
                 } else {
-                    throw new DbClientException(namedStatementErrorMessage(namesOrder, parameters));
+                    if (context().missingMapParametersAsNull()) {
+                        LOGGER.log(Level.TRACE, String.format("Mapped parameter %d: %s -> null", i, name));
+                        setParameter(preparedStatement, i, null);
+                        i++;
+                    } else {
+                        throw new DbClientException(namedStatementErrorMessage(namesOrder, parameters));
+                    }
                 }
             }
             return preparedStatement;

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcStatement.java
@@ -148,12 +148,16 @@ public abstract class JdbcStatement<S extends DbStatement<S>> extends DbStatemen
             for (String name : namesOrder) {
                 if (parameters.containsKey(name)) {
                     Object value = parameters.get(name);
-                    LOGGER.log(Level.TRACE, String.format("Mapped parameter %d: %s -> %s", i, name, value));
+                    if (LOGGER.isLoggable(Level.TRACE)) {
+                        LOGGER.log(Level.TRACE, String.format("Mapped parameter %d: %s -> %s", i, name, value));
+                    }
                     setParameter(preparedStatement, i, value);
                     i++;
                 } else {
                     if (context().missingMapParametersAsNull()) {
-                        LOGGER.log(Level.TRACE, String.format("Mapped parameter %d: %s -> null", i, name));
+                        if (LOGGER.isLoggable(Level.TRACE)) {
+                            LOGGER.log(Level.TRACE, String.format("Mapped parameter %d: %s -> null", i, name));
+                        }
                         setParameter(preparedStatement, i, null);
                         i++;
                     } else {
@@ -174,7 +178,9 @@ public abstract class JdbcStatement<S extends DbStatement<S>> extends DbStatemen
             preparedStatement = prepareStatement(stmtName, stmt);
             int i = 1; // JDBC set position parameter starts from 1.
             for (Object value : parameters) {
-                LOGGER.log(Level.TRACE, String.format("Indexed parameter %d: %s", i, value));
+                if (LOGGER.isLoggable(Level.TRACE)) {
+                    LOGGER.log(Level.TRACE, String.format("Indexed parameter %d: %s", i, value));
+                }
                 setParameter(preparedStatement, i, value);
                 i++;
             }

--- a/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/QueryStatementIT.java
+++ b/tests/integration/dbclient/common/src/main/java/io/helidon/tests/integration/dbclient/common/tests/QueryStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static io.helidon.tests.integration.dbclient.common.utils.VerifyData.verifyPokemonsIdRange;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * Test DbStatementQuery methods.
@@ -85,6 +88,19 @@ public class QueryStatementIT {
                 .execute();
 
         verifyPokemonsIdRange(rows, 1, 7);
+    }
+
+    @Test
+    public void testQueryMapMissingParams() {
+        Map<String, Integer> params = new HashMap<>(2);
+        params.put("id", 1);
+        Stream<DbRow> rows = dbClient.execute()
+                .createNamedQuery("select-pokemons-idname-named-arg")
+                .params(params)
+                .execute();
+        assertThat(rows, notNullValue());
+        List<DbRow> rowsList = rows.toList();
+        assertThat(rowsList, hasSize(0));
     }
 
     /**

--- a/tests/integration/dbclient/h2/pom.xml
+++ b/tests/integration/dbclient/h2/pom.xml
@@ -135,37 +135,11 @@
                         <phase>integration-test</phase>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
-            <!--plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
-                    <parallel>methods</parallel>
-                    <threadCount>10</threadCount>
-                    <systemPropertyVariables>
-                        <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
-                    </systemPropertyVariables>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>**/*SuiteIT</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin-->
         </plugins>
     </build>
 </project>

--- a/tests/integration/dbclient/h2/src/test/resources/h2.yaml
+++ b/tests/integration/dbclient/h2/src/test/resources/h2.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ db:
   port: 9092
   password: "password"
   database: "test"
+  missing-map-parameters-as-null: true
   connection:
     url: jdbc:h2:tcp://${db.host}:${db.port}/${db.database};DATABASE_TO_UPPER=FALSE
   health-check:
@@ -56,6 +57,7 @@ db:
     select-pokemons-idrng-named-arg: "SELECT id, name FROM Pokemons WHERE id > :idmin AND id < :idmax"
     select-pokemons-idrng-order-arg: "SELECT id, name FROM Pokemons WHERE id > ? AND id < ?"
     select-pokemons-error-arg: "SELECT id, name FROM Pokemons WHERE id > :id AND name = ?"
+    select-pokemons-idname-named-arg: "SELECT id, name FROM Pokemons WHERE name=:name AND id=:id"
 
 test:
   ping-dml: false


### PR DESCRIPTION
Introduces `missing-map-parameters-as-null` boolean argument of DbClient config:
- when `true`: missing named parameters values in the parameters Map are considered as null values
- when `false` (default): missing named parameters values in the parameters Map will cause an exception

Fixes issue #8613

Tested with no `missing-map-parameters-as-null`:
```
[ERROR] Errors: 
[ERROR]   QueryStatementIT.testQueryMapMissingParams:100 » DbClient Query parameters missing in Map: name
```

Tested with no `missing-map-parameters-as-null` set to `true`:
```
[INFO] Tests run: 142, Failures: 0, Errors: 0, Skipped: 0
```
Test setup contains `missing-map-parameters-as-null` set to `true`