### PR TITLE
4.x : Updates links to examples that are in documentation to point to the `helidon-examples` repository.

### DIFF
--- a/docs/src/main/asciidoc/includes/attributes.adoc
+++ b/docs/src/main/asciidoc/includes/attributes.adoc
@@ -24,16 +24,18 @@ ifndef::attributes-included[]
 :imagesdir: {rootdir}/images
 
 :helidon-version: 4.1.0-SNAPSHOT
-:helidon-version-is-release: true
+:helidon-version-is-release: false
 
 :sourcedir: {rootdir}/../java/io/helidon/docs
 
 ifeval::["{helidon-version-is-release}" != "true"]
 :helidon-github-tree-url: https://github.com/oracle/helidon/tree/main
+:helidon-github-examples-url: https://github.com/helidon-io/helidon-examples/tree/helidon-4.x/examples
 endif::[]
 
 ifeval::["{helidon-version-is-release}" == "true"]
 :helidon-github-tree-url: https://github.com/oracle/helidon/tree/{helidon-version}
+:helidon-github-examples-url: https://github.com/helidon-io/helidon-examples/tree/{helidon-version}/examples
 endif::[]
 
 // versions

--- a/docs/src/main/asciidoc/includes/guides/gradle-build.adoc
+++ b/docs/src/main/asciidoc/includes/guides/gradle-build.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/includes/guides/gradle-build.adoc
+++ b/docs/src/main/asciidoc/includes/guides/gradle-build.adoc
@@ -26,7 +26,7 @@ with a Gradle project. Gradle 8.4+ is required to build Helidon 4 projects.
 == Gradle Example
 
 The Helidon
-link:{helidon-github-tree-url}/examples/quickstarts/helidon-quickstart-{flavor-lc}[Quickstart Example]
+link:{helidon-github-examples-url}/quickstarts/helidon-quickstart-{flavor-lc}[Quickstart Example]
 contains a `build.gradle` file that you can use as an example for building
 your Helidon application using Gradle.
 

--- a/docs/src/main/asciidoc/includes/guides/maven-build.adoc
+++ b/docs/src/main/asciidoc/includes/guides/maven-build.adoc
@@ -37,7 +37,7 @@ use a Helidon application POM as their parent. This parent POM provides the foll
    Helidon application.
 
 If you want to use your own parent POM, then take a look at the
-link:{helidon-github-tree-url}/examples/quickstarts/helidon-standalone-quickstart-{flavor-lc}[standalone quickstart example].
+link:{helidon-github-examples-url}/quickstarts/helidon-standalone-quickstart-{flavor-lc}[standalone quickstart example].
 This example has a standalone POM that you can pattern your own application POM after.
 
 For more details on Helidon application POMs see the

--- a/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
@@ -215,11 +215,11 @@ Once it has a reference to a `MetricRegistry` your code can use the reference to
 // tag::example-apps[]
 Helidon {flavor-uc} includes several pre-written example applications illustrating aspects of metrics:
 
-* link:{helidon-github-tree-url}/examples/metrics/filtering/{flavor-lc}[Enabling/disabling {metrics}] using
+* link:{helidon-github-examples-url}/metrics/filtering/{flavor-lc}[Enabling/disabling {metrics}] using
 ifdef::se-flavor[`MetricsObserver` and `MetricsConfig`]
 ifdef::mp-flavor[configuration]
 ifdef::se-flavor[]
-* link:{helidon-github-tree-url}/examples/metrics/kpi[Controlling key performance indicator metrics] using configuration and `KeyPerformanceIndicatorMetricsSettings`.
+* link:{helidon-github-examples-url}/metrics/kpi[Controlling key performance indicator metrics] using configuration and `KeyPerformanceIndicatorMetricsSettings`.
 endif::[]
 
 // end::example-apps[]

