### PR TITLE
POM cleanups

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-applications-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.applications</groupId>
     <artifactId>helidon-applications</artifactId>

--- a/builder/api/pom.xml
+++ b/builder/api/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.builder</groupId>
         <artifactId>helidon-builder-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/builder/codegen/pom.xml
+++ b/builder/codegen/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.builder</groupId>
         <artifactId>helidon-builder-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -26,7 +26,6 @@
         <groupId>io.helidon</groupId>
         <artifactId>helidon-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/builder/processor/pom.xml
+++ b/builder/processor/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.builder</groupId>
         <artifactId>helidon-builder-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/builder/tests/builder/pom.xml
+++ b/builder/tests/builder/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.builder.tests</groupId>
         <artifactId>helidon-builder-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/builder/tests/codegen/pom.xml
+++ b/builder/tests/codegen/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.builder.tests</groupId>
         <artifactId>helidon-builder-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/builder/tests/common-types/pom.xml
+++ b/builder/tests/common-types/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.builder.tests</groupId>
         <artifactId>helidon-builder-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/builder/tests/pom.xml
+++ b/builder/tests/pom.xml
@@ -26,7 +26,6 @@
         <groupId>io.helidon.builder</groupId>
         <artifactId>helidon-builder-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/security/pom.xml
+++ b/bundles/security/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.bundles</groupId>
         <artifactId>helidon-bundles-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-bundles-security</artifactId>

--- a/codegen/helidon-copyright/pom.xml
+++ b/codegen/helidon-copyright/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.codegen</groupId>
         <artifactId>helidon-codegen-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-codegen-helidon-copyright</artifactId>

--- a/common/features/api/pom.xml
+++ b/common/features/api/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.common.features</groupId>
         <artifactId>helidon-common-features-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     
     <artifactId>helidon-common-features-api</artifactId>

--- a/common/features/features/pom.xml
+++ b/common/features/features/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.common.features</groupId>
         <artifactId>helidon-common-features-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-common-features</artifactId>

--- a/common/features/pom.xml
+++ b/common/features/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>io.helidon.common.features</groupId>

--- a/common/features/processor/pom.xml
+++ b/common/features/processor/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.common.features</groupId>
         <artifactId>helidon-common-features-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-common-features-processor</artifactId>
     <name>Helidon Common Features Annotation Processor</name>

--- a/common/processor/helidon-copyright/pom.xml
+++ b/common/processor/helidon-copyright/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.common.processor</groupId>
         <artifactId>helidon-common-processor-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-common-processor-helidon-copyright</artifactId>

--- a/common/processor/pom.xml
+++ b/common/processor/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <packaging>pom</packaging>

--- a/common/processor/processor/pom.xml
+++ b/common/processor/processor/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.common.processor</groupId>
         <artifactId>helidon-common-processor-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-common-processor</artifactId>

--- a/config/metadata/codegen/pom.xml
+++ b/config/metadata/codegen/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>io.helidon.config.metadata</groupId>

--- a/config/metadata/metadata/pom.xml
+++ b/config/metadata/metadata/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-config-metadata</artifactId>
     <name>Helidon Config Metadata</name>

--- a/config/metadata/pom.xml
+++ b/config/metadata/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <!-- normally we would use io.helidon.config.metadata group id, but this would introduce backward incompatibility -->
     <artifactId>helidon-config-metadata-project</artifactId>

--- a/config/metadata/processor/pom.xml
+++ b/config/metadata/processor/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-config-metadata-processor</artifactId>
     <name>Helidon Config Metadata Annotation Processor</name>

--- a/config/tests/config-metadata-builder-api/pom.xml
+++ b/config/tests/config-metadata-builder-api/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-config-tests-config-metadata-builder-api</artifactId>
     <name>Helidon Config Tests Config Meta-Data Meta API</name>

--- a/config/tests/config-metadata-meta-api/pom.xml
+++ b/config/tests/config-metadata-meta-api/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.config.tests</groupId>
         <artifactId>helidon-config-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-config-tests-config-metadata-meta-api</artifactId>
     <name>Helidon Config Tests Config Meta-Data Meta API</name>

--- a/dbclient/dbclient/pom.xml
+++ b/dbclient/dbclient/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dbclient</artifactId>
     <name>Helidon Database Client API</name>

--- a/dbclient/health/pom.xml
+++ b/dbclient/health/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dbclient-health</artifactId>
     <name>Helidon Database Client Health</name>

--- a/dbclient/hikari/pom.xml
+++ b/dbclient/hikari/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dbclient-hikari</artifactId>
     <name>Helidon Database Client Hikari Connection Pool</name>

