### PR TITLE
Mark deprecations for Micrometer integration component

### DIFF
--- a/integrations/micrometer/cdi/pom.xml
+++ b/integrations/micrometer/cdi/pom.xml
@@ -79,6 +79,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/integrations/micrometer/cdi/src/test/java/io/helidon/integrations/micrometer/cdi/MixedAnnotationsResource.java
+++ b/integrations/micrometer/cdi/src/test/java/io/helidon/integrations/micrometer/cdi/MixedAnnotationsResource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.micrometer.cdi;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Mixed annotations class.
+ */
+@Path("mixed")
+@RequestScoped
+public class MixedAnnotationsResource {
+
+    static final String MESSAGE_COUNTER = "mixedMessageCounter";
+    static final String MESSAGE_TIMER = "mixedMessageTimer";
+    static final String MESSAGE_RESPONSE = "Hello Mixed World";
+
+    @Counted(value = MESSAGE_COUNTER, extraTags = {"scope", "application"})
+    @org.eclipse.microprofile.metrics.annotation.Counted(name = MESSAGE_COUNTER, absolute = true)
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String message() {
+        return MESSAGE_RESPONSE;
+    }
+
+    @GET
+    @Timed(value = MESSAGE_TIMER, extraTags = {"scope", "application"})
+    @org.eclipse.microprofile.metrics.annotation.Timed(name = MESSAGE_TIMER, absolute = true)
+    @Path("/withArg/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String messageWithArg(@PathParam("name") String input) {
+        return "Hello World, " + input;
+    }
+}

--- a/integrations/micrometer/cdi/src/test/java/io/helidon/integrations/micrometer/cdi/TestMixedAnnotations.java
+++ b/integrations/micrometer/cdi/src/test/java/io/helidon/integrations/micrometer/cdi/TestMixedAnnotations.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.micrometer.cdi;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import io.helidon.common.testing.junit5.OptionalMatcher;
+import io.helidon.microprofile.metrics.MetricsCdiExtension;
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddExtension;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@HelidonTest
+@AddBean(MixedAnnotationsResource.class)
+class TestMixedAnnotations {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Inject
+    private MeterRegistry mMeterRegistry;
+
+    @Inject
+    private MetricRegistry mpMetricRegistry;
+
+    @Test
+    void testMixedAnnotations() {
+        final int iterations = 2;
+        IntStream.range(0, iterations).forEach(
+                i -> webTarget
+                        .path("mixed/withArg/Hans")
+                        .request()
+                        .accept(MediaType.TEXT_PLAIN_TYPE)
+                        .get(String.class));
+        Optional<Long> mTimerCount =  mMeterRegistry.getMeters().stream()
+                .filter(m -> m instanceof Timer
+                        && m.getId().getName().equals(MixedAnnotationsResource.MESSAGE_TIMER)
+                        && m.getId().getTag("scope") != null
+                        && m.getId().getTag("scope").equals("application"))
+                .findFirst()
+                        .map(Timer.class::cast)
+                .map(Timer::count);
+
+        assertThat("Micrometer timer count", mTimerCount, OptionalMatcher.optionalValue(is((long) iterations)));
+
+        org.eclipse.microprofile.metrics.Timer mpTimer =
+                mpMetricRegistry.getTimer(new MetricID(MixedAnnotationsResource.MESSAGE_TIMER));
+        assertThat("MicroProfile timer count", mpTimer.getCount(), is((long) iterations));
+    }
+}

--- a/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MeterRegistryFactory.java
+++ b/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MeterRegistryFactory.java
@@ -84,7 +84,9 @@ import io.micrometer.core.instrument.config.MeterRegistryConfig;
  *     order of enrollment. The first function that returns a non-empty {@code Optional} wins and must populate and return the
  *     {@link ServerResponse}.
  * </p>
+ * @deprecated Use the Helidon neutral metrics API and {@code unwrap} its types to their Micrometer counterparts
  */
