### PR TITLE
3.x: Add classesDirectory to failsafe plugin configuration

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -91,6 +91,7 @@
                     <configuration>
                         <useModulePath>false</useModulePath>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
### Description

fix #9065

backport of #9059

### Documentation

no impact
