### PR TITLE
4.x: Bugfixes log builder

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
@@ -129,14 +129,18 @@ class BuilderCodegen implements CodegenExtension {
         if (lines.isEmpty()) {
             lines.add("# List of service contracts we want to support either from service registry, or from service loader");
         }
+        boolean modified = false;
         for (String serviceLoaderContract : this.serviceLoaderContracts) {
             if (!lines.contains(serviceLoaderContract)) {
+                modified = true;
                 lines.add(serviceLoaderContract);
             }
         }
 
-        serviceLoaderResource.lines(lines);
-        serviceLoaderResource.write();
+        if (modified) {
+            serviceLoaderResource.lines(lines);
+            serviceLoaderResource.write();
+        }
     }
 
     private void process(RoundContext roundContext, TypeInfo blueprint) {

--- a/logging/jul/src/main/java/io/helidon/logging/jul/JulProvider.java
+++ b/logging/jul/src/main/java/io/helidon/logging/jul/JulProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,10 @@ public class JulProvider implements LoggingProvider {
         if (runtime || NativeImageHelper.isBuildTime()) {
             String when = runtime ? WHEN_RUNTIME : WHEN_INIT;
             Logger.getLogger(JulProvider.class.getName()).info("Logging at " + when + " configured using " + source);
+        } else {
+            // build time without native image (when not in native, this is executed only on class initialization,
+            // so for the user it is runtime)
+            Logger.getLogger(JulProvider.class.getName()).info("Logging at " + WHEN_RUNTIME + " configured using " + source);
         }
     }
 


### PR DESCRIPTION
A couple of bugfixes for problems discovered while working on #9036 

- Fix JUL logging provider to log information about source of logging configuration even when not running in native image
- Fix blueprint processor to generate `service.loader` file only when not-empty