### PR TITLE
Do not automatically trigger assign-issue-to-project workflow

### DIFF
--- a/.github/workflows/assign-issue-to-project.yml
+++ b/.github/workflows/assign-issue-to-project.yml
@@ -1,11 +1,12 @@
 name: Assign Issue to Project
 
 on:
-  issues:
-    types: [opened, reopened]
-env:
-  GITHUB_API_KEY: ${{ secrets.GITHUB_TOKEN }}
-
+  workflow_dispatch:
+#  issues:
+#    types: [opened, reopened]
+#env:
+#  GITHUB_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+#
 
 jobs:
   Assign-Issue-To-Backlog:


### PR DESCRIPTION
This workflow is currently broken due to the migration of projects to new boards.

We disable it until we fix it or replace it using one of the built-in workflows.