### PR TITLE
Update oci.auth-strategy values in generated OCI archetype to avoid UnsatisfiedResolutionException

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/oci/files/README-Description.md
+++ b/archetypes/archetypes/src/main/archetype/mp/oci/files/README-Description.md
@@ -10,7 +10,7 @@ This example demonstrates Helidon's integration with Oracle Cloud Infrastructure
 6. Logs published to OCI Logging Service
 7. OCI Custom Logs Monitoring using Unified Monitoring Agent
 8. Health and Liveness checks
-9. Configuration profiles for switching between `config_file` and `instance_principal` configurations
+9. Configuration profiles for switching between `config-file` and `instance-principals` configurations
 
 This project demonstrates OpenApi-driven development approach where the practice of designing and building APIs is done first, 
 then creating the rest of an application around them is implemented next. Below are the modules that are part of this project:

--- a/archetypes/archetypes/src/main/archetype/mp/oci/files/server/README.md.mustache
+++ b/archetypes/archetypes/src/main/archetype/mp/oci/files/server/README.md.mustache
@@ -203,16 +203,16 @@ and currently has the following parameters:
 7. `oci.logging.id` - Custom log id configured. Please see [Custom Logs Monitoring](#Custom-Logs-Monitoring) for more information.
 8. `oci.auth-strategy` - Allows OCI client authentication mechanism to be specified and can either be an individual
 value or a list of authentication types separated by comma. If specified as a list, it will cycle through each until a 
-successful authentication is reached. This is currently set to `config_file,instance_principals,resource_principal` 
-which means that `config_file` will be tried first, then falls back to `instance_principals` if it fails, and 
-eventually falls back to `resource_principals` if `instance_principals` fails. The following are the different types
+successful authentication is reached. This is currently set to `config-file,instance-principals,resource-principal`
+which means that `config-file` will be tried first, then falls back to `instance-principals` if it fails, and
+eventually falls back to `resource-principal` if `instance-principals` fails. The following are the different types
 of OCI client authentication:
-   * `config_file` - Uses user authentication set in ~/.oci/config
+   * `config-file` - Uses user authentication set in ~/.oci/config
    * `config` - Sets user authentication in the helidon config, i.e. microprofile-config.properties
-   * `instance_principals` - Uses the compute instance as the authentication and authorization principal. Please see 
+   * `instance-principals` - Uses the compute instance as the authentication and authorization principal. Please see
 [Calling Services from an Instance](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm)
 for more details.
-   * `resource_principal` - Very similar to instance principal auth but uses OCI resources and services as the 
+   * `resource-principal` - Very similar to instance principal auth but uses OCI resources and services as the
 authentication and authorization principal such as serverless functions. Please see 
 [About Using Resource Principal to Access Oracle Cloud Infrastructure Resources](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/resource-principal-about.html#GUID-7EED5198-2C92-41B6-99DD-29F4187CABF5) for more information.
 

--- a/archetypes/archetypes/src/main/archetype/mp/oci/files/server/src/main/resources/META-INF/microprofile-config-prod.properties
+++ b/archetypes/archetypes/src/main/archetype/mp/oci/files/server/src/main/resources/META-INF/microprofile-config-prod.properties
@@ -1,2 +1,2 @@
 # Oci Authentication method using Instance Principals
-oci.auth-strategy=instance_principals
+oci.auth-strategy=instance-principals

--- a/archetypes/archetypes/src/main/archetype/mp/oci/files/server/src/main/resources/META-INF/microprofile-config-test.properties
+++ b/archetypes/archetypes/src/main/archetype/mp/oci/files/server/src/main/resources/META-INF/microprofile-config-test.properties
@@ -1,2 +1,2 @@
 # Oci Authentication method using User Credentials in an oci config file
-oci.auth-strategy=config_file
+oci.auth-strategy=config-file

--- a/archetypes/archetypes/src/main/archetype/mp/oci/oci-mp.xml
+++ b/archetypes/archetypes/src/main/archetype/mp/oci/oci-mp.xml
@@ -88,7 +88,7 @@ oci.monitoring.namespace=<your monitoring namespace e.g. helidon_oci>
 oci.logging.id=<your oci custom log id>
 
 # OCI Authentication strategy
-oci.auth-strategy=config_file,instance_principals,resource_principal
+oci.auth-strategy=config-file,instance-principals,resource-principal
                     ]]></value>
                 </list>
                 <list key="yaml-config-entries">
@@ -342,7 +342,7 @@ principal when running it in an oci compute instance.
 
 ### Run the application
 
-1. Default with no profile will use `config_file,instance_principals,resource_principal` authentication strategy
+1. Default with no profile will use `config-file,instance-principals,resource-principal` authentication strategy
      ```bash
      java -jar server/target/{{artifactId}}.jar
      ```


### PR DESCRIPTION
### Description
The allowed values for oci.auth-strategy has changed with the occurence of "_" replaced with "-", so the use of the following needs to be changed:
1. instance_principals to instance-principals
2. config_file to config-file
3. resource_principal to resource-principal

### Documentation

Looks like the values are not mentioned in the docs so no changes are needed there.

If no doc impact: None
