### PR TITLE
4.x: Handling enum and type values in a consistent way in code generation.

### DIFF
--- a/builder/tests/common-types/src/main/java/io/helidon/common/types/AnnotationSupport.java
+++ b/builder/tests/common-types/src/main/java/io/helidon/common/types/AnnotationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -663,6 +663,15 @@ final class AnnotationSupport {
         }
         if (value instanceof String str) {
             return Enum.valueOf(type, str);
+        }
+        if (value instanceof EnumValue enumValue) {
+            if (enumValue.type().equals(TypeName.create(type))) {
+                return Enum.valueOf(type, enumValue.name());
+            }
+
+            throw new IllegalStateException("Property " + property + " is of enum type for enum "
+                                                    + enumValue.type().fqName() + ", yet you requested "
+                                                    + type.getName());
         }
 
         throw new IllegalArgumentException(typeName.fqName() + " property " + property

--- a/builder/tests/common-types/src/main/java/io/helidon/common/types/EnumValue.java
+++ b/builder/tests/common-types/src/main/java/io/helidon/common/types/EnumValue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.types;
+
+/**
+ * When creating an {@link io.helidon.common.types.Annotation}, we may need to create an enum value
+ * without access to the enumeration.
+ * <p>
+ * In such a case, you can use this type when calling {@link io.helidon.common.types.Annotation.Builder#putValue(String, Object)}
+ */
+public interface EnumValue {
+    /**
+     * Create a new enum value, when the enum is not available on classpath.
+     *
+     * @param enumType type of the enumeration
+     * @param enumName value of the enumeration
+     * @return enum value
+     */
+    static EnumValue create(TypeName enumType, String enumName) {
+        return new EnumValue() {
+            @Override
+            public TypeName type() {
+                return enumType;
+            }
+
+            @Override
+            public String name() {
+                return enumName;
+            }
+        };
+    }
+
+    /**
+     * Type of the enumeration.
+     *
+     * @return type name of the enumeration
+     */
+    TypeName type();
+
+    /**
+     * The enum value.
+     *
+     * @return enum value
+     */
+    String name();
+}

--- a/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanAnnotationFactory.java
+++ b/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanAnnotationFactory.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.helidon.common.types.Annotation;
+import io.helidon.common.types.EnumValue;
 import io.helidon.common.types.TypeName;
 
 import io.github.classgraph.AnnotationClassRef;
@@ -85,15 +86,12 @@ final class ScanAnnotationFactory {
             return result;
         }
 
-        if (scanAnnotationValue instanceof AnnotationEnumValue anEnum) {
-            return anEnum.getValueName();
-        } else if (scanAnnotationValue instanceof AnnotationClassRef aClass) {
-            return TypeName.create(aClass.getName());
-        } else if (scanAnnotationValue instanceof AnnotationInfo annotation) {
-            return createAnnotation(ctx, annotation);
-        }
+        return switch (scanAnnotationValue) {
+            case AnnotationEnumValue anEnum -> EnumValue.create(TypeName.create(anEnum.getClassName()), anEnum.getValueName());
+            case AnnotationClassRef aClass -> TypeName.create(aClass.getName());
+            case AnnotationInfo annotation -> createAnnotation(ctx, annotation);
+            default -> scanAnnotationValue;
+        };
 
-        // supported type
-        return scanAnnotationValue;
     }
 }

--- a/common/types/src/main/java/io/helidon/common/types/AnnotationSupport.java
+++ b/common/types/src/main/java/io/helidon/common/types/AnnotationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -532,6 +532,14 @@ final class AnnotationSupport {
             return str;
         }
 
+        if (value instanceof TypeName tn) {
+            return tn.fqName();
+        }
+
+        if (value instanceof EnumValue ev) {
+            return ev.name();
+        }
+
         if (value instanceof List<?>) {
             throw new IllegalArgumentException(typeName.fqName() + " property " + property
                                                        + " is a list, cannot be converted to String");
@@ -619,22 +627,33 @@ final class AnnotationSupport {
         if (value instanceof Class<?> theClass) {
             return theClass;
         }
-        if (value instanceof String str) {
-            try {
-                return Class.forName(str);
-            } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException(typeName.fqName() + " property " + property
-                                                           + " of type String and value \"" + str + "\""
-                                                           + " cannot be converted to Class");
-            }
+
+        String className;
+
+        if (value instanceof TypeName tn) {
+            className = tn.fqName();
+        } else if (value instanceof String str) {
+            className = str;
+        } else {
+
+            throw new IllegalArgumentException(typeName.fqName() + " property " + property
+                                                       + " of type " + value.getClass().getName()
+                                                       + " cannot be converted to Class");
         }
 
-        throw new IllegalArgumentException(typeName.fqName() + " property " + property
-                                                   + " of type " + value.getClass().getName()
-                                                   + " cannot be converted to Class");
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(typeName.fqName() + " property " + property
+                                                       + " of type String and value \"" + className + "\""
+                                                       + " cannot be converted to Class");
+        }
     }
 
     private static TypeName asTypeName(TypeName typeName, String property, Object value) {
+        if (value instanceof TypeName tn) {
+            return tn;
+        }
         if (value instanceof Class<?> theClass) {
             return TypeName.create(theClass);
         }
@@ -663,6 +682,15 @@ final class AnnotationSupport {
         }
         if (value instanceof String str) {
             return Enum.valueOf(type, str);
+        }
+        if (value instanceof EnumValue enumValue) {
+            if (enumValue.type().equals(TypeName.create(type))) {
+                return Enum.valueOf(type, enumValue.name());
+            }
+
+            throw new IllegalStateException("Property " + property + " is of enum type for enum "
+                                                    + enumValue.type().fqName() + ", yet you requested "
+                                                    + type.getName());
         }
 
         throw new IllegalArgumentException(typeName.fqName() + " property " + property

--- a/common/types/src/main/java/io/helidon/common/types/EnumValue.java
+++ b/common/types/src/main/java/io/helidon/common/types/EnumValue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.types;
+
+/**
+ * When creating an {@link io.helidon.common.types.Annotation}, we may need to create an enum value
+ * without access to the enumeration.
+ * <p>
+ * In such a case, you can use this type when calling {@link io.helidon.common.types.Annotation.Builder#putValue(String, Object)}
+ */
+public interface EnumValue {
+    /**
+     * Create a new enum value, when the enum is not available on classpath.
+     *
+     * @param enumType type of the enumeration
+     * @param enumName value of the enumeration
+     * @return enum value
+     */
+    static EnumValue create(TypeName enumType, String enumName) {
+        return new EnumValue() {
+            @Override
+            public TypeName type() {
+                return enumType;
+            }
+
+            @Override
+            public String name() {
+                return enumName;
+            }
+        };
+    }
+
+    /**
+     * Type of the enumeration.
+     *
+     * @return type name of the enumeration
+     */
+    TypeName type();
+
+    /**
+     * The enum value.
+     *
+     * @return enum value
+     */
+    String name();
+}


### PR DESCRIPTION
Related to #9158 

Adds end to end support for enums and type names in annotation processing and code generation, to make sure we keep track of enum type (which was previously lost, and so could not be properly code generated).

Support in classpath scanning will come in a later commit.