### PR TITLE
4.x: Mapper manager cache key fix

### DIFF
--- a/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MapperManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,14 @@ final class MapperManagerImpl implements MapperManager {
         return Optional.of(mapper);
     }
 
+    int classCacheSize() {
+        return classCache.size();
+    }
+
+    int typeCacheSize() {
+        return typeCache.size();
+    }
+
     @SuppressWarnings("unchecked")
     private static <SOURCE, TARGET> Mapper<SOURCE, TARGET> notFoundMapper(GenericType<SOURCE> sourceType,
                                                                           GenericType<TARGET> targetType,
@@ -99,7 +107,7 @@ final class MapperManagerImpl implements MapperManager {
                                                                Class<TARGET> targetType,
                                                                boolean fromTypes,
                                                                String... qualifiers) {
-        Mapper<?, ?> mapper = classCache.computeIfAbsent(new ClassCacheKey(sourceType, targetType, qualifiers), key -> {
+        Mapper<?, ?> mapper = classCache.computeIfAbsent(new ClassCacheKey(sourceType, targetType, List.of(qualifiers)), key -> {
             // first attempt to find by classes
             return fromProviders(sourceType, targetType, qualifiers)
                     .orElseGet(() -> {
@@ -119,7 +127,7 @@ final class MapperManagerImpl implements MapperManager {
                                                                GenericType<TARGET> targetType,
                                                                boolean fromClasses,
                                                                String... qualifiers) {
-        Mapper<?, ?> mapper = typeCache.computeIfAbsent(new GenericCacheKey(sourceType, targetType, qualifiers), key -> {
+        Mapper<?, ?> mapper = typeCache.computeIfAbsent(new GenericCacheKey(sourceType, targetType, List.of(qualifiers)), key -> {
             // first attempt to find by types
             return fromProviders(sourceType, targetType, qualifiers)
                     .orElseGet(() -> {
@@ -199,10 +207,10 @@ final class MapperManagerImpl implements MapperManager {
                              qualifiers);
     }
 
-    private record GenericCacheKey(GenericType<?> sourceType, GenericType<?> targetType, String... qualifiers) {
+    private record GenericCacheKey(GenericType<?> sourceType, GenericType<?> targetType, List<String> qualifiers) {
     }
 
-    private record ClassCacheKey(Class<?> sourceType, Class<?> targetType, String... qualifiers) {
+    private record ClassCacheKey(Class<?> sourceType, Class<?> targetType, List<String> qualifiers) {
     }
 
     @SuppressWarnings("rawtypes")

--- a/common/mapper/src/test/java/io/helidon/common/mapper/MapperManagerTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/MapperManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -242,5 +242,35 @@ class MapperManagerTest {
         assertThat(doubleValue.isEmpty(), is(true));
 
         assertThrows(MapperException.class, () -> doubleValue.as(Integer.class));
+    }
+
+    @Test
+    void testCacheWorks() {
+        MapperManagerImpl mm = new MapperManagerImpl(MapperManager.builder()
+                                                             .addMapperProvider(new TestProvider()));
+        assertThat(mm.classCacheSize(), is(0));
+        assertThat(mm.typeCacheSize(), is(0));
+
+        mm.map("value", String.class, String.class, "value");
+        mm.map("value", String.class, String.class, "value");
+        mm.map("value", String.class, String.class, "value");
+        assertThat(mm.classCacheSize(), is(1));
+
+        mm.map("value", GenericType.STRING, GenericType.STRING, "value");
+        mm.map("value", GenericType.STRING, GenericType.STRING, "value");
+        mm.map("value", GenericType.STRING, GenericType.STRING, "value");
+        assertThat(mm.typeCacheSize(), is(1));
+    }
+
+    private static class TestProvider implements MapperProvider {
+        @Override
+        public ProviderResponse mapper(Class<?> sourceClass, Class<?> targetClass, String qualifier) {
+            return new ProviderResponse(Support.SUPPORTED, req -> req);
+        }
+
+        @Override
+        public ProviderResponse mapper(GenericType<?> sourceType, GenericType<?> targetType, String qualifier) {
+            return MapperProvider.super.mapper(sourceType, targetType, qualifier);
+        }
     }
 }


### PR DESCRIPTION
Resolves #9113 

Fix cache key. It was using array, which does not have a good equals method. Replaced with List.
