### PR TITLE
4.x: docs: Cleanup prerequisites and use of prereq table

### DIFF
--- a/docs/src/main/asciidoc/about/cli.adoc
+++ b/docs/src/main/asciidoc/about/cli.adoc
@@ -37,7 +37,11 @@ and you’re ready to go.
 
 == Prerequisites
 
-include::{rootdir}/about/introduction.adoc[tag=prereqs]
+.Prerequisite product versions for Helidon {helidon-version}
+[%autowidth]
+|=======
+include::{rootdir}/includes/prerequisites.adoc[tag=prerequisites-table-rows-core]
+|=======
 
 You should make sure `java` and `mvn` are in your path.
 
@@ -77,6 +81,12 @@ PowerShell -Command Invoke-WebRequest -Uri "https://helidon.io/cli/latest/window
 
 For Windows you will also need the Visual C++ Redistributable Runtime. See xref:windows.adoc[Helidon on Windows]
 for more information.
+
+[source,bash]
+.Verify CLI installation
+----
+helidon version
+----
 
 == Create a New Project
 

--- a/docs/src/main/asciidoc/about/cli.adoc
+++ b/docs/src/main/asciidoc/about/cli.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/about/introduction.adoc
+++ b/docs/src/main/asciidoc/about/introduction.adoc
@@ -116,7 +116,7 @@ You might also need Docker and Kubernetes depending on how you plan to deploy yo
 .Prerequisite product versions for Helidon {helidon-version}
 [%autowidth]
 |====
-include::{rootdir}/includes/prerequisites.adoc[tag=prerequisites-table-details]
+include::{rootdir}/includes/prerequisites.adoc[tag=prerequisites-table-rows]
 |====
 // end::prereqs[]
 We also strongly suggest installing the xref:cli.adoc[Helidon CLI] (command line interface) which helps in generating and building Helidon projects.

--- a/docs/src/main/asciidoc/includes/prerequisites.adoc
+++ b/docs/src/main/asciidoc/includes/prerequisites.adoc
@@ -26,29 +26,20 @@ ifndef::h1-prefix[:h1-prefix: SE]
 
 // tag::prerequisites[]
 
-
-[role="flex, sm7"]
+.Prerequisite product versions for Helidon {helidon-version}
+[%autowidth]
 |=======
-
-// tag::prerequisites-table-contents[]
-
-|A Helidon {flavor-uc} Application | You can use your own application or use the
- xref:{rootdir}/{flavor-lc}/guides/quickstart.adoc[Helidon {flavor-uc} Quickstart] to create a sample application.
-// tag::prerequisites-table-details[]
+// tag::prerequisites-table-rows[]
+// tag::prerequisites-table-rows-core[]
 |https://www.oracle.com/technetwork/java/javase/downloads[Java{nbsp}SE{nbsp}21] (http://jdk.java.net[Open{nbsp}JDK{nbsp}21]) |Helidon requires Java 21+.
 |https://maven.apache.org/download.cgi[Maven 3.8+]|Helidon requires Maven 3.8+.
