### PR TITLE
4.x: Use Helidon metadata format (HSON) for service registry generated file.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -1092,6 +1092,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-metadata</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
             <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1438,6 +1438,11 @@
             <!-- Service registry -->
             <dependency>
                 <groupId>io.helidon.service</groupId>
+                <artifactId>helidon-service-metadata</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.service</groupId>
                 <artifactId>helidon-service-registry</artifactId>
                 <version>${helidon.version}</version>
             </dependency>

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptFiler.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptFiler.java
@@ -17,6 +17,7 @@
 package io.helidon.codegen.apt;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -35,6 +36,7 @@ import javax.tools.StandardLocation;
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenFiler;
 import io.helidon.codegen.CodegenOptions;
+import io.helidon.codegen.FilerResource;
 import io.helidon.codegen.FilerTextResource;
 import io.helidon.codegen.IndentType;
 import io.helidon.codegen.classmodel.ClassModel;
@@ -104,6 +106,20 @@ class AptFiler implements CodegenFiler {
             return new FilerTextResourceImpl(filer, location, toElements(originatingElements), resource, lines);
         } catch (IOException e) {
             return new FilerTextResourceImpl(filer, location, toElements(originatingElements));
+        }
+    }
+
+    @Override
+    public FilerResource resource(String location, Object... originatingElements) {
+        try {
+            var resource = filer.getResource(StandardLocation.CLASS_OUTPUT, "", location);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (var is = resource.openInputStream()) {
+                is.transferTo(baos);
+            }
+            return new FilerResourceImpl(filer, location, toElements(originatingElements), resource, baos.toByteArray());
+        } catch (IOException e) {
+            return new FilerResourceImpl(filer, location, toElements(originatingElements));
         }
     }
 

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/FilerResourceImpl.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/FilerResourceImpl.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen.apt;
+
+import java.util.Arrays;
+
+import javax.annotation.processing.Filer;
+import javax.lang.model.element.Element;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+import io.helidon.codegen.CodegenException;
+import io.helidon.codegen.FilerResource;
+
+class FilerResourceImpl implements FilerResource {
+    private final Filer filer;
+    private final String location;
+    private final Element[] originatingElements;
+    private final FileObject originalResource; // may be null
+
+    private byte[] currentBytes;
+
+    private boolean modified;
+
+    FilerResourceImpl(Filer filer, String location, Element[] originatingElements) {
+        this.filer = filer;
+        this.location = location;
+        this.originatingElements = originatingElements;
+        this.originalResource = null;
+        this.currentBytes = new byte[0];
+    }
+
+    FilerResourceImpl(Filer filer,
+                      String location,
+                      Element[] originatingElements,
+                      FileObject originalResource,
+                      byte[] existingBytes) {
+        this.filer = filer;
+        this.location = location;
+        this.originatingElements = originatingElements;
+        this.originalResource = originalResource;
+        this.currentBytes = existingBytes;
+    }
+
+    @Override
+    public byte[] bytes() {
+        return Arrays.copyOf(currentBytes, currentBytes.length);
+    }
+
+    @Override
+    public void bytes(byte[] newBytes) {
+        currentBytes = Arrays.copyOf(newBytes, newBytes.length);
+        modified = true;
+    }
+
+    @Override
+    public void write() {
+        if (modified) {
+            if (originalResource != null) {
+                originalResource.delete();
+            }
+            try {
+                FileObject newResource = filer.createResource(StandardLocation.CLASS_OUTPUT,
+                                                              "",
+                                                              location,
+                                                              originatingElements);
+                try (var os = newResource.openOutputStream()) {
+                    os.write(currentBytes);
+                }
+            } catch (Exception e) {
+                throw new CodegenException("Failed to create resource: " + location, e);
+            }
+        }
+    }
+}

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenFiler.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenFiler.java
@@ -65,6 +65,18 @@ public interface CodegenFiler {
     }
 
     /**
+     * A text resource that can be updated in the output.
+     * Note that the resource can only be written once per processing round.
+     *
+     * @param location            location to read/write to in the classes output directory
+     * @param originatingElements elements that caused this file to be generated
+     * @return the resource that can be used to update the file
+     */
+    default FilerResource resource(String location, Object... originatingElements) {
+        throw new UnsupportedOperationException("Method resource not implemented yet on " + getClass().getName());
+    }
+
+    /**
      * Write a {@code META-INF/services} file for a specific provider interface and implementation(s).
      *
      * @param generator type of the generator (to mention in the generated code)

--- a/codegen/codegen/src/main/java/io/helidon/codegen/FilerResource.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/FilerResource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen;
+
+/**
+ * A resource from output (such as {@code target/META-INF/helidon}) that can have existing
+ * values, and may be replaced with a new value.
+ */
+public interface FilerResource {
+    /**
+     * Existing bytes of the resource. Returns empty array, if the resource does not exist or is empty.
+     *
+     * @return bytes of the resource
+     */
+    byte[] bytes();
+
+    /**
+     * New bytes of the resource.
+     *
+     * @param newBytes new bytes to {@link #write()} to the resource file
+     */
+    void bytes(byte[] newBytes);
+
+    /**
+     * Writes the new bytes to the output. This operation can only be called once per codegen round.
+     */
+    void write();
+}

--- a/integrations/graal/native-image-extension/src/main/java/io/helidon/integrations/graal/nativeimage/extension/HelidonReflectionFeature.java
+++ b/integrations/graal/native-image-extension/src/main/java/io/helidon/integrations/graal/nativeimage/extension/HelidonReflectionFeature.java
@@ -35,7 +35,7 @@ import io.helidon.common.Reflected;
 import io.helidon.common.features.HelidonFeatures;
 import io.helidon.common.types.TypeName;
 import io.helidon.logging.common.LogConfig;
-import io.helidon.service.registry.DescriptorMetadata;
+import io.helidon.service.registry.DescriptorHandler;
 import io.helidon.service.registry.ServiceDiscovery;
 import io.helidon.service.registry.ServiceLoader__ServiceDescriptor;
 import io.helidon.service.registry.ServiceRegistryConfig;
@@ -190,7 +190,7 @@ public class HelidonReflectionFeature implements Feature {
 
         sd.allMetadata()
                 .stream()
-                .map(DescriptorMetadata::descriptor)
+                .map(DescriptorHandler::descriptor)
                 .filter(it -> it instanceof ServiceLoader__ServiceDescriptor)
                 .map(it -> (ServiceLoader__ServiceDescriptor) it)
                 .map(ServiceLoader__ServiceDescriptor::serviceType)

--- a/service/README.md
+++ b/service/README.md
@@ -98,14 +98,39 @@ reflection (the class, and the field).
 
 ### Registry file format
 
-The service registry uses a `service.registry` in `META-INF/helidon` directory to store the main metadata of
+The service registry uses a `service-registry.json` file in `META-INF/helidon` directory to store the main metadata of
 the service. This is to allow proper ordering of services (Service weight is one of the information stored) and
 lazy loading of services (which is the approach chosen in the core service registry).
 
-The format is as follows:
+The format is as follows (using `//` to comment sections, not part of the format):
 
-```
-registry-type:service-descriptor-type:weight(double):contracts(comma separated)
+```json
+// root is an array of modules (we always generate a single module, but this allows a combined array, i.e. when using shading
+[
+  {
+    // version of the metadata file, defaults to 1 (and will always default to 1)
+    "version": 1,
+    // name of the module
+    "module": "io.helidon.example",
+    // all services in this module
+    "services": [
+      {
+        // version of the service descriptor, defaults to 1 (and will always default to 1)
+        "version": 1,
+        // core (Service registry) or inject (Service Injection), defaults to core
+        "type": "inject",
+        // weight, defaults to 100
+        "weight": 91.4,
+        // class of the service descriptor - generated type that contains public constant INSTANCE
+        "descriptor": "io.helidon.example.ServiceImpl__ServiceDescriptor",
+        // all contracts this service implements
+        "contracts": [
+          "io.helidon.example.ServiceApi"
+        ]
+      }
+    ]
+  }
+]
 ```
 
 Example:

--- a/service/codegen/src/main/java/io/helidon/service/codegen/HelidonMetaInfServices.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/HelidonMetaInfServices.java
@@ -16,23 +16,25 @@
 
 package io.helidon.service.codegen;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenFiler;
-import io.helidon.codegen.FilerTextResource;
-import io.helidon.common.types.Annotation;
-import io.helidon.common.types.TypeName;
+import io.helidon.codegen.FilerResource;
+import io.helidon.metadata.hson.Hson;
+import io.helidon.service.metadata.DescriptorMetadata;
+import io.helidon.service.metadata.Descriptors;
 
-import static io.helidon.codegen.CodegenUtil.generatedAnnotation;
+import static io.helidon.service.metadata.Descriptors.SERVICE_REGISTRY_LOCATION;
 
 /**
  * Support for reading and writing Helidon services to the resource.
@@ -45,18 +47,13 @@ import static io.helidon.codegen.CodegenUtil.generatedAnnotation;
  * The service descriptor is then discoverable at runtime through our own resource in {@value #SERVICES_RESOURCE}.
  */
 class HelidonMetaInfServices {
-    /**
-     * Location of the Helidon meta services file.
-     */
-    static final String SERVICES_RESOURCE = "META-INF/helidon/service.registry";
+    private final FilerResource services;
+    private final String moduleName;
+    private final Set<DescriptorMetadata> descriptors;
 
-    private final FilerTextResource services;
-    private final List<String> comments;
-    private final Set<DescriptorMeta> descriptors;
-
-    private HelidonMetaInfServices(FilerTextResource services, List<String> comments, Set<DescriptorMeta> descriptors) {
+    private HelidonMetaInfServices(FilerResource services, String moduleName, Set<DescriptorMetadata> descriptors) {
         this.services = services;
-        this.comments = comments;
+        this.moduleName = moduleName;
         this.descriptors = descriptors;
     }
 
@@ -64,39 +61,23 @@ class HelidonMetaInfServices {
      * Create new instance from the current filer.
      *
      * @param filer      filer to find the file, and to write it
-     * @param generator  generator used in generated comment if we are creating a new file
-     * @param trigger    trigger that caused this file to be created (can be same as generator)
      * @param moduleName module that is being built
      * @return a new instance of the service metadata manager
      */
-    static HelidonMetaInfServices create(CodegenFiler filer, TypeName generator, TypeName trigger, String moduleName) {
-        FilerTextResource services = filer.textResource(SERVICES_RESOURCE);
+    static HelidonMetaInfServices create(CodegenFiler filer, String moduleName) {
+        FilerResource serviceRegistryMetadata = filer.resource(SERVICE_REGISTRY_LOCATION);
+        byte[] bytes = serviceRegistryMetadata.bytes();
 
-        List<String> comments = new ArrayList<>();
-        Set<DescriptorMeta> descriptors = new TreeSet<>(Comparator.comparing(DescriptorMeta::descriptor));
+        Set<DescriptorMetadata> descriptors = new TreeSet<>(Comparator.comparing(DescriptorMetadata::descriptorType));
 
-        for (String line : services.lines()) {
-            String trimmedLine = line.trim();
-            if (trimmedLine.startsWith("#")) {
-                comments.add(line);
-            } else if (trimmedLine.isEmpty()) {
-                // ignore empty lines
-                continue;
-            } else {
-                descriptors.add(DescriptorMeta.parse(trimmedLine));
-            }
+        if (bytes.length != 0) {
+            Hson.Array moduleRegistry = Hson.parse(new ByteArrayInputStream(bytes))
+                    .asArray();
+            descriptors.addAll(Descriptors.descriptors("helidon-service-codegen for " + moduleName,
+                                                       moduleRegistry));
         }
 
-        if (comments.isEmpty()) {
-            // @Generated
-            comments.add("# Generated list of service descriptors in module " + moduleName);
-            comments.add("# " + toAnnotationText(generatedAnnotation(generator,
-                                                                     trigger,
-                                                                     TypeName.create("io.helidon.services.ServicesMeta"),
-                                                                     "1",
-                                                                     "")));
-        }
-        return new HelidonMetaInfServices(services, comments, descriptors);
+        return new HelidonMetaInfServices(serviceRegistryMetadata, moduleName, descriptors);
     }
 
     /**
@@ -105,7 +86,7 @@ class HelidonMetaInfServices {
      *
      * @param services service descriptor metadata to add
      */
-    void addAll(Collection<DescriptorMeta> services) {
+    void addAll(Collection<DescriptorMetadata> services) {
         services.forEach(this::add);
     }
 
@@ -115,9 +96,9 @@ class HelidonMetaInfServices {
      *
      * @param service service descriptor metadata to add
      */
-    void add(DescriptorMeta service) {
+    void add(DescriptorMetadata service) {
         // if it is the same descriptor class, remove it
-        descriptors.removeIf(it -> it.descriptor().equals(service.descriptor()));
+        descriptors.removeIf(it -> it.descriptorType().equals(service.descriptorType()));
 
         // always add the new descriptor (either it does not exist, or it was deleted)
         descriptors.add(service);
@@ -127,60 +108,23 @@ class HelidonMetaInfServices {
      * Write the file to output.
      */
     void write() {
-        List<String> lines = new ArrayList<>(comments);
+        var root = Hson.objectBuilder()
+                .set("module", moduleName);
+        List<Hson.Object> servicesHson = new ArrayList<>();
+
         descriptors.stream()
-                .map(DescriptorMeta::toLine)
-                .forEach(lines::add);
-        services.lines(lines);
+                .map(DescriptorMetadata::toHson)
+                .forEach(servicesHson::add);
+
+        root.setObjects("services", servicesHson);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (var pw = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8))) {
+            Hson.Array.create(List.of(root.build()))
+                    .write(pw);
+        }
+
+        services.bytes(baos.toByteArray());
         services.write();
-    }
-
-    private static String toAnnotationText(Annotation annotation) {
-        List<String> valuePairs = new ArrayList<>();
-        Map<String, Object> annotationValues = annotation.values();
-        annotationValues.forEach((key, value) -> valuePairs.add(key + "=\"" + value + "\""));
-        return "@" + annotation.typeName().fqName() + "(" + String.join(", ", valuePairs) + ")";
-    }
-
-    /**
-     * Metadata of a single service descriptor.
-     * This information is stored within the Helidon specific {code META-INF} services file.
-     *
-     * @param registryType type of registry, such as {@code core}
-     * @param descriptor   descriptor type
-     * @param weight       weight of the service
-     * @param contracts    contracts the service implements/provides
-     */
-    record DescriptorMeta(String registryType, TypeName descriptor, double weight, Set<TypeName> contracts) {
-        private static DescriptorMeta parse(String line) {
-            String[] elements = line.split(":");
-            if (elements.length < 4) {
-                throw new CodegenException("Failed to parse line from existing META-INF/helidon/service.registry: "
-                                                   + line + ", expecting registry-type:serviceDescriptor:weight:contracts");
-            }
-            Set<TypeName> contracts = Stream.of(elements[3].split(","))
-                    .map(String::trim)
-                    .map(TypeName::create)
-                    .collect(Collectors.toSet());
-
-            try {
-                return new DescriptorMeta(elements[0],
-                                          TypeName.create(elements[1]),
-                                          Double.parseDouble(elements[2]),
-                                          contracts);
-            } catch (NumberFormatException e) {
-                throw new CodegenException("Unexpected line structure in service.registry. Third element should be weight "
-                                                   + "(double). Got: " + line + ", message: " + e.getMessage(), e);
-            }
-        }
-
-        private String toLine() {
-            return registryType + ":"
-                    + descriptor.fqName() + ":"
-                    + weight + ":"
-                    + contracts.stream()
-                    .map(TypeName::fqName)
-                    .collect(Collectors.joining(","));
-        }
     }
 }

--- a/service/metadata/pom.xml
+++ b/service/metadata/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -28,36 +28,24 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>helidon-service-codegen</artifactId>
-    <name>Helidon Service Codegen</name>
+    <artifactId>helidon-service-metadata</artifactId>
+    <name>Helidon Service Metadata</name>
     <description>
-        Code generation implementation for Helidon Service, to be used from annotation processing and from maven plugin
+        Metadata library to read and write service registry information.
     </description>
 
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-types</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.codegen</groupId>
-            <artifactId>helidon-codegen</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.codegen</groupId>
-            <artifactId>helidon-codegen-class-model</artifactId>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-types</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.metadata</groupId>
             <artifactId>helidon-metadata-hson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.service</groupId>
-            <artifactId>helidon-service-metadata</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
@@ -14,21 +14,34 @@
  * limitations under the License.
  */
 
-package io.helidon.service.registry;
+package io.helidon.service.metadata;
 
 import java.util.Set;
 
 import io.helidon.common.types.TypeName;
+import io.helidon.metadata.hson.Hson;
 
 /**
- * Metadata of a single service descriptor.
- * This information is stored within the Helidon specific {code META-INF} services file.
+ * Metadata of a service descriptor, as stored in Helidon specific file {@value Descriptors#SERVICE_REGISTRY_LOCATION}.
  */
 public interface DescriptorMetadata {
     /**
      * {@link #registryType()} for core services.
      */
     String REGISTRY_TYPE_CORE = "core";
+
+    /**
+     * Create a new instance from descriptor information, i.e. when code generating the descriptor metadata.
+     *
+     * @param registryType type of registry, such as {@link #REGISTRY_TYPE_CORE}
+     * @param descriptor   type of the service descriptor (the generated file from {@code helidon-service-codegen})
+     * @param weight       weight of the service descriptor
+     * @param contracts    contracts the service implements
+     * @return a new descriptor metadata instance
+     */
+    static DescriptorMetadata create(String registryType, TypeName descriptor, double weight, Set<TypeName> contracts) {
+        return new DescriptorMetadataImpl(registryType, weight, descriptor, contracts);
+    }
 
     /**
      * Type of registry, such as {@code core}.
@@ -60,9 +73,10 @@ public interface DescriptorMetadata {
     double weight();
 
     /**
-     * Descriptor instance.
+     * Create the metadata in Helidon metadata format. This is used by components that store
+     * the metadata.
      *
-     * @return the descriptor
+     * @return HSON object (similar to JSON)
      */
-    GeneratedService.Descriptor<?> descriptor();
+    Hson.Object toHson();
 }

--- a/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadataImpl.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadataImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.metadata;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.helidon.common.Weighted;
+import io.helidon.common.types.TypeName;
+import io.helidon.metadata.hson.Hson;
+
+record DescriptorMetadataImpl(String registryType,
+                              double weight,
+                              TypeName descriptorType,
+                              Set<TypeName> contracts) implements DescriptorMetadata {
+
+    private static final int CURRENT_DESCRIPTOR_VERSION = 1;
+    private static final int DEFAULT_DESCRIPTOR_VERSION = 1;
+
+    static DescriptorMetadata create(String moduleName, String location, Hson.Object service) {
+        int version = service.intValue("version", DEFAULT_DESCRIPTOR_VERSION);
+        if (version != CURRENT_DESCRIPTOR_VERSION) {
+            throw new IllegalStateException("Invalid descriptor version: " + version
+                                                    + " for module \"" + moduleName + "\""
+                                                    + " loaded from \"" + location + "\", "
+                                                    + "expected version: \"" + CURRENT_DESCRIPTOR_VERSION + "\","
+                                                    + " descriptor (if available): "
+                                                    + service.stringValue("descriptor", "N/A"));
+        }
+
+        String type = service.stringValue("type", REGISTRY_TYPE_CORE);
+        TypeName descriptor = service.stringValue("descriptor")
+                .map(TypeName::create)
+                .orElseThrow(() -> new IllegalStateException("Could not parse service metadata "
+                                                                     + " for module \"" + moduleName + "\""
+                                                                     + " loaded from \"" + location + "\", "
+                                                                     + "missing \"descriptor\" value"));
+        double weight = service.doubleValue("weight", Weighted.DEFAULT_WEIGHT);
+        Set<TypeName> contracts = service.stringArray("contracts")
+                .orElseGet(List::of)
+                .stream()
+                .map(TypeName::create)
+                .collect(Collectors.toSet());
+
+        return new DescriptorMetadataImpl(type, weight, descriptor, contracts);
+    }
+
+    @Override
+    public Hson.Object toHson() {
+        var builder = Hson.objectBuilder();
+
+        if (!registryType.equals(REGISTRY_TYPE_CORE)) {
+            builder.set("type", registryType);
+        }
+        if (weight != Weighted.DEFAULT_WEIGHT) {
+            builder.set("weight", weight);
+        }
+        builder.set("descriptor", descriptorType.fqName());
+        builder.setStrings("contracts", contracts.stream()
+                .map(TypeName::fqName)
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .collect(Collectors.toUnmodifiableList()));
+
+        return builder.build();
+    }
+}

--- a/service/metadata/src/main/java/io/helidon/service/metadata/Descriptors.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/Descriptors.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.metadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.helidon.metadata.hson.Hson;
+
+/**
+ * Service descriptor utilities.
+ */
+public class Descriptors {
+    /**
+     * Location of the Helidon service registry metadata file.
+     */
+    public static final String SERVICE_REGISTRY_LOCATION = "META-INF/helidon/service-registry.json";
+    private static final int CURRENT_REGISTRY_VERSION = 1;
+    private static final int DEFAULT_REGISTRY_VERSION = 1;
+
+    private Descriptors() {
+    }
+
+    /**
+     * Get all service descriptors from the array of descriptors discovered from classpath (or other source).
+     *
+     * @param location where was thi array obtained (such as "Classpath URL: ...")
+     * @param moduleRegistries array of modules
+     * @return a list of descriptor metadata
+     * @throws java.lang.IllegalStateException in case the format is not as expected
+     */
+    public static List<DescriptorMetadata> descriptors(String location, Hson.Array moduleRegistries) {
+        List<DescriptorMetadata> descriptors = new ArrayList<>();
+
+        for (Hson.Object moduleRegistry : moduleRegistries.getObjects()) {
+            String moduleName = moduleRegistry.stringValue("module", "unknown");
+            int version = moduleRegistry.intValue("version", DEFAULT_REGISTRY_VERSION);
+            if (version != CURRENT_REGISTRY_VERSION) {
+                throw new IllegalStateException("Invalid registry version: " + version
+                                                        + " for module \"" + moduleName + "\""
+                                                        + " loaded from \"" + location + "\", "
+                                                        + "expected version: \"" + CURRENT_REGISTRY_VERSION + "\"");
+            }
+
+            moduleRegistry.objectArray("services")
+                    .orElseGet(List::of)
+                    .stream()
+                    .map(it -> DescriptorMetadataImpl.create(moduleName, location, it))
+                    .forEach(descriptors::add);
+        }
+        return descriptors;
+    }
+}

--- a/service/metadata/src/main/java/io/helidon/service/metadata/package-info.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/package-info.java
@@ -14,21 +14,12 @@
  * limitations under the License.
  */
 
-import io.helidon.service.codegen.ServiceRegistryCodegenProvider;
-
 /**
- * Code generation for Helidon Service Registry.
+ * Metadata for service registry.
+ * <p>
+ * This module is used both from codegen and from runtime to parser service registry metadata into
+ * Java objects.
+ *
+ * @see io.helidon.service.metadata.Descriptors
  */
-module io.helidon.service.codegen {
-    requires transitive io.helidon.builder.api;
-    requires transitive io.helidon.codegen.classmodel;
-    requires transitive io.helidon.codegen;
-
-    requires io.helidon.metadata.hson;
-    requires io.helidon.service.metadata;
-
-    exports io.helidon.service.codegen;
-
-    provides io.helidon.codegen.spi.CodegenExtensionProvider
-            with ServiceRegistryCodegenProvider;
-}
+package io.helidon.service.metadata;

--- a/service/metadata/src/main/java/module-info.java
+++ b/service/metadata/src/main/java/module-info.java
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-import io.helidon.service.codegen.ServiceRegistryCodegenProvider;
-
 /**
- * Code generation for Helidon Service Registry.
+ * Metadata for service registry.
+ *
+ * @see io.helidon.service.metadata
  */
-module io.helidon.service.codegen {
-    requires transitive io.helidon.builder.api;
-    requires transitive io.helidon.codegen.classmodel;
-    requires transitive io.helidon.codegen;
-
+module io.helidon.service.metadata {
     requires io.helidon.metadata.hson;
-    requires io.helidon.service.metadata;
+    requires io.helidon.common.types;
 
-    exports io.helidon.service.codegen;
-
-    provides io.helidon.codegen.spi.CodegenExtensionProvider
-            with ServiceRegistryCodegenProvider;
+    exports io.helidon.service.metadata;
 }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -41,6 +41,7 @@
     </properties>
 
     <modules>
+        <module>metadata</module>
         <module>codegen</module>
         <module>registry</module>
         <module>tests</module>

--- a/service/registry/pom.xml
+++ b/service/registry/pom.xml
@@ -57,6 +57,14 @@
             <artifactId>helidon-common-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metadata</groupId>
+            <artifactId>helidon-metadata-hson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-metadata</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -82,8 +82,8 @@ class CoreServiceRegistry implements ServiceRegistry {
         boolean logUnsupported = LOGGER.isLoggable(Level.TRACE);
 
         // and finally add discovered instances
-        for (DescriptorMetadata descriptorMeta : serviceDiscovery.allMetadata()) {
-            if (!descriptorMeta.registryType().equals(DescriptorMetadata.REGISTRY_TYPE_CORE)) {
+        for (DescriptorHandler descriptorMeta : serviceDiscovery.allMetadata()) {
+            if (!descriptorMeta.registryType().equals(DescriptorHandler.REGISTRY_TYPE_CORE)) {
                 // we can only support core services, others should be handled by other registry implementations
                 if (logUnsupported) {
                     LOGGER.log(Level.TRACE,
@@ -173,7 +173,7 @@ class CoreServiceRegistry implements ServiceRegistry {
         }
     }
 
-    private Supplier<Optional<Object>> instanceSupplier(DescriptorMetadata descriptorMeta) {
+    private Supplier<Optional<Object>> instanceSupplier(DescriptorHandler descriptorMeta) {
         LazyValue<Optional<Object>> serviceInstance = LazyValue.create(() -> instance(descriptorMeta.descriptor()));
 
         if (descriptorMeta.contracts().contains(TypeNames.SUPPLIER)) {
@@ -319,12 +319,12 @@ class CoreServiceRegistry implements ServiceRegistry {
     }
 
     private record DiscoveredDescriptor(CoreServiceRegistry registry,
-                                        DescriptorMetadata metadata,
+                                        DescriptorHandler metadata,
                                         Supplier<Optional<Object>> instanceSupplier,
                                         ReentrantLock lock) implements ServiceProvider {
 
         private DiscoveredDescriptor(CoreServiceRegistry registry,
-                                     DescriptorMetadata metadata,
+                                     DescriptorHandler metadata,
                                      Supplier<Optional<Object>> instanceSupplier) {
             this(registry, metadata, instanceSupplier, new ReentrantLock());
         }

--- a/service/registry/src/main/java/io/helidon/service/registry/DescriptorHandler.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/DescriptorHandler.java
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-import io.helidon.service.codegen.ServiceRegistryCodegenProvider;
+package io.helidon.service.registry;
 
 /**
- * Code generation for Helidon Service Registry.
+ * Metadata of a single service descriptor.
+ * This information is stored within the Helidon specific {code META-INF} services file.
  */
-module io.helidon.service.codegen {
-    requires transitive io.helidon.builder.api;
-    requires transitive io.helidon.codegen.classmodel;
-    requires transitive io.helidon.codegen;
-
-    requires io.helidon.metadata.hson;
-    requires io.helidon.service.metadata;
-
-    exports io.helidon.service.codegen;
-
-    provides io.helidon.codegen.spi.CodegenExtensionProvider
-            with ServiceRegistryCodegenProvider;
+public interface DescriptorHandler extends io.helidon.service.metadata.DescriptorMetadata {
+    /**
+     * Descriptor instance.
+     *
+     * @return the descriptor
+     */
+    GeneratedService.Descriptor<?> descriptor();
 }

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -131,12 +131,12 @@ public final class Service {
 
         /**
          * Type of service registry that should read this descriptor. Defaults to
-         * {@value DescriptorMetadata#REGISTRY_TYPE_CORE}, so the descriptor must only implement
+         * {@value DescriptorHandler#REGISTRY_TYPE_CORE}, so the descriptor must only implement
          * {@link io.helidon.service.registry.GeneratedService.Descriptor}.
          *
          * @return type of registry this descriptor supports
          */
-        String registryType() default DescriptorMetadata.REGISTRY_TYPE_CORE;
+        String registryType() default DescriptorHandler.REGISTRY_TYPE_CORE;
 
         /**
          * The weight of the service. This is required for predefined descriptors, as we do not want

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceDiscovery.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceDiscovery.java
@@ -23,17 +23,10 @@ import java.util.List;
  */
 public interface ServiceDiscovery {
     /**
-     * A file that contains all services within a module. Each service has an identifier of the registry that
-     * created it (such as {@code core}), the class of the service descriptor,
-     * weight of the service, and a list of contracts it implements.
-     * <p>
-     * This file is used by {@link io.helidon.service.registry.ServiceDiscovery} to find services.
-     */
-    String SERVICES_RESOURCE = "META-INF/helidon/service.registry";
-    /**
      * A file that contains all service provider interfaces that expose a service for
      * Java {@link java.util.ServiceLoader} that is used to tell Helidon Service Registry to add implementations to
-     * the registry to be discoverable in addition to services defined in {@link #SERVICES_RESOURCE}.
+     * the registry to be discoverable in addition to services defined in
+     * {@link io.helidon.service.metadata.Descriptors#SERVICE_REGISTRY_LOCATION}.
      */
     String SERVICES_LOADER_RESOURCE = "META-INF/helidon/service.loader";
 
@@ -70,5 +63,5 @@ public interface ServiceDiscovery {
      *
      * @return all discovered metadata
      */
-    List<DescriptorMetadata> allMetadata();
+    List<DescriptorHandler> allMetadata();
 }

--- a/service/registry/src/main/java/module-info.java
+++ b/service/registry/src/main/java/module-info.java
@@ -22,13 +22,16 @@ import io.helidon.common.features.api.Preview;
  * Core service registry, supporting {@link io.helidon.service.registry.Service.Provider}.
  */
 @Feature(value = "registry",
-        description = "Service Registry",
-        in = HelidonFlavor.SE,
-        path = "Registry"
+         description = "Service Registry",
+         in = HelidonFlavor.SE,
+         path = "Registry"
 )
 @Preview
 module io.helidon.service.registry {
     requires static io.helidon.common.features.api;
+
+    requires io.helidon.service.metadata;
+    requires io.helidon.metadata.hson;
 
     requires transitive io.helidon.common.config;
     requires transitive io.helidon.builder.api;

--- a/service/registry/src/main/resources/META-INF/native-image/io.helidon.service/helidon-service-registry/resource-config.json
+++ b/service/registry/src/main/resources/META-INF/native-image/io.helidon.service/helidon-service-registry/resource-config.json
@@ -1,7 +1,7 @@
 {
     "resources": [
         {
-            "pattern": "META-INF/helidon/service.registry"
+            "pattern": "META-INF/helidon/service-registry.json"
         },
         {
             "pattern": "META-INF/helidon/service.loader"


### PR DESCRIPTION
Resolves #9055

- Add format description.
- Add module that can be used both from code generator and from runtime to read the service registry metadata.