--- a/dbclient/jdbc/pom.xml
+++ b/dbclient/jdbc/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dbclient-jdbc</artifactId>
     <name>Helidon Database Client JDBC</name>

--- a/dbclient/jsonp/pom.xml
+++ b/dbclient/jsonp/pom.xml
@@ -22,7 +22,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-dbclient-jsonp</artifactId>

--- a/dbclient/metrics-hikari/pom.xml
+++ b/dbclient/metrics-hikari/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dbclient-metrics-hikari</artifactId>
     <name>Helidon Database Client Hikari Pool Metrics</name>

--- a/dbclient/metrics/pom.xml
+++ b/dbclient/metrics/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dbclient-metrics</artifactId>
     <name>Helidon Database Client Metrics</name>

--- a/dbclient/mongodb/pom.xml
+++ b/dbclient/mongodb/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dbclient-mongodb</artifactId>
     <name>Helidon Database Client MongoDB</name>

--- a/dbclient/tracing/pom.xml
+++ b/dbclient/tracing/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.dbclient</groupId>
         <artifactId>helidon-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-dbclient-tracing</artifactId>
     <name>Helidon Database Client Tracing</name>

--- a/inject/api/pom.xml
+++ b/inject/api/pom.xml
@@ -22,7 +22,6 @@
         <groupId>io.helidon.inject</groupId>
         <artifactId>helidon-inject-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/configdriven/api/pom.xml
+++ b/inject/configdriven/api/pom.xml
@@ -20,16 +20,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.inject.configdriven</groupId>
         <artifactId>helidon-inject-configdriven-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>helidon-inject-configdriven-api</artifactId>
-    <name>Helidon Injection Config-Driven ConfiguredBy</name>
+    <name>Helidon Injection ConfigDriven ConfiguredBy</name>
 
     <dependencies>
         <dependency>

--- a/inject/configdriven/pom.xml
+++ b/inject/configdriven/pom.xml
@@ -20,17 +20,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.inject</groupId>
         <artifactId>helidon-inject-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <groupId>io.helidon.inject.configdriven</groupId>
     <artifactId>helidon-inject-configdriven-project</artifactId>
-    <name>Helidon Injection Config-Driven Project</name>
+    <name>Helidon Injection ConfigDriven Project</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/inject/configdriven/processor/pom.xml
+++ b/inject/configdriven/processor/pom.xml
@@ -20,16 +20,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.inject.configdriven</groupId>
         <artifactId>helidon-inject-configdriven-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>helidon-inject-configdriven-processor</artifactId>
-    <name>Helidon Injection Config-Driven Processor</name>
+    <name>Helidon Injection ConfigDriven Processor</name>
 
     <dependencies>
         <dependency>

--- a/inject/configdriven/runtime/pom.xml
+++ b/inject/configdriven/runtime/pom.xml
@@ -20,16 +20,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.inject.configdriven</groupId>
         <artifactId>helidon-inject-configdriven-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>helidon-inject-configdriven-runtime</artifactId>
-    <name>Helidon Injection Config-Driven Runtime Services</name>
+    <name>Helidon Injection ConfigDriven Runtime Services</name>
 
     <dependencies>
         <dependency>

--- a/inject/configdriven/tests/config/pom.xml
+++ b/inject/configdriven/tests/config/pom.xml
@@ -18,14 +18,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.inject.configdriven.tests</groupId>
         <artifactId>helidon-inject-configdriven-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>helidon-inject-configdriven-tests-config</artifactId>
     <name>Helidon Injection ConfigDriven Tests Config</name>
     <description>Test builder with configuration</description>

--- a/inject/configdriven/tests/configuredby-application/pom.xml
+++ b/inject/configdriven/tests/configuredby-application/pom.xml
@@ -18,17 +18,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.inject.configdriven.tests</groupId>
         <artifactId>helidon-inject-configdriven-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>helidon-inject-configdriven-tests-configuredby-application</artifactId>
-    <name>Helidon Injection Config-Driven ConfiguredBy Appl Tests</name>
-    <description>the same tests as test-configuredby, but instead using the maven application generation in order to calc di plan at compile-time</description>
+    <name>Helidon Injection ConfigDriven Tests CfgedBy App</name>
+    <description>
+        The same tests as test-configuredby, but instead using the maven application generation
+        in order to compute di plan at compile-time
+    </description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/inject/configdriven/tests/configuredby/pom.xml
+++ b/inject/configdriven/tests/configuredby/pom.xml
@@ -18,17 +18,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.inject.configdriven.tests</groupId>
         <artifactId>helidon-inject-configdriven-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>helidon-inject-configdriven-tests-configuredby</artifactId>
