### PR TITLE
3.x: Fixes links in documentation to point to `helidon-examples` repository.

### DIFF
--- a/docs/includes/cors.adoc
+++ b/docs/includes/cors.adoc
@@ -315,7 +315,7 @@ application's configuration file, the configuration for each service appears und
 | xref:{openapi-page}[OpenAPI] | `openapi`
 |====
 
-The link:{helidon-github-tree-url}/examples/quickstarts/helidon-quickstart-{flavor-lc}[Helidon {flavor-uc} QuickStart example]
+The link:{helidon-github-examples-url}/quickstarts/helidon-quickstart-{flavor-lc}[Helidon {flavor-uc} QuickStart example]
 uses these services, so you can use that as a template for your
 own application, or use the example project itself to experiment with customizing the CORS
 behavior in the built-in services.

--- a/docs/includes/cors.adoc
+++ b/docs/includes/cors.adoc
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/guides/gradle-build.adoc
+++ b/docs/includes/guides/gradle-build.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/guides/gradle-build.adoc
+++ b/docs/includes/guides/gradle-build.adoc
@@ -26,7 +26,7 @@ with a Gradle project. We recommend Gradle 6+.
 == Gradle Example
 
 The Helidon
-link:{helidon-github-tree-url}/examples/quickstarts/helidon-quickstart-{flavor-lc}[Quickstart Example]
+link:{helidon-github-examples-url}/quickstarts/helidon-quickstart-{flavor-lc}[Quickstart Example]
 contains a `build.gradle` file that you can use as an example for building
 your Helidon application using Gradle.
 

--- a/docs/includes/guides/metrics.adoc
+++ b/docs/includes/guides/metrics.adoc
@@ -193,7 +193,7 @@ The `vendor` metrics shown above appear in two groups:
 
 - Helidon thread pools +
 +
-Helidon uses these thread pools for its own internal work, and your application can also use Helidon-managed thread pools if it needs to do work asynchronously. (See link:{helidon-github-tree-url}/examples/webserver/threadpool[this example].)
+Helidon uses these thread pools for its own internal work, and your application can also use Helidon-managed thread pools if it needs to do work asynchronously. (See link:{helidon-github-examples-url}/webserver/threadpool[this example].)
 The metrics in this group show information about the thread pools which can help you assess how efficiently they are utilized.
 Helidon uses tags to distinguish the metrics which describe different thread pools.
 In some cases the specific metrics exposed depend on the particular type of thread pool.

--- a/docs/includes/guides/metrics.adoc
+++ b/docs/includes/guides/metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/metrics/metrics-shared.adoc
+++ b/docs/includes/metrics/metrics-shared.adoc
@@ -161,11 +161,11 @@ The `MetricRegistry` allows your code to register new metrics, look up previousl
 // tag::example-apps[]
 Helidon {flavor-uc} includes several prewritten example applications illustrating aspects of metrics:
 
-* link:{helidon-github-tree-url}/examples/metrics/filtering/{flavor-lc}[Enabling/disabling metrics] using
+* link:{helidon-github-examples-url}/metrics/filtering/{flavor-lc}[Enabling/disabling metrics] using
 ifdef::se-flavor[`MetricsSettings`]
 ifdef::mp-flavor[configuration]
 ifdef::se-flavor[]
-* link:{helidon-github-tree-url}/examples/metrics/kpi[Controlling key performance indicator metrics] using configuration and `KeyPerformanceIndicatorMetricsSettings`.
+* link:{helidon-github-examples-url}/metrics/kpi[Controlling key performance indicator metrics] using configuration and `KeyPerformanceIndicatorMetricsSettings`.
 endif::[]
 
 // end::example-apps[]

