### PR TITLE
Add context propagation to the Zipkin tracing provider

### DIFF
--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryDataPropagationProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryDataPropagationProvider.java
@@ -62,7 +62,7 @@ public class OpenTelemetryDataPropagationProvider
     }
 
     /**
-     * OpenTelementry context.
+     * OpenTelemetry context.
      */
     public static class OpenTelemetryContext {
         private final Span span;

--- a/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingTracerProvider.java
+++ b/tracing/providers/opentracing/src/main/java/io/helidon/tracing/providers/opentracing/OpenTracingTracerProvider.java
@@ -51,11 +51,13 @@ public class OpenTracingTracerProvider implements TracerProvider {
     private LazyValue<Tracer> globalHelidonTracer = LazyValue.create(() -> {
         Config tracingConfig = GlobalConfig.config().get("tracing");
 
-        // The service name is required, so assign a default one that might be overridden by config.
-        io.opentracing.Tracer openTracingTracer = OpenTracingTracerBuilder.create("helidon-open-tracing-service")
-                .config(tracingConfig)
-                .build();
-        GlobalTracer.registerIfAbsent(openTracingTracer);
+        // Set up to create an explicit OpenTracing tracer only if we have config for tracing, indicating that the user wants
+        // something other than the no-op implementation.
+        if (tracingConfig.exists()) {
+            io.opentracing.Tracer openTracingTracer = OpenTracingTracerBuilder.create(tracingConfig)
+                    .build();
+            GlobalTracer.registerIfAbsent(openTracingTracer);
+        }
         return OpenTracingTracer.create(GlobalTracer.get());
     });
 

--- a/tracing/providers/zipkin/pom.xml
+++ b/tracing/providers/zipkin/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>brave-opentracing</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
@@ -138,17 +142,33 @@
                 </dependencies>
             </plugin>
             <!--
-                Because the Helidon Zipkin provider does not itself implement the Helidon tracing API (it does so through
-                OpenTracing), exempt this build from a test that requires that.
+               The propagation test expects the global tracer to be enabled. Other tests run with their own explicit config which
+               might have disabled the global tracer, so run the propagation test separately.
             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>io.helidon.tracing.providers.tests.TestTracerAndSpanPropagation.java</exclude>
-                    </excludes>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>io.helidon.tracing.providers.tests.TestTracerAndSpanPropagation.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>zipkin-propagation-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io.helidon.tracing.providers.tests.TestTracerAndSpanPropagation.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tracing/providers/zipkin/src/main/java/io/helidon/tracing/providers/zipkin/ZipkinDataPropagationProvider.java
+++ b/tracing/providers/zipkin/src/main/java/io/helidon/tracing/providers/zipkin/ZipkinDataPropagationProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing.providers.zipkin;
+
+import io.helidon.common.context.Contexts;
+import io.helidon.common.context.spi.DataPropagationProvider;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+
+/**
+ * Data propagation provider for the Helidon Zipkin tracing provider.
+ */
+public class ZipkinDataPropagationProvider implements DataPropagationProvider<ZipkinDataPropagationProvider.ZipkinContext> {
+
+    private static final System.Logger LOGGER = System.getLogger(ZipkinDataPropagationProvider.class.getName());
+
+    @Override
+    public ZipkinContext data() {
+        Tracer tracer = Contexts.context()
+                .flatMap(ctx -> ctx.get(Tracer.class))
+                .orElseGet(GlobalTracer::get);
+        Span span = tracer.activeSpan();
+        return new ZipkinContext(tracer, span);
+    }
+
+    @Override
+    public void propagateData(ZipkinContext data) {
+        if (data != null && data.span != null) {
+            data.scope = data.tracer.activateSpan(data.span);
+        }
+    }
+
+    @Override
+    public void clearData(ZipkinContext data) {
+        if (data != null && data.scope != null) {
+            try {
+                data.scope.close();
+            } catch (Exception e) {
+                LOGGER.log(System.Logger.Level.TRACE, "Cannot close tracing span", e);
+            }
+        }
+    }
+
+    /**
+     * Zipkin-specific propagation context.
+     */
+    public static class ZipkinContext {
+
+        private final Tracer tracer;
+        private final Span span;
+        private Scope scope;
+
+        private ZipkinContext(Tracer tracer, Span span) {
+            this.tracer = tracer;
+            this.span = span;
+        }
+    }
+}

--- a/tracing/providers/zipkin/src/main/java/io/helidon/tracing/providers/zipkin/ZipkinDataPropagationProvider.java
+++ b/tracing/providers/zipkin/src/main/java/io/helidon/tracing/providers/zipkin/ZipkinDataPropagationProvider.java
@@ -30,6 +30,12 @@ public class ZipkinDataPropagationProvider implements DataPropagationProvider<Zi
 
     private static final System.Logger LOGGER = System.getLogger(ZipkinDataPropagationProvider.class.getName());
 
+    /**
+     * Creates new provider; public for service loading.
+     */
+    public ZipkinDataPropagationProvider() {
+    }
+
     @Override
     public ZipkinContext data() {
         Tracer tracer = Contexts.context()
@@ -60,7 +66,7 @@ public class ZipkinDataPropagationProvider implements DataPropagationProvider<Zi
     /**
      * Zipkin-specific propagation context.
      */
-    public static class ZipkinContext {
+    static class ZipkinContext {
 
         private final Tracer tracer;
         private final Span span;

--- a/tracing/providers/zipkin/src/main/java/io/helidon/tracing/providers/zipkin/ZipkinTracerProvider.java
+++ b/tracing/providers/zipkin/src/main/java/io/helidon/tracing/providers/zipkin/ZipkinTracerProvider.java
@@ -48,6 +48,12 @@ public class ZipkinTracerProvider implements OpenTracingProvider {
     private static final List<String> TRACING_CONTEXT_PROPAGATION_HEADERS =
             List.of(X_OT_SPAN_CONTEXT, X_B3_TRACE_ID, X_B3_SPAN_ID, X_B3_PARENT_SPAN_ID, X_B3_SAMPLED, X_B3_FLAGS);
 
+    /**
+     * Public constructor for service loading.
+     */
+    public ZipkinTracerProvider() {
+    }
+
     @Override
     public ZipkinTracerBuilder createBuilder() {
         return ZipkinTracerBuilder.create();

--- a/tracing/providers/zipkin/src/main/java/module-info.java
+++ b/tracing/providers/zipkin/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module io.helidon.tracing.providers.zipkin {
     requires brave.opentracing;
     requires brave;
     requires io.helidon.common;
+    requires io.helidon.common.context;
     requires io.helidon.tracing.providers.opentracing;
     requires io.opentracing.noop;
     requires io.opentracing.util;
@@ -51,4 +52,6 @@ module io.helidon.tracing.providers.zipkin {
     provides io.helidon.tracing.providers.opentracing.spi.OpenTracingProvider
             with io.helidon.tracing.providers.zipkin.ZipkinTracerProvider;
 
+    provides io.helidon.common.context.spi.DataPropagationProvider
+            with io.helidon.tracing.providers.zipkin.ZipkinDataPropagationProvider;
 }

--- a/tracing/providers/zipkin/src/test/resources/application.yaml
+++ b/tracing/providers/zipkin/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,4 +45,5 @@ tracing:
     int-tags:
       tag5: 145
       tag6: 741
-
+  # With changes to OpenTracing global tracer handling, provide a service name for the Zipkin implementation to use.
+  service: "helidon-test-service"


### PR DESCRIPTION
### Description
Resolves #8848 for Zipkin.

Changes:
1. Add a context propagator implementation for Zipkin. This permits Helidon to propagate Zipkin trace information across threads within a Helidon server. (That's distinct from trace propagation via HTTP headers which is handled in other code and already worked prior to this PR.)
2. Correct the handling of the global tracer in the Helidon OpenTracing provider component. 
   
   Our Zipkin tracing provider component relies to some extent on our OpenTracing provider types. If a user includes the Zipkin tracing provider then OpenTracing comes along and our Zipkin implementation uses OpenTracing.
   
   Previously, invoking `OpenTracingTracerProvider#global()` would return a new Helidon `Tracer` instance every time. Those instances would all wrap the single OpenTracing global tracer (whatever it is), but that's inefficient and caused failures in an existing propagation test in the `provider-tests` component. That test had been excluded for Zipkin because of the prior lack of propagation support. 
   
   This PR changes two aspects of the global tracer handling in OpenTracing:
   1. Use `LazyValue` for the Helidon global tracer maintained by our OpenTracing provider so we reuse it appropriately rather than creating a new one on each invocation of `global()`.
   2. Both in the `LazyValue` factory lambda and in the `OpenTracingTracerProvider#global(Tracer)` method not only set or update the Helidon global tracer lazy value but also manage OpenTracing's similar mechanism. OpenTracing lets us supply  code we want OpenTracing to run to create the OpenTracing global tracer. By specifying our code for this work we make sure our global Helidon tracer and the delegate global tracer in OpenTracing are in step.
3. Remove the exclusion in the Zipkin provider `pom.xml` of the common context propagation test. The pom does now  invoke it in a separate surefire execution to make sure the test has a functioning global tracer undisturbed by other tests.
4. (Otherwise untouched for this enhancement) Add public constructor to `ZipkinTracerProvider` to clear the Javadoc warning.
### Documentation
Bug fix. Our tracing documentation does not discuss context propagation across threads within a server, so this PR has no doc impact.