-    <name>Helidon Injection Config-Driven ConfiguredBy Svcs Tests</name>
-    <description>tests the fuller config-driven services (i.e., full config not just common and with config-driven services)</description>
+    <name>Helidon Injection ConfigDriven Tests CfgedBy Svc</name>
+    <description>
+        Tests the fuller config-driven services (i.e., full config not just common and with config-driven services)
+    </description>
 
     <dependencies>
         <dependency>

--- a/inject/configdriven/tests/pom.xml
+++ b/inject/configdriven/tests/pom.xml
@@ -20,13 +20,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.inject.configdriven</groupId>
         <artifactId>helidon-inject-configdriven-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.helidon.inject.configdriven.tests</groupId>
+    <artifactId>helidon-inject-configdriven-tests-project</artifactId>
+    <name>Helidon Injection ConfigDriven Tests Project</name>
+    <packaging>pom</packaging>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -36,11 +39,6 @@
         <dependency-check.skip>true</dependency-check.skip>
         <helidon.services.skip>true</helidon.services.skip>
     </properties>
-
-    <groupId>io.helidon.inject.configdriven.tests</groupId>
-    <artifactId>helidon-inject-configdriven-tests-project</artifactId>
-    <name>Helidon Injection Config-Driven Tests Project</name>
-    <packaging>pom</packaging>
 
     <modules>
         <module>config</module>

--- a/inject/maven-plugin/pom.xml
+++ b/inject/maven-plugin/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.inject</groupId>
         <artifactId>helidon-inject-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/processor/pom.xml
+++ b/inject/processor/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.inject</groupId>
         <artifactId>helidon-inject-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/runtime/pom.xml
+++ b/inject/runtime/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.inject</groupId>
         <artifactId>helidon-inject-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/testing/pom.xml
+++ b/inject/testing/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.inject</groupId>
         <artifactId>helidon-inject-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/tests/api/pom.xml
+++ b/inject/tests/api/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.inject.tests</groupId>
         <artifactId>helidon-inject-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/tests/interception/pom.xml
+++ b/inject/tests/interception/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.inject.tests</groupId>
         <artifactId>helidon-inject-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/tests/pom.xml
+++ b/inject/tests/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.inject</groupId>
         <artifactId>helidon-inject-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/tests/resources-inject/pom.xml
+++ b/inject/tests/resources-inject/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.inject.tests</groupId>
         <artifactId>helidon-inject-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/tests/resources-plain/pom.xml
+++ b/inject/tests/resources-plain/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.inject.tests</groupId>
         <artifactId>helidon-inject-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/tests/runtime/pom.xml
+++ b/inject/tests/runtime/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.inject.tests</groupId>
         <artifactId>helidon-inject-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/tests/tck-jsr330/pom.xml
+++ b/inject/tests/tck-jsr330/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.inject.tests</groupId>
         <artifactId>helidon-inject-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inject/tools/pom.xml
+++ b/inject/tools/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.inject</groupId>
         <artifactId>helidon-inject-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/cdi/common-cdi/reference-counted-context/pom.xml
+++ b/integrations/cdi/common-cdi/reference-counted-context/pom.xml
@@ -26,7 +26,7 @@
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-integrations-cdi-reference-counted-context</artifactId>
-    <name>Helidon CDI Integrations Common Reference Counted Context</name>
+    <name>Helidon Integrations CDI Common Ref Counted Context</name>
 
     <dependencies>
 

--- a/integrations/micronaut/cdi-processor/pom.xml
+++ b/integrations/micronaut/cdi-processor/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>helidon-integrations-micronaut-cdi-processor</artifactId>
-    <name>Helidon Integrations Micronaut CDI Annotation Processor</name>
+    <name>Helidon Integrations Micronaut CDI Processor</name>
 
     <description>Integration with Micronaut to be used in CDI environment.</description>
 

--- a/integrations/oci/sdk/processor/pom.xml
+++ b/integrations/oci/sdk/processor/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.integrations.oci.sdk</groupId>
         <artifactId>helidon-integrations-oci-sdk-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/oci/sdk/runtime/pom.xml
+++ b/integrations/oci/sdk/runtime/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.integrations.oci.sdk</groupId>
         <artifactId>helidon-integrations-oci-sdk-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/oci/sdk/tests/pom.xml
+++ b/integrations/oci/sdk/tests/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.integrations.oci.sdk</groupId>
         <artifactId>helidon-integrations-oci-sdk-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/oci/sdk/tests/test-application/pom.xml
