### PR TITLE
Cleanup validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,14 +7,15 @@ name: "Validate"
 on:
   pull_request:
   push:
-    branches-ignore: [ 'main', 'helidon-*.x' ]
+    branches-ignore: [ 'main', 'helidon-*.x', 'release-*' ]
+    tags-ignore: [ '**' ]
   workflow_call:
 
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRO: 'oracle'
-  HELIDON_PIPELINES: 'true'
   MAVEN_ARGS: |
+    -B -fae -e
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
     -Dmaven.wagon.http.retryHandler.count=3
 
@@ -74,7 +75,7 @@ jobs:
           mvn ${MAVEN_ARGS} -e \
             -DskipTests \
             -Dmaven.test.skip=true \
-            -Pspotbugs,pipeline \
+            -Pspotbugs \
             install
   docs:
     timeout-minutes: 30
@@ -89,12 +90,10 @@ jobs:
           cache: maven
       - name: Docs
         run: |
-          mvn ${MAVEN_ARGS} -e \
-            -Dmaven.test.skip=true \
+          mvn ${MAVEN_ARGS} \
             -DskipTests \
-            -Ppipeline \
             install
-          mvn ${MAVEN_ARGS} -e \
+          mvn ${MAVEN_ARGS} \
             -f docs/pom.xml \
             -Pjavadoc \
              install
@@ -114,9 +113,9 @@ jobs:
           cache: maven
       - name: Maven build
         run: |
-          mvn ${MAVEN_ARGS} -e \
+          mvn ${MAVEN_ARGS} \
             -Dmaven.test.failure.ignore=false \
-            -Pjavadoc,sources,tests,pipeline \
+            -Pjavadoc,sources,tests \
             install
   examples:
     timeout-minutes: 40
@@ -142,29 +141,22 @@ jobs:
       - name: Maven build
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -e \
-          -Dmaven.test.skip=true \
+          mvn ${MAVEN_ARGS} -T8 \
           -DskipTests \
-          -Ppipeline \
           install
-      - name: Examples checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-          repository: helidon-io/helidon-examples.git
-          ref: dev-4.x
-          path: helidon-examples
       - name: Examples build
         run: etc/scripts/build-examples.sh
       - name: Test quickstarts native image
         run: etc/scripts/test-quickstarts.sh
   mp-tck:
     timeout-minutes: 60
-    name: "MicroProfile TCKs"
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
+        include:
+          - { os: ubuntu-20.04, platform: linux }
     runs-on: ${{ matrix.os }}
+    name: tests/tck-${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ env.JAVA_VERSION }}
@@ -176,12 +168,10 @@ jobs:
       - name: Maven build
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -e \
-            -Dmaven.test.skip=true \
+          mvn ${MAVEN_ARGS} -T8 \
             -DskipTests \
-            -Ppipeline \
             install
-          mvn ${MAVEN_ARGS} -e \
+          mvn ${MAVEN_ARGS} \
             -f microprofile/tests/tck/pom.xml \
             -Ptck-ft \
             verify
@@ -202,10 +192,8 @@ jobs:
       - name: Test archetypes
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -e \
-            -Dmaven.test.skip=true \
+          mvn ${MAVEN_ARGS} -T8 \
             -DskipTests \
-            -Ppipeline \
             install
           mvn ${MAVEN_ARGS} -e \
             -f archetypes/pom.xml \
@@ -240,7 +228,7 @@ jobs:
       - name: Build Helidon
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -e \
+          mvn ${MAVEN_ARGS} -T8 \
             -DskipTests \
             -Ptests \
             install
@@ -281,7 +269,7 @@ jobs:
       - name: Build Helidon
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -e \
+          mvn ${MAVEN_ARGS} -T8 \
             -DskipTests \
             -Ptests \
             install
@@ -297,10 +285,13 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
+        os: [ ubuntu-20.04 ]
         group: [ oracle, others ]
         include:
           - { group: others, modules: '!oracle' }
-    runs-on: ubuntu-20.04
+          - { os: ubuntu-20.04, platform: linux }
+    runs-on: ${{ matrix.os }}
+    name: tests/dbclient-${{ matrix.group }}-${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ env.JAVA_VERSION }}
@@ -309,16 +300,22 @@ jobs:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
+      - name: Free Space
+        shell: bash
+        run: |
+          # See https://github.com/actions/runner-images/issues/2840
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/share/powershell
       - name: Build Helidon
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -e \
+          mvn ${MAVEN_ARGS} -T8 \
             -DskipTests \
             -Ptests \
             install
       - name: Run Tests
         run: |