--- a/docs/src/main/asciidoc/includes/metrics/micrometer-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/micrometer-shared.adoc
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/includes/metrics/micrometer-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/micrometer-shared.adoc
@@ -187,7 +187,7 @@ can create, look up, and update metrics programmatically using the Micrometer `M
 // end::use-micrometer-api[]
 
 // tag::example-apps[]
-Helidon {flavor-uc} includes an link:{helidon-github-tree-url}/examples/integrations/micrometer/{flavor-lc}[example application] which uses Micrometer support.
+Helidon {flavor-uc} includes an link:{helidon-github-examples-url}/integrations/micrometer/{flavor-lc}[example application] which uses Micrometer support.
 // end::example-apps[]
 
 // end::all-micrometer[]

--- a/docs/src/main/asciidoc/includes/metrics/prometheus-exemplar-support.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/prometheus-exemplar-support.adoc
@@ -108,7 +108,7 @@ But some consumers, such as trace collectors and their UIs, understand the exemp
 == Examples
 
 ifdef::se-flavor[]
-Helidon includes an link:{helidon-github-tree-url}/examples/metrics/exemplar[example application], based on the QuickStart application, which illustrates exemplar support.
+Helidon includes an link:{helidon-github-examples-url}/metrics/exemplar[example application], based on the QuickStart application, which illustrates exemplar support.
 endif::[]
 
 Once you enable exemplar support you can see the exemplars in the metrics output.

--- a/docs/src/main/asciidoc/includes/openapi/openapi.adoc
+++ b/docs/src/main/asciidoc/includes/openapi/openapi.adoc
@@ -98,7 +98,7 @@ You can also define any request parameters the endpoint expects, although this
 endpoint uses none.
 
 This excerpt shows only a few annotations for illustration. The
-link:{helidon-github-tree-url}/examples/microprofile/openapi-basic[Helidon MP OpenAPI example] illustrates more,
+link:{helidon-github-examples-url}/microprofile/openapi[Helidon MP OpenAPI example] illustrates more,
 and the link:{microprofile-open-api-spec-url}[MicroProfile OpenAPI spec] describes them all.
 
 ===== A static OpenAPI file

--- a/docs/src/main/asciidoc/includes/security/providers/abac.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/abac.adoc
@@ -44,7 +44,7 @@ include::{rootdir}/config/io_helidon_security_providers_abac_AbacProvider.adoc[l
 
 ==== Example code
 
-See the link:{helidon-github-tree-url}/examples/security/attribute-based-access-control[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/attribute-based-access-control[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/src/main/asciidoc/includes/security/providers/google-login.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/google-login.adoc
@@ -42,7 +42,7 @@ include::{rootdir}/config/io_helidon_security_providers_google_login_GoogleToken
 
 ==== Example code
 
-See the link:{helidon-github-tree-url}/examples/security/google-login[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/google-login[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/src/main/asciidoc/includes/security/providers/http-basic-auth.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/http-basic-auth.adoc
@@ -42,7 +42,7 @@ include::{rootdir}/config/io_helidon_security_providers_httpauth_HttpBasicAuthPr
 
 ==== Example code
 
-See the link:{helidon-github-tree-url}/examples/security/outbound-override[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/outbound-override[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/src/main/asciidoc/includes/security/providers/http-signatures.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/http-signatures.adoc
@@ -43,7 +43,7 @@ include::{rootdir}/config/io_helidon_security_providers_httpsign_HttpSignProvide
 
 ==== Example code
 
-See the link:{helidon-github-tree-url}/examples/security/webserver-signatures[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/webserver-signatures[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/src/main/asciidoc/includes/security/providers/idcs-role-mapper.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/idcs-role-mapper.adoc
@@ -46,7 +46,7 @@ include::{rootdir}/config/io_helidon_security_providers_idcs_mapper_IdcsMtRoleMa
 
 ==== Example code
 
-See the link:{helidon-github-tree-url}/examples/security/idcs-login/[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/idcs-login/[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/src/main/asciidoc/includes/security/providers/jwt.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/jwt.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/includes/security/providers/jwt.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/jwt.adoc
@@ -42,7 +42,7 @@ include::{rootdir}/config/io_helidon_security_providers_jwt_JwtProvider.adoc[lev
 
 ==== Example code
 
-See the link:{helidon-github-tree-url}/examples/security/outbound-override[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/outbound-override[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/oidc.adoc
@@ -26,7 +26,7 @@ ifndef::rootdir[:rootdir: {docdir}/../../..]
 include::{rootdir}/config/io_helidon_security_providers_oidc_OidcProvider.adoc[leveloffset=+2,tag=config]
 
 === Example code
-See the link:{helidon-github-tree-url}/examples/security/idcs-login[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/idcs-login[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/src/main/asciidoc/includes/security/providers/provider-template.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/provider-template.adoc
@@ -48,7 +48,7 @@ provider-config-key
 ----
 
 ==== Example code
-See the link:{helidon-github-tree-url}/examples/security/[example] on GitHub.
+See the link:{helidon-github-examples-url}/security/[example] on GitHub.
 
 [source,yaml]
 .Configuration example

--- a/docs/src/main/asciidoc/includes/security/providers/provider-template.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/provider-template.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/mp/beanvalidation.adoc
+++ b/docs/src/main/asciidoc/mp/beanvalidation.adoc
@@ -387,7 +387,7 @@ include::{sourcedir}/mp/BeanvalidationSnippets.java[tag=snippet_3, indent=0]
 +
 NOTE: `beans.xml` is required to identify beans and for bean validation to work properly.
 
-Examples are available in link:{helidon-github-tree-url}/examples/microprofile/bean-validation[our official GitHub repository].
+Examples are available in link:{helidon-github-examples-url}/microprofile/bean-validation[our official GitHub repository].
 
 == Additional Information
 

--- a/docs/src/main/asciidoc/mp/cors/cors.adoc
+++ b/docs/src/main/asciidoc/mp/cors/cors.adoc
@@ -135,12 +135,12 @@ include::{rootdir}/includes/cors.adoc[tag=cors-config-table]
 
 == Examples
 
-The link:{helidon-github-tree-url}/examples/quickstarts/helidon-quickstart-mp[Helidon MP Quickstart application] allows users to:
+The link:{helidon-github-examples-url}/quickstarts/helidon-quickstart-mp[Helidon MP Quickstart application] allows users to:
 
 * obtain greetings by sending `GET` requests to the `/greet` resource, and
 * change the greeting message by sending a `PUT` request to the `/greet/greeting` resource.
 
-The link:{helidon-github-tree-url}/examples/microprofile/cors[Helidon MP CORS Example] shows the basic quickstart example enhanced for CORS.
+The link:{helidon-github-examples-url}/microprofile/cors[Helidon MP CORS Example] shows the basic quickstart example enhanced for CORS.
 
 The discussion below describes the changes in the application which:
 

--- a/docs/src/main/asciidoc/mp/graphql.adoc
+++ b/docs/src/main/asciidoc/mp/graphql.adoc
@@ -132,7 +132,7 @@ additional information on how to change the location of these resources.
 
 If you wish to use the
 link:https://github.com/graphql/graphiql[GraphQL UI] then please see the
-link:{helidon-github-tree-url}/examples/microprofile/graphql[GraphQL MP Example].
+link:{helidon-github-examples-url}/microprofile/graphql[GraphQL MP Example].
 
 == Configuration
 
@@ -154,7 +154,7 @@ include::{rootdir}/includes/graphql.adoc[]
 == Examples
 
 For a complete example, see
-link:{helidon-github-tree-url}/examples/microprofile/graphql[GraphQL MP Example].
+link:{helidon-github-examples-url}/microprofile/graphql[GraphQL MP Example].
 
 == Additional Information
 

--- a/docs/src/main/asciidoc/mp/health.adoc
+++ b/docs/src/main/asciidoc/mp/health.adoc
@@ -351,7 +351,7 @@ curl -v http://localhost:8080/health/ready
 }
 ----
 
-Full example code is available link:{helidon-github-tree-url}/examples/microprofile[here].
+Full example code is available link:{helidon-github-examples-url}/microprofile[here].
 
 === Custom Startup Health Checks
 
@@ -459,7 +459,7 @@ curl http://localhost:8080/health
 }
 ----
 
-Full example code is available link:{helidon-github-tree-url}/examples/microprofile[here].
+Full example code is available link:{helidon-github-examples-url}/microprofile[here].
 
 == Reference
 

--- a/docs/src/main/asciidoc/mp/integrations/hcv.adoc
+++ b/docs/src/main/asciidoc/mp/integrations/hcv.adoc
@@ -235,4 +235,4 @@ This will create a Vault docker image, run it in background and open it on `loca
 
 == References
 
