### PR TITLE
4.x: GraphQL upgrade

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -1130,16 +1130,4 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!--
-                    Work-around for https://github.com/helidon-io/helidon/issues/8172
-                 -->
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>4.10.1</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/config/metadata/docs/pom.xml
+++ b/config/metadata/docs/pom.xml
@@ -103,21 +103,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!--
-                    Work-around for https://github.com/helidon-io/helidon/issues/8172
-                    dependency convergence of antlr, where graphql uses an older version
-                    and fails when we upgrade antlr
-                 -->
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>4.10.1</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -55,8 +55,8 @@
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.google-protobuf>3.21.7</version.lib.google-protobuf>
         <version.lib.graalvm>23.1.0</version.lib.graalvm>
-        <version.lib.graphql-java>18.6</version.lib.graphql-java>
-        <version.lib.graphql-java.extended.scalars>18.3</version.lib.graphql-java.extended.scalars>
+        <version.lib.graphql-java>22.1</version.lib.graphql-java>
+        <version.lib.graphql-java.extended.scalars>22.0</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
         <version.lib.grpc>1.60.0</version.lib.grpc>
         <version.lib.guava>32.0.1-jre</version.lib.guava>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -88,19 +88,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!--
-                    Work-around for https://github.com/helidon-io/helidon/issues/8172
-                 -->
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>4.10.1</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>

--- a/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandlerImpl.java
+++ b/graphql/server/src/main/java/io/helidon/graphql/server/InvocationHandlerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import graphql.ExceptionWhileDataFetching;
 import graphql.ExecutionInput;
@@ -49,6 +51,11 @@ import static io.helidon.graphql.server.GraphQlConstants.PATH;
 
 class InvocationHandlerImpl implements InvocationHandler {
     private static final System.Logger LOGGER = System.getLogger(InvocationHandlerImpl.class.getName());
+    private static final Pattern VALIDATION_ERROR_PATTERN = Pattern.compile("Validation error \\((\\w+)@\\[(.*)]\\) : (.*$)");
+    private static final Pattern ERROR_ENUM_REPLACE_PATTERN =
+            Pattern.compile("Literal value not in allowable values for enum '.*?' - ('.*\\{.*}')");
+    private static final Pattern INVALID_TYPE_REPLACE_PATTERN =
+            Pattern.compile("- Expected an AST type of ('.*?') but it was a ('.*?') (@.*?)$");
 
     private final String defaultErrorMessage;
     private final Set<String> exceptionDenySet = new HashSet<>();
@@ -201,7 +208,71 @@ class InvocationHandlerImpl implements InvocationHandler {
             path = listPath.get(0).toString();
         }
 
-        addErrorPayload(resultMap, error.getMessage(), path, line, column, error.getExtensions());
+        addErrorPayload(resultMap, fixMessage(error.getMessage()), path, line, column, error.getExtensions());
+    }
+
+    // this works around https://github.com/eclipse/microprofile-graphql/issues/520
+    // once the TCK is fixed, we can remove this work-around
+    // this is depending on version of GraphQL (heavily), and any change in error message format
+    // will result in wrong responses
+    private String fixMessage(String message) {
+        if (!message.startsWith("Validation error")) {
+            return message;
+        }
+        /*
+        What we get (first) and what we want (second)
+        Validation error (FieldUndefined@[allHeroes/weaknesses]) : Field 'weaknesses' in type 'SuperHero' is undefined
+        Validation error of type FieldUndefined: Field 'weaknesses' in type 'SuperHero' is undefined @ 'allHeroes/weaknesses'
+         */
+        /*
+        1: type of error (FieldUndefined)
+        2: path (allHeroes/weaknesses)
+        3: Message (Field 'weaknesses' in type 'SuperHero' is undefined)
+         */
+        Matcher matcher = VALIDATION_ERROR_PATTERN.matcher(message);
+        if (matcher.matches()) {
+            String fixedMessage = "Validation error of type " + matcher.group(1)
+                    + ": " + matcher.group(3)
+                    + " @ '" + matcher.group(2) + "'";
+
+            if (fixedMessage.contains("Literal value not in allowable values for enum")) {
+             /*
+             What we get (first) and what we want (second)
+             Validation error (WrongType@[createNewHero]) : argument 'hero.tshirtSize' with value 'EnumValue{name='XLTall'}'
+                is not a valid 'ShirtSize' - Literal value not in allowable values for enum 'ShirtSize'
+                - 'EnumValue{name='XLTall'}'
+             Validation error of type WrongType: argument 'hero.tshirtSize' with value 'EnumValue{name='XLTall'}' is not a valid
+                'ShirtSize' - Expected enum literal value not in allowable values
+                -  'EnumValue{name='XLTall'}'. @ 'createNewHero'
+             */
+                // enum failures
+                return ERROR_ENUM_REPLACE_PATTERN.matcher(fixedMessage)
+                        .replaceAll("Expected enum literal value not in allowable values -  $1.");
+            }
+
+            /*
+            actual graphql message
+            fixed graphql message
+            expected graphql message
+            Validation error (WrongType@[updateItemPowerLevel]) : argument 'powerLevel' with value
+                    'StringValue{value='Unlimited'}' is not a valid 'Int' -
+                    Expected an AST type of 'IntValue' but it was a 'StringValue'
+            Validation error of type WrongType: argument 'powerLevel' with value 'StringValue{value='Unlimited'}'
+                    is not a valid 'Int' - Expected an AST type of 'IntValue' but it
+                    was a 'StringValue' @ 'updateItemPowerLevel'
+            Validation error of type WrongType: argument 'powerLevel' with value 'StringValue{value='Unlimited'}'
+                    is not a valid 'Int' - Expected AST type 'IntValue' but
+                    was 'StringValue'. @ 'updateItemPowerLevel
+             */
+            if (fixedMessage.contains("type WrongType")) {
+                return INVALID_TYPE_REPLACE_PATTERN.matcher(fixedMessage)
+                        .replaceAll("- Expected AST type $1 but was $2. $3");
+            }
+
+            return fixedMessage;
+        } else {
+            return message;
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/microprofile/graphql/server/src/main/java/io/helidon/microprofile/graphql/server/DataFetcherUtils.java
+++ b/microprofile/graphql/server/src/main/java/io/helidon/microprofile/graphql/server/DataFetcherUtils.java
@@ -44,13 +44,12 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-import graphql.schema.GraphQLFieldDefinition;
-
 import io.helidon.graphql.server.ExecutionContext;
 
 import graphql.GraphQLException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.PropertyDataFetcher;
 import graphql.schema.PropertyDataFetcherHelper;
 import jakarta.enterprise.inject.spi.CDI;

--- a/microprofile/tests/tck/tck-graphql/src/test/resources/arquillian.xml
+++ b/microprofile/tests/tck/tck-graphql/src/test/resources/arquillian.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
         xmlns="http://jboss.org/schema/arquillian"
         xsi:schemaLocation="
         http://jboss.org/schema/arquillian
-        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+        https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <engine>
         <property name="deploymentExportPath">target/deployments</property>


### PR DESCRIPTION
Resolves #6963 
Resolves #8172 
Resolves #8164

This change introduces
- upgraded GraphQL dependencies
- fixes to Helidon implementation to work on the new version
- fixes to error messages that have new format in new version (to pass TCK, workaround for https://github.com/eclipse/microprofile-graphql/issues/520
- removed dependency convergence fixes for antlr, which is no longer an issue with new version