+@Deprecated(forRemoval = true, since = "4.1")
 public final class MeterRegistryFactory {
 
     /**

--- a/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MeterRegistryFactory.java
+++ b/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MeterRegistryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerFeature.java
+++ b/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerFeature.java
@@ -42,7 +42,9 @@ import io.micrometer.core.instrument.MeterRegistry;
  * {@code MicrometerSupport} object, developers can invoke the {@link #registry()} method and use the returned {@code
  * MeterRegistry} to create or locate meters.
  * </p>
+ * @deprecated Use the normal Helidon {@code /metrics} endpoint and configuration instead of {@code /micrometer}.
  */
+@Deprecated(forRemoval = true, since = "4.1")
 public class MicrometerFeature extends HelidonFeatureSupport {
 
     static final String DEFAULT_CONTEXT = "/micrometer";

--- a/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerFeature.java
+++ b/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestIntegration.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestIntegration.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.providers.micrometer;
+
+import io.helidon.common.testing.junit5.OptionalMatcher;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Meter;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.Metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class TestIntegration {
+
+    @Test
+    void testHelidonRegistrationViaMicrometer() {
+
+        MeterRegistry hMeterRegistry = Metrics.globalRegistry();
+
+        Counter hCounter = hMeterRegistry.getOrCreate(Counter.builder("hCounter1"));
+        hCounter.increment(2);
+
+        io.micrometer.core.instrument.Counter unwrappedCounter = hCounter.unwrap(io.micrometer.core.instrument.Counter.class);
+        assertThat("hCounter via unwrap", unwrappedCounter.count(), equalTo(2D));
+
+        unwrappedCounter.increment(3);
+
+        assertThat("hCounter via Helidon unwrap after Micrometer increment", hCounter.count(), equalTo(5L));
+
+        io.micrometer.core.instrument.MeterRegistry mMeterRegistry = io.micrometer.core.instrument.Metrics.globalRegistry;
+        io.micrometer.core.instrument.Counter mCounter = mMeterRegistry.counter("hCounter1", "scope", "application");
+        assertThat("hCounter via Micrometer meter registry", mCounter.count(), equalTo(5D));
+    }
+
+    @Test
+    void testMicrometerRegistrationViaHelidon() {
+        MeterRegistry hMeterRegistry = Metrics.globalRegistry();
+        io.micrometer.core.instrument.MeterRegistry mMeterRegistry = io.micrometer.core.instrument.Metrics.globalRegistry;
+        io.micrometer.core.instrument.Counter mCounter = mMeterRegistry.counter("mCounter1", "scope", "application");
+        mCounter.increment(2);
+
+        // Should find the previously-registered counter.
+        Counter hCounter = hMeterRegistry.getOrCreate(Counter.builder("mCounter1"));
+        assertThat("mCounter via Helidon with no explicit tag",
+                   hCounter.count(),
+                   equalTo(2L));
+
+        // Should find the previously-registered counter via a general search.
+        assertThat("mCounter via Helidon meters with predicate",
+                   hMeterRegistry.meters(m -> m.id().name().equals("mCounter1"))
+                           .stream()
+                           .filter(m -> m.type() == Meter.Type.COUNTER)
+                           .map(m -> ((Counter) m).count())
+                           .findFirst(),
+                   OptionalMatcher.optionalValue(equalTo(2L)));
+    }
+}


### PR DESCRIPTION
### Description
Resolves #8946 

Releases before 4.x provided some convenient ways developers could use Micrometer in their applications, including some configuration help and CDI injection and interceptor support for the Micrometer annotations and meter types. Using those tools, the Micrometer meters were completely separate from the Helidon metrics managed using the Helidon metrics API.

Now that Helidon 4 uses Micrometer for its own metrics implementation, the former approach is obsolete, inefficient, and unneeded. 

As one step of providing even better integration with Micrometer, this PR marks as deprecated-for-removal the public types of the integration component; we plan to remove them in a future major release of Helidon.

We will update the documentation in a later PR. In the meantime see the possible release note text below.

### Documentation
There are existing files in our docs area for Micrometer integration, but there are no links to them on our 4.x doc pages. So there are no doc updates needed as part of this PR.

(possible short-term text for release note...)

Users who want to use Micrometer from their Helidon 4.x apps can take advantage of the fact that Helidon now uses Micrometer for its metrics implementation. The following are simple approaches for using Micrometer from a Helidon 4.x app:
* Use the Helidon neutral metrics API to register, locate, and update meters. Helidon registers meters  in the Micrometer global meter registry. Then, as needed, use the `unwrap` method that is provided on most of the Helidon metrics types to cast them to their underlying Micrometer implementation counterparts and operate on those Micrometer types.
* Use the Micrometer `Metrics.globalRegistry` to access the Micrometer global registry directly. Register and retrieve meters using the Micrometer API. 
* If it makes sense, use one API from some of your code and the other API from other parts of your application. 
* Make sure you access the Helidon global registry in your app before you access the Micrometer global registry. This allows Helidon to properly initialize its internal data structures.
* Include the tag `scope=application` when you register or look up a meter using the Micrometer API.
  
  The Helidon metrics API automatically adds a `scope` tag to each meter. Normally, meters Helidon registers from your application will have `scope=application`. If you look up such a meter using the Micrometer API you will need to add that tag for Micrometer to find it.
  
  Similarly, if you register a meter using the Micrometer API be sure to specify the `scope=application` tag so the Helidon API will find it successfully.

Further, for Helidon 4 MP apps:
* Add the following dependency to your project:
  ```xml
  <dependency>
      <groupId>io.helidon.integrations.micrometer</groupId>
      <artifactId>helidon-integrations-micrometer-cdi</artifactId>
  </dependency>
  ```
* Annotate CDI bean methods with either the MP metrics annotations or the Micrometer annotations `@Timed` or `@Counted`.  Helidon automatically registers those meters and updates them each time the annotated bean methods are invoked.
* Inject the Micrometer global registry, for example:
  ```java
  @Inject
  private io.micrometer.core.instrument.MeterRegistry meterRegistry;
  ```
  and then work with the injected meter registry.

In SE and MP, meters registered using either API are accessible to both because the meters are in the Micrometer global registry regardless.

(end of possible release note)