### PR TITLE
Add deprecation logging and mention in Micrometer integration doc pages

### DIFF
--- a/docs/src/main/asciidoc/includes/metrics/micrometer-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/micrometer-shared.adoc
@@ -29,6 +29,14 @@ endif::[]
 :keywords: helidon, java, micrometer, integration, se, mp
 
 == Overview
+
+[NOTE]
+====
+Micrometer integration is deprecated beginning in Helidon 4.1 and is planned for removal in a future major release. Please use
+ifdef::se-flavor[the link:{rootdir}/se/metrics/metrics.adoc[Helidon neutral metrics API].]
+ifdef::mp-flavor[the link:{rootdir}/mp/metrics/metrics.adoc[Helidon MicroProfile Metrics API implementation and annotations].]
+====
+
 Helidon {h1-prefix} simplifies how you can use Micrometer for application-specific metrics:
 
 * The endpoint `/micrometer`: A configurable endpoint that exposes metrics according to which Micrometer meter registry

--- a/integrations/micrometer/cdi/src/main/java/io/helidon/integrations/micrometer/cdi/MicrometerCdiExtension.java
+++ b/integrations/micrometer/cdi/src/main/java/io/helidon/integrations/micrometer/cdi/MicrometerCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,10 @@ import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 /**
  * CDI extension for handling Micrometer artifacts.
+ *
+ * @deprecated To be removed in a future release. No replacement.
  */
+@Deprecated(forRemoval = true, since = "4.1")
 public class MicrometerCdiExtension extends HelidonRestCdiExtension {
 
     private static final System.Logger LOGGER = System.getLogger(MicrometerCdiExtension.class.getName());
@@ -126,6 +129,8 @@ public class MicrometerCdiExtension extends HelidonRestCdiExtension {
                                  annotation.annotationType(),
                                  MeterWorkItem.create(newMeter, isOnlyOnException));
         });
+
+        LOGGER.log(Level.WARNING, "Micrometer integration is deprecated and will be removed in a future major release.");
     }
     MeterRegistry meterRegistry() {
         if (feature == null) {

--- a/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerFeature.java
+++ b/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerFeature.java
@@ -49,6 +49,7 @@ public class MicrometerFeature extends HelidonFeatureSupport {
 
     static final String DEFAULT_CONTEXT = "/micrometer";
     private static final String SERVICE_NAME = "Micrometer";
+    private static final System.Logger LOGGER = System.getLogger(MicrometerFeature.class.getName());
 
     private final MeterRegistryFactory meterRegistryFactory;
 
@@ -105,6 +106,8 @@ public class MicrometerFeature extends HelidonFeatureSupport {
     @Override
     public void beforeStart() {
         Contexts.globalContext().register(registry());
+        LOGGER.log(System.Logger.Level.WARNING,
+                   "Micrometer integration is deprecated and will be removed in a future major release.");
     }
 
     private void getOrOptions(ServerRequest serverRequest, ServerResponse serverResponse) throws Exception {


### PR DESCRIPTION
### Description
Resolves #9090 

We plan to remove the Micrometer integration in Helidon 5. This PR marks additional classes as deprecated and updates the doc accordingly.

### Documentation
This PR updates the Micrometer integration doc pages to note the deprecation.