-          mvn ${MAVEN_ARGS} -e \
+          mvn ${MAVEN_ARGS} \
             -f tests/integration/dbclient/pom.xml \
             -pl ${{ matrix.modules || matrix.group }} \
             -am \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Build Helidon
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -T8 \
+          mvn ${MAVEN_ARGS} -T4 \
             -DskipTests \
             -Ptests \
             install
@@ -269,7 +269,7 @@ jobs:
       - name: Build Helidon
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -T8 \
+          mvn ${MAVEN_ARGS} -T4 \
             -DskipTests \
             -Ptests \
             install
@@ -309,7 +309,7 @@ jobs:
       - name: Build Helidon
         run: |
           # prime build
-          mvn ${MAVEN_ARGS} -T8 \
+          mvn ${MAVEN_ARGS} -T4 \
             -DskipTests \
             -Ptests \
             install

--- a/etc/scripts/build-examples.sh
+++ b/etc/scripts/build-examples.sh
@@ -47,11 +47,12 @@ readonly WS_DIR
 readonly HELIDON_EXAMPLES_PATH=${WS_DIR}/helidon-examples
 if [ ! -d "${WS_DIR}/helidon-examples" ]; then
   echo "Cloning examples repository into ${WS_DIR}/helidon-examples"
-  git clone --branch dev-4.x --single-branch git@github.com:helidon-io/helidon-examples.git "${WS_DIR}/helidon-examples"
+  git clone --branch dev-4.x --single-branch https://github.com/helidon-io/helidon-examples.git "${WS_DIR}/helidon-examples"
 fi
 
 version() {
-    mvn -B -N -f "${1}" -Dexpression=helidon.version help:evaluate | grep -v '\[INFO\]'
+    # shellcheck disable=SC2086
+    mvn ${MAVEN_ARGS} -B -N -f "${1}" -Dexpression=helidon.version help:evaluate | grep -v '\[INFO\]'
 }
 
 # Make sure the helidon version from the example repo aligns with this repository

--- a/etc/scripts/test-quickstarts.sh
+++ b/etc/scripts/test-quickstarts.sh
@@ -58,7 +58,7 @@ mvn ${MAVEN_ARGS} --version
 # If needed we clone the helidon-examples repo into a subdirectory of the helidon repository
 if [ ! -d "${WS_DIR}/helidon-examples" ]; then
   echo "Cloning examples repository into ${HELIDON_EXAMPLES_PATH}"
-  git clone --branch dev-4.x --single-branch git@github.com:helidon-io/helidon-examples.git "${WS_DIR}/helidon-examples"
+  git clone --branch dev-4.x --single-branch https://github.com/helidon-io/helidon-examples.git "${WS_DIR}/helidon-examples"
 fi
 
 # Build quickstart native-image executable and run jar file

--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -149,23 +149,6 @@
 
     <profiles>
         <profile>
-            <id>pipeline</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <helidon.concurrentGauge.minRequiredSeconds>45</helidon.concurrentGauge.minRequiredSeconds>
-                                <helidon.histogram.tolerance>0.25</helidon.histogram.tolerance>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>release</id>
             <build>
                 <plugins>
@@ -190,5 +173,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/metrics/provider-tests/pom.xml
+++ b/metrics/provider-tests/pom.xml
@@ -150,27 +150,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>pipeline</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <helidon.concurrentGauge.minRequiredSeconds>45</helidon.concurrentGauge.minRequiredSeconds>
-                                <helidon.histogram.tolerance>0.25</helidon.histogram.tolerance>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
-
-
 </project>

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -213,23 +213,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>pipeline</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <helidon.microprofile.metrics.perfTest.enabled>false</helidon.microprofile.metrics.perfTest.enabled>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
### Description

Cleanup validate workflow:

- Remove 'pipeline' Maven profile
- Add `-B -fae -e` to `MAVEN_ARGS` environment variable
- Remove usage of `-Dmaven.test.skip=true` (breaks tests jars)
- Use -T for prime builds
- Remove `HELIDON_PIPELINES` environment variable
- Update example scripts to use https URL instead of SSH, use `MAVEN_ARGS`
- Add a free disk space step to the dbclient job

### Documentation

None.