-* link:{helidon-github-tree-url}/examples/integrations/vault[Hashicorp Vault Usage Examples]
+* link:{helidon-github-examples-url}/integrations/vault[Hashicorp Vault Usage Examples]

--- a/docs/src/main/asciidoc/mp/integrations/neo4j.adoc
+++ b/docs/src/main/asciidoc/mp/integrations/neo4j.adoc
@@ -142,7 +142,7 @@ Movies can now be returned as JSON objects:
 include::{sourcedir}/mp/integrations/Neo4jSnippets.java[tag=snippet_3, indent=0]
 ----
 
-Now build and run with JDK17+
+Now build and run.
 [source,bash]
 ----
 mvn package

--- a/docs/src/main/asciidoc/mp/integrations/oci.adoc
+++ b/docs/src/main/asciidoc/mp/integrations/oci.adoc
@@ -129,4 +129,4 @@ Once you have injected an ObjectStorage client you can use it as described in:
 == References
 
 * link:{integration-oci-sdk-cdi-javadoc-base-url}/io/helidon/integrations/oci/sdk/cdi/OciExtension.html[OciExtension] Javadocs
-* link:{helidon-github-tree-url}/examples/integrations/oci[OCI SDK Usage Examples]
+* link:{helidon-github-examples-url}/integrations/oci[OCI SDK Usage Examples]

