### PR TITLE
4.x: Excluding generated service descriptors from javadoc plugin(s).

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -207,6 +207,11 @@
                                 <exclude>**/generated-test-sources</exclude>
                                 <exclude>**/extracted-sources/**</exclude>
                             </sourceExcludes>
+                            <fileNameExcludes>
+                                <!-- exclude generated files that are not public API -->
+                                <exclude>*__*.java</exclude>
+                                <exclude>*_.java</exclude>
+                            </fileNameExcludes>
                             <moduleIncludes>
                                 <include>io.helidon*</include>
                                 <!-- See https://github.com/helidon-io/helidon/issues/8163 -->
@@ -216,6 +221,9 @@
                                 <!-- Unsupported modules -->
                                 <exclude>io.helidon.inject*</exclude>
                                 <exclude>*.processor*</exclude>
+                                <exclude> io.helidon.integrations.oci.authentication.instance</exclude>
+                                <exclude> io.helidon.integrations.oci.authentication.resource</exclude>
+                                <exclude> io.helidon.integrations.oci.authentication.okeworkload</exclude>
                             </moduleExcludes>
                             <packageIncludes>
                                 <include>io.helidon*</include>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -207,11 +207,11 @@
                                 <exclude>**/generated-test-sources</exclude>
                                 <exclude>**/extracted-sources/**</exclude>
                             </sourceExcludes>
-                            <fileNameExcludes>
+                            <fileExcludes>
                                 <!-- exclude generated files that are not public API -->
                                 <exclude>*__*.java</exclude>
                                 <exclude>*_.java</exclude>
-                            </fileNameExcludes>
+                            </fileExcludes>
                             <moduleIncludes>
                                 <include>io.helidon*</include>
                                 <!-- See https://github.com/helidon-io/helidon/issues/8163 -->

--- a/integrations/oci/authentication/instance/pom.xml
+++ b/integrations/oci/authentication/instance/pom.xml
@@ -30,6 +30,10 @@
         Authentication based on Instance's principal
     </description>
 
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.integrations.oci</groupId>

--- a/integrations/oci/authentication/oke-workload/pom.xml
+++ b/integrations/oci/authentication/oke-workload/pom.xml
@@ -30,6 +30,10 @@
         Authentication based on Workload identity
     </description>
 
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.integrations.oci</groupId>

--- a/integrations/oci/authentication/resource/pom.xml
+++ b/integrations/oci/authentication/resource/pom.xml
@@ -30,6 +30,10 @@
         Authentication based on Resource principal
     </description>
 
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.integrations.oci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,7 @@
                         <sourceFileExcludes>
                             <sourceFileExclude>**/target/**/*.java</sourceFileExclude>
                             <sourceFileExclude>**/*_.java</sourceFileExclude>
+                            <sourceFileExclude>**/*__*.java</sourceFileExclude>
                         </sourceFileExcludes>
                         <dependencySourceExcludes/>
                     </configuration>


### PR DESCRIPTION
docs/pom.xml modification will work once the change is merged to build tools and we use newer version.

Resolves #9076 