+++ b/integrations/oci/sdk/tests/test-application/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.integrations.oci.sdk.tests</groupId>
         <artifactId>helidon-integrations-oci-sdk-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/oci/sdk/tests/test-module1/pom.xml
+++ b/integrations/oci/sdk/tests/test-module1/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.integrations.oci.sdk.tests</groupId>
         <artifactId>helidon-integrations-oci-sdk-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/oci/sdk/tests/test-module2/pom.xml
+++ b/integrations/oci/sdk/tests/test-module2/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.integrations.oci.sdk.tests</groupId>
         <artifactId>helidon-integrations-oci-sdk-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/metadata/hson/pom.xml
+++ b/metadata/hson/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.metadata</groupId>
         <artifactId>helidon-metadata-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-metadata-hson</artifactId>

--- a/metrics/providers/pom.xml
+++ b/metrics/providers/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.metrics</groupId>
         <artifactId>helidon-metrics-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.metrics.providers</groupId>

--- a/microprofile/testing/junit5/pom.xml
+++ b/microprofile/testing/junit5/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.microprofile.testing</groupId>
         <artifactId>helidon-microprofile-testing-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-microprofile-testing-junit5</artifactId>

--- a/microprofile/testing/mocking/pom.xml
+++ b/microprofile/testing/mocking/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.microprofile.testing</groupId>
         <artifactId>helidon-microprofile-testing-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-microprofile-testing-mocking</artifactId>

--- a/microprofile/testing/pom.xml
+++ b/microprofile/testing/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.testing</groupId>

--- a/microprofile/testing/testng/pom.xml
+++ b/microprofile/testing/testng/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.microprofile.testing</groupId>
         <artifactId>helidon-microprofile-testing-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-microprofile-testing-testng</artifactId>

--- a/microprofile/tests/arquillian/pom.xml
+++ b/microprofile/tests/arquillian/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>helidon-microprofile-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-arquillian</artifactId>
     <name>Helidon Microprofile Arquillian Integration</name>

--- a/microprofile/tests/config/pom.xml
+++ b/microprofile/tests/config/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>helidon-microprofile-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-microprofile-tests-config</artifactId>
     <name>Helidon Microprofile Config Tests</name>

--- a/microprofile/tests/pom.xml
+++ b/microprofile/tests/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile</groupId>
         <artifactId>helidon-microprofile-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.tests</groupId>

--- a/microprofile/tests/server/pom.xml
+++ b/microprofile/tests/server/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>helidon-microprofile-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-microprofile-tests-server</artifactId>

--- a/microprofile/tests/tck/pom.xml
+++ b/microprofile/tests/tck/pom.xml
@@ -20,13 +20,12 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://maven.apache.org/POM/4.0.0"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>helidon-microprofile-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <groupId>io.helidon.microprofile.tests.tck</groupId>
     <artifactId>helidon-microprofile-tests-tck-project</artifactId>

--- a/microprofile/tests/tck/tck-annotations/pom.xml
+++ b/microprofile/tests/tck/tck-annotations/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-annotations</artifactId>
     <name>Helidon Microprofile Tests TCK Annotations</name>

--- a/microprofile/tests/tck/tck-cdi-lang-model/pom.xml
+++ b/microprofile/tests/tck/tck-cdi-lang-model/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-cdi-lang-model</artifactId>
     <name>Helidon Microprofile Tests TCK CDI Lang model</name>

--- a/microprofile/tests/tck/tck-cdi/pom.xml
+++ b/microprofile/tests/tck/tck-cdi/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-cdi</artifactId>
     <name>Helidon Microprofile Tests TCK CDI</name>

--- a/microprofile/tests/tck/tck-config/pom.xml
+++ b/microprofile/tests/tck/tck-config/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-config</artifactId>
     <name>Helidon Microprofile Tests TCK Config</name>

--- a/microprofile/tests/tck/tck-core-profile/pom.xml
+++ b/microprofile/tests/tck/tck-core-profile/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <artifactId>helidon-microprofile-tests-tck-core-profile</artifactId>

--- a/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/pom.xml
+++ b/microprofile/tests/tck/tck-core-profile/tck-core-profile-test/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-core-profile</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-microprofile-tests-tck-core-profile-test</artifactId>
     <name>Helidon Microprofile Tests TCK Core Profile</name>

--- a/microprofile/tests/tck/tck-fault-tolerance/pom.xml
+++ b/microprofile/tests/tck/tck-fault-tolerance/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-fault-tolerance</artifactId>
     <name>Helidon Microprofile Tests TCK Fault Tolerance</name>

