### PR TITLE
4.x: Use string constructor of BigDecimal to avoid bad decimals in output.

### DIFF
--- a/metadata/hson/src/main/java/io/helidon/metadata/hson/Hson.java
+++ b/metadata/hson/src/main/java/io/helidon/metadata/hson/Hson.java
@@ -340,6 +340,15 @@ public final class Hson {
             Builder set(String key, double value);
 
             /**
+             * Set a float value.
+             *
+             * @param key   key to set
+             * @param value value to assign to the key
+             * @return updated instance (this instance)
+             */
+            Builder set(String key, float value);
+
+            /**
              * Set an int value.
              *
              * @param key   key to set

--- a/metadata/hson/src/main/java/io/helidon/metadata/hson/HsonArray.java
+++ b/metadata/hson/src/main/java/io/helidon/metadata/hson/HsonArray.java
@@ -77,7 +77,8 @@ final class HsonArray implements Hson.Array {
 
     static Hson.Array create(double... values) {
         List<BigDecimal> collect = DoubleStream.of(values)
-                .mapToObj(BigDecimal::new)
+                .mapToObj(String::valueOf)
+                .map(BigDecimal::new)
                 .collect(Collectors.toUnmodifiableList());
         return Hson.Array.createNumbers(collect);
     }
@@ -85,7 +86,7 @@ final class HsonArray implements Hson.Array {
     static Hson.Array create(float... values) {
         List<BigDecimal> list = new ArrayList<>(values.length);
         for (float value : values) {
-            list.add(new BigDecimal(value));
+            list.add(new BigDecimal(String.valueOf(value)));
         }
 
         return Hson.Array.createNumbers(list);

--- a/metadata/hson/src/main/java/io/helidon/metadata/hson/HsonObject.java
+++ b/metadata/hson/src/main/java/io/helidon/metadata/hson/HsonObject.java
@@ -260,11 +260,17 @@ final class HsonObject implements Hson.Object {
         }
 
         @Override
+        public Builder set(String key, float value) {
+            Objects.requireNonNull(key, "key cannot be null");
+
+            return set(key, new BigDecimal(String.valueOf(value)));
+        }
+
+        @Override
         public Builder set(String key, double value) {
             Objects.requireNonNull(key, "key cannot be null");
 
-            values.put(key, HsonValues.NumberValue.create(new BigDecimal(value)));
-            return this;
+            return set(key, new BigDecimal(String.valueOf(value)));
         }
 
         @Override

--- a/metadata/hson/src/test/java/io/helidon/metadata/hson/HsonTest.java
+++ b/metadata/hson/src/test/java/io/helidon/metadata/hson/HsonTest.java
@@ -212,7 +212,7 @@ class HsonTest {
         String string = sw.toString();
         String expected = "[{\"string\":\"value\","
                 + "\"long\":4,"
-                + "\"double\":4,"
+                + "\"double\":4.0,"
                 + "\"boolean\":true,"
                 + "\"strings\":[\"a\",\"b\"],"
                 + "\"longs\":[1,2],"
@@ -233,6 +233,7 @@ class HsonTest {
         assertThat(readSecond, is(second));
     }
 
+    @Test
     void testSetObjects() {
         Hson.Object first = Hson.objectBuilder()
                 .set("key", "value1")
@@ -266,6 +267,22 @@ class HsonTest {
                 .build();
 
         assertThat(object.value("null-key"), optionalEmpty());
+    }
+
+    @Test
+    void testFunnyDoubles() {
+        StringWriter stringWriter = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(stringWriter)) {
+            Hson.objectBuilder()
+                    .set("first", 1.1d)
+                    .set("second", 1.2f)
+                    .set("third", 1.3)
+                    .set("fourth", 4)
+                    .set("fifth", 5L)
+                    .build()
+                    .write(pw);
+        }
+        assertThat(stringWriter.toString(), is("{\"first\":1.1,\"second\":1.2,\"third\":1.3,\"fourth\":4,\"fifth\":5}"));
     }
 
     @Test


### PR DESCRIPTION
Small fix for better handling of doubles and floats.