--- a/docs/includes/metrics/metrics-shared.adoc
+++ b/docs/includes/metrics/metrics-shared.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/metrics/micrometer-shared.adoc
+++ b/docs/includes/metrics/micrometer-shared.adoc
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/metrics/micrometer-shared.adoc
+++ b/docs/includes/metrics/micrometer-shared.adoc
@@ -187,7 +187,7 @@ can create, look up, and update metrics programmatically using the Micrometer `M
 // end::use-micrometer-api[]
 
 // tag::example-apps[]
-Helidon {flavor-uc} includes an link:{helidon-github-tree-url}/examples/integrations/micrometer/{flavor-lc}[example application] which uses Micrometer support.
+Helidon {flavor-uc} includes an link:{helidon-github-examples-url}/integrations/micrometer/{flavor-lc}[example application] which uses Micrometer support.
 // end::example-apps[]
 
 // end::all-micrometer[]

--- a/docs/includes/metrics/prometheus-exemplar-support.adoc
+++ b/docs/includes/metrics/prometheus-exemplar-support.adoc
@@ -151,7 +151,7 @@ endif::[]
 == Examples
 
 ifdef::se-flavor[]
-Helidon includes an link:{helidon-github-tree-url}/examples/metrics/exemplar[example application], based on the QuickStart application, which illustrates exemplar support.
+Helidon includes an link:{helidon-github-examples-url}/metrics/exemplar[example application], based on the QuickStart application, which illustrates exemplar support.
 endif::[]
 
 Once you enable exemplar support you can see the exemplars in the metrics output.

--- a/docs/includes/metrics/prometheus-exemplar-support.adoc
+++ b/docs/includes/metrics/prometheus-exemplar-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/openapi.adoc
+++ b/docs/includes/openapi.adoc
@@ -90,7 +90,7 @@ You can also define any request parameters the endpoint expects, although this
 endpoint uses none.
 
 This excerpt shows only a few annotations for illustration. The
-link:{helidon-github-tree-url}/examples/microprofile/openapi-basic[Helidon MP OpenAPI example] illustrates more,
+link:{helidon-github-examples-url}/microprofile/openapi-basic[Helidon MP OpenAPI example] illustrates more,
 and the link:{microprofile-open-api-spec-url}[MicroProfile OpenAPI spec] describes them all.
 
 ===== Provide a static OpenAPI file

--- a/docs/includes/openapi.adoc
+++ b/docs/includes/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/openapi/openapi.adoc
+++ b/docs/includes/openapi/openapi.adoc
@@ -98,7 +98,7 @@ You can also define any request parameters the endpoint expects, although this
 endpoint uses none.
 
 This excerpt shows only a few annotations for illustration. The
-link:{helidon-github-tree-url}/examples/microprofile/openapi-basic[Helidon MP OpenAPI example] illustrates more,
+link:{helidon-github-examples-url}/microprofile/openapi-basic[Helidon MP OpenAPI example] illustrates more,
 and the link:{microprofile-open-api-spec-url}[MicroProfile OpenAPI spec] describes them all.
 
 ===== Provide a static OpenAPI file

--- a/docs/includes/openapi/openapi.adoc
+++ b/docs/includes/openapi/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/security/providers/abac.adoc
+++ b/docs/includes/security/providers/abac.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/security/providers/abac.adoc
+++ b/docs/includes/security/providers/abac.adoc
@@ -51,7 +51,7 @@ include::{rootdir}/config/io_helidon_security_providers_abac_AbacProvider.adoc[l
 
 === Examples [[ABAC-Provider-Examples]]
 
-See the link:{helidon-github-tree-url}/examples/security/attribute-based-access-control[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/attribute-based-access-control[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/includes/security/providers/google-login.adoc
+++ b/docs/includes/security/providers/google-login.adoc
@@ -47,7 +47,7 @@ include::{rootdir}/config/io_helidon_security_providers_google_login_GoogleToken
 
 === Example Code [[Google-Provider-Example]]
 
-See the link:{helidon-github-tree-url}/examples/security/google-login[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/google-login[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/includes/security/providers/google-login.adoc
+++ b/docs/includes/security/providers/google-login.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/security/providers/idcs-role-mapper.adoc
+++ b/docs/includes/security/providers/idcs-role-mapper.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/security/providers/idcs-role-mapper.adoc
+++ b/docs/includes/security/providers/idcs-role-mapper.adoc
@@ -46,7 +46,7 @@ include::{rootdir}/config/io_helidon_security_providers_idcs_mapper_IdcsMtRoleMa
 
 ==== Example code
 
-See the link:{helidon-github-tree-url}/examples/security/idcs-login/[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/idcs-login/[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/includes/security/providers/jwt.adoc
+++ b/docs/includes/security/providers/jwt.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/includes/security/providers/jwt.adoc
+++ b/docs/includes/security/providers/jwt.adoc
@@ -47,7 +47,7 @@ include::{rootdir}/config/io_helidon_security_providers_jwt_JwtProvider.adoc[lev
 
 === Example Code [[JWT-Provider-Example]]
 
-See the link:{helidon-github-tree-url}/examples/security/outbound-override[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/outbound-override[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/includes/security/providers/oidc.adoc
+++ b/docs/includes/security/providers/oidc.adoc
@@ -26,7 +26,7 @@ ifndef::rootdir[:rootdir: {docdir}/../../..]
 include::{rootdir}/config/io_helidon_security_providers_oidc_OidcProvider.adoc[leveloffset=+2,tag=config]
 
 === Example Code [[OIDC-Provider-Example]]
-See the link:{helidon-github-tree-url}/examples/security/idcs-login[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/idcs-login[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/includes/security/providers/oidc.adoc
+++ b/docs/includes/security/providers/oidc.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/cors/cors.adoc
+++ b/docs/mp/cors/cors.adoc
@@ -132,12 +132,12 @@ include::{rootdir}/includes/cors.adoc[tag=cors-config-table]
 
 == Examples
 
-The link:{helidon-github-tree-url}/examples/quickstarts/helidon-quickstart-mp[Helidon MP Quickstart application] allows users to:
+The link:{helidon-github-examples-url}/quickstarts/helidon-quickstart-mp[Helidon MP Quickstart application] allows users to:
 
 * obtain greetings by sending `GET` requests to the `/greet` resource, and
 * change the greeting message by sending a `PUT` request to the `/greet/greeting` resource.
 
-The link:{helidon-github-tree-url}/examples/microprofile/cors[Helidon MP CORS Example] shows the basic quickstart example enhanced for CORS.
+The link:{helidon-github-examples-url}/microprofile/cors[Helidon MP CORS Example] shows the basic quickstart example enhanced for CORS.
 
 The discussion below describes the changes in the application which:
 

--- a/docs/mp/cors/cors.adoc
+++ b/docs/mp/cors/cors.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/grpc/client.adoc
+++ b/docs/mp/grpc/client.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/grpc/client.adoc
+++ b/docs/mp/grpc/client.adoc
@@ -283,8 +283,8 @@ public interface StringService {
 ----
 
 == Examples
-link:{helidon-github-tree-url}/examples/grpc/microprofile/basic-client[Basic gRPC Client] example demonstrates  a
+link:{helidon-github-examples-url}/grpc/microprofile/basic-client[Basic gRPC Client] example demonstrates  a
 simple gRPC client that invokes services from deployed gRPC server applications provided in the
-link:{helidon-github-tree-url}/examples/grpc/microprofile/basic-server-implicit[Basic gRPC Server] and
-link:{helidon-github-tree-url}/examples/grpc/microprofile/metrics[gRPC Server metrics] examples.
+link:{helidon-github-examples-url}/grpc/microprofile/basic-server-implicit[Basic gRPC Server] and
+link:{helidon-github-examples-url}/grpc/microprofile/metrics[gRPC Server metrics] examples.
 

--- a/docs/mp/grpc/server.adoc
+++ b/docs/mp/grpc/server.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/grpc/server.adoc
+++ b/docs/mp/grpc/server.adoc
@@ -362,9 +362,9 @@ grpc:
 == Examples
 Helidon MP includes some examples that demonstrate the gRPC server usage:
 
-* link:{helidon-github-tree-url}/examples/grpc/microprofile/basic-server-implicit[Basic gRPC Server example] provides
+* link:{helidon-github-examples-url}/grpc/microprofile/basic-server-implicit[Basic gRPC Server example] provides
 a simple gRPC application that deploys a gRPC service that will be discovered by CDI. Two additional services are
 included that are not normally CDI managed beans, but are manually added as CDI managed beans so that they can also be
 discovered by Helidon MP.
-* link:{helidon-github-tree-url}/examples/grpc/microprofile/metrics[gRPC Server Metrics example] demonstrates a
+* link:{helidon-github-examples-url}/grpc/microprofile/metrics[gRPC Server Metrics example] demonstrates a
 Helidon MP application that enables `metrics` and `tracing` on a gRPC Service.

--- a/docs/mp/health.adoc
+++ b/docs/mp/health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/health.adoc
+++ b/docs/mp/health.adoc
@@ -288,7 +288,7 @@ curl http://localhost:8080/health/live
 }
 ----
 
-Full example code is available link:{helidon-github-tree-url}/examples/microprofile[here].
+Full example code is available link:{helidon-github-examples-url}/microprofile[here].
 
 
 === Custom Readiness Health Checks
@@ -387,7 +387,7 @@ curl -v http://localhost:8080/health/ready
 }
 ----
 
-Full example code is available link:{helidon-github-tree-url}/examples/microprofile[here].
+Full example code is available link:{helidon-github-examples-url}/microprofile[here].
 
 === Custom Startup Health Checks
 
@@ -517,7 +517,7 @@ curl http://localhost:8080/health
 }
 ----
 
-Full example code is available link:{helidon-github-tree-url}/examples/microprofile[here].
+Full example code is available link:{helidon-github-examples-url}/microprofile[here].
 
 == Reference
 

--- a/docs/mp/integrations/hcv.adoc
+++ b/docs/mp/integrations/hcv.adoc
@@ -534,4 +534,4 @@ This will create a Vault docker image, run it in background and open it on `loca
 
 == References
 
