### PR TITLE
4.x: Replace deprecated method Scheduling.fixedRateBuilder() on Scheduling.fixedRate()

### DIFF
--- a/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/CoordinatorService.java
+++ b/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/CoordinatorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public class CoordinatorService implements HttpService {
 
     private void init() {
         lraPersistentRegistry.load(this);
-        recoveryTask = Scheduling.fixedRateBuilder()
+        recoveryTask = Scheduling.fixedRate()
                 .delay(config.get("recovery-interval").asLong().orElse(200L))
                 .initialDelay(200)
                 .timeUnit(TimeUnit.MILLISECONDS)
@@ -105,7 +105,7 @@ public class CoordinatorService implements HttpService {
                 .build();
 
         if (config.get("periodical-persist").asBoolean().orElse(false)) {
-            persistTask = Scheduling.fixedRateBuilder()
+            persistTask = Scheduling.fixedRate()
                     .delay(config.get("persist-interval").asLong().orElse(5000L))
                     .initialDelay(200)
                     .timeUnit(TimeUnit.MILLISECONDS)


### PR DESCRIPTION
### Description
I've found, that the deprecated method `Scheduling.fixedRateBuilder()` is used in the code. The method was marked as deprecated in [this commit](https://github.com/helidon-io/helidon/commit/e492423826d003cbf328cc9a0eb37df63aad5367#diff-00241b86b77b293b3a01442977eda4462b33de67f1d1d514fb5cb26bda7517a4R53).

<img width="866" alt="Screenshot 2024-08-03 at 17 55 44" src="https://github.com/user-attachments/assets/d6cf7af7-2163-490a-84d0-0338fb0296ea">

It can be replaced on `Scheduling.fixedRate()`

There are some tests for `Scheduling.fixedRateBuilder()`, but I didn't touch them. Should I do it? 
