### PR TITLE
Re-add tck-fault-tolerance module in the reactor

### DIFF
--- a/microprofile/tests/tck/pom.xml
+++ b/microprofile/tests/tck/pom.xml
@@ -52,6 +52,7 @@
         <module>tck-jsonp</module>
         <module>tck-inject</module>
         <module>tck-annotations</module>
+        <module>tck-fault-tolerance</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### Description

`microprofile/tests/tck/tck-fault-tolerance` was previously isolated in a profile.
The profile got removed in #9111 however the module wasn't added back in the default reactor.

### Documentation

None.