-* link:{helidon-github-tree-url}/examples/integrations/vault[Hashicorp Vault Usage Examples]
+* link:{helidon-github-examples-url}/integrations/vault[Hashicorp Vault Usage Examples]

--- a/docs/mp/integrations/hcv.adoc
+++ b/docs/mp/integrations/hcv.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/integrations/jedis.adoc
+++ b/docs/mp/integrations/jedis.adoc
@@ -176,7 +176,7 @@ with `redis.clients.jedis.JedisPoolConfig.default` and `redis.clients.jedis.Jedi
 
 == References
 
-* link:{helidon-github-tree-url}/examples/integrations/cdi/jedis[Helidon Jedis Example]
+* link:{helidon-github-examples-url}/integrations/cdi/jedis[Helidon Jedis Example]
 * link:{jedis-base-url}/jedis/package-summary.html[Jedis Javadoc]
 * link:https://github.com/xetorthio/jedis[Jedis]
 * link:https://github.com/redis/redis[Redis]

--- a/docs/mp/integrations/jedis.adoc
+++ b/docs/mp/integrations/jedis.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/integrations/oci.adoc
+++ b/docs/mp/integrations/oci.adoc
@@ -142,4 +142,4 @@ Once you have injected an ObjectStorage client you can use it as described in:
 == References
 
 * link:{integration-oci-sdk-cdi-javadoc-base-url}/io/helidon/integrations/oci/sdk/cdi/OciExtension.html[OciExtension] Javadocs
-* link:{helidon-github-tree-url}/examples/integrations/oci[OCI SDK Usage Examples]
+* link:{helidon-github-examples-url}/integrations/oci[OCI SDK Usage Examples]

--- a/docs/mp/integrations/oci.adoc
+++ b/docs/mp/integrations/oci.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/metrics/metrics.adoc
+++ b/docs/mp/metrics/metrics.adoc
@@ -136,7 +136,7 @@ include::{rootdir}/includes/metrics/metrics-config.adoc[tag=config-intro]
 == Examples
 
 Helidon MP includes a prewritten example application illustrating
-link:{helidon-github-tree-url}/examples/metrics/filtering/mp[enabling/disabling metrics] using configuration.
+link:{helidon-github-examples-url}/metrics/filtering/mp[enabling/disabling metrics] using configuration.
 
 The rest of this section contains other examples of working with metrics:
 

--- a/docs/mp/metrics/metrics.adoc
+++ b/docs/mp/metrics/metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/openapi.adoc
+++ b/docs/mp/openapi.adoc
@@ -95,7 +95,7 @@ include::{rootdir}/config/io_helidon_microprofile_openapi_MPOpenAPISupport.adoc[
 
 == Examples
 
-Helidon MP includes a link:{helidon-github-tree-url}/examples/microprofile/openapi-basic[complete OpenAPI example]
+Helidon MP includes a link:{helidon-github-examples-url}/microprofile/openapi-basic[complete OpenAPI example]
 based on the MP quick-start sample app. The rest of this section shows, step-by-step, how one might change the original QuickStart service to adopt OpenAPI.
 
 === Helidon MP Basic OpenAPI Example

--- a/docs/mp/openapi.adoc
+++ b/docs/mp/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/openapi/openapi.adoc
+++ b/docs/mp/openapi/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/openapi/openapi.adoc
+++ b/docs/mp/openapi/openapi.adoc
@@ -92,7 +92,7 @@ include::{rootdir}/config/io_helidon_microprofile_openapi_MPOpenAPISupport.adoc[
 
 == Examples
 
-Helidon MP includes a link:{helidon-github-tree-url}/examples/microprofile/openapi-basic[complete OpenAPI example]
+Helidon MP includes a link:{helidon-github-examples-url}/microprofile/openapi-basic[complete OpenAPI example]
 based on the MP quick-start sample app. The rest of this section shows, step-by-step, how one might change the original QuickStart service to adopt OpenAPI.
 
 === Helidon MP Basic OpenAPI Example

--- a/docs/mp/reactivemessaging/kafka.adoc
+++ b/docs/mp/reactivemessaging/kafka.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/mp/reactivemessaging/kafka.adoc
+++ b/docs/mp/reactivemessaging/kafka.adoc
@@ -163,4 +163,4 @@ mp.messaging:
 
 Don't forget to check out the examples with pre-configured Kafka docker image, for easy testing:
 
-* {helidon-github-tree-url}/examples/messaging
+* {helidon-github-examples-url}/messaging

--- a/docs/mp/websocket.adoc
+++ b/docs/mp/websocket.adoc
@@ -172,7 +172,7 @@ the root path for WebSocket endpoints will be  `"/web"` instead of the default `
 
 All endpoint methods in Helidon MP are executed in a separate thread pool, independently of Netty. Therefore, there is no need to create additional threads for blocking or long-running operations as these will not affect Netty's ability to process networking data.
 
