### PR TITLE
4.x: Clarify javadoc for HealthCheckResponse.Builder.status(boolean)

### DIFF
--- a/health/health/src/main/java/io/helidon/health/HealthCheckResponse.java
+++ b/health/health/src/main/java/io/helidon/health/HealthCheckResponse.java
@@ -60,7 +60,7 @@ public interface HealthCheckResponse {
          */
         DOWN,
         /**
-         * This health check failed with an exception that was not excpected.
+         * This health check failed with an exception that was not expected.
          */
         ERROR
     }
@@ -94,7 +94,7 @@ public interface HealthCheckResponse {
         /**
          * Status of health check, defaults to {@link HealthCheckResponse.Status#UP}.
          *
-         * @param status status as a boolean ({@code true} for {@link HealthCheckResponse.Status#UP})
+         * @param status status as a boolean ({@code true} for {@link HealthCheckResponse.Status#UP}), ({@code false} for {@link HealthCheckResponse.Status#DOWN})
          * @return updated builder
          */
         public Builder status(boolean status) {


### PR DESCRIPTION
### Description
Javadoc for `HealthCheckResponse.Builder.status(boolean)` tells:
`status as a boolean ({@code true} for {@link HealthCheckResponse.Status#UP})` . 

But which status should be for `false`? There is `DOWN` and `ERROR`. I think, that better is to be specific.

