### PR TITLE
4.x: Add `classesDirectory` configuration to failsafe plugin

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -89,6 +89,7 @@
                     <configuration>
                         <useModulePath>false</useModulePath>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
### Description

fix #9039

### Documentation

none