-For more information see the link:{helidon-github-tree-url}/examples/webserver/websocket[example].
+For more information see the link:{helidon-github-examples-url}/webserver/websocket[example].
 
 === WebSocket Endpoints on Different Ports
 

--- a/docs/mp/websocket.adoc
+++ b/docs/mp/websocket.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/cors.adoc
+++ b/docs/se/cors.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/cors.adoc
+++ b/docs/se/cors.adoc
@@ -100,7 +100,7 @@ include::{rootdir}/includes/cors.adoc[tag=cors-config-table]
 [[se-api-routing-example]]
 === Sample Routing Setup Using the `CrossOriginConfig` API
 
-The link:{helidon-github-tree-url}/examples/quickstarts/helidon-quickstart-se[Helidon SE Quickstart application]
+The link:{helidon-github-examples-url}/quickstarts/helidon-quickstart-se[Helidon SE Quickstart application]
  lets you change the greeting by sending a `PUT` request to the `/greet/greeting` resource.
 
 This example, based on the QuickStart greeting app, uses the low-level `CrossOriginConfig` API and
@@ -243,7 +243,7 @@ rebuild and restart your application for any changes to take effect.
 
 == Examples
 
-For a complete example, see {helidon-github-tree-url}/examples/cors[Helidon SE CORS Example].
+For a complete example, see {helidon-github-examples-url}/cors[Helidon SE CORS Example].
 
 == Additional Information
 