--- a/docs/src/main/asciidoc/mp/metrics/metrics.adoc
+++ b/docs/src/main/asciidoc/mp/metrics/metrics.adoc
@@ -123,7 +123,7 @@ include::{rootdir}/includes/metrics/metrics-config.adoc[tag=config-intro]
 == Examples
 
 Helidon MP includes a pre-written example application illustrating
-link:{helidon-github-tree-url}/examples/metrics/filtering/mp[enabling/disabling metrics] using configuration.
+link:{helidon-github-examples-url}/metrics/filtering/mp[enabling/disabling metrics] using configuration.
 
 The rest of this section contains other examples of working with metrics:
 

--- a/docs/src/main/asciidoc/mp/openapi/openapi.adoc
+++ b/docs/src/main/asciidoc/mp/openapi/openapi.adoc
@@ -94,7 +94,7 @@ Further, Helidon OpenAPI supports the MicroProfile OpenAPI settings described in
 
 == Examples
 
-Helidon MP includes a link:{helidon-github-tree-url}/examples/microprofile/openapi[complete OpenAPI example]
+Helidon MP includes a link:{helidon-github-examples-url}/microprofile/openapi[complete OpenAPI example]
 based on the MP quick-start sample app. The rest of this section shows, step-by-step, how one might change the original QuickStart service to adopt OpenAPI.
 
 === Helidon MP OpenAPI Example
@@ -167,7 +167,7 @@ curl -X GET http://localhost:8080/openapi
 The output describes not only then endpoints from `GreetResource` but
 also one contributed by the `SimpleAPIModelReader`.
 