--- a/microprofile/tests/tck/tck-graphql/pom.xml
+++ b/microprofile/tests/tck/tck-graphql/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-graphql</artifactId>
     <name>Helidon Microprofile Tests TCK GraphQL</name>

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tests/tck/tck-inject/pom.xml
+++ b/microprofile/tests/tck/tck-inject/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <artifactId>helidon-microprofile-tests-tck-inject</artifactId>

--- a/microprofile/tests/tck/tck-inject/tck-inject-test/pom.xml
+++ b/microprofile/tests/tck/tck-inject/tck-inject-test/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-inject</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-microprofile-tests-tck-inject-test</artifactId>
     <name>Helidon Microprofile Tests TCK Inject</name>

--- a/microprofile/tests/tck/tck-jsonb/pom.xml
+++ b/microprofile/tests/tck/tck-jsonb/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <artifactId>helidon-microprofile-tests-tck-jsonb</artifactId>

--- a/microprofile/tests/tck/tck-jsonb/tck-jsonb-test/pom.xml
+++ b/microprofile/tests/tck/tck-jsonb/tck-jsonb-test/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-jsonb</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-microprofile-tests-tck-jsonb-test</artifactId>
     <name>Helidon Microprofile Tests TCK JSONB</name>

--- a/microprofile/tests/tck/tck-jsonp/pom.xml
+++ b/microprofile/tests/tck/tck-jsonp/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <artifactId>helidon-microprofile-tests-tck-jsonp</artifactId>

--- a/microprofile/tests/tck/tck-jsonp/tck-jsonp-pluggability-test/pom.xml
+++ b/microprofile/tests/tck/tck-jsonp/tck-jsonp-pluggability-test/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-jsonp</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-microprofile-tests-tck-jsonp-pluggability-test</artifactId>
     <name>Helidon Microprofile Tests TCK JSONP</name>

--- a/microprofile/tests/tck/tck-jsonp/tck-jsonp-test/pom.xml
+++ b/microprofile/tests/tck/tck-jsonp/tck-jsonp-test/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-jsonp</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-microprofile-tests-tck-jsonp-test</artifactId>
     <name>Helidon Microprofile Tests TCK JSONP</name>

--- a/microprofile/tests/tck/tck-jwt-auth/pom.xml
+++ b/microprofile/tests/tck/tck-jwt-auth/pom.xml
@@ -22,7 +22,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-jwt-auth</artifactId>
     <name>Helidon Microprofile Tests TCK JWT-Auth</name>

--- a/microprofile/tests/tck/tck-lra/pom.xml
+++ b/microprofile/tests/tck/tck-lra/pom.xml
@@ -22,7 +22,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>tck-lra</artifactId>

--- a/microprofile/tests/tck/tck-messaging/pom.xml
+++ b/microprofile/tests/tck/tck-messaging/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-messaging</artifactId>
     <name>Helidon Microprofile Tests TCK Messaging</name>

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-metrics</artifactId>
     <name>Helidon Microprofile Tests TCK Metrics</name>

--- a/microprofile/tests/tck/tck-openapi/pom.xml
+++ b/microprofile/tests/tck/tck-openapi/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-opentracing</artifactId>
     <name>Helidon Microprofile Tests TCK Opentracing</name>

--- a/microprofile/tests/tck/tck-reactive-operators/pom.xml
+++ b/microprofile/tests/tck/tck-reactive-operators/pom.xml
@@ -24,10 +24,9 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tck-reactive-operators</artifactId>
-    <name>Helidon Microprofile Tests TCK Reactive Streams Operators</name>
+    <name>Helidon Microprofile Tests TCK Reactive Operators</name>
 
     <dependencies>
         <dependency>

--- a/microprofile/tests/tck/tck-rest-client/pom.xml
+++ b/microprofile/tests/tck/tck-rest-client/pom.xml
@@ -22,7 +22,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tests/tck/tck-restful/pom.xml
+++ b/microprofile/tests/tck/tck-restful/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <artifactId>tck-restful</artifactId>

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
@@ -25,7 +25,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>tck-restful</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-microprofile-tests-tck-restful-test</artifactId>
     <name>Helidon Microprofile Tests TCK Restful</name>

--- a/microprofile/tests/tck/tck-telemetry/pom.xml
+++ b/microprofile/tests/tck/tck-telemetry/pom.xml
@@ -22,7 +22,6 @@
         <groupId>io.helidon.microprofile.tests.tck</groupId>
         <artifactId>helidon-microprofile-tests-tck-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/microprofile/tests/telemetry/pom.xml
