### PR TITLE
4.x: Replace deprecated method Span.baggage(key) on Span.baggage().get(key)

### DIFF
--- a/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/JaegerBaggageTest.java
+++ b/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/JaegerBaggageTest.java
@@ -40,7 +40,7 @@ class JaegerBaggageTest {
     void testBaggage(){
         Span span = tracer.spanBuilder("test-span").start();
         Span spanWithBaggage = span.baggage("key", "value");
-        Optional<String> result = spanWithBaggage.baggage("key");
+        Optional<String> result = spanWithBaggage.baggage().get("key");
         assertThat(result.isPresent(), is(true));
         assertThat(result.get(), equalTo("value"));
 

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
@@ -281,7 +281,7 @@ class OpenTelemetrySpan implements Span {
 
         @Override
         public Optional<String> baggage(String key) {
-            return delegate.baggage(key);
+            return delegate.baggage().get(key);
         }
 
         @Override

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestBaggageApi.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestBaggageApi.java
@@ -49,7 +49,7 @@ class TestBaggageApi {
 
         baggage.set("keyB", "valB");
         assertThat("Assigned baggage via baggage API value from span",
-                   span.baggage("keyB"),
+                   span.baggage().get("keyB"),
                    OptionalMatcher.optionalValue(is(equalTo("valB"))));
         assertThat("Assigned via baggage API value is present", baggage.containsKey("keyB"), is(true));
         assertThat("Assigned via baggage API value from baggage API",

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestSpanAndBaggage.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestSpanAndBaggage.java
@@ -104,8 +104,8 @@ class TestSpanAndBaggage {
         assertThat("Span context from inbound headers", spanContextOpt, OptionalMatcher.optionalPresent());
         Span span = tracer.spanBuilder("inbound").parent(spanContextOpt.get()).start();
         span.end();
-        assertThat("Inbound baggage bag1", span.baggage("bag1"), OptionalMatcher.optionalValue(is("val1")));
-        assertThat("Inbound baggage bag1", span.baggage("bag2"), OptionalMatcher.optionalValue(is("val2")));
+        assertThat("Inbound baggage bag1", span.baggage().get("bag1"), OptionalMatcher.optionalValue(is("val1")));
+        assertThat("Inbound baggage bag1", span.baggage().get("bag2"), OptionalMatcher.optionalValue(is("val2")));
     }
 
     @Test
@@ -161,7 +161,7 @@ class TestSpanAndBaggage {
     }
 
     private void checkBaggage(Tracer tracer, Span span, Supplier<SpanContext> spanContextSupplier) {
-        String value = span.baggage(BAGGAGE_KEY).orElseThrow();
+        String value = span.baggage().get(BAGGAGE_KEY).orElseThrow();
         assertThat("baggage value right after set", value, Matchers.is(Matchers.equalTo(BAGGAGE_VALUE)));
 
         // Inject the span (context) into the consumer

--- a/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpan.java
+++ b/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingSpan.java
@@ -209,7 +209,7 @@ class OpenTracingSpan implements Span {
 
         @Override
         public Optional<String> baggage(String key) {
-            return delegate.baggage(key);
+            return delegate.baggage().get(key);
         }
 
         @Override

--- a/tracing/providers/opentracing/src/test/java/io/helidon/tracing/providers/opentracing/TestBaggageApi.java
+++ b/tracing/providers/opentracing/src/test/java/io/helidon/tracing/providers/opentracing/TestBaggageApi.java
@@ -48,7 +48,7 @@ class TestBaggageApi {
 
         baggage.set("keyB", "valB");
         assertThat("Assigned baggage via baggage API value from span",
-                   span.baggage("keyB"),
+                   span.baggage().get("keyB"),
                    OptionalMatcher.optionalValue(is(equalTo("valB"))));
         assertThat("Assigned via baggage API value is present", baggage.containsKey("keyB"), is(true));
         assertThat("Assigned via baggage API value from baggage API",


### PR DESCRIPTION
### Description
I've found, that the deprecated method `Span.baggage(String key)` is used in the code. The method was marked as deprecated in [this commit](https://github.com/helidon-io/helidon/commit/0b16c29c22c0691a4aade898a7467692539c6263#diff-d0ca182466860d79537658e4b49b6bd56d6fd8c492719be03a70d86e371ee60bR142)
<img width="402" alt="Screenshot 2024-07-27 at 19 06 07" src="https://github.com/user-attachments/assets/2308a8f0-0855-4810-99b0-1d1db93c4ac1">

It can be replaced on `Span.baggage().get(String key)`.