-Full example is available link:{helidon-github-tree-url}/examples/microprofile/openapi[in our official repository]
+Full example is available link:{helidon-github-examples-url}/microprofile/openapi[in our official repository]
 
 
 == Additional Information

--- a/docs/src/main/asciidoc/mp/persistence.adoc
+++ b/docs/src/main/asciidoc/mp/persistence.adoc
@@ -1349,7 +1349,7 @@ relational database tables, and how to perform other related tasks.
 
 === Examples [[JPA-Examples]]
 
-* link:{helidon-github-tree-url}/examples/integrations/cdi/pokemons[JPA
+* link:{helidon-github-examples-url}/integrations/cdi/pokemons[JPA
   Pokemons Example]
 
 == References [[References]]

--- a/docs/src/main/asciidoc/mp/reactivemessaging/kafka.adoc
+++ b/docs/src/main/asciidoc/mp/reactivemessaging/kafka.adoc
@@ -157,4 +157,4 @@ mp.messaging:
 
 Don't forget to check out the examples with pre-configured Kafka docker image, for easy testing:
 
-* {helidon-github-tree-url}/examples/messaging
+* {helidon-github-examples-url}/messaging

--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -331,7 +331,7 @@ Launch the Jaeger UI at link:http://localhost:16686/[] to see the expected outpu
 
 image::telemetry/telemetry-outbound-jaeger.png[Secondary service outbound call,role="fit"]
 
-This example is available at the link:{helidon-github-tree-url}/examples/microprofile/telemetry[Helidon official GitHub repository].
+This example is available at the link:{helidon-github-examples-url}/microprofile/telemetry[Helidon official GitHub repository].
 
 == Reference
 

--- a/docs/src/main/asciidoc/mp/websocket.adoc
+++ b/docs/src/main/asciidoc/mp/websocket.adoc
@@ -131,7 +131,7 @@ the root path for WebSocket endpoints will be  `"/web"` instead of the default `
 
 All endpoint methods in Helidon MP are executed in a separate thread pool, independently of Netty. Therefore, there is no need to create additional threads for blocking or long-running operations as these will not affect Netty's ability to process networking data.
 
-For more information see the link:{helidon-github-tree-url}/examples/webserver/websocket[example].
+For more information see the link:{helidon-github-examples-url}/webserver/websocket[example].
 
 === WebSocket Endpoints on Different Ports
 

--- a/docs/src/main/asciidoc/se/cors.adoc
+++ b/docs/src/main/asciidoc/se/cors.adoc
@@ -135,7 +135,7 @@ include::{rootdir}/includes/cors.adoc[tag=cors-config-table]
 [[se-api-routing-example]]
 === Sample Routing Setup Using the `CrossOriginConfig` API
 
-The link:{helidon-github-tree-url}/examples/quickstarts/helidon-quickstart-se[Helidon SE Quickstart application]
+The link:{helidon-github-examples-url}/quickstarts/helidon-quickstart-se[Helidon SE Quickstart application]
  lets you change the greeting by sending a `PUT` request to the `/greet/greeting` resource.
 
 This example, based on the QuickStart greeting app, uses the low-level `CrossOriginConfig` API and
@@ -245,7 +245,7 @@ rebuild and restart your application for any changes to take effect.
 
 == Examples
 
-For a complete example, see {helidon-github-tree-url}/examples/cors[Helidon SE CORS Example].
+For a complete example, see {helidon-github-examples-url}/cors[Helidon SE CORS Example].
 
 == Additional Information
 

--- a/docs/src/main/asciidoc/se/dbclient.adoc
+++ b/docs/src/main/asciidoc/se/dbclient.adoc
@@ -279,4 +279,4 @@ Execution of a query statement will always return `Stream<DbRow>>`.
 == Additional Information
 
 Now that you understand how to build and execute statements, try it for yourself.
-link:{helidon-github-tree-url}/examples/dbclient[DB Client Examples].
+link:{helidon-github-examples-url}/dbclient[DB Client Examples].

--- a/docs/src/main/asciidoc/se/grpc/server.adoc
+++ b/docs/src/main/asciidoc/se/grpc/server.adoc
@@ -182,4 +182,4 @@ include::{sourcedir}/se/grpc/ServerSnippets.java[tag=snippet_3, indent=0]
 
 The following gRPC examples for Helidon SE are available:
 
-* link:{helidon-github-tree-url}/examples/webserver/protocols[Multiple protocols on a single WebServer]
+* link:{helidon-github-examples-url}/webserver/protocols[Multiple protocols on a single WebServer]

--- a/docs/src/main/asciidoc/se/guides/dbclient.adoc
+++ b/docs/src/main/asciidoc/se/guides/dbclient.adoc
@@ -555,4 +555,4 @@ The select-book statement was invoked four times.
 === Summary
 
 This guide provided an introduction to the Helidon DB Client's key features. If you want to learn more, see the
-Helidon DB Client samples in link:{helidon-github-tree-url}/examples/dbclient[GitHub].
+Helidon DB Client samples in link:{helidon-github-examples-url}/dbclient[GitHub].

--- a/docs/src/main/asciidoc/se/guides/upgrade_4x.adoc
+++ b/docs/src/main/asciidoc/se/guides/upgrade_4x.adoc
@@ -303,4 +303,4 @@ If you use this handler in your `logging.properties` you will need to update it 
 Please proceed to xref:../introduction.adoc[Helidon SE Introduction] to find more information and documentation about each module.
 
 Also, the
-link:{helidon-github-tree-url}/examples/[Helidon examples] are a good resource for seeing how things are done in Helidon 4.
+link:{helidon-github-examples-url}/[Helidon examples] are a good resource for seeing how things are done in Helidon 4.

--- a/docs/src/main/asciidoc/se/integrations/hcv.adoc
+++ b/docs/src/main/asciidoc/se/integrations/hcv.adoc
@@ -278,4 +278,4 @@ but it can be easily used with the examples below.
 
 == References
 
-* link:{helidon-github-tree-url}/examples/integrations/vault[Hashicorp Vault Usage Examples]
+* link:{helidon-github-examples-url}/integrations/vault[Hashicorp Vault Usage Examples]

--- a/docs/src/main/asciidoc/se/integrations/neo4j.adoc
+++ b/docs/src/main/asciidoc/se/integrations/neo4j.adoc
@@ -154,7 +154,7 @@ include::{sourcedir}/se/integrations/Neo4jSnippets.java[tag=snippet_4, indent=0]
 <3> Use of `Neo4jHealthCheck` to add _Neo4j_ health support.
 <4> Register  `MovieService`  in _Routing_.
 
-Now build and run with JDK17+
+Now build and run.
 [source,bash]
 ----
 mvn package

--- a/docs/src/main/asciidoc/se/integrations/neo4j.adoc
+++ b/docs/src/main/asciidoc/se/integrations/neo4j.adoc
@@ -158,7 +158,7 @@ Now build and run with JDK17+
 [source,bash]
 ----
 mvn package
-java -jar target/helidon-examples-integration-neo4j-mp.jar
+java -jar target/helidon-examples-integration-neo4j.jar
 ----
 
 Exercise the application:
@@ -177,7 +177,7 @@ curl -s -X GET http://localhost:8080/metrics
 curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
 ----
 
-Full example code is available in link:{helidon-github-tree-url}/examples/integrations/neo4j/neo4j-mp[Helidon GitHub Repository].
+Full example code is available in link:{helidon-github-examples-url}/integrations/neo4j[Helidon Examples Repository].
 
 
 == Additional Information

--- a/docs/src/main/asciidoc/se/integrations/oci.adoc
+++ b/docs/src/main/asciidoc/se/integrations/oci.adoc
@@ -104,5 +104,5 @@ Once you have created an ObjectStorage client you can use it as described in:
 
 == References
 
-* link:{helidon-github-tree-url}/examples/integrations/oci[OCI SDK Usage Examples]
+* link:{helidon-github-examples-url}/integrations/oci[OCI SDK Usage Examples]
 * link:https://docs.oracle.com/en-us/iaas/Content/home.htm[OCI Documentation]

--- a/docs/src/main/asciidoc/se/openapi/openapi.adoc
+++ b/docs/src/main/asciidoc/se/openapi/openapi.adoc
@@ -91,7 +91,7 @@ include::{rootdir}/config/io_helidon_openapi_OpenApiFeature.adoc[leveloffset=+1,
 
 == Examples
 
-Helidon SE provides a link:{helidon-github-tree-url}/examples/openapi[complete OpenAPI example]
+Helidon SE provides a link:{helidon-github-examples-url}/openapi[complete OpenAPI example]
 based on the SE QuickStart sample app.
 
 Most Helidon {flavor-uc} applications need only add the dependency as explained above; Helidon discovers and registers OpenAPI

--- a/docs/src/main/asciidoc/se/reactive-messaging.adoc
+++ b/docs/src/main/asciidoc/se/reactive-messaging.adoc
@@ -301,7 +301,7 @@ include::{sourcedir}/se/ReactiveMessagingSnippets.java[tag=snippet_12, indent=0]
 
 Don't forget to check out the examples with pre-configured Kafka docker image, for easy testing:
 
-* {helidon-github-tree-url}/examples/messaging
+* {helidon-github-examples-url}/messaging
 
 ==== JMS Connector
 
@@ -382,7 +382,7 @@ include::{sourcedir}/se/ReactiveMessagingSnippets.java[tag=snippet_16, indent=0]
 
 Don't forget to check out the examples with pre-configured ActiveMQ docker image, for easy testing:
 
-* link:{helidon-github-tree-url}/examples/messaging[Helidon Messaging Examples]
+* link:{helidon-github-examples-url}/messaging[Helidon Messaging Examples]
 
 ==== AQ Connector
 
@@ -424,4 +424,4 @@ include::{sourcedir}/se/ReactiveMessagingSnippets.java[tag=snippet_17, indent=0]
 
 * link:{microprofile-reactive-messaging-spec-url}[MicroProfile Reactive Messaging Specification]
 * link:https://github.com/eclipse/microprofile-reactive-messaging[MicroProfile Reactive Messaging on GitHub]
-* link:{helidon-github-tree-url}/examples/messaging[Helidon Messaging Examples]
+* link:{helidon-github-examples-url}/messaging[Helidon Messaging Examples]

--- a/docs/src/main/asciidoc/se/websocket.adoc
+++ b/docs/src/main/asciidoc/se/websocket.adoc
@@ -69,7 +69,7 @@ one at a time, over a connection.
 The example will show how REST and WebSocket connections can
 be seamlessly combined into a Helidon application.
 
-The complete Helidon SE example is available {helidon-github-tree-url}/examples/webserver/websocket[here]. Let us start by
+The complete Helidon SE example is available {helidon-github-examples-url}/webserver/websocket[here]. Let us start by
 looking at `MessageQueueService`:
 
 [source,java]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,8 @@
+<p align="center">
+    <img src="../etc/images/Primary_logo_blue.png" height="180">
+</p>
+
+# Helidon Examples
+
+Helidon 4 examples have moved to the [helidon-examples](https://github.com/helidon-io/helidon-examples/tree/helidon-4.x) repository.
+


### PR DESCRIPTION
### Description

Updates the links to examples that are in documentation to point to the `helidon-examples` repository.

Also places a small README in the (now empty) `examples` directory.

### Documentation

Docs updated.