### PR TITLE
Parallelized pipelines

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -1,0 +1,176 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: 'Common Job Steps'
+description: A composite action that abstracts the common steps needed to implement a job
+inputs:
+  native-image:
+    description: Whether to setup GraalVM native-image
+    required: false
+    default: 'false'
+  maven-cache:
+    description: Whether to cache the Maven local repository (read-only or read-write)
+    required: false
+    default: 'read-only'
+  build-cache:
+    description:  Whether to cache the Maven build (read-only or read-write)
+    required: false
+    default: ''
+  build-cache-id:
+    description:  Build cache id
+    required: false
+    default: 'default'
+  GPG_PASSPHRASE:
+    description: Value of the GPG_PASSPHRASE environment variable
+    required: false
+    default: ''
+  GPG_PRIVATE_KEY:
+    description: Value of the GPG_PRIVATE_KEY environment variable
+    required: false
+    default: ''
+  MAVEN_SETTINGS:
+    description: Value of the MAVEN_SETTINGS environment variable
+    required: false
+    default: ''
+  run:
+    description: The bash command to run
+    required: true
+  artifact-name:
+    description: Name of the artifact to create
+    required: false
+    default: ''
+  artifact-path:
+    description: Path of the files to include in the artifact
+    required: false
+    default: ''
+  test-artifact-name:
+    description: Name of the test artifact to create (excluded on windows), if non empty tests are archived
+    required: false
+    default: ''
+  free-space:
+    description: Whether to aggressively free disk space on the runner
+    default: 'false'
+runs:
+  using: "composite"
+  steps:
+    - if: ${{ inputs.free-space == 'true' }}
+      # See https://github.com/actions/runner-images/issues/2840
+      name: Free disk space
+      shell: bash
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/share/powershell
+    - if: ${{ runner.os == 'Windows' }}
+      name: Use GNU tar
+      shell: cmd
+      run: |
+        echo "Adding GNU tar to PATH"
+        echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+    - name: Set up GraalVM
+      if: ${{ inputs.native-image == 'true' }}
+      uses: graalvm/setup-graalvm@v1.2.1
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+        version: ${{ env.GRAALVM_VERSION }}
+        components: ${{ env.GRAALVM_COMPONENTS }}
+        check-for-updates: 'false'
+        set-java-home: 'false'
+    - name: Set up JDK
+      uses: actions/setup-java@v4.1.0
+      with:
+        distribution: ${{ env.JAVA_DISTRO }}
+        java-version: ${{ env.JAVA_VERSION }}
+    - name: Cache local Maven repository (read-write)
+      if: ${{ inputs.maven-cache == 'read-write' }}
+      uses: actions/cache@v4.0.2
+      with:
+        # See https://github.com/actions/toolkit/issues/713
+        # Include must not match top level directories
+        path: |
+          .m2/repository/**/*.*
+          !.m2/repository/io/helidon/**
+        enableCrossOsArchive: true
+        # only hash top-level poms to keep it fast
+        key: local-maven-${{ hashFiles('*/pom.xml', 'pom.xml') }}
+        restore-keys: |
+          local-maven-
+    - name: Cache local Maven repository (read-only)
+      if: ${{ inputs.maven-cache == 'read-only' }}
+      uses: actions/cache/restore@v4.0.2
+      with:
+        path: |
+          .m2/repository/**/*.*
+          !.m2/repository/io/helidon/**
+        enableCrossOsArchive: true
+        key: local-maven-${{ hashFiles('*/pom.xml', 'pom.xml') }}
+        restore-keys: |
+          local-maven-
+    - name: Build cache (read-write)
+      if: ${{ inputs.build-cache == 'read-write' }}
+      uses: actions/cache@v4.0.2
+      with:
+        path: |
+          ./**/target/**
+          .m2/repository/io/helidon/**
+        enableCrossOsArchive: true
+        key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.build-cache-id }}
+        restore-keys: |
+          build-cache-${{ github.run_id }}-${{ github.run_attempt }}-
+          build-cache-${{ github.run_id }}-
+    - name: Build cache (read-only)
+      if: ${{ inputs.build-cache == 'read-only' }}
+      uses: actions/cache/restore@v4.0.2
+      with:
+        path: |
+          ./**/target/**
+          .m2/repository/io/helidon/**
+        enableCrossOsArchive: true
+        fail-on-cache-miss: true
+        key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.build-cache-id }}
+        restore-keys: |
+          build-cache-${{ github.run_id }}-${{ github.run_attempt }}-
+          build-cache-${{ github.run_id }}-
+    - name: Exec
+      env:
+        GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}
+        GPG_PRIVATE_KEY: ${{ inputs.GPG_PRIVATE_KEY }}
+        MAVEN_SETTINGS: ${{ inputs.MAVEN_SETTINGS }}
+        MAVEN_ARGS: |
+          ${{ env.MAVEN_ARGS }}
+          -Dmaven.repo.local=${{ github.workspace }}/.m2/repository
+          -Dcache.record=${{ inputs.build-cache == 'read-write' }}
+      run: ${{ inputs.run }}
+      shell: bash
+    - name: Archive test results
+      # https://github.com/actions/upload-artifact/issues/240
+      if: ${{ inputs.test-artifact-name != '' && runner.os != 'Windows' && always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: 'ignore'
+        name: ${{ inputs.test-artifact-name }}
+        path: |
+          **/target/surefire-reports/*.txt
+          **/target/failsafe-reports/*.txt
+          **/target/it/**/*.log
+    - name: Archive artifacts
+      if: ${{ inputs.artifact-name != '' && inputs.artifact-path != ''  && always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: 'ignore'
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.artifact-path }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,17 @@
-# Notes
-# - cannot run on Windows, as we use shell scripts
-# - removed macos from most jobs to speed up the process
+#
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: "Validate"
 
@@ -10,195 +21,282 @@ on:
     branches-ignore: [ 'main', 'helidon-*.x', 'release-*' ]
     tags-ignore: [ '**' ]
   workflow_call:
+    inputs:
+      ref:
+        description: The branch, tag or SHA to checkout
+        required: false
+        type: string
+        default: ''
 
 env:
-  JAVA_VERSION: '21'
-  JAVA_DISTRO: 'oracle'
+  JAVA_VERSION: 21
+  JAVA_DISTRO: oracle
   MAVEN_ARGS: |
     -B -fae -e
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
     -Dmaven.wagon.http.retryHandler.count=3
+    -Djdk.toolchain.version=${JAVA_VERSION}
+    -Dcache.enabled=true
 
 concurrency:
-  group: Validate-${{ github.ref }}
+  group: validate-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   copyright:
-    timeout-minutes: 10
-    runs-on: ubuntu-20.04
-    steps:
-     - uses: actions/checkout@v4
-       with:
-         fetch-depth: 0
-     - name: Set up JDK ${{ env.JAVA_VERSION }}
-       uses: actions/setup-java@v4.1.0
-       with:
-         distribution: ${{ env.JAVA_DISTRO }}
-         java-version: ${{ env.JAVA_VERSION }}
-         cache: maven
-     - name: Copyright
-       run: etc/scripts/copyright.sh
-  checkstyle:
-    timeout-minutes: 10
+    timeout-minutes: 5
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
         with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: Checkstyle
-        run: etc/scripts/checkstyle.sh
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - uses: ./.github/actions/common
+        with:
+          run: etc/scripts/copyright.sh
+  checkstyle:
+    timeout-minutes: 5
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          run: etc/scripts/checkstyle.sh
   shellcheck:
     timeout-minutes: 5
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - name: ShellCheck
-        run: etc/scripts/shellcheck.sh
-  spotbugs:
-    timeout-minutes: 45
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
         with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: Spotbugs
-        run: |
-          mvn ${MAVEN_ARGS} -e \
-            -DskipTests \
-            -Dmaven.test.skip=true \
-            -Pspotbugs \
-            install
-  docs:
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
         with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: Docs
-        run: |
-          mvn ${MAVEN_ARGS} \
-            -DskipTests \
-            install
-          mvn ${MAVEN_ARGS} \
-            -f docs/pom.xml \
-            -Pjavadoc \
-             install
+          maven-cache: none
+          run: etc/scripts/shellcheck.sh
   build:
-    timeout-minutes: 60
+    timeout-minutes: 15
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-write
+          maven-cache: read-write
+          run: |
+            mvn ${MAVEN_ARGS} build-cache:go-offline
+            mvn ${MAVEN_ARGS} -T8 \
+              -Dorg.slf4j.simpleLogger.showThreadName=true \
+              -DskipTests \
+              -Ptests \
+              install
+  _tests:
+    needs: build
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
-        with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: Maven build
-        run: |
-          mvn ${MAVEN_ARGS} \
-            -Dmaven.test.failure.ignore=false \
-            -Pjavadoc,sources,tests \
-            install
-  examples:
-    timeout-minutes: 40
-    strategy:
-      matrix:
-        os: [ ubuntu-20.04, macos-14 ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
-        with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: graalvm-community
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          native-image-job-reports: true
-          cache: maven
-      - name: Maven build
-        run: |
-          # prime build
-          mvn ${MAVEN_ARGS} -T8 \
-          -DskipTests \
-          install
-      - name: Examples build
-        run: etc/scripts/build-examples.sh
-      - name: Test quickstarts native image
-        run: etc/scripts/test-quickstarts.sh
-  mp-tck:
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        os: [ ubuntu-20.04 ]
+        moduleSet: [ core, it, dbclient, dbclient-oracle, others ]
         include:
           - { os: ubuntu-20.04, platform: linux }
     runs-on: ${{ matrix.os }}
-    name: tests/tck-${{ matrix.platform }}
+    name: tests/${{ matrix.moduleSet }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
         with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: Maven build
-        run: |
-          # prime build
-          mvn ${MAVEN_ARGS} -T8 \
-            -DskipTests \
-            install
-          mvn ${MAVEN_ARGS} \
-            -f microprofile/tests/tck/pom.xml \
-            -Ptck-ft \
-            verify
-  archetypes:
-    timeout-minutes: 45
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-only
+          test-artifact-name: tests-${{ matrix.moduleSet }}
+          run: |
+            mvn ${MAVEN_ARGS} \
+              -DreactorRule=tests \
+              -DmoduleSet=${{ matrix.moduleSet }} \
+              -Dsurefire.reportNameSuffix=${{ matrix.platform }} \
+              verify
+  _tck:
+    needs: build
+    timeout-minutes: 30
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
-    runs-on: ${{ matrix.os }}
+        moduleSet: [ cdi, rest, others ]
+    runs-on: ubuntu-20.04
+    name: tests/tck-${{ matrix.moduleSet }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
         with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: Test archetypes
-        run: |
-          # prime build
-          mvn ${MAVEN_ARGS} -T8 \
-            -DskipTests \
-            install
-          mvn ${MAVEN_ARGS} -e \
-            -f archetypes/pom.xml \
-            install
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-only
+          test-artifact-name: tests-tck-${{ matrix.moduleSet }}
+          run: |
+            mvn ${MAVEN_ARGS} \
+              -DreactorRule=tck \
+              -DmoduleSet=${{ matrix.moduleSet }} \
+              verify
+  _spotbugs:
+    needs: build
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        moduleSet: [ core, integrations, others ]
+    runs-on: ubuntu-20.04
+    name: spotbugs/${{ matrix.moduleSet }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-only
+          run: |
+            mvn ${MAVEN_ARGS} -T8 \
+              -Dorg.slf4j.simpleLogger.showThreadName=true \
+              -DreactorRule=default \
+              -DmoduleSet=${{ matrix.moduleSet }} \
+              -DskipTests \
+              -Pspotbugs \
+              verify
+  javadoc:
+    needs: build
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        moduleSet: [ core, integrations, others ]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-only
+          run: |
+            mvn ${MAVEN_ARGS} -T8 \
+              -Dorg.slf4j.simpleLogger.showThreadName=true \
+              -DreactorRule=default \
+              -DmoduleSet=${{ matrix.moduleSet }} \
+              -DskipTests \
+              -Pjavadoc \
+              package
+  docs:
+    needs: build
+    timeout-minutes: 15
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-only
+          run: |
+            mvn ${MAVEN_ARGS} \
+              -f docs/pom.xml \
+              -Pjavadoc \
+              install
+  quickstarts:
+    needs: build
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, macos-14 ]
+        include:
+          - { os: ubuntu-20.04, platform: linux }
+          - { os: macos-14, platform: macos }
+    runs-on: ${{ matrix.os }}
+    name: quickstarts/${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          free-space: true
+          build-cache: read-only
+          native-image: true
+          test-artifact-name: tests-quickstarts-${{ matrix.platform }}
+          run: |
+            etc/scripts/test-quickstarts.sh
+  examples:
+    needs: build
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, macos-14 ]
+        include:
+          - { os: ubuntu-20.04, platform: linux }
+          - { os: macos-14, platform: macos }
+    runs-on: ${{ matrix.os }}
+    name: examples/${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          free-space: true
+          build-cache: read-only
+          test-artifact-name: tests-examples-${{ matrix.platform }}
+          run: etc/scripts/build-examples.sh
+  archetypes:
+    needs: build
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        group: [ r1, r2, r3, r4, r5 ]
+        packaging: [ jar ]
+        include:
+          - { group: r1, start: 1, end: 25 }
+          - { group: r2, start: 26, end: 50 }
+          - { group: r3, start: 51, end: 75 }
+          - { group: r4, start: 75, end: 100 }
+          - { group: r5, start: 101, end: -1 }
+          - { packaging: jar }
+    runs-on: ubuntu-20.04
+    name: archetypes/${{ matrix.group }}-${{ matrix.packaging }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-only
+          native-image: ${{ matrix.packaging == 'native' }}
+          test-artifact-name: tests-archetypes-${{ matrix.group }}-${{ matrix.packaging }}
+          run: |
+            mvn ${MAVEN_ARGS} \
+              -f archetypes/archetypes/pom.xml \
+              -Darchetype.test.permutationStartIndex=${{ matrix.start }} \
+              -Darchetype.test.permutationEndIndex=${{ matrix.end }} \
+              -Darchetype.test.testGoal=verify \
+              -Darchetype.test.testProfiles=${{ matrix.profile }} \
+              verify
+  legacy-archetypes:
+    needs: build
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    name: archetypes/legacy
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-only
+          test-artifact-name: tests-legacy-archetypes
+          run: |
+            mvn ${MAVEN_ARGS} \
+              -f archetypes/pom.xml \
+              -Darchetype.test.generatePermutations=false \
+              install
   packaging:
+    needs: build
     timeout-minutes: 30
     strategy:
       matrix:
@@ -213,32 +311,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
+      - uses: ./.github/actions/common
         with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: Free Space
-        shell: bash
-        run: |
-          # See https://github.com/actions/runner-images/issues/2840
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/share/powershell
-      - name: Build Helidon
-        run: |
-          # prime build
-          mvn ${MAVEN_ARGS} -T4 \
-            -DskipTests \
-            -Ptests \
-            install
-      - name: Run Test
-        run: |
+          free-space: true
+          build-cache: read-only
+          test-artifact-name: tests-packaging-${{ matrix.packaging }}-${{ matrix.platform }}
+          run: |
             mvn ${MAVEN_ARGS} \
               -f tests/integration/packaging/pom.xml \
               -P${{ matrix.packaging }}-image \
               verify
-  native-image:
+  _native-image:
+    needs: build
     timeout-minutes: 30
     strategy:
       matrix:
@@ -253,76 +337,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: graalvm/setup-graalvm@v1
+      - uses: ./.github/actions/common
         with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: graalvm-community
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          native-image-job-reports: true
-          cache: maven
-      - name: Free Space
-        shell: bash
-        run: |
-          # See https://github.com/actions/runner-images/issues/2840
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/share/powershell
-      - name: Build Helidon
-        run: |
-          # prime build
-          mvn ${MAVEN_ARGS} -T4 \
-            -DskipTests \
-            -Ptests \
-            install
-      - name: Run Test
-        run: |
-          mvn ${MAVEN_ARGS} -e \
-            -f tests/integration/packaging/pom.xml \
-            -pl ${{ matrix.module }} \
-            -Pnative-image \
-            -am \
-            verify
-  dbclient:
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        os: [ ubuntu-20.04 ]
-        group: [ oracle, others ]
-        include:
-          - { group: others, modules: '!oracle' }
-          - { os: ubuntu-20.04, platform: linux }
-    runs-on: ${{ matrix.os }}
-    name: tests/dbclient-${{ matrix.group }}-${{ matrix.platform }}
+          free-space: true
+          build-cache: read-only
+          native-image: true
+          test-artifact-name: tests-native-image-${{ matrix.module }}-${{ matrix.platform }}
+          run: |
+            mvn ${MAVEN_ARGS} \
+              -f tests/integration/packaging/pom.xml \
+              -pl ${{ matrix.module }} \
+              -Pnative-image \
+              -am \
+              verify
+  test-results:
+    runs-on: ubuntu-20.04
+    needs: [ _tests, archetypes, legacy-archetypes, _tck, packaging, _native-image ]
+    name: tests/results
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4.1.0
+      - uses: actions/upload-artifact/merge@v4
         with:
-          distribution: ${{ env.JAVA_DISTRO }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: Free Space
-        shell: bash
-        run: |
-          # See https://github.com/actions/runner-images/issues/2840
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/share/powershell
-      - name: Build Helidon
-        run: |
-          # prime build
-          mvn ${MAVEN_ARGS} -T4 \
-            -DskipTests \
-            -Ptests \
-            install
-      - name: Run Tests
-        run: |
-          mvn ${MAVEN_ARGS} \
-            -f tests/integration/dbclient/pom.xml \
-            -pl ${{ matrix.modules || matrix.group }} \
-            -am \
-            verify
+          name: test-results
+          pattern: "tests-*"
   gate:
     runs-on: ubuntu-20.04
-    needs: [ copyright, checkstyle, shellcheck, build, docs, spotbugs, packaging, native-image, dbclient, archetypes, mp-tck ]
+    needs: [ copyright, checkstyle, shellcheck, docs, javadoc, _spotbugs, test-results ]
     steps:
       - shell: bash
         run: |

--- a/.mvn/cache-config.xml
+++ b/.mvn/cache-config.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<cacheConfig>
+    <enabled>false</enabled>
+    <lifecycleConfig>
+        <project glob="**/*">
+            <projectFilesExcludes>
+                <exclude>.*/**</exclude>
+                <exclude>etc/**</exclude>
+            </projectFilesExcludes>
+        </project>
+        <executionsExcludes>
+            <!-- exclude target/libs -->
+            <exclude>*@copy-libs</exclude>
+        </executionsExcludes>
+    </lifecycleConfig>
+    <reactorRules>
+        <reactorRule name="tests">
+            <profiles>
+                <profile>tests</profile>
+            </profiles>
+            <moduleSets>
+                <moduleSet name="core">
+                    <includes>
+                        <include>webserver/**</include>
+                        <include>webclient/**</include>
+                        <include>common/**</include>
+                        <include>config/**</include>
+                        <include>security/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="jpa-oracle">
+                    <includes>
+                        <include>tests/integration/jpa/oracle/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="jpa">
+                    <includes>
+                        <include>tests/integration/jpa/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="dbclient-oracle">
+                    <includes>
+                        <include>tests/integration/dbclient/oracle/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="dbclient">
+                    <includes>
+                        <include>tests/integration/dbclient/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="packaging">
+                    <includes>
+                        <include>tests/integration/packaging/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="jpa">
+                    <includes>
+                        <include>tests/integration/packaging/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="it">
+                    <includes>
+                        <include>tests/integration/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="others">
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                    <excludes>
+                        <exclude>tests/benchmark/**</exclude>
+                    </excludes>
+                </moduleSet>
+            </moduleSets>
+        </reactorRule>
+        <reactorRule name="tck">
+            <profiles>
+                <profile>tck</profile>
+            </profiles>
+            <moduleSets>
+                <moduleSet name="cdi">
+                    <includes>
+                        <include>microprofile/tests/tck/tck-cdi*/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="rest">
+                    <includes>
+                        <include>microprofile/tests/tck/tck-rest*/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="others">
+                    <includes>
+                        <include>microprofile/tests/tck/**</include>
+                    </includes>
+                </moduleSet>
+            </moduleSets>
+        </reactorRule>
+        <reactorRule name="default">
+            <moduleSets>
+                <moduleSet name="core">
+                    <includes>
+                        <include>webserver/**</include>
+                        <include>webclient/**</include>
+                        <include>common/**</include>
+                        <include>config/**</include>
+                        <include>security/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="integrations">
+                    <includes>
+                        <include>integrations/**</include>
+                    </includes>
+                </moduleSet>
+                <moduleSet name="others">
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                </moduleSet>
+            </moduleSets>
+        </reactorRule>
+    </reactorRules>
+</cacheConfig>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
+    <extension>
+        <groupId>io.helidon.build-tools</groupId>
+        <artifactId>helidon-build-cache-maven-extension</artifactId>
+        <version>4.0.9</version>
+    </extension>
+</extensions>

--- a/microprofile/tests/tck/pom.xml
+++ b/microprofile/tests/tck/pom.xml
@@ -61,13 +61,4 @@
          -->
         <enforcer.skip>true</enforcer.skip>
     </properties>
-
-    <profiles>
-        <profile>
-            <id>tck-ft</id>
-            <modules>
-                <module>tck-fault-tolerance</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -192,6 +192,11 @@
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${version.plugin.versions}</version>
                 </plugin>
+                <plugin>
+                    <groupId>io.helidon.build-tools</groupId>
+                    <artifactId>helidon-build-cache-maven-plugin</artifactId>
+                    <version>4.0.9</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
         <version.plugin.helidon-build-tools>4.0.9</version.plugin.helidon-build-tools>
         <version.plugin.hibernate-enhance>${version.lib.hibernate}</version.plugin.hibernate-enhance>
+        <version.plugin.install>3.1.2</version.plugin.install>
         <version.plugin.jacoco>0.8.5</version.plugin.jacoco>
         <version.plugin.jandex>3.1.2</version.plugin.jandex>
         <version.plugin.jar>3.3.0</version.plugin.jar>
@@ -562,6 +563,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${version.plugin.install}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-publish-plugin</artifactId>
                     <version>${version.plugin.scm-publish-plugin}</version>
                 </plugin>
@@ -843,6 +849,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>${version.plugin.ant}</version>
                 </plugin>
@@ -1384,8 +1391,10 @@
                         <executions>
                             <execution>
                                 <goals>
-                                    <goal>check</goal>
+                                    <goal>spotbugs</goal>
+                                    <goal>verify</goal>
                                 </goals>
+                                <phase>verify</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -38,6 +38,7 @@
 
     <modules>
         <module>config</module>
+        <module>dbclient</module>
         <module>harness</module>
         <module>health</module>
         <module>jep290</module>
@@ -59,6 +60,7 @@
         <module>mp-graphql</module>
         <module>mp-security-client</module>
         <module>mp-ws-services</module>
+        <module>packaging</module>
         <module>oidc</module>
         <module>restclient</module>
         <module>restclient-connector</module>
@@ -85,19 +87,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <profiles>
-        <profile>
-            <id>dbclient</id>
-            <modules>
-                <module>dbclient</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>packaging</id>
-            <modules>
-                <module>packaging</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
### Description

Parallelized pipelines

- Introduce helidon-build-cache-maven-extension
  * Cache lifecycle to fast-forward downstream jobs
  * Split reactor to parallelize downstream jobs

- Update validate workflow
  * Implement an upstream/downstream pattern where the build is cached and re-used
  * Implement a common action to reduce boilerplate and ensure consistency
  * Archive tests results

- ReactorSet and moduleSets
  * Shape the reactor subset to split and parallelize the jobs
  * Initial configuration targets a job duration between 5 and 20 minutes

Other changes
- Use spotbugs:spotbugs + spotbugs:verify instead of spotbugs:check (to avoid lifecycle duplication)
- Add missing plugin management for maven-install-plugin
- Inline packaging and dbclient profiles under tests/integration/pom.xml

### Documentation

None.