@@ -266,7 +266,7 @@ service type has a `Builder` class. To control the CORS behavior of a built-in s
 . Use the service instance in preparing the routing rules.
 
 The following excerpt shows changes to the
- link:{helidon-github-tree-url}/examples/quickstarts/helidon-quickstart-se[Helidon SE QuickStart example] which limit
+ link:{helidon-github-examples-url}/quickstarts/helidon-quickstart-se[Helidon SE QuickStart example] which limit
 sharing of the `/metrics` endpoint to `\http://foo.com`.
 
 [source,java]

--- a/docs/se/dbclient.adoc
+++ b/docs/se/dbclient.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/dbclient.adoc
+++ b/docs/se/dbclient.adoc
@@ -305,7 +305,7 @@ Execution of a query statement will always return `Multi<DbRow>>`. `Multi` has s
 == Additional Information
 
 Now that you understand how to build and execute statements, try it for yourself.
-link:{helidon-github-tree-url}/examples/dbclient[DB Client Examples].
+link:{helidon-github-examples-url}/dbclient[DB Client Examples].
 
 
 

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -553,10 +553,10 @@ a client that can be used to define the set of methods described by the specifie
 === Additional gRPC Client Examples
 A set of gRPC client examples for Helidon SE can be found in the following links:
 
-* link:{helidon-github-tree-url}/examples/grpc/client-standalone[Basic gRPC Standalone Client]
-* link:{helidon-github-tree-url}/examples/grpc/metrics[gRPC Server Metrics]
-* link:{helidon-github-tree-url}/examples/grpc/opentracing[OpenTracing on a gRPC Server]
-* link:{helidon-github-tree-url}/examples/grpc/security[Basic Auth Security on a gRPC Server]
-* link:{helidon-github-tree-url}/examples/grpc/security-abac[Attribute-Based Access Control (ABAC) security on a gRPC Server]
-* link:{helidon-github-tree-url}/examples/grpc/security-outbound[Outbound Security on a gRPC Server]
+* link:{helidon-github-examples-url}/grpc/client-standalone[Basic gRPC Standalone Client]
+* link:{helidon-github-examples-url}/grpc/metrics[gRPC Server Metrics]
+* link:{helidon-github-examples-url}/grpc/opentracing[OpenTracing on a gRPC Server]
+* link:{helidon-github-examples-url}/grpc/security[Basic Auth Security on a gRPC Server]
+* link:{helidon-github-examples-url}/grpc/security-abac[Attribute-Based Access Control (ABAC) security on a gRPC Server]
+* link:{helidon-github-examples-url}/grpc/security-outbound[Outbound Security on a gRPC Server]
 

