### PR TITLE
4.x: Use Hson.Struct instead of Hson.Object to prevent confusion with java.lang.Object

### DIFF
--- a/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfigMetadataCodegenExtension.java
+++ b/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfigMetadataCodegenExtension.java
@@ -92,16 +92,16 @@ class ConfigMetadataCodegenExtension implements CodegenExtension {
     }
 
     private void storeMetadata() {
-        List<Hson.Object> root = new ArrayList<>();
+        List<Hson.Struct> root = new ArrayList<>();
 
         for (var module : moduleTypes.entrySet()) {
             String moduleName = module.getKey();
             var types = module.getValue();
-            List<Hson.Object> typeArray = new ArrayList<>();
+            List<Hson.Struct> typeArray = new ArrayList<>();
             types.forEach(it -> newOptions.get(it).write(typeArray));
-            root.add(Hson.objectBuilder()
+            root.add(Hson.structBuilder()
                              .set("module", moduleName)
-                             .setObjects("types", typeArray)
+                             .setStructs("types", typeArray)
                              .build());
         }
 

--- a/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfiguredType.java
+++ b/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfiguredType.java
@@ -81,8 +81,8 @@ final class ConfiguredType {
         return configured.prefix().orElse(null);
     }
 
-    void write(List<Hson.Object> typeArray) {
-        var typeObject = Hson.Object.builder();
+    void write(List<Hson.Struct> typeArray) {
+        var typeObject = Hson.Struct.builder();
 
         typeObject.set("type", targetClass());
         typeObject.set("annotatedType", annotatedClass());
@@ -108,11 +108,11 @@ final class ConfiguredType {
                     .collect(Collectors.toList()));
         }
 
-        List<Hson.Object> options = new ArrayList<>();
+        List<Hson.Struct> options = new ArrayList<>();
         for (ConfiguredProperty property : allProperties) {
             writeProperty(options, "", property);
         }
-        typeObject.setObjects("options", options);
+        typeObject.setStructs("options", options);
 
         typeArray.add(typeObject.build());
     }
@@ -132,11 +132,11 @@ final class ConfiguredType {
                 .collect(Collectors.joining(", "));
     }
 
-    private void writeProperty(List<Hson.Object> optionsBuilder,
+    private void writeProperty(List<Hson.Struct> optionsBuilder,
                                String prefix,
                                ConfiguredProperty property) {
 
-        var optionBuilder = Hson.Object.builder();
+        var optionBuilder = Hson.Struct.builder();
         if (property.key() != null && !property.key.isBlank()) {
             optionBuilder.set("key", prefix(prefix, property.key()));
         }
@@ -181,10 +181,10 @@ final class ConfiguredType {
                     .forEach(it -> writeProperty(optionsBuilder, finalPrefix, it));
         }
         if (!property.allowedValues.isEmpty()) {
-            List<Hson.Object> allowedValues = new ArrayList<>();
+            List<Hson.Struct> allowedValues = new ArrayList<>();
 
             for (ConfiguredOptionData.AllowedValue allowedValue : property.allowedValues) {
-                var allowedJson = Hson.Object.builder()
+                var allowedJson = Hson.Struct.builder()
                         .set("value", allowedValue.value());
                 if (!allowedValue.description().isBlank()) {
                     allowedJson.set("description", allowedValue.description().trim());
@@ -192,7 +192,7 @@ final class ConfiguredType {
                 allowedValues.add(allowedJson.build());
             }
 
-            optionBuilder.setObjects("allowedValues", allowedValues);
+            optionBuilder.setStructs("allowedValues", allowedValues);
         }
 
         optionsBuilder.add(optionBuilder.build());

--- a/config/metadata/processor/src/main/java/io/helidon/config/metadata/processor/ConfigMetadataHandler.java
+++ b/config/metadata/processor/src/main/java/io/helidon/config/metadata/processor/ConfigMetadataHandler.java
@@ -187,16 +187,16 @@ class ConfigMetadataHandler {
              This is to allow merging of files - such as when we would want to create on-the-fly
              JSON for a project with only its dependencies.
              */
-            List<Hson.Object> moduleArray = new ArrayList<>();
+            List<Hson.Struct> moduleArray = new ArrayList<>();
 
             for (var module : moduleTypes.entrySet()) {
                 String moduleName = module.getKey();
                 var types = module.getValue();
-                List<Hson.Object>  typeArray = new ArrayList<>();
+                List<Hson.Struct>  typeArray = new ArrayList<>();
                 types.forEach(it -> newOptions.get(it).write(typeArray));
-                moduleArray.add(Hson.Object.builder()
+                moduleArray.add(Hson.Struct.builder()
                                         .set("module", moduleName)
-                                        .setObjects("types", typeArray)
+                                        .setStructs("types", typeArray)
                                         .build());
             }
 

--- a/config/metadata/processor/src/main/java/io/helidon/config/metadata/processor/ConfiguredType.java
+++ b/config/metadata/processor/src/main/java/io/helidon/config/metadata/processor/ConfiguredType.java
@@ -81,8 +81,8 @@ final class ConfiguredType {
         return configured.prefix().orElse(null);
     }
 
-    void write(List<Hson.Object> typeArray) {
-        var typeObject = Hson.Object.builder();
+    void write(List<Hson.Struct> typeArray) {
+        var typeObject = Hson.Struct.builder();
 
         typeObject.set("type", targetClass());
         typeObject.set("annotatedType", annotatedClass());
@@ -108,11 +108,11 @@ final class ConfiguredType {
                     .collect(Collectors.toList()));
         }
 
-        List<Hson.Object> options = new ArrayList<>();
+        List<Hson.Struct> options = new ArrayList<>();
         for (ConfiguredProperty property : allProperties) {
             writeProperty(options, "", property);
         }
-        typeObject.setObjects("options", options);
+        typeObject.setStructs("options", options);
 
         typeArray.add(typeObject.build());
     }
@@ -132,11 +132,11 @@ final class ConfiguredType {
                 .collect(Collectors.joining(", "));
     }
 
-    private void writeProperty(List<Hson.Object> optionsBuilder,
+    private void writeProperty(List<Hson.Struct> optionsBuilder,
                                String prefix,
                                ConfiguredProperty property) {
 
-        var optionBuilder = Hson.Object.builder();
+        var optionBuilder = Hson.Struct.builder();
         if (property.key() != null && !property.key.isBlank()) {
             optionBuilder.set("key", prefix(prefix, property.key()));
         }
@@ -181,16 +181,16 @@ final class ConfiguredType {
                     .forEach(it -> writeProperty(optionsBuilder, finalPrefix, it));
         }
         if (!property.allowedValues.isEmpty()) {
-            List<Hson.Object> allowedValues = new ArrayList<>();
+            List<Hson.Struct> allowedValues = new ArrayList<>();
 
             for (ConfiguredOptionData.AllowedValue allowedValue : property.allowedValues) {
-                allowedValues.add(Hson.Object.builder()
+                allowedValues.add(Hson.Struct.builder()
                                           .set("value", allowedValue.value())
                                           .set("description", allowedValue.description())
                                           .build());
             }
 
-            optionBuilder.setObjects("allowedValues", allowedValues);
+            optionBuilder.setStructs("allowedValues", allowedValues);
         }
 
         optionsBuilder.add(optionBuilder.build());

--- a/metadata/hson/src/main/java/io/helidon/metadata/hson/Hson.java
+++ b/metadata/hson/src/main/java/io/helidon/metadata/hson/Hson.java
@@ -37,7 +37,7 @@ public final class Hson {
      * @param inputStream stream to parse
      * @return a value
      * @see io.helidon.metadata.hson.Hson.Value#type()
-     * @see io.helidon.metadata.hson.Hson.Value#asObject()
+     * @see io.helidon.metadata.hson.Hson.Value#asStruct()
      * @see io.helidon.metadata.hson.Hson.Value#asArray()
      */
     public static Value<?> parse(InputStream inputStream) {
@@ -45,12 +45,12 @@ public final class Hson {
     }
 
     /**
-     * A new fluent API builder to construct an HSON Object.
+     * A new fluent API builder to construct na HSON Struct.
      *
      * @return a new builder
      */
-    public static Object.Builder objectBuilder() {
-        return Object.builder();
+    public static Struct.Builder structBuilder() {
+        return Struct.builder();
     }
 
     /**
@@ -74,9 +74,9 @@ public final class Hson {
          */
         NULL,
         /**
-         * Nested object value.
+         * Nested struct value.
          */
-        OBJECT,
+        STRUCT,
         /**
          * Array value.
          */
@@ -84,34 +84,34 @@ public final class Hson {
     }
 
     /**
-     * HSON Object.
+     * HSON Struct.
      * <p>
-     * A representation of an object, with possible child values.
+     * A representation of a struct, with possible child values. This is similar to {@code JsonObject} in JSON-P.
      */
-    public sealed interface Object extends Value<Hson.Object> permits HsonObject {
+    public sealed interface Struct extends Value<Struct> permits HsonStruct {
 
         /**
-         * A new fluent API builder to construct a HSON Object.
+         * A new fluent API builder to construct a HSON Struct.
          *
          * @return a new builder
          */
         static Builder builder() {
-            return new HsonObject.Builder();
+            return new HsonStruct.Builder();
         }
 
         /**
-         * Create an empty object.
+         * Create an empty struct.
          *
          * @return new empty instance
          */
-        static Object create() {
+        static Struct create() {
             return builder().build();
         }
 
         /**
          * Get a value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return value of that key, or empty if not present; may return value that represents null
          * @see io.helidon.metadata.hson.Hson.Type
          */
@@ -120,7 +120,7 @@ public final class Hson {
         /**
          * Get a boolean value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return boolean value if present
          * @throws HsonException in case the key exists, but is not a {@code boolean}
          */
@@ -129,7 +129,7 @@ public final class Hson {
         /**
          * Get a boolean value with default if not defined.
          *
-         * @param key          key under this object
+         * @param key          key under this struct
          * @param defaultValue default value to use if the key does not exist
          * @return boolean value, or default value if the key does not exist
          * @throws HsonException in case the key exists, but is not a
@@ -138,19 +138,19 @@ public final class Hson {
         boolean booleanValue(String key, boolean defaultValue);
 
         /**
-         * Get object value. If the value represents {@code null}, returns empty optional.
+         * Get struct value. If the value represents {@code null}, returns empty optional.
          *
-         * @param key key under this object
-         * @return object value if present
+         * @param key key under this struct
+         * @return struct value if present
          * @throws HsonException in case the key exists, but is not a
-         *                       {@link io.helidon.metadata.hson.Hson.Type#OBJECT}
+         *                       {@link io.helidon.metadata.hson.Hson.Type#STRUCT}
          */
-        Optional<Object> objectValue(String key);
+        Optional<Struct> structValue(String key);
 
         /**
          * Get string value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return string value if present
          * @throws HsonException in case the key exists, but is not a
          *                       {@link io.helidon.metadata.hson.Hson.Type#STRING}
@@ -160,7 +160,7 @@ public final class Hson {
         /**
          * Get a string value with default if not defined.
          *
-         * @param key          key under this object
+         * @param key          key under this struct
          * @param defaultValue default value to use if the key does not exist
          * @return string value, or default value if the key does not exist
          * @throws HsonException in case the key exists, but is not a
@@ -171,7 +171,7 @@ public final class Hson {
         /**
          * Get int value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return int value if present, from {@link java.math.BigDecimal#intValue()}
          * @throws HsonException in case the key exists, but is not a
          *                       {@link io.helidon.metadata.hson.Hson.Type#NUMBER}
@@ -181,7 +181,7 @@ public final class Hson {
         /**
          * Get an int value with default if not defined.
          *
-         * @param key          key under this object
+         * @param key          key under this struct
          * @param defaultValue default value to use if the key does not exist
          * @return int value, or default value if the key does not exist
          * @throws HsonException in case the key exists, but is not a
@@ -193,7 +193,7 @@ public final class Hson {
         /**
          * Get double value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return double value if present, from {@link java.math.BigDecimal#doubleValue()}
          * @throws HsonException in case the key exists, but is not a
          *                       {@link io.helidon.metadata.hson.Hson.Type#NUMBER}
@@ -203,7 +203,7 @@ public final class Hson {
         /**
          * Get a double value with default if not defined (or null).
          *
-         * @param key          key under this object
+         * @param key          key under this struct
          * @param defaultValue default value to use if the key does not exist
          * @return double value, or default value if the key does not exist
          * @throws HsonException in case the key exists, but is not a
@@ -215,7 +215,7 @@ public final class Hson {
         /**
          * Get number value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return big decimal value if present
          * @throws HsonException in case the key exists, but is not a
          *                       {@link io.helidon.metadata.hson.Hson.Type#NUMBER}
@@ -225,7 +225,7 @@ public final class Hson {
         /**
          * Get number value with default if not defined (or null).
          *
-         * @param key          key under this object
+         * @param key          key under this struct
          * @param defaultValue default value to use if not present or null
          * @return big decimal value
          */
@@ -234,7 +234,7 @@ public final class Hson {
         /**
          * Get string array value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return string array value, if the key exists
          * @throws HsonException in case the key exists, is an array, but elements are not strings
          * @throws HsonException in case the key exists, but is not an array
@@ -242,19 +242,19 @@ public final class Hson {
         Optional<List<String>> stringArray(String key);
 
         /**
-         * Get object array value.
+         * Get struct array value.
          *
-         * @param key key under this object
-         * @return object array value, if the key exists
-         * @throws HsonException in case the key exists, is an array, but elements are not objects
+         * @param key key under this struct
+         * @return struct array value, if the key exists
+         * @throws HsonException in case the key exists, is an array, but elements are not structs
          * @throws HsonException in case the key exists, but is not an array
          */
-        Optional<List<Object>> objectArray(String key);
+        Optional<List<Struct>> structArray(String key);
 
         /**
          * Get number array value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return number array value, if the key exists
          * @throws HsonException in case the key exists, is an array, but elements are not numbers
          * @throws HsonException in case the key exists, but is not an array
@@ -264,7 +264,7 @@ public final class Hson {
         /**
          * Get boolean array value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return boolean array value, if the key exists
          * @throws HsonException in case the key exists, is an array, but elements are not booleans
          * @throws HsonException in case the key exists, but is not an array
@@ -274,18 +274,18 @@ public final class Hson {
         /**
          * Get array value.
          *
-         * @param key key under this object
+         * @param key key under this struct
          * @return array value, if the key exists
          * @throws HsonException in case the key exists, but is not an array
          */
         Optional<Array> arrayValue(String key);
 
         /**
-         * Fluent API builder for {@link io.helidon.metadata.hson.Hson.Object}.
+         * Fluent API builder for {@link io.helidon.metadata.hson.Hson.Struct}.
          *
          * @see #build()
          */
-        interface Builder extends io.helidon.common.Builder<Builder, Object> {
+        interface Builder extends io.helidon.common.Builder<Builder, Struct> {
             /**
              * Unset an existing value assigned to the key.
              * This method does not care if the key is mapped or not.
@@ -385,13 +385,13 @@ public final class Hson {
             Builder set(String key, Array value);
 
             /**
-             * Set an array of objects.
+             * Set an array of structs.
              *
              * @param key   key to set
              * @param value value to assign to the key
              * @return updated instance (this instance)
              */
-            Builder setObjects(String key, List<Hson.Object> value);
+            Builder setStructs(String key, List<Struct> value);
 
             /**
              * Set an array of strings.
@@ -449,7 +449,7 @@ public final class Hson {
                                              HsonValues.NumberValue,
                                              HsonValues.BooleanValue,
                                              HsonValues.NullValue,
-                                             Hson.Object,
+                                             Struct,
                                              Hson.Array {
         /**
          * Write the HSON value.
@@ -473,33 +473,33 @@ public final class Hson {
         Type type();
 
         /**
-         * Get an object array from this parsed value.
+         * Get this parsed value as an array.
          *
-         * @return object array, or this object as an array
-         * @throws HsonException in case this object is not of type
-         *                       {@link io.helidon.metadata.hson.Hson.Type#OBJECT}
+         * @return this value as an array
+         * @throws HsonException in case this value is not of type
+         *                       {@link io.helidon.metadata.hson.Hson.Type#ARRAY}
          */
         default Array asArray() {
             if (type() != Type.ARRAY) {
-                throw new HsonException("Attempting to read object of type " + type() + " as an array");
+                throw new HsonException("Attempting to read value of type " + type() + " as an array");
             }
 
             return (Array) this;
         }
 
         /**
-         * Get an object from this parsed value.
+         * Get this parsed value as a struct.
          *
-         * @return this value as an object
-         * @throws HsonException in case this object is not of type
-         *                       {@link io.helidon.metadata.hson.Hson.Type#OBJECT}
+         * @return this value as a struct
+         * @throws HsonException in case this value is not of type
+         *                       {@link io.helidon.metadata.hson.Hson.Type#STRUCT}
          */
-        default Hson.Object asObject() {
-            if (type() != Type.OBJECT) {
-                throw new HsonException("Attempting to get object of type " + type() + " as an Object");
+        default Struct asStruct() {
+            if (type() != Type.STRUCT) {
+                throw new HsonException("Attempting to get value of type " + type() + " as a Struct");
             }
 
-            return (Hson.Object) this;
+            return (Struct) this;
         }
     }
 
@@ -622,11 +622,11 @@ public final class Hson {
         List<BigDecimal> getNumbers();
 
         /**
-         * Assume this is an array of objects, and return the list.
+         * Assume this is an array of structs, and return the list.
          *
-         * @return all object values of this array, except for nulls
-         * @throws HsonException in case not all elements of this array are objects (or nulls)
+         * @return all struct values of this array, except for nulls
+         * @throws HsonException in case not all elements of this array are structs (or nulls)
          */
-        List<Object> getObjects();
+        List<Struct> getStructs();
     }
 }

--- a/metadata/hson/src/main/java/io/helidon/metadata/hson/HsonArray.java
+++ b/metadata/hson/src/main/java/io/helidon/metadata/hson/HsonArray.java
@@ -132,8 +132,8 @@ final class HsonArray implements Hson.Array {
     }
 
     @Override
-    public List<Hson.Object> getObjects() {
-        return getTypedList(Hson.Type.OBJECT);
+    public List<Hson.Struct> getStructs() {
+        return getTypedList(Hson.Type.STRUCT);
     }
 
     @Override

--- a/metadata/hson/src/main/java/io/helidon/metadata/hson/HsonStruct.java
+++ b/metadata/hson/src/main/java/io/helidon/metadata/hson/HsonStruct.java
@@ -27,15 +27,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-final class HsonObject implements Hson.Object {
+final class HsonStruct implements Hson.Struct {
     private final Map<String, Hson.Value<?>> values;
 
-    private HsonObject(Map<String, Hson.Value<?>> values) {
+    private HsonStruct(Map<String, Hson.Value<?>> values) {
         this.values = values;
     }
 
     @Override
-    public Hson.Object value() {
+    public Hson.Struct value() {
         return this;
     }
 
@@ -55,8 +55,8 @@ final class HsonObject implements Hson.Object {
     }
 
     @Override
-    public Optional<Hson.Object> objectValue(String key) {
-        return getValue(key, Hson.Type.OBJECT);
+    public Optional<Hson.Struct> structValue(String key) {
+        return getValue(key, Hson.Type.STRUCT);
     }
 
     @Override
@@ -105,8 +105,8 @@ final class HsonObject implements Hson.Object {
     }
 
     @Override
-    public Optional<List<Hson.Object>> objectArray(String key) {
-        return getTypedList(key, Hson.Array::getObjects);
+    public Optional<List<Hson.Struct>> structArray(String key) {
+        return getTypedList(key, Hson.Array::getStructs);
     }
 
     @Override
@@ -152,7 +152,7 @@ final class HsonObject implements Hson.Object {
 
     @Override
     public Hson.Type type() {
-        return Hson.Type.OBJECT;
+        return Hson.Type.STRUCT;
     }
 
     @Override
@@ -160,10 +160,10 @@ final class HsonObject implements Hson.Object {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof HsonObject object)) {
+        if (!(o instanceof HsonStruct struct)) {
             return false;
         }
-        return Objects.equals(values, object.values);
+        return Objects.equals(values, struct.values);
     }
 
     @Override
@@ -200,7 +200,7 @@ final class HsonObject implements Hson.Object {
     }
 
     private String exceptionMessage(String key, String message) {
-        return "Object key \"" + key + "\": " + message;
+        return "Struct key \"" + key + "\": " + message;
     }
 
     private void writeNext(PrintWriter metaWriter, AtomicBoolean first) {
@@ -211,15 +211,15 @@ final class HsonObject implements Hson.Object {
         metaWriter.write(',');
     }
 
-    static class Builder implements Hson.Object.Builder {
+    static class Builder implements Hson.Struct.Builder {
         private final Map<String, Hson.Value<?>> values = new LinkedHashMap<>();
 
         Builder() {
         }
 
         @Override
-        public Hson.Object build() {
-            return new HsonObject(new LinkedHashMap<>(values));
+        public Hson.Struct build() {
+            return new HsonStruct(new LinkedHashMap<>(values));
         }
 
         @Override
@@ -231,7 +231,7 @@ final class HsonObject implements Hson.Object {
         }
 
         @Override
-        public Hson.Object.Builder setNull(String key) {
+        public Hson.Struct.Builder setNull(String key) {
             values.put(key, HsonValues.NullValue.INSTANCE);
             return this;
         }
@@ -308,7 +308,7 @@ final class HsonObject implements Hson.Object {
         }
 
         @Override
-        public Builder setObjects(String key, List<Hson.Object> value) {
+        public Builder setStructs(String key, List<Hson.Struct> value) {
             Objects.requireNonNull(key, "key cannot be null");
             Objects.requireNonNull(value, "value cannot be null");
 

--- a/metadata/hson/src/main/java/io/helidon/metadata/hson/package-info.java
+++ b/metadata/hson/src/main/java/io/helidon/metadata/hson/package-info.java
@@ -21,7 +21,7 @@
  * To write HSON (compatible with JSON), start with either of the following types:
  * <ul>
  *     <li>{@link io.helidon.metadata.hson.Hson.Array}</li>
- *     <li>{@link io.helidon.metadata.hson.Hson.Object}</li>
+ *     <li>{@link io.helidon.metadata.hson.Hson.Struct}</li>
  * </ul>
  * To read HSON, start with {@link io.helidon.metadata.hson.Hson#parse(java.io.InputStream)}.
  * <p>
@@ -29,8 +29,8 @@
  * <ul>
  *     <li>Only UTF-8 is supported</li>
  *     <li>Arrays</li>
- *     <li>Objects</li>
- *     <li>Nesting of objects and arrays</li>
+ *     <li>Structs (Same as JsonObject from JSON-P in semantics)</li>
+ *     <li>Nesting of structs and arrays</li>
  *     <li>String, BigDecimal, boolean, null</li>
  *     <li>No pretty print (always writes as small as possible)</li>
  *     <li>Keeps order of insertion on write</li>
@@ -51,6 +51,6 @@
  * above. This module is not Helidon JSON solution - please use one of the supported JSON libraries,
  * such as JSON-P, JSON-B, or Jackson.</b>
  * <p>
- * <b>WARNING:</b> The HSON object is always fully read into memory
+ * <b>WARNING:</b> The HSON value is always fully read into memory
  */
 package io.helidon.metadata.hson;

--- a/metadata/hson/src/test/java/io/helidon/metadata/hson/ExistingTypesTest.java
+++ b/metadata/hson/src/test/java/io/helidon/metadata/hson/ExistingTypesTest.java
@@ -35,15 +35,15 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 class ExistingTypesTest {
     @Test
     void testServiceRegistry() throws IOException {
-        Hson.Object object;
+        Hson.Struct object;
         try (InputStream inputStream = resource("/service-registry.json")) {
             assertThat(inputStream, notNullValue());
             object = Hson.parse(inputStream)
-                    .asObject()
+                    .asStruct()
                     .value();
         }
 
-        Hson.Object generated = object.objectValue("generated")
+        Hson.Struct generated = object.structValue("generated")
                 .orElseThrow(() -> new IllegalStateException("Cannot find 'generated' object under root"));
 
         assertThat(generated.stringValue("trigger"),
@@ -55,12 +55,12 @@ class ExistingTypesTest {
         assertThat(generated.stringValue("comments"),
                    optionalValue(is("Service descriptors in module unnamed/io.helidon.examples.quickstart.se")));
 
-        List<Hson.Object> services = object.objectArray("services")
+        List<Hson.Struct> services = object.structArray("services")
                 .orElseThrow(() -> new IllegalStateException("Cannot find 'services' object under root"));
 
         assertThat(services, hasSize(2));
 
-        Hson.Object service = services.get(0);
+        Hson.Struct service = services.get(0);
 
         assertThat(service.doubleValue("version"), optionalValue(is(1d)));
         assertThat(service.stringValue("type"),
@@ -89,25 +89,25 @@ class ExistingTypesTest {
 
     @Test
     void testConfigMetadata() throws IOException {
-        List<Hson.Object> objects;
+        List<Hson.Struct> objects;
         try (InputStream inputStream = resource("/config-metadata.json")) {
             assertThat(inputStream, notNullValue());
             objects = Hson.parse(inputStream)
                     .asArray()
-                    .getObjects();
+                    .getStructs();
         }
 
         assertThat(objects, hasSize(1));
 
-        Hson.Object module = objects.getFirst();
+        Hson.Struct module = objects.getFirst();
 
         assertThat(module.stringValue("module"), optionalValue(is("io.helidon.common.configurable")));
-        Optional<List<Hson.Object>> types = module.objectArray("types");
+        Optional<List<Hson.Struct>> types = module.structArray("types");
         assertThat(types, optionalPresent());
-        List<Hson.Object> typesList = types.get();
+        List<Hson.Struct> typesList = types.get();
         assertThat(typesList, hasSize(5));
 
-        Hson.Object first = typesList.getFirst();
+        Hson.Struct first = typesList.getFirst();
         assertThat(first.stringValue("annotatedType"),
                    optionalValue(is("io.helidon.common.configurable.ResourceConfig")));
         assertThat(first.stringValue("type"),
@@ -117,10 +117,10 @@ class ExistingTypesTest {
         assertThat(first.intValue("number"),
                    optionalValue(is(49)));
 
-        List<Hson.Object> optionsList = first.objectArray("options")
+        List<Hson.Struct> optionsList = first.structArray("options")
                 .orElse(List.of());
         assertThat(optionsList, hasSize(9));
-        Hson.Object firstOption = optionsList.getFirst();
+        Hson.Struct firstOption = optionsList.getFirst();
         assertThat(firstOption.stringValue("description"),
                    optionalValue(is("Resource is located on filesystem.\n\n Path of the resource")));
         assertThat(firstOption.stringValue("key"),

--- a/metadata/hson/src/test/java/io/helidon/metadata/hson/HsonTest.java
+++ b/metadata/hson/src/test/java/io/helidon/metadata/hson/HsonTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class HsonTest {
     @Test
     void testWrongTypes() {
-        Hson.Object object = Hson.objectBuilder()
+        Hson.Struct object = Hson.structBuilder()
                 .set("number", 1)
                 .set("string", "hi")
                 .setLongs("numbers", List.of(1L, 2L, 3L))
@@ -53,11 +53,11 @@ class HsonTest {
         assertThrows(HsonException.class,
                      () -> object.doubleValue("string"));
         assertThrows(HsonException.class,
-                     () -> object.objectValue("string"));
+                     () -> object.structValue("string"));
         assertThrows(HsonException.class,
                      () -> object.stringArray("string"));
         assertThrows(HsonException.class,
-                     () -> object.objectArray("string"));
+                     () -> object.structArray("string"));
         assertThrows(HsonException.class,
                      () -> object.booleanArray("string"));
         assertThrows(HsonException.class,
@@ -70,11 +70,11 @@ class HsonTest {
         assertThrows(HsonException.class,
                      () -> object.doubleValue("strings"));
         assertThrows(HsonException.class,
-                     () -> object.objectValue("strings"));
+                     () -> object.structValue("strings"));
         assertThrows(HsonException.class,
                      () -> object.stringArray("numbers"));
         assertThrows(HsonException.class,
-                     () -> object.objectArray("strings"));
+                     () -> object.structArray("strings"));
         assertThrows(HsonException.class,
                      () -> object.booleanArray("strings"));
         assertThrows(HsonException.class,
@@ -83,7 +83,7 @@ class HsonTest {
 
     @Test
     void testReads() {
-        Hson.Object empty = Hson.Object.create();
+        Hson.Struct empty = Hson.Struct.create();
 
         assertThat(empty.booleanValue("anyKey"), optionalEmpty());
         assertThat(empty.booleanValue("anyKey", true), is(true));
@@ -102,7 +102,7 @@ class HsonTest {
         assertThat(empty.numberValue("anyKey", bd), sameInstance(bd));
 
         assertThat(empty.stringArray("anyKey"), optionalEmpty());
-        assertThat(empty.objectArray("anyKey"), optionalEmpty());
+        assertThat(empty.structArray("anyKey"), optionalEmpty());
         assertThat(empty.numberArray("anyKey"), optionalEmpty());
     }
 
@@ -112,7 +112,7 @@ class HsonTest {
         BigDecimal one = new BigDecimal(14);
         BigDecimal two = new BigDecimal(15);
 
-        Hson.Object jObject = Hson.objectBuilder()
+        Hson.Struct jObject = Hson.structBuilder()
                 .setNumbers("numbers", List.of(one, two))
                 .build();
 
@@ -124,7 +124,7 @@ class HsonTest {
 
     @Test
     void testSetBooleans() {
-        Hson.Object jObject = Hson.objectBuilder()
+        Hson.Struct jObject = Hson.structBuilder()
                 .setBooleans("booleans", List.of(true, false, true))
                 .build();
 
@@ -188,7 +188,7 @@ class HsonTest {
 
     @Test
     void testWriteObjectArray() {
-        Hson.Object first = Hson.objectBuilder()
+        Hson.Struct first = Hson.structBuilder()
                 .set("string", "value")
                 .set("long", 4L)
                 .set("double", 4d)
@@ -198,7 +198,7 @@ class HsonTest {
                 .setDoubles("doubles", List.of(1.5d, 2.5d))
                 .setBooleans("booleans", List.of(true, false))
                 .build();
-        Hson.Object second = Hson.objectBuilder()
+        Hson.Struct second = Hson.structBuilder()
                 .set("string", "value2")
                 .build();
 
@@ -225,33 +225,33 @@ class HsonTest {
         assertThat(read.type(), is(Hson.Type.ARRAY));
 
         Hson.Array objects = read.asArray();
-        List<Hson.Object> value = objects.getObjects();
+        List<Hson.Struct> value = objects.getStructs();
         assertThat(value, hasSize(2));
-        Hson.Object readFirst = value.get(0);
+        Hson.Struct readFirst = value.get(0);
         assertThat(readFirst, is(first));
-        Hson.Object readSecond = value.get(1);
+        Hson.Struct readSecond = value.get(1);
         assertThat(readSecond, is(second));
     }
 
     @Test
-    void testSetObjects() {
-        Hson.Object first = Hson.objectBuilder()
+    void testSetStructs() {
+        Hson.Struct first = Hson.structBuilder()
                 .set("key", "value1")
                 .build();
-        Hson.Object second = Hson.objectBuilder()
+        Hson.Struct second = Hson.structBuilder()
                 .set("key", "value2")
                 .build();
-        Hson.Object withArray = Hson.objectBuilder()
-                .setObjects("objects", List.of(first, second))
+        Hson.Struct withArray = Hson.structBuilder()
+                .setStructs("objects", List.of(first, second))
                 .build();
 
-        List<Hson.Object> objects = withArray.objectArray("objects").get();
+        List<Hson.Struct> objects = withArray.structArray("objects").get();
         assertThat(objects, hasItems(first, second));
     }
 
     @Test
     void testNull() {
-        Hson.Object object = Hson.objectBuilder()
+        Hson.Struct object = Hson.structBuilder()
                 .setNull("null-key")
                 .build();
 
@@ -261,7 +261,7 @@ class HsonTest {
 
     @Test
     void testUnset() {
-        Hson.Object object = Hson.objectBuilder()
+        Hson.Struct object = Hson.structBuilder()
                 .setNull("null-key")
                 .unset("null-key")
                 .build();
@@ -273,7 +273,7 @@ class HsonTest {
     void testFunnyDoubles() {
         StringWriter stringWriter = new StringWriter();
         try (PrintWriter pw = new PrintWriter(stringWriter)) {
-            Hson.objectBuilder()
+            Hson.structBuilder()
                     .set("first", 1.1d)
                     .set("second", 1.2f)
                     .set("third", 1.3)
@@ -288,8 +288,8 @@ class HsonTest {
     @Test
     void testFeatures() {
         Hson.Value<?> parsedValue = Hson.parse(HsonTest.class.getResourceAsStream("/json-features.json"));
-        assertThat(parsedValue.type(), is(Hson.Type.OBJECT));
-        Hson.Object object = parsedValue.asObject();
+        assertThat(parsedValue.type(), is(Hson.Type.STRUCT));
+        Hson.Struct object = parsedValue.asStruct();
 
         testFeaturesNull(object);
         testFeaturesArray(object);
@@ -297,10 +297,10 @@ class HsonTest {
         testFeaturesNumbers(object);
     }
 
-    private void testFeaturesNumbers(Hson.Object object) {
-        Optional<Hson.Object> maybeObject = object.objectValue("numbers");
+    private void testFeaturesNumbers(Hson.Struct object) {
+        Optional<Hson.Struct> maybeObject = object.structValue("numbers");
         assertThat(maybeObject, optionalPresent());
-        Hson.Object numbers = maybeObject.get();
+        Hson.Struct numbers = maybeObject.get();
 
         assertThat(numbers.numberValue("number1"), optionalValue(is(new BigDecimal(1))));
         assertThat(numbers.numberValue("number2"), optionalValue(is(new BigDecimal("1.5"))));
@@ -309,10 +309,10 @@ class HsonTest {
         assertThat(numbers.numberValue("number5"), optionalValue(is(new BigDecimal("1.5e2"))));
     }
 
-    private void testFeaturesEscapes(Hson.Object object) {
-        Optional<Hson.Object> maybeObject = object.objectValue("escapes");
+    private void testFeaturesEscapes(Hson.Struct object) {
+        Optional<Hson.Struct> maybeObject = object.structValue("escapes");
         assertThat(maybeObject, optionalPresent());
-        Hson.Object escapes = maybeObject.get();
+        Hson.Struct escapes = maybeObject.get();
 
         assertThat(escapes.stringValue("newline"), optionalValue(is("a\nb")));
         assertThat(escapes.stringValue("quotes"), optionalValue(is("a\"b")));
@@ -326,7 +326,7 @@ class HsonTest {
 
     }
 
-    private void testFeaturesArray(Hson.Object object) {
+    private void testFeaturesArray(Hson.Struct object) {
         Optional<Hson.Array> maybeArray = object.arrayValue("array");
         assertThat(maybeArray, optionalPresent());
         List<Hson.Value<?>> value = maybeArray.get().value();
@@ -335,12 +335,12 @@ class HsonTest {
         assertThat(value.get(1).type(), is(Hson.Type.NULL));
         assertThat(value.get(2).type(), is(Hson.Type.STRING));
         assertThat(value.get(3).type(), is(Hson.Type.NUMBER));
-        assertThat(value.get(4).type(), is(Hson.Type.OBJECT));
+        assertThat(value.get(4).type(), is(Hson.Type.STRUCT));
         assertThat(value.get(5).type(), is(Hson.Type.ARRAY));
     }
 
-    private void testFeaturesNull(Hson.Object object) {
-        Optional<Hson.Value<?>> maybeValue = object.objectValue("nulls")
+    private void testFeaturesNull(Hson.Struct object) {
+        Optional<Hson.Value<?>> maybeValue = object.structValue("nulls")
                 .flatMap(it -> it.value("field"));
         assertThat(maybeValue, optionalPresent());
         Hson.Value<?> value = maybeValue.get();

--- a/service/codegen/src/main/java/io/helidon/service/codegen/HelidonMetaInfServices.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/HelidonMetaInfServices.java
@@ -108,15 +108,15 @@ class HelidonMetaInfServices {
      * Write the file to output.
      */
     void write() {
-        var root = Hson.objectBuilder()
+        var root = Hson.structBuilder()
                 .set("module", moduleName);
-        List<Hson.Object> servicesHson = new ArrayList<>();
+        List<Hson.Struct> servicesHson = new ArrayList<>();
 
         descriptors.stream()
                 .map(DescriptorMetadata::toHson)
                 .forEach(servicesHson::add);
 
-        root.setObjects("services", servicesHson);
+        root.setStructs("services", servicesHson);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (var pw = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8))) {

--- a/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadata.java
@@ -78,5 +78,5 @@ public interface DescriptorMetadata {
      *
      * @return HSON object (similar to JSON)
      */
-    Hson.Object toHson();
+    Hson.Struct toHson();
 }

--- a/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadataImpl.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/DescriptorMetadataImpl.java
@@ -32,7 +32,7 @@ record DescriptorMetadataImpl(String registryType,
     private static final int CURRENT_DESCRIPTOR_VERSION = 1;
     private static final int DEFAULT_DESCRIPTOR_VERSION = 1;
 
-    static DescriptorMetadata create(String moduleName, String location, Hson.Object service) {
+    static DescriptorMetadata create(String moduleName, String location, Hson.Struct service) {
         int version = service.intValue("version", DEFAULT_DESCRIPTOR_VERSION);
         if (version != CURRENT_DESCRIPTOR_VERSION) {
             throw new IllegalStateException("Invalid descriptor version: " + version
@@ -61,8 +61,8 @@ record DescriptorMetadataImpl(String registryType,
     }
 
     @Override
-    public Hson.Object toHson() {
-        var builder = Hson.objectBuilder();
+    public Hson.Struct toHson() {
+        var builder = Hson.structBuilder();
 
         if (!registryType.equals(REGISTRY_TYPE_CORE)) {
             builder.set("type", registryType);

--- a/service/metadata/src/main/java/io/helidon/service/metadata/Descriptors.java
+++ b/service/metadata/src/main/java/io/helidon/service/metadata/Descriptors.java
@@ -46,7 +46,7 @@ public class Descriptors {
     public static List<DescriptorMetadata> descriptors(String location, Hson.Array moduleRegistries) {
         List<DescriptorMetadata> descriptors = new ArrayList<>();
 
-        for (Hson.Object moduleRegistry : moduleRegistries.getObjects()) {
+        for (Hson.Struct moduleRegistry : moduleRegistries.getStructs()) {
             String moduleName = moduleRegistry.stringValue("module", "unknown");
             int version = moduleRegistry.intValue("version", DEFAULT_REGISTRY_VERSION);
             if (version != CURRENT_REGISTRY_VERSION) {
@@ -56,7 +56,7 @@ public class Descriptors {
                                                         + "expected version: \"" + CURRENT_REGISTRY_VERSION + "\"");
             }
 
-            moduleRegistry.objectArray("services")
+            moduleRegistry.structArray("services")
                     .orElseGet(List::of)
                     .stream()
                     .map(it -> DescriptorMetadataImpl.create(moduleName, location, it))

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceDiscovery.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceDiscovery.java
@@ -228,7 +228,7 @@ class CoreServiceDiscovery implements ServiceDiscovery {
         }
 
         @Override
-        public Hson.Object toHson() {
+        public Hson.Struct toHson() {
             return metadata.toHson();
         }
 


### PR DESCRIPTION
Resolves #9075 

The module is for Helidon internal metadata handling only, so no docs changes.