### PR TITLE
4.x: Replace deprecated method Span.baggage(key, value) on Span.baggage().set(key, value)

### DIFF
--- a/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/JaegerBaggageTest.java
+++ b/tracing/providers/jaeger/src/test/java/io/helidon/tracing/providers/jaeger/JaegerBaggageTest.java
@@ -39,8 +39,8 @@ class JaegerBaggageTest {
     @Test
     void testBaggage(){
         Span span = tracer.spanBuilder("test-span").start();
-        Span spanWithBaggage = span.baggage("key", "value");
-        Optional<String> result = spanWithBaggage.baggage().get("key");
+        span.baggage().set("key", "value");
+        Optional<String> result = span.baggage().get("key");
         assertThat(result.isPresent(), is(true));
         assertThat(result.get(), equalTo("value"));
 
@@ -49,8 +49,8 @@ class JaegerBaggageTest {
     @Test
     void testBadBaggage(){
         Span span = tracer.spanBuilder("test-bad-span").start();
-        assertThrows(NullPointerException.class, () -> span.baggage(null, "value"));
-        assertThrows(NullPointerException.class, () -> span.baggage("key", null));
-        assertThrows(NullPointerException.class, () -> span.baggage(null, null));
+        assertThrows(NullPointerException.class, () -> span.baggage().set(null, "value"));
+        assertThrows(NullPointerException.class, () -> span.baggage().set("key", null));
+        assertThrows(NullPointerException.class, () -> span.baggage().set(null, null));
     }
 }

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestBaggageApi.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestBaggageApi.java
@@ -41,7 +41,7 @@ class TestBaggageApi {
     void testWritableBaggageFromSpan() {
         Span span = Tracer.global().spanBuilder("otel-span").start();
         WritableBaggage baggage = span.baggage();
-        span.baggage("keyA", "valA");
+        span.baggage().set("keyA", "valA");
         assertThat("Assigned baggage via span is present", baggage.containsKey("keyA"), is(true));
         assertThat("Assigned baggage via span value from baggage",
                    baggage.get("keyA"),

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestSpanAndBaggage.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestSpanAndBaggage.java
@@ -83,7 +83,7 @@ class TestSpanAndBaggage {
                        currentJustAfterActivation.get().context().spanId(),
                        is(outerSpan.context().spanId()));
 
-            outerSpan.baggage("myItem", "myValue");
+            outerSpan.baggage().set("myItem", "myValue");
             outerSpan.end();
         } catch (Exception e) {
             outerSpan.end(e);

--- a/tracing/providers/opentracing/src/test/java/io/helidon/tracing/providers/opentracing/TestBaggageApi.java
+++ b/tracing/providers/opentracing/src/test/java/io/helidon/tracing/providers/opentracing/TestBaggageApi.java
@@ -40,7 +40,7 @@ class TestBaggageApi {
     void testWritableBaggageFromSpan() {
         Span span = io.helidon.tracing.Tracer.global().spanBuilder("otel-span").start();
         WritableBaggage baggage = span.baggage();
-        span.baggage("keyA", "valA");
+        span.baggage().set("keyA", "valA");
         assertThat("Assigned baggage via span is present", baggage.containsKey("keyA"), is(true));
         assertThat("Assigned baggage via span value from baggage",
                    baggage.get("keyA"),


### PR DESCRIPTION
### Description

I've found, that the deprecated method `Span.baggage(String key, String value)` is used in the code. The method was marked as deprecated in [this commit](https://github.com/helidon-io/helidon/commit/0b16c29c22c0691a4aade898a7467692539c6263#diff-d0ca182466860d79537658e4b49b6bd56d6fd8c492719be03a70d86e371ee60bR132)
<img width="597" alt="Screenshot 2024-08-03 at 16 25 04" src="https://github.com/user-attachments/assets/c990728c-2fd0-4e95-83ef-4eb5a8326ef3">

It can be replaced on `Span.baggage().set(String key, String value)`.