--- a/docs/se/grpc/server.adoc
+++ b/docs/se/grpc/server.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/grpc/server.adoc
+++ b/docs/se/grpc/server.adoc
@@ -948,10 +948,10 @@ static class HelloService implements GrpcService { // <5>
 === Additional gRPC Server Examples
 A set of gRPC server examples for Helidon SE can be found in the following links:
 
-* link:{helidon-github-tree-url}/examples/grpc/basics[Basic gRPC Server]
-* link:{helidon-github-tree-url}/examples/grpc/metrics[gRPC Server Metrics]
-* link:{helidon-github-tree-url}/examples/grpc/opentracing[OpenTracing on a gRPC Server]
-* link:{helidon-github-tree-url}/examples/grpc/security[Basic Auth Security on a gRPC Server]
-* link:{helidon-github-tree-url}/examples/grpc/security-abac[Attribute-Based Access Control (ABAC) security on a gRPC Server]
-* link:{helidon-github-tree-url}/examples/grpc/security-outbound[Outbound Security on a gRPC Server]
+* link:{helidon-github-examples-url}/grpc/basics[Basic gRPC Server]
+* link:{helidon-github-examples-url}/grpc/metrics[gRPC Server Metrics]
+* link:{helidon-github-examples-url}/grpc/opentracing[OpenTracing on a gRPC Server]
+* link:{helidon-github-examples-url}/grpc/security[Basic Auth Security on a gRPC Server]
+* link:{helidon-github-examples-url}/grpc/security-abac[Attribute-Based Access Control (ABAC) security on a gRPC Server]
+* link:{helidon-github-examples-url}/grpc/security-outbound[Outbound Security on a gRPC Server]
 

--- a/docs/se/integrations/hcv.adoc
+++ b/docs/se/integrations/hcv.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/integrations/hcv.adoc
+++ b/docs/se/integrations/hcv.adoc
@@ -575,4 +575,4 @@ This will create a Vault docker image, run it in background and open it on local
 
 == References
 
-* link:{helidon-github-tree-url}/examples/integrations/vault[Hashicorp Vault Usage Examples]
+* link:{helidon-github-examples-url}/integrations/vault[Hashicorp Vault Usage Examples]

--- a/docs/se/integrations/oci.adoc
+++ b/docs/se/integrations/oci.adoc
@@ -109,6 +109,6 @@ Once you have created an ObjectStorage client you can use it as described in:
 
 == References
 
-* link:{helidon-github-tree-url}/examples/integrations/oci[OCI SDK Usage Examples]
+* link:{helidon-github-examples-url}/integrations/oci[OCI SDK Usage Examples]
 * link:https://docs.oracle.com/en-us/iaas/Content/home.htm[OCI Documentation]
 ]

