### PR TITLE
4.x: JPA testing-related improvements

### DIFF
--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -111,6 +111,11 @@
             <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
@@ -146,6 +151,12 @@
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
         </dependency>
 
         <!-- Test-scoped dependencies. -->

--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -153,8 +153,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-mp</artifactId>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -102,6 +102,8 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import static jakarta.interceptor.Interceptor.Priority.LIBRARY_AFTER;
 import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
@@ -316,7 +318,10 @@ public class JpaExtension implements Extension {
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.entering(cn, mn);
         }
-        this.enabled = Boolean.parseBoolean(System.getProperty(this.getClass().getName() + ".enabled", "false"));
+        this.enabled =
+            Boolean.parseBoolean(ConfigProvider.getConfig()
+                                 .getOptionalValue(this.getClass().getName() + ".enabled", String.class)
+                                 .orElse("false"));
         if (LOGGER.isLoggable(Level.FINE) && !this.enabled) {
             LOGGER.logp(Level.FINE, cn, mn, "jpaExtensionDisabled", this.getClass().getName());
         }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -101,7 +101,6 @@ import jakarta.persistence.spi.PersistenceUnitInfo;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
-
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import static jakarta.interceptor.Interceptor.Priority.LIBRARY_AFTER;

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
@@ -34,6 +34,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -74,7 +75,6 @@ import jakarta.enterprise.inject.spi.Annotated;
 import jakarta.enterprise.inject.spi.AnnotatedCallable;
 import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanAttributes;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
@@ -107,13 +107,18 @@ import jakarta.persistence.spi.PersistenceUnitInfo;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.Config;
 
 import static jakarta.interceptor.Interceptor.Priority.LIBRARY_AFTER;
 import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 import static jakarta.persistence.PersistenceContextType.EXTENDED;
 import static jakarta.persistence.SynchronizationType.SYNCHRONIZED;
 import static jakarta.persistence.SynchronizationType.UNSYNCHRONIZED;
+import static java.util.Spliterator.DISTINCT;
+import static java.util.Spliterator.IMMUTABLE;
+import static java.util.Spliterator.NONNULL;
+import static java.util.stream.StreamSupport.stream;
+import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 
 /**
  * An {@link Extension} that integrates <em>container-mode</em> <a
@@ -128,13 +133,6 @@ public final class PersistenceExtension implements Extension {
      * Static fields.
      */
 
-
-    private static final TypeLiteral<Bean<EntityManagerFactory>> BEAN_ENTITYMANAGERFACTORY_TYPELITERAL = new TypeLiteral<>() {};
-
-    private static final TypeLiteral<Bean<JtaExtendedEntityManager>> BEAN_JTAEXTENDEDENTITYMANAGER_TYPELITERAL =
-        new TypeLiteral<>() {};
-
-    private static final TypeLiteral<Bean<JtaEntityManager>> BEAN_JTAENTITYMANAGER_TYPELITERAL = new TypeLiteral<>() {};
 
     /**
      * The name used to designate the only persistence unit in the environment, when there is exactly one persistence
@@ -272,7 +270,7 @@ public final class PersistenceExtension implements Extension {
     public PersistenceExtension() {
         super();
         this.enabled =
-            Boolean.parseBoolean(ConfigProvider.getConfig()
+            Boolean.parseBoolean(getConfig()
                                  .getOptionalValue(this.getClass().getName() + ".enabled", String.class)
                                  .orElse("true"));
         this.containerManagedEntityManagerQualifiers = new HashSet<>();
@@ -591,7 +589,7 @@ public final class PersistenceExtension implements Extension {
         // Next, and most commonly, load all META-INF/persistence.xml resources with JAXB, and turn them into
         // PersistenceUnitInfo instances, and add beans for all of them as well as their associated PersistenceProviders
         // (if applicable).
-        String persistenceXmlResourceName = ConfigProvider.getConfig()
+        String persistenceXmlResourceName = getConfig()
             .getOptionalValue("jakarta.persistence.descriptor.resource.name", String.class)
             .orElse("META-INF/persistence.xml");
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -1297,7 +1295,7 @@ public final class PersistenceExtension implements Extension {
                 .addTransitiveTypeClosure(EntityManagerFactory.class)
                 .scope(Singleton.class)
                 .qualifiers(qualifiers)
-                .produceWith(PersistenceExtension::produceEntityManagerFactory)
+                .produceWith(i -> produceEntityManagerFactory(i, qualifiers))
                 .disposeWith(PersistenceExtension::disposeEntityManagerFactory);
         }
     }
@@ -1324,8 +1322,8 @@ public final class PersistenceExtension implements Extension {
             .addTransitiveTypeClosure(JtaExtendedEntityManager.class)
             .scope(Dependent.class) // critical: must be Dependent scope
             .qualifiers(qualifiers)
-            .produceWith(PersistenceExtension::produceJtaExtendedEntityManager)
-            .disposeWith(PersistenceExtension::disposeJtaExtendedEntityManager);
+            .produceWith(i -> produceJtaExtendedEntityManager(i, qualifiers))
+            .disposeWith((em, i) -> disposeJtaExtendedEntityManager(em, i, qualifiers));
     }
 
     private void addJtaTransactionScopedEntityManagerBeans(AfterBeanDiscovery event, Set<Annotation> suppliedQualifiers) {
@@ -1350,8 +1348,8 @@ public final class PersistenceExtension implements Extension {
             .addTransitiveTypeClosure(JtaEntityManager.class)
             .scope(Dependent.class) // critical: must be Dependent scope
             .qualifiers(qualifiers)
-            .produceWith(PersistenceExtension::produceJtaEntityManager)
-            .disposeWith(PersistenceExtension::disposeJtaEntityManager);
+            .produceWith(i -> produceJtaEntityManager(i, qualifiers))
+            .disposeWith((em, i) -> disposeJtaEntityManager(em, i, qualifiers));
     }
 
 
@@ -1360,17 +1358,15 @@ public final class PersistenceExtension implements Extension {
      */
 
 
