### PR TITLE
DbClient IT tests job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -134,7 +134,7 @@ jobs:
           cache: maven
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: graalvm-community
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: true
@@ -293,9 +293,39 @@ jobs:
             -Pnative-image \
             -am \
             verify
+  dbclient:
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        group: [ oracle, others ]
+        include:
+          - { group: others, modules: '!oracle' }
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4.1.0
+        with:
+          distribution: ${{ env.JAVA_DISTRO }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: Build Helidon
+        run: |
+          # prime build
+          mvn ${MAVEN_ARGS} -e \
+            -DskipTests \
+            -Ptests \
+            install
+      - name: Run Tests
+        run: |
+          mvn ${MAVEN_ARGS} -e \
+            -f tests/integration/dbclient/pom.xml \
+            -pl ${{ matrix.modules || matrix.group }} \
+            -am \
+            verify
   gate:
     runs-on: ubuntu-20.04
-    needs: [ copyright, checkstyle, shellcheck, build, docs, spotbugs, packaging, native-image, archetypes, mp-tck ]
+    needs: [ copyright, checkstyle, shellcheck, build, docs, spotbugs, packaging, native-image, dbclient, archetypes, mp-tck ]
     steps:
       - shell: bash
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -635,6 +635,7 @@
                         <skipTestScope>true</skipTestScope>
                         <failBuildOnCVSS>0</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <!--suppress MavenModelInspection -->
                         <nvdApiKey>${nvd-api-key}</nvdApiKey>
                         <excludes>
                             <!-- Exclude stuff we do not deploy -->
@@ -1319,6 +1320,7 @@
         <profile>
             <id>examples</id>
             <modules>
+                <!--suppress MavenModelInspection -->
                 <module>helidon-examples</module>
             </modules>
         </profile>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -38,7 +38,6 @@
 
     <modules>
         <module>config</module>
-        <module>dbclient</module>
         <module>harness</module>
         <module>health</module>
         <module>jep290</module>
@@ -88,6 +87,12 @@
     </dependencyManagement>
 
     <profiles>
+        <profile>
+            <id>dbclient</id>
+            <modules>
+                <module>dbclient</module>
+            </modules>
+        </profile>
         <profile>
             <id>packaging</id>
             <modules>


### PR DESCRIPTION
### Description

Add a CI job for DbClient integration tests.

- Exclude tests/integration/dbclient from the default reactor
- Add a separate matrix job to execute the tests
- Add a few IntelliJ suppressions in the top level pom.xml

### Documentation

None.