--- a/docs/se/integrations/oci.adoc
+++ b/docs/se/integrations/oci.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/openapi/openapi.adoc
+++ b/docs/se/openapi/openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/openapi/openapi.adoc
+++ b/docs/se/openapi/openapi.adoc
@@ -98,7 +98,7 @@ include::{rootdir}/config/io_helidon_openapi_SEOpenAPISupport.adoc[leveloffset=+
 
 == Examples
 
-Helidon SE provides a link:{helidon-github-tree-url}/examples/openapi[complete OpenAPI example]
+Helidon SE provides a link:{helidon-github-examples-url}/openapi[complete OpenAPI example]
 based on the SE QuickStart sample app which includes a model reader and a filter.
 
 Most Helidon {flavor-uc} applications need only to create and register `OpenAPISupport`.

--- a/docs/se/reactive-messaging.adoc
+++ b/docs/se/reactive-messaging.adoc
@@ -694,4 +694,4 @@ Messaging.builder()<5>
 
 * link:{microprofile-reactive-messaging-spec-url}[MicroProfile Reactive Messaging Specification]
 * link:https://github.com/eclipse/microprofile-reactive-messaging[MicroProfile Reactive Messaging on GitHub]
-* link:{helidon-github-tree-url}/examples/messaging[Helidon Messaging Examples]
+* link:{helidon-github-examples-url}/messaging[Helidon Messaging Examples]

--- a/docs/se/websocket.adoc
+++ b/docs/se/websocket.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/se/websocket.adoc
+++ b/docs/se/websocket.adoc
@@ -68,7 +68,7 @@ one at a time, over a connection.
 The example will show how REST and WebSocket connections can
 be seamlessly combined into a Helidon application.
 
-The complete Helidon SE example is available {helidon-github-tree-url}/examples/webserver/websocket[here]. Let us start by
+The complete Helidon SE example is available {helidon-github-examples-url}/webserver/websocket[here]. Let us start by
 looking at `MessageQueueService`:
 
 [source,java]
@@ -162,7 +162,7 @@ This code snippet uses multiple builders for `Routing`, `WebSocketRouting` and `
 In particular, it registers `MessageBoardEndpoint.class` at `"/websocket/board"` and associates
 with it a _message encoder_. For more information on message encoders and decoders the
 reader see the {jakarta-websocket-spec-url}[websocket specification]; in this
- {helidon-github-tree-url}/examples/webserver/websocket[example], `UppercaseEncoder.class` simply uppercases every
+ {helidon-github-examples-url}/webserver/websocket[example], `UppercaseEncoder.class` simply uppercases every
  message sent from the server.
 
 Endpoint methods in Helidon SE are executed in Netty's worker thread pool. Threads in this


### PR DESCRIPTION
### Description

Fixes #9092

Fixes links in documentation to point to `helidon-examples` repository.

`helidon-github-examples-url` was already defined in attributes.adoc but was not universally used.

### Documentation

Docs fix.