+++ b/microprofile/tests/telemetry/pom.xml
@@ -22,7 +22,6 @@
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>helidon-microprofile-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-microprofile-tests-telemetry</artifactId>

--- a/microprofile/tests/testing/junit5/pom.xml
+++ b/microprofile/tests/testing/junit5/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.microprofile.tests.testing</groupId>
         <artifactId>helidon-microprofile-tests-testing-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-microprofile-tests-testing-junit5</artifactId>

--- a/microprofile/tests/testing/pom.xml
+++ b/microprofile/tests/testing/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.microprofile.tests</groupId>
         <artifactId>helidon-microprofile-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <version>4.1.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>

--- a/microprofile/tests/testing/testng/pom.xml
+++ b/microprofile/tests/testing/testng/pom.xml
@@ -22,7 +22,6 @@
         <groupId>io.helidon.microprofile.tests.testing</groupId>
         <artifactId>helidon-microprofile-tests-testing-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-microprofile-tests-testing-testng</artifactId>

--- a/microprofile/weld/weld-core-impl/pom.xml
+++ b/microprofile/weld/weld-core-impl/pom.xml
@@ -20,14 +20,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.microprofile.weld</groupId>
         <artifactId>helidon-microprofile-weld-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>weld-core-impl</artifactId>
+    <name>Helidon Weld SE Impl</name>
 
     <properties>
         <spotbugs.skip>true</spotbugs.skip>

--- a/microprofile/weld/weld-se-core/pom.xml
+++ b/microprofile/weld/weld-se-core/pom.xml
@@ -20,14 +20,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.microprofile.weld</groupId>
         <artifactId>helidon-microprofile-weld-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
     <artifactId>weld-se-core</artifactId>
+    <name>Helidon Weld SE Core</name>
 
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/service/codegen/pom.xml
+++ b/service/codegen/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.service</groupId>
         <artifactId>helidon-service-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/metadata/pom.xml
+++ b/service/metadata/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.service</groupId>
         <artifactId>helidon-service-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/registry/pom.xml
+++ b/service/registry/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.service</groupId>
         <artifactId>helidon-service-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/tests/codegen/pom.xml
+++ b/service/tests/codegen/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.service.tests</groupId>
         <artifactId>helidon-service-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/tests/pom.xml
+++ b/service/tests/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.service</groupId>
         <artifactId>helidon-service-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/tests/registry/pom.xml
+++ b/service/tests/registry/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.service.tests</groupId>
         <artifactId>helidon-service-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/apps/pom.xml
+++ b/tests/apps/pom.xml
@@ -20,13 +20,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
-
     <groupId>io.helidon.tests.apps</groupId>
     <artifactId>helidon-tests-apps-project</artifactId>
     <packaging>pom</packaging>

--- a/tests/functional/jax-rs-multiple-apps/pom.xml
+++ b/tests/functional/jax-rs-multiple-apps/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>helidon-tests-functional-jax-rs-multiple-apps</artifactId>
-    <name>Helidon Tests Functional Injection Manager Sharing Multiple Apps</name>
+    <name>Helidon Tests Functional JAX-RS Multiple Apps</name>
 
     <dependencies>
         <dependency>

--- a/tests/functional/param-converter-provider/pom.xml
+++ b/tests/functional/param-converter-provider/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>helidon-tests-param-converter-provider</artifactId>
-    <name>Helidon Tests Functional ParamConverterProviders and injection managers</name>
+    <name>Helidon Tests Functional ParamConverterProviders</name>
 
     <dependencies>
         <dependency>

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>helidon-tests-functional-project</artifactId>
     <packaging>pom</packaging>
 
-    <name>Helidon Tests Functional</name>
+    <name>Helidon Tests Functional Project</name>
 
     <modules>
         <module>bookstore</module>

--- a/tests/functional/request-scope-cdi/pom.xml
+++ b/tests/functional/request-scope-cdi/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>helidon-tests-functional-request-scope-cdi</artifactId>
-    <name>Helidon Tests Functional CDI Request Scopes and Fault Tolerance</name>
+    <name>Helidon Tests Functional Request Scope CDI</name>
 
     <dependencies>
         <dependency>

--- a/tests/functional/request-scope-injection/pom.xml
+++ b/tests/functional/request-scope-injection/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>helidon-tests-functional-request-scope-injection</artifactId>
-    <name>Helidon Tests Functional Helidon Request Scope Injection</name>
+    <name>Helidon Tests Functional Request Scope Injection</name>
 
     <dependencies>
         <dependency>

--- a/tests/functional/request-scope/pom.xml
+++ b/tests/functional/request-scope/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>helidon-tests-functional-request-scope</artifactId>
-    <name>Helidon Tests Functional Request Scope and Fault Tolerance</name>
+    <name>Helidon Tests Functional Request Scope</name>
 
     <dependencies>
         <dependency>

--- a/tests/integration/config/hocon-mp/pom.xml
+++ b/tests/integration/config/hocon-mp/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>helidon-tests-integration-config-hocon-mp</artifactId>
-    <name>Helidon Tests Integration for HOCON/JSON Config on MP</name>
+    <name>Helidon Tests Integration Config HOCON MP</name>
     <description>Validation for HOCON/JSON Config on MP</description>
 
     <dependencies>

--- a/tests/integration/config/pom.xml
+++ b/tests/integration/config/pom.xml
@@ -22,7 +22,7 @@
 
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
 

--- a/tests/integration/dbclient/common/pom.xml
+++ b/tests/integration/dbclient/common/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.tests.integration.dbclient</groupId>
         <artifactId>helidon-tests-integration-dbclient-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-tests-integration-dbclient-common</artifactId>
     <name>Helidon Tests Integration DbClient Common</name>

--- a/tests/integration/dbclient/pom.xml
+++ b/tests/integration/dbclient/pom.xml
@@ -21,9 +21,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration.dbclient</groupId>
     <artifactId>helidon-tests-integration-dbclient-project</artifactId>

--- a/tests/integration/harness/pom.xml
+++ b/tests/integration/harness/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-tests-integration-harness</artifactId>

--- a/tests/integration/health/pom.xml
+++ b/tests/integration/health/pom.xml
@@ -22,7 +22,7 @@
 
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.tests.integration.health</groupId>

--- a/tests/integration/jep290/pom.xml
+++ b/tests/integration/jep290/pom.xml
@@ -22,7 +22,7 @@
 
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <groupId>io.helidon.tests.integration.jep290</groupId>

--- a/tests/integration/jms/pom.xml
+++ b/tests/integration/jms/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
 

--- a/tests/integration/jpa/model/pom.xml
+++ b/tests/integration/jpa/model/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.tests.integration.jpa</groupId>
         <artifactId>helidon-tests-integration-jpa-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>io.helidon.tests.integration.jpa</groupId>

--- a/tests/integration/jpa/pom.xml
+++ b/tests/integration/jpa/pom.xml
@@ -22,9 +22,8 @@
 
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <packaging>pom</packaging>

--- a/tests/integration/jpa/simple/pom.xml
+++ b/tests/integration/jpa/simple/pom.xml
@@ -24,7 +24,6 @@
         <groupId>io.helidon.tests.integration.jpa</groupId>
         <artifactId>helidon-tests-integration-jpa-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-tests-integration-jpa-simple</artifactId>

--- a/tests/integration/kafka/pom.xml
+++ b/tests/integration/kafka/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
 

--- a/tests/integration/mp-gh-2421/pom.xml
+++ b/tests/integration/mp-gh-2421/pom.xml
@@ -20,7 +20,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>

--- a/tests/integration/mp-gh-2461/pom.xml
+++ b/tests/integration/mp-gh-2461/pom.xml
@@ -20,7 +20,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>

--- a/tests/integration/mp-gh-3246/pom.xml
+++ b/tests/integration/mp-gh-3246/pom.xml
@@ -20,7 +20,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>

--- a/tests/integration/mp-gh-3974/pom.xml
+++ b/tests/integration/mp-gh-3974/pom.xml
@@ -20,7 +20,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>

--- a/tests/integration/mp-gh-4123/pom.xml
+++ b/tests/integration/mp-gh-4123/pom.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/mp-gh-4654/pom.xml
+++ b/tests/integration/mp-gh-4654/pom.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/mp-gh-5328/pom.xml
+++ b/tests/integration/mp-gh-5328/pom.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/mp-gh-8349/pom.xml
+++ b/tests/integration/mp-gh-8349/pom.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/mp-gh-8478/pom.xml
+++ b/tests/integration/mp-gh-8478/pom.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/mp-gh-8493/pom.xml
+++ b/tests/integration/mp-gh-8493/pom.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/mp-gh-8495/pom.xml
+++ b/tests/integration/mp-gh-8495/pom.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/mp-graphql/pom.xml
+++ b/tests/integration/mp-graphql/pom.xml
@@ -20,9 +20,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>helidon-tests-integration-mp-graphql</artifactId>

--- a/tests/integration/mp-security-client/pom.xml
+++ b/tests/integration/mp-security-client/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <groupId>io.helidon.tests.integration</groupId>
     <artifactId>helidon-tests-integration-mp-security-client</artifactId>
-    <name>Helidon Tests Integration MP Security with client</name>
+    <name>Helidon Tests Integration MP Security Client</name>
 
     <dependencies>
         <dependency>

--- a/tests/integration/mp-ws-services/pom.xml
+++ b/tests/integration/mp-ws-services/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <groupId>io.helidon.tests.integration</groupId>
     <artifactId>helidon-tests-integration-mp-ws-services</artifactId>
-    <name>Helidon Tests Integration MP WebServer services</name>
+    <name>Helidon Tests Integration MP WebServer Services</name>
 
     <dependencies>
         <dependency>

--- a/tests/integration/oidc/pom.xml
+++ b/tests/integration/oidc/pom.xml
@@ -19,7 +19,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>

--- a/tests/integration/packaging/pom.xml
+++ b/tests/integration/packaging/pom.xml
@@ -22,9 +22,8 @@
 
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     <groupId>io.helidon.tests.integration.packaging</groupId>

--- a/tests/integration/packaging/static-content/pom.xml
+++ b/tests/integration/packaging/static-content/pom.xml
@@ -23,7 +23,6 @@
         <groupId>io.helidon.tests.integration.packaging</groupId>
         <artifactId>helidon-tests-integration-packaging</artifactId>
         <version>4.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>helidon-tests-integration-packaging-static-content</artifactId>
     <name>Helidon Tests Integration Packaging Static Content</name>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -19,18 +19,16 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>io.helidon.tests</groupId>
         <artifactId>helidon-tests-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
-
     <groupId>io.helidon.tests.integration</groupId>
-    <artifactId>helidon-tests-integration</artifactId>
+    <artifactId>helidon-tests-integration-project</artifactId>
     <packaging>pom</packaging>
 
-    <name>Helidon Tests Integration</name>
+    <name>Helidon Tests Integration Project</name>
 
     <properties>
         <version.lib.testcontainers.keycloak>2.3.0</version.lib.testcontainers.keycloak>

--- a/tests/integration/restclient-connector/pom.xml
+++ b/tests/integration/restclient-connector/pom.xml
@@ -21,12 +21,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-restclient-connector</artifactId>
-    <name>Helidon Integration Test RestClient Webclient Connector</name>
+    <name>Helidon Tests Integration RestClient Connector</name>
 
     <dependencies>
         <dependency>

--- a/tests/integration/restclient/pom.xml
+++ b/tests/integration/restclient/pom.xml
@@ -19,7 +19,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>

--- a/tests/integration/security/pom.xml
+++ b/tests/integration/security/pom.xml
@@ -22,7 +22,7 @@
 
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
 

--- a/tests/integration/tls-revocation-config/pom.xml
+++ b/tests/integration/tls-revocation-config/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
 

--- a/tests/integration/vault/pom.xml
+++ b/tests/integration/vault/pom.xml
@@ -21,7 +21,7 @@
                              https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>helidon-tests-integration</artifactId>
+        <artifactId>helidon-tests-integration-project</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>

--- a/tests/integration/zipkin-mp-2.2/pom.xml
+++ b/tests/integration/zipkin-mp-2.2/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <groupId>io.helidon.tests.integration</groupId>
     <artifactId>helidon-tests-integration-zipkin-mp-2-2</artifactId>
-    <name>Helidon Tests Integration: Zipkin with MP</name>
+    <name>Helidon Tests Integration Zipkin with MP</name>
 
     <dependencies>
         <dependency>

--- a/webserver/observe/pom.xml
+++ b/webserver/observe/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.helidon.webserver.observe</groupId>
     <artifactId>helidon-webserver-observe-project</artifactId>
-    <name>Helidon Observe Project</name>
+    <name>Helidon WebServer Observe Project</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/webserver/static-content/pom.xml
+++ b/webserver/static-content/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>helidon-webserver-static-content</artifactId>
-    <name>Helidon Server Static Content</name>
+    <name>Helidon WebServer Static Content</name>
 
     <properties>
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>


### PR DESCRIPTION
### Description

POM cleanups

- Remove `<relativePath>../pom.xml</relativePath>`
- Update names to match the artifactId
- Shorten names that break reactor summary
- Add FT tck back in the default profile (update validate job too)
- Update `tests/integration/pom.xml` to be `helidon-tests-integration-project`

### Documentation

None.