-|https://docs.docker.com/install/[Docker 18.09+]|You need Docker if you
-want to build and deploy Docker containers.
-|https://kubernetes.io/docs/tasks/tools/install-kubectl/[Kubectl 1.16.5+]|If you want to
-deploy to Kubernetes, you need `kubectl` and a Kubernetes cluster (you can
-xref:{rootdir}/about/kubernetes.adoc[install one on your desktop].
-// end::prerequisites-table-details[]
-// end::prerequisites-table-contents[]
-
+// end::prerequisites-table-rows-core[]
+|https://docs.docker.com/install/[Docker 18.09+]|If you want to build and run Docker containers.
+|https://kubernetes.io/docs/tasks/tools/install-kubectl/[Kubectl 1.16.5+]|If you want to deploy to Kubernetes, you need `kubectl` and a Kubernetes cluster (you can xref:{rootdir}/about/kubernetes.adoc[install one on your desktop].
+// end::prerequisites-table-rows[]
 |=======
 
-
-
+// tag::prerequisites-setup[]
 [source,bash]
 .Verify Prerequisites
 ----
@@ -57,7 +48,6 @@ mvn --version
 docker --version
 kubectl version --short
 ----
-
 
 [source,bash]
 .Setting JAVA_HOME
@@ -69,104 +59,42 @@ export JAVA_HOME=`/usr/libexec/java_home -v 21`
 # Use the appropriate path to your JDK
 export JAVA_HOME=/usr/lib/jvm/jdk-21
 ----
+// end::prerequisites-setup[]
 // end::prerequisites[]
 
-
-// tag::prerequisites-helm[]
-
+// tag::prerequisites-cli[]
 [role="flex, sm7"]
 |=======
-include::prerequisites.adoc[tag=prerequisites-table-contents]
+include::prerequisites.adoc[tag=prerequisites-table-rows]
+|xref:{rootdir}/about/cli.adoc[Helidon CLI]|If you want to use the Helidon CLI to create and build your application
+|=======
+include::prerequisites.adoc[tag=prerequisites-setup]
+// end::prerequisites-cli[]
 
+// tag::prerequisites-helm[]
+[role="flex, sm7"]
+|=======
+include::prerequisites.adoc[tag=prerequisites-table-rows]
 |https://github.com/helm/helm[Helm] | To manage Kubernetes applications.
 |=======
-
-
-
-[source,bash]
-.Verify Prerequisites
-----
-java -version
-mvn --version
-docker --version
-kubectl version --short
-----
-
-
-[source,bash]
-.Setting JAVA_HOME
-----
-# On Mac
-export JAVA_HOME=`/usr/libexec/java_home -v 21`
-
-# On Linux
-# Use the appropriate path to your JDK
-export JAVA_HOME=/usr/lib/jvm/jdk-21
-----
-
+include::prerequisites.adoc[tag=prerequisites-setup]
 // end::prerequisites-helm[]
 
 // tag::prerequisites-curl[]
-
 [role="flex, sm7"]
 |=======
-include::prerequisites.adoc[tag=prerequisites-table-contents]
+include::prerequisites.adoc[tag=prerequisites-table-rows]
 |https://curl.se/download.html[curl]
 |(Optional) for testing
 |=======
-
-[source,bash]
-.Verify Prerequisites
-----
-java -version
-mvn --version
-docker --version
-kubectl version --short
-----
-
-
-[source,bash]
-.Setting JAVA_HOME
-----
-# On Mac
-export JAVA_HOME=`/usr/libexec/java_home -v 21`
-
-# On Linux
-# Use the appropriate path to your JDK
-export JAVA_HOME=/usr/lib/jvm/jdk-21
-----
+include::prerequisites.adoc[tag=prerequisites-setup]
 // end::prerequisites-curl[]
 
-
 // tag::prerequisites-graal[]
-
-
 [role="flex, sm7"]
 |=======
-include::prerequisites.adoc[tag=prerequisites-table-contents]
+include::prerequisites.adoc[tag=prerequisites-table-rows]
 | https://www.graalvm.org/release-notes/JDK_21/[GraalVM for JDK 21]| `native-image` support requires GraalVM for JDK 21. When running in the Graal JVM (not native-image) Helidon supports GraalVM for JDK 21 or newer.
 |=======
-
-
-
-[source,bash]
-.Verify Prerequisites
-----
-java -version
-mvn --version
-docker --version
-kubectl version --short
-----
-
-
-[source,bash]
-.Setting JAVA_HOME
-----
-# On Mac
-export JAVA_HOME=`/usr/libexec/java_home -v 21`
-
-# On Linux
-# Use the appropriate path to your JDK
-export JAVA_HOME=/usr/lib/jvm/jdk-21
-----
+include::prerequisites.adoc[tag=prerequisites-setup]
 // end::prerequisites-graal[]

--- a/docs/src/main/asciidoc/mp/guides/quickstart.adoc
+++ b/docs/src/main/asciidoc/mp/guides/quickstart.adoc
@@ -29,13 +29,13 @@ This guide describes a basic example of an Helidon MP application using Docker a
 
 For this 5 minute tutorial, you will need the following:
 
-include::{rootdir}/includes/prerequisites.adoc[tag=prerequisites]
+include::{rootdir}/includes/prerequisites.adoc[tag=prerequisites-cli]
 
 == Generate the Project
 
-Generate the project sources using one (or both) of the Helidon Maven
- archetypes. The result is a simple project that shows the basics of configuring
- the WebServer and implementing basic routing rules.
+Generate the project sources using the Helidon Maven archetype.
+The result is a simple project that shows the basics of
+a MicroProfile application.
 
 [source,bash,subs="attributes+"]
 .Run the Maven archetype
@@ -47,6 +47,12 @@ mvn -U archetype:generate -DinteractiveMode=false \
     -DgroupId=io.helidon.examples \
     -DartifactId=helidon-quickstart-mp \
     -Dpackage=io.helidon.examples.quickstart.mp
+----
+
+[source,bash]
+.Or alternatively run the helidon CLI
+----
+helidon init --batch -Dflavor=mp -Dapp-type=quickstart
 ----
 
 The archetype generates a Maven project in your current directory

--- a/docs/src/main/asciidoc/se/guides/quickstart.adoc
+++ b/docs/src/main/asciidoc/se/guides/quickstart.adoc
@@ -33,9 +33,9 @@ include::{rootdir}/includes/prerequisites.adoc[tag=prerequisites]
 
 == Generate The Project
 
-Generate the project sources using one (or both) of the Helidon Maven
- archetypes. The result is a simple project that shows the basics of configuring
- the WebServer and implementing basic routing rules.
+Generate the project sources using the Helidon Maven archetype.
+The result is a simple project that shows the basics of
+a Helidon SE application using simple WebServer routing rules.
 
 [source,bash,subs="attributes+"]
 .Run the Maven archetype
@@ -47,6 +47,12 @@ mvn -U archetype:generate -DinteractiveMode=false \
     -DgroupId=io.helidon.examples \
     -DartifactId=helidon-quickstart-se \
     -Dpackage=io.helidon.examples.quickstart.se
+----
+
+[source,bash]
+.Or alternatively run the helidon CLI
+----
+helidon init --batch -Dflavor=mp -Dapp-type=quickstart
 ----
 
 The archetype generates a Maven project in your current directory


### PR DESCRIPTION
### Description

* Add Helidon CLI as an optional pre-req and show use in quickstart guides
* Remove "A Helidon {flavor-uc} Application" as a pre-req 
* Simplify use of prerequisite table and tag names
* Add `prerequisites-setup` tag to reduce duplicate text
* Minor changes to some text

Fixes #8108

### Documentation

Updates documentation