-    private static JtaExtendedEntityManager produceJtaExtendedEntityManager(Instance<Object> instance) {
-        BeanAttributes<?> ba = instance.select(BEAN_JTAEXTENDEDENTITYMANAGER_TYPELITERAL).get();
+    private static JtaExtendedEntityManager produceJtaExtendedEntityManager(Instance<Object> instance,
+                                                                            Set<? extends Annotation> beanQualifiers) {
         Set<Annotation> containerManagedSelectionQualifiers = new HashSet<>();
         containerManagedSelectionQualifiers.add(ContainerManaged.Literal.INSTANCE);
         Set<Annotation> selectionQualifiers = new HashSet<>();
         SynchronizationType syncType = null;
         Map<String, String> properties = new HashMap<>();
-        for (Annotation beanQualifier : ba.getQualifiers()) {
-            if (beanQualifier == Any.Literal.INSTANCE) {
-                continue;
-            } else if (beanQualifier == Unsynchronized.Literal.INSTANCE) {
+        for (Annotation beanQualifier : beanQualifiers) {
+            if (beanQualifier == Unsynchronized.Literal.INSTANCE) {
                 if (syncType == null) {
                     syncType = UNSYNCHRONIZED;
                 }
@@ -1386,12 +1382,19 @@ public final class PersistenceExtension implements Extension {
             }
         }
         SynchronizationType finalSyncType = syncType == null ? SYNCHRONIZED : syncType;
+        Config config = getOrDefault(instance.select(Config.class), selectionQualifiers);
+        Map<String, Object> stackedProperties =
+            new StackedMap<>(List.of(properties.keySet()::stream,
+                                     () -> stream(config.getPropertyNames()::spliterator,
+                                                  DISTINCT | IMMUTABLE | NONNULL,
+                                                  false)),
+                             List.of(properties::get,
+                                     k -> config.getOptionalValue(k, String.class).orElse(null)));
         return instance.select(ReferenceCountingProducer.class)
             .get()
             .produce(() -> {
                     TransactionRegistry tr =
-                        getOrDefault(instance.select(TransactionRegistry.class),
-                                     selectionQualifiers.toArray(EMPTY_ANNOTATION_ARRAY));
+                        getOrDefault(instance.select(TransactionRegistry.class), selectionQualifiers);
                     return
                         new JtaExtendedEntityManager(tr::active,
                                                      tr::get,
@@ -1400,7 +1403,7 @@ public final class PersistenceExtension implements Extension {
                                                                      containerManagedSelectionQualifiers
                                                                      .toArray(EMPTY_ANNOTATION_ARRAY))
                                                      .get()
-                                                     .createEntityManager(finalSyncType, properties),
+                                                     .createEntityManager(finalSyncType, stackedProperties),
                                                      finalSyncType == SYNCHRONIZED);
                 },
                 JtaExtendedEntityManager::dispose,
@@ -1408,9 +1411,11 @@ public final class PersistenceExtension implements Extension {
                 containerManagedSelectionQualifiers);
     }
 
-    private static void disposeJtaExtendedEntityManager(JtaExtendedEntityManager em, Instance<Object> instance) {
+    private static void disposeJtaExtendedEntityManager(JtaExtendedEntityManager em,
+                                                        Instance<Object> instance,
+                                                        Set<? extends Annotation> beanQualifiers) {
         Set<Annotation> containerManagedSelectionQualifiers = new HashSet<>();
-        for (Annotation beanQualifier : instance.select(BEAN_JTAEXTENDEDENTITYMANAGER_TYPELITERAL).get().getQualifiers()) {
+        for (Annotation beanQualifier : beanQualifiers) {
             if (beanQualifier == ContainerManaged.Literal.INSTANCE
                 || beanQualifier != Any.Literal.INSTANCE
                 && !SyntheticJpaQualifiers.INSTANCE.contains(beanQualifier)) {
@@ -1431,24 +1436,20 @@ public final class PersistenceExtension implements Extension {
         return pui;
     }
 
-    private static EntityManagerFactory produceEntityManagerFactory(Instance<Object> instance) {
-        BeanAttributes<?> ba = instance.select(BEAN_ENTITYMANAGERFACTORY_TYPELITERAL).get();
+    private static EntityManagerFactory produceEntityManagerFactory(Instance<Object> instance,
+                                                                    Set<? extends Annotation> beanQualifiers) {
         Set<Annotation> selectionQualifiers = new HashSet<>();
         Set<Annotation> namedSelectionQualifiers = new HashSet<>();
-        for (Annotation beanQualifier: ba.getQualifiers()) {
-            if (beanQualifier == Any.Literal.INSTANCE) {
-                continue;
-            } else if (beanQualifier instanceof Named) {
+        for (Annotation beanQualifier: beanQualifiers) {
+            if (beanQualifier instanceof Named) {
                 namedSelectionQualifiers.add(beanQualifier);
-            } else if (!SyntheticJpaQualifiers.INSTANCE.contains(beanQualifier)) {
+            } else if (beanQualifier != Any.Literal.INSTANCE && !SyntheticJpaQualifiers.INSTANCE.contains(beanQualifier)) {
                 namedSelectionQualifiers.add(beanQualifier);
                 selectionQualifiers.add(beanQualifier);
             }
         }
-        PersistenceUnitInfo pui =
-            getOrDefault(instance.select(PersistenceUnitInfo.class), namedSelectionQualifiers);
-        PersistenceProvider pp =
-            getOrDefault(instance.select(PersistenceProvider.class), selectionQualifiers);
+        PersistenceUnitInfo pui = getOrDefault(instance.select(PersistenceUnitInfo.class), namedSelectionQualifiers);
+        PersistenceProvider pp = getOrDefault(instance.select(PersistenceProvider.class), selectionQualifiers);
         Map<String, Object> properties = new HashMap<>(5);
         properties.put("jakarta.persistence.bean.manager", instance.select(BeanManager.class).get());
         try {
@@ -1462,6 +1463,14 @@ public final class PersistenceExtension implements Extension {
         } catch (final ClassNotFoundException classNotFoundException) {
 
         }
+        Config config = getOrDefault(instance.select(Config.class), namedSelectionQualifiers);
+        properties =
+          new StackedMap<>(List.of(properties.keySet()::stream,
+                                   () -> stream(config.getPropertyNames()::spliterator,
+                                                DISTINCT | IMMUTABLE | NONNULL,
+                                                false)),
+                           List.of(properties::get,
+                                   k -> config.getOptionalValue(k, String.class).orElse(null)));
         return pp.createContainerEntityManagerFactory(pui, properties);
     }
 
@@ -1469,16 +1478,15 @@ public final class PersistenceExtension implements Extension {
         emf.close();
     }
 
-    private static JtaEntityManager produceJtaEntityManager(Instance<Object> instance) {
+    private static JtaEntityManager produceJtaEntityManager(Instance<Object> instance,
+                                                            Set<? extends Annotation> beanQualifiers) {
         Set<Annotation> containerManagedSelectionQualifiers = new HashSet<>();
         containerManagedSelectionQualifiers.add(ContainerManaged.Literal.INSTANCE);
         Set<Annotation> selectionQualifiers = new HashSet<>();
         SynchronizationType syncType = null;
         Map<String, String> properties = new HashMap<>();
-        for (Annotation beanQualifier : instance.select(BEAN_JTAENTITYMANAGER_TYPELITERAL).get().getQualifiers()) {
-            if (beanQualifier == Any.Literal.INSTANCE) {
-                continue;
-            } else if (beanQualifier == Unsynchronized.Literal.INSTANCE) {
+        for (Annotation beanQualifier : beanQualifiers) {
+            if (beanQualifier == Unsynchronized.Literal.INSTANCE) {
                 if (syncType == null) {
                     syncType = UNSYNCHRONIZED;
                 }
@@ -1488,12 +1496,20 @@ public final class PersistenceExtension implements Extension {
                     containerManagedSelectionQualifiers.add(pp);
                     properties.put(ppName, pp.value());
                 }
-            } else if (!SyntheticJpaQualifiers.INSTANCE.contains(beanQualifier)) {
+            } else if (beanQualifier != Any.Literal.INSTANCE && !SyntheticJpaQualifiers.INSTANCE.contains(beanQualifier)) {
                 containerManagedSelectionQualifiers.add(beanQualifier);
                 selectionQualifiers.add(beanQualifier);
             }
         }
         SynchronizationType finalSyncType = syncType == null ? SYNCHRONIZED : syncType;
+        Config config = getOrDefault(instance.select(Config.class), selectionQualifiers);
+        Map<String, Object> stackedProperties =
+            new StackedMap<>(List.of(properties.keySet()::stream,
+                                     () -> stream(config.getPropertyNames()::spliterator,
+                                                  DISTINCT | IMMUTABLE | NONNULL,
+                                                  false)),
+                             List.of(properties::get,
+                                     k -> config.getOptionalValue(k, String.class).orElse(null)));
         return instance.select(ReferenceCountingProducer.class)
             .get()
             .produce(() -> {
@@ -1507,19 +1523,20 @@ public final class PersistenceExtension implements Extension {
                                                              containerManagedSelectionQualifiers.toArray(EMPTY_ANNOTATION_ARRAY))
                                              .get()::createEntityManager,
                                              finalSyncType,
-                                             properties);
+                                             stackedProperties);
                 },
                 JtaEntityManager::dispose,
                 JtaEntityManager.class,
                 containerManagedSelectionQualifiers);
     }
 
-    private static void disposeJtaEntityManager(JtaEntityManager em, Instance<Object> instance) {
+    private static void disposeJtaEntityManager(JtaEntityManager em,
+                                                Instance<Object> instance,
+                                                Set<? extends Annotation> beanQualifiers) {
         Set<Annotation> containerManagedSelectionQualifiers = new HashSet<>();
-        for (Annotation beanQualifier : instance.select(BEAN_JTAENTITYMANAGER_TYPELITERAL).get().getQualifiers()) {
+        for (Annotation beanQualifier : beanQualifiers) {
             if (beanQualifier == ContainerManaged.Literal.INSTANCE
-                || beanQualifier != Any.Literal.INSTANCE
-                && !SyntheticJpaQualifiers.INSTANCE.contains(beanQualifier)) {
+                || beanQualifier != Any.Literal.INSTANCE && !SyntheticJpaQualifiers.INSTANCE.contains(beanQualifier)) {
                 containerManagedSelectionQualifiers.add(beanQualifier);
             }
         }

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/PersistenceExtension.java
@@ -107,7 +107,6 @@ import jakarta.persistence.spi.PersistenceUnitInfo;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
-
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import static jakarta.interceptor.Interceptor.Priority.LIBRARY_AFTER;

--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/StackedMap.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/StackedMap.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.cdi.jpa;
+
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static java.util.stream.StreamSupport.stream;
+
+final class StackedMap<K, V> extends AbstractMap<K, V> {
+
+
+    /*
+     * Instance fields.
+     */
+
+
+    private final Supplier<? extends Set<? extends K>> ks;
+
+    private final Function<? super K, ? extends V> vf;
+
+
+    /*
+     * Constructors.
+     */
+
+
+    StackedMap(Iterable<? extends Supplier<? extends Stream<? extends K>>> kss,
+               Iterable<? extends Function<? super K, ? extends V>> vfs) {
+        this(union(kss), vf(vfs));
+    }
+
+    StackedMap(Supplier<Set<? extends K>> ks, Function<? super K, ? extends V> vf) {
+        super();
+        this.ks = Objects.requireNonNull(ks, "ks");
+        this.vf = Objects.requireNonNull(vf, "vf");
+    }
+
+
+    /*
+     * Instance methods.
+     */
+
+
+    @Override // AbstractMap<K, V>
+    public Set<Entry<K, V>> entrySet() {
+        return new EntrySet();
+    }
+
+
+    /*
+     * Static methods.
+     */
+
+
+    private static <K> Supplier<Set<? extends K>> union(Iterable<? extends Supplier<? extends Stream<? extends K>>> i) {
+        Objects.requireNonNull(i, "i");
+        return () -> stream(i.spliterator(), false)
+            .flatMap(Supplier::get)
+            .collect(toUnmodifiableSet());
+    }
+
+    private static <K, V> Function<? super K, ? extends V> vf(Iterable<? extends Function<? super K, ? extends V>> vfs) {
+        Objects.requireNonNull(vfs, "vfs");
+        return k -> stream(vfs.spliterator(), false)
+            .flatMap(vf -> Optional.ofNullable(vf.apply(k)).stream())
+            .findFirst()
+            .orElse(null);
+    }
+
+
+    /*
+     * Inner and nested classes.
+     */
+
+
+    private final class EntrySet extends AbstractSet<Entry<K, V>> {
+
+
+        /*
+         * Constructors.
+         */
+
+
+        private EntrySet() {
+            super();
+        }
+
+
+        /*
+         * Instance methods.
+         */
+
+
+        @Override // AbstractSet<Entry<K, V>>
+        public int size() {
+            return ks.get().size();
+        }
+
+        @Override // AbstractSet<Entry<K, V>>
+        public Iterator<Entry<K, V>> iterator() {
+            return new I();
+        }
+
+
+        /*
+         * Inner and nested classes.
+         */
+
+
+        private final class I implements Iterator<Entry<K, V>> {
+
+
+            /*
+             * Instance fields.
+             */
+
+
+            private final Iterator<? extends K> ki;
+
+
+            /*
+             * Constructors.
+             */
+
+
+            private I() {
+                super();
+                this.ki = ks.get().iterator();
+            }
+
+
+            /*
+             * Instance methods.
+             */
+
+
+            @Override // Iterator<Entry<K, V>>
+            public boolean hasNext() {
+                return this.ki.hasNext();
+            }
+
+            @Override // Iterator<Entry<K, V>>
+            public Entry<K, V> next() {
+                K k = this.ki.next();
+                return new SimpleImmutableEntry<>(k, vf.apply(k));
+            }
+
+        }
+
+    }
+
+}

--- a/integrations/cdi/jpa-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,13 +28,13 @@ import io.helidon.common.features.api.HelidonFlavor;
  * @see io.helidon.integrations.cdi.jpa.PersistenceUnitInfoBean
  */
 @Feature(value = "JPA",
-        description = "Jakarta persistence API support for Helidon MP",
-        in = HelidonFlavor.MP,
-        path = "JPA"
+         description = "Jakarta persistence API support for Helidon MP",
+         in = HelidonFlavor.MP,
+         path = "JPA"
 )
-@SuppressWarnings({ "deprecation", "requires-automatic"})
+@SuppressWarnings({ "deprecation", "requires-automatic" })
 module io.helidon.integrations.cdi.jpa {
-  
+
     requires jakarta.xml.bind;
 
     requires jakarta.inject; // automatic module
@@ -47,8 +47,8 @@ module io.helidon.integrations.cdi.jpa {
     requires transitive jakarta.persistence; // automatic module
     requires transitive java.sql;
 
-    // JTA is optional at runtime, as well as the modules that support
-    // it.
+    requires microprofile.config.api;
+
     requires static io.helidon.common.features.api;
 
     // Static metamodel generation requires access to java.compiler at

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAlternatePersistenceXmlLocation.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestAlternatePersistenceXmlLocation.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.cdi.jpa;
+
+import jakarta.annotation.sql.DataSourceDefinition;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceContext;
+
+import io.helidon.microprofile.config.ConfigCdiExtension;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TestAlternatePersistenceXmlLocation {
+
+    private SeContainer sec;
+
+    private TestAlternatePersistenceXmlLocation() {
+        super();
+    }
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    final void initializeCdiContainer() {
+        System.setProperty(JpaExtension.class.getName() + ".enabled", "false");
+        System.setProperty(PersistenceExtension.class.getName() + ".enabled", "true");
+        System.setProperty("jakarta.persistence.descriptor.resource.name", "META-INF/test-persistence.xml");
+        Class<?> cdiSeJtaPlatformClass;
+        try {
+            // Load it dynamically because Hibernate won't be on the classpath when we're testing with Eclipselink
+            cdiSeJtaPlatformClass =
+                Class.forName("io.helidon.integrations.cdi.hibernate.CDISEJtaPlatform",
+                              false,
+                              Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            cdiSeJtaPlatformClass = null;
+        }
+        SeContainerInitializer i = SeContainerInitializer.newInstance()
+            .disableDiscovery()
+            .addExtensions(PersistenceExtension.class,
+                           ConfigCdiExtension.class,
+                           com.arjuna.ats.jta.cdi.TransactionExtension.class,
+                           io.helidon.integrations.datasource.hikaricp.cdi.HikariCPBackedDataSourceExtension.class)
+            .addBeanClasses(Frobnicator.class);
+        if (cdiSeJtaPlatformClass != null) {
+            i = i.addBeanClasses(cdiSeJtaPlatformClass);
+        }
+        this.sec = i.initialize();
+    }
+
+    @AfterEach
+    final void closeCdiContainer() {
+        if (this.sec != null) {
+            this.sec.close();
+        }
+        System.setProperty(PersistenceExtension.class.getName() + ".enabled", "false");
+        System.setProperty(JpaExtension.class.getName() + ".enabled", "true");
+        System.clearProperty("jakarta.persistence.descriptor.resource.name");
+    }
+
+    @Test
+    final void testAlternatePersistenceXmlLocation() {
+        Instance<Frobnicator> fi = sec.select(Frobnicator.class);
+        Frobnicator f = fi.get();
+        assertThat(f.em.isOpen(), is(true));
+        fi.destroy(f);
+    }
+
+    @DataSourceDefinition(
+        name = "test",
+        className = "org.h2.jdbcx.JdbcDataSource",
+        url = "jdbc:h2:mem:TestAlternatePersistenceXmlLocation",
+        serverName = "",
+        properties = {
+            "user=sa"
+        }
+    )
+    @Dependent
+    private static class Frobnicator {
+
+        @PersistenceContext(unitName = "test-alternate")
+        private EntityManager em;
+
+        @Inject
+        Frobnicator() {
+            super();
+        }
+
+    }
+
+}

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestPersistenceExtension.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/TestPersistenceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package io.helidon.integrations.cdi.jpa;
 
+import java.util.Map;
+
 import jakarta.annotation.sql.DataSourceDefinition;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
@@ -24,22 +26,29 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PersistenceUnit;
 
+import io.helidon.microprofile.config.ConfigCdiExtension;
+
+import org.eclipse.microprofile.config.Config;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class TestPersistenceExtension {
 
     private SeContainer sec;
+
+    private boolean hibernate;
 
     private TestPersistenceExtension() {
         super();
@@ -60,9 +69,11 @@ class TestPersistenceExtension {
         } catch (ClassNotFoundException e) {
             cdiSeJtaPlatformClass = null;
         }
+        this.hibernate = cdiSeJtaPlatformClass != null;
         SeContainerInitializer i = SeContainerInitializer.newInstance()
             .disableDiscovery()
             .addExtensions(PersistenceExtension.class,
+                           ConfigCdiExtension.class,
                            com.arjuna.ats.jta.cdi.TransactionExtension.class,
                            io.helidon.integrations.datasource.hikaricp.cdi.HikariCPBackedDataSourceExtension.class)
             .addBeanClasses(Caturgiator.class,
@@ -82,13 +93,44 @@ class TestPersistenceExtension {
         System.setProperty(JpaExtension.class.getName() + ".enabled", "true");
     }
 
-    // @Disabled
     @Test
     final void testSpike() {
         Instance<Frobnicator> fi = sec.select(Frobnicator.class);
         Frobnicator f = fi.get();
+
         assertThat(f.em.isOpen(), is(true));
         assertThat(f.em, instanceOf(JtaEntityManager.class));
+        Map<?, ?> properties = f.em.getProperties();
+        assertThat(properties.containsKey("java.vendor.url"), is(true)); // proves MicroProfile Config integration works
+        // This is kind of odd. Eclipselink implements EntityManager#getProperties() such that the returned map has
+        // all discoverable properties: those from the persistence unit, and of course any explicitly specified by
+        // the user. Hibernate does not: properties starting with "eclipselink.", as an arbitrary example, are not
+        // present.
+        assertThat(properties.get("eclipselink.jdbc.native-sql"), this.hibernate ? nullValue() : is("true"));
+
+        assertThat(f.emf.isOpen(), is(true));
+        properties = f.emf.getProperties();
+        assertThat(properties.containsKey("java.vendor.url"), is(true)); // (proves that MicroProfile Config works)
+        // Note that this assertion also means that Hibernate's strange properties behavior above does not apply to the
+        // equivalent scenario involving EntityManagerFactory instances (for no particular reason?).
+        assertThat(properties.get("eclipselink.jdbc.native-sql"), is("true"));
+
+        // (Setting system properties to a different value does not change anything, because the persistence unit
+        // properties in META-INF/persistence.xml overrule any other sources.)
+        String old = System.setProperty("eclipselink.jdbc.native-sql", "false");
+        try {
+            assertThat(properties.get("eclipselink.jdbc.native-sql"), is("true"));
+            // (Note that Helidon's MicroProfile Config implementation reflects the change.)
+            assertThat(sec.select(Config.class).get()
+                       .getOptionalValue("eclipselink.jdbc.native-sql", String.class).orElse(null),
+                       is("false"));
+        } finally {
+            if (old == null) {
+                System.clearProperty("eclipselink.jdbc.native-sql");
+            } else {
+                System.setProperty("eclipselink.jdbc.native-sql", old);
+            }
+        }
 
         Instance<Caturgiator> ci = sec.select(Caturgiator.class);
         Caturgiator c = ci.get();
@@ -110,6 +152,9 @@ class TestPersistenceExtension {
     )
     @Dependent
     private static class Frobnicator {
+
+        @PersistenceUnit(unitName = "test")
+        private EntityManagerFactory emf;
 
         @PersistenceContext(unitName = "test")
         private EntityManager em;

--- a/integrations/cdi/jpa-cdi/src/test/resources/META-INF/test-persistence.xml
+++ b/integrations/cdi/jpa-cdi/src/test/resources/META-INF/test-persistence.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+                                 https://jakarta.ee/xml/ns/persistence/persistence_3_1.xsd"
+             version="3.1">
+
+    <persistence-unit name="test-alternate" transaction-type="JTA">
+        <description>A persistence unit for use by the unit test that tests an alternate descriptor location.</description>
+        <jta-data-source>test</jta-data-source>
+        <properties>
+            <property name="eclipselink.deploy-on-startup" value="true"/>
+            <property name="eclipselink.jdbc.native-sql" value="true"/>
+            <property name="eclipselink.logging.logger" value="JavaLogger"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="eclipselink.target-database" value="org.eclipse.persistence.platform.database.H2Platform"/>
+            <property name="eclipselink.target-server" value="io.helidon.integrations.cdi.eclipselink.CDISEPlatform"/>
+            <property name="eclipselink.weaving" value="false"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>


### PR DESCRIPTION
This PR introduces MicroProfile Config as a dependency of the JPA CDI integration and uses it to blend MicroProfile Config properties with persistence unit properties. It also allows a user to specify an alternate location for a JPA descriptor, which can be useful in unit testing scenarios.

May close and/or address #7552. 