### PR TITLE
4.x: Udpates to types and annotation processing

### DIFF
--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptAnnotationFactory.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptAnnotationFactory.java
@@ -17,15 +17,10 @@
 package io.helidon.codegen.apt;
 
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.util.Elements;
 
@@ -35,32 +30,9 @@ import io.helidon.common.types.TypeName;
 /**
  * Factory for annotations.
  */
+@SuppressWarnings("removal")
 final class AptAnnotationFactory {
     private AptAnnotationFactory() {
-    }
-
-    /**
-     * Creates a set of annotations using annotation processor.
-     *
-     * @param annoMirrors the annotation type mirrors
-     * @param elements annotation processing element utils
-     * @return the annotation value set
-     */
-    public static Set<Annotation> createAnnotations(List<? extends AnnotationMirror> annoMirrors, Elements elements) {
-        return annoMirrors.stream()
-                .map(it -> createAnnotation(it, elements))
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    /**
-     * Creates a set of annotations based using annotation processor.
-     *
-     * @param type the enclosing/owing type element
-     * @param elements annotation processing element utils
-     * @return the annotation value set
-     */
-    public static Set<Annotation> createAnnotations(Element type, Elements elements) {
-        return createAnnotations(type.getAnnotationMirrors(), elements);
     }
 
     /**

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptContext.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptContext.java
@@ -16,16 +16,22 @@
 
 package io.helidon.codegen.apt;
 
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.annotation.processing.ProcessingEnvironment;
 
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.Option;
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
 
 /**
  * Annotation processing code generation context.
+ * @deprecated this API will be package local in the future, use through Helidon codegen only
  */
+@Deprecated(forRemoval = true, since = "4.1.0")
 public interface AptContext extends CodegenContext {
     /**
      * Create context from the processing environment, and a set of additional supported options.
@@ -44,4 +50,14 @@ public interface AptContext extends CodegenContext {
      * @return environment
      */
     ProcessingEnvironment aptEnv();
+
+    /**
+     * Get a cached instance of the type info, and if not cached, cache the provided one.
+     * Only type infos known not to be modified during this build are cached.
+     *
+     * @param typeName type name
+     * @param typeInfoSupplier supplier of value if it is not yet cached
+     * @return type info for that name, in case the type info cannot be created, an empty optional
+     */
+    Optional<TypeInfo> cache(TypeName typeName, Supplier<Optional<TypeInfo>> typeInfoSupplier);
 }

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentSupport.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentSupport.java
@@ -84,7 +84,7 @@ final class ContentSupport {
 
         Set<Modifier> modifiers = element.elementModifiers();
         for (Modifier modifier : modifiers) {
-            contentBuilder.addContent(".addModifier(")
+            contentBuilder.addContent(".addElementModifier(")
                     .addContent(MODIFIER)
                     .addContent(".")
                     .addContent(modifier.name())

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Field.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Field.java
@@ -33,12 +33,14 @@ public final class Field extends AnnotatedComponent {
     private final Content defaultValue;
     private final boolean isFinal;
     private final boolean isStatic;
+    private final boolean isVolatile;
 
     private Field(Builder builder) {
         super(builder);
         this.defaultValue = builder.defaultValueBuilder.build();
         this.isFinal = builder.isFinal;
         this.isStatic = builder.isStatic;
+        this.isVolatile = builder.isVolatile;
     }
 
     /**
@@ -71,6 +73,9 @@ public final class Field extends AnnotatedComponent {
             }
             if (isFinal) {
                 writer.write("final ");
+            }
+            if (isVolatile) {
+                writer.write("volatile ");
             }
         }
         type().writeComponent(writer, declaredTokens, imports, classType);
@@ -136,6 +141,7 @@ public final class Field extends AnnotatedComponent {
 
         private final Content.Builder defaultValueBuilder = Content.builder();
         private boolean isFinal = false;
+        private boolean isVolatile = false;
         private boolean isStatic = false;
 
         private Builder() {
@@ -239,6 +245,17 @@ public final class Field extends AnnotatedComponent {
          */
         public Builder isFinal(boolean isFinal) {
             this.isFinal = isFinal;
+            return this;
+        }
+
+        /**
+         * Whether this field is {@code volatile}.
+         *
+         * @param isVolatile volatile field
+         * @return updated builder instance
+         */
+        public Builder isVolatile(boolean isVolatile) {
+            this.isVolatile = isVolatile;
             return this;
         }
 

--- a/codegen/codegen/src/main/java/io/helidon/codegen/Codegen.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/Codegen.java
@@ -32,10 +32,8 @@ import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
 import io.helidon.common.HelidonServiceLoader;
-import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
-import io.helidon.common.types.TypedElementInfo;
 
 /**
  * Central piece of code processing and generation.
@@ -222,7 +220,7 @@ public class Codegen {
         List<TypeInfoAndAnnotations> result = new ArrayList<>();
 
         for (TypeInfo typeInfo : allTypes) {
-            result.add(new TypeInfoAndAnnotations(typeInfo, annotations(typeInfo)));
+            result.add(new TypeInfoAndAnnotations(typeInfo, TypeHierarchy.nestedAnnotations(ctx, typeInfo)));
         }
         return result;
     }
@@ -271,39 +269,10 @@ public class Codegen {
         }
 
         return new RoundContextImpl(
+                ctx,
                 Set.copyOf(extAnnots),
                 Map.copyOf(extAnnotToType),
                 List.copyOf(extTypes.values()));
-    }
-
-    private Set<TypeName> annotations(TypeInfo theTypeInfo) {
-        Set<TypeName> result = new HashSet<>();
-
-        // on type
-        theTypeInfo.annotations()
-                .stream()
-                .map(Annotation::typeName)
-                .forEach(result::add);
-
-        // on fields, methods etc.
-        theTypeInfo.elementInfo()
-                .stream()
-                .map(TypedElementInfo::annotations)
-                .flatMap(List::stream)
-                .map(Annotation::typeName)
-                .forEach(result::add);
-
-        // on parameters
-        theTypeInfo.elementInfo()
-                .stream()
-                .map(TypedElementInfo::parameterArguments)
-                .flatMap(List::stream)
-                .map(TypedElementInfo::annotations)
-                .flatMap(List::stream)
-                .map(Annotation::typeName)
-                .forEach(result::add);
-
-        return result;
     }
 
     private record TypeInfoAndAnnotations(TypeInfo typeInfo, Set<TypeName> annotations) {

--- a/codegen/codegen/src/main/java/io/helidon/codegen/RoundContext.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/RoundContext.java
@@ -44,7 +44,8 @@ public interface RoundContext {
     Collection<TypeInfo> types();
 
     /**
-     * All types annotated with a specific annotation.
+     * All types annotated with a specific annotation (including types that inherit such annotation from super types or
+     * through interfaces).
      *
      * @param annotationType annotation to check
      * @return types that contain the annotation

--- a/codegen/codegen/src/main/java/io/helidon/codegen/RoundContextImpl.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/RoundContextImpl.java
@@ -33,12 +33,14 @@ class RoundContextImpl implements RoundContext {
     private final Map<TypeName, ClassCode> newTypes = new HashMap<>();
     private final Map<TypeName, List<TypeInfo>> annotationToTypes;
     private final List<TypeInfo> types;
+    private final CodegenContext ctx;
     private final Collection<TypeName> annotations;
 
-    RoundContextImpl(Set<TypeName> annotations,
+    RoundContextImpl(CodegenContext ctx,
+                     Set<TypeName> annotations,
                      Map<TypeName, List<TypeInfo>> annotationToTypes,
                      List<TypeInfo> types) {
-
+        this.ctx = ctx;
         this.annotations = annotations;
         this.annotationToTypes = annotationToTypes;
         this.types = types;
@@ -83,7 +85,9 @@ class RoundContextImpl implements RoundContext {
         List<TypeInfo> result = new ArrayList<>();
 
         for (TypeInfo typeInfo : typeInfos) {
-            if (typeInfo.hasAnnotation(annotationType)) {
+            if (typeInfo.hasAnnotation(annotationType) || TypeHierarchy.hierarchyAnnotations(ctx, typeInfo)
+                    .stream()
+                    .anyMatch(it -> it.typeName().equals(annotationType))) {
                 result.add(typeInfo);
             }
         }

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.helidon.common.types.AccessModifier;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.TypeInfo;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypedElementInfo;
+
+import static io.helidon.common.types.TypeNames.INHERITED;
+import static java.util.function.Predicate.not;
+
+/**
+ * Utilities for type hierarchy.
+ */
+public final class TypeHierarchy {
+    private TypeHierarchy() {
+    }
+
+    /**
+     * Find all annotations on the whole type hierarchy.
+     * Adds all annotations on the provided type, and all
+     * {@link java.lang.annotation.Inherited} annotations on supertype(s) and/or interface(s).
+     *
+     * @param ctx  codegen context
+     * @param type type info to process
+     * @return all annotations on the type and in its hierarchy
+     */
+    public static List<Annotation> hierarchyAnnotations(CodegenContext ctx, TypeInfo type) {
+        Map<TypeName, Annotation> annotations = new LinkedHashMap<>();
+
+        // this type
+        type.annotations().forEach(annot -> annotations.put(annot.typeName(), annot));
+        // inherited from supertype
+        type.superTypeInfo().ifPresent(it -> {
+            it.inheritedAnnotations()
+                    .forEach(annot -> annotations.putIfAbsent(annot.typeName(), annot));
+        });
+        // and from interfaces (in order of implementation)
+        for (TypeInfo typeInfo : type.interfaceTypeInfo()) {
+            typeInfo.annotations()
+                    .stream()
+                    .filter(annot -> typeInfo.hasMetaAnnotation(annot.typeName(), INHERITED))
+                    .forEach(annot -> annotations.putIfAbsent(annot.typeName(), annot));
+        }
+
+        Set<TypeName> processedTypes = new HashSet<>(annotations.keySet());
+
+        // now we have a full list of annotations that are explicitly written in sources, now collect meta-annotations
+        // i.e. all annotations on the annotations we have that have @Inherited placed on them
+        processMetaAnnotations(ctx, processedTypes, annotations);
+
+        return List.copyOf(annotations.values());
+    }
+
+    /**
+     * Find all annotations on the whole type hierarchy.
+     * Adds all annotations on the provided element, and all
+     * {@link java.lang.annotation.Inherited} annotations on the same element from supertype(s),
+     * and/or interfaces, and/or annotations.
+     * <p>
+     * Based on element type:
+     * <ul>
+     *     <li>Constructor: only uses annotations from the current element</li>
+     *     <li>Constructor parameter: ditto</li>
+     *     <li>Method: uses annotations from the current element, and from the overridden method/interface method</li>
+     *     <li>Method parameter: use
+     *     {@link #hierarchyAnnotations(CodegenContext,
+     *                                  io.helidon.common.types.TypeInfo,
+     *                                  io.helidon.common.types.TypedElementInfo,
+     *                                  io.helidon.common.types.TypedElementInfo,
+     *                                  int)} instead</li>
+     *     <li>Field: only uses annotations from the current element</li>
+     * </ul>
+     * If the same annotation is on multiple levels (i.e. method, super type method, and interface), it will always be used
+     * ONLY from the "closest" type - order is: this element, super type element, interface element.
+     *
+     * @param ctx     codegen context
+     * @param type    type info owning the executable
+     * @param element executable (method or constructor) element info
+     * @return all annotations on the type and in its hierarchy
+     */
+    public static List<Annotation> hierarchyAnnotations(CodegenContext ctx, TypeInfo type, TypedElementInfo element) {
+        if (element.kind() != ElementKind.METHOD) {
+            return element.annotations();
+        }
+
+        // find the same method on supertype/interfaces
+        List<TypedElementInfo> prototypes = new ArrayList<>();
+        Set<TypeName> processedTypes = new HashSet<>();
+        String packageName = type.typeName().packageName();
+        // extends
+        type.superTypeInfo().ifPresent(it -> collectInheritedMethods(
+                processedTypes,
+                prototypes,
+                it,
+                element,
+                packageName));
+        // implements
+        type.interfaceTypeInfo().forEach(it -> collectInheritedMethods(
+                processedTypes,
+                prototypes,
+                it,
+                element,
+                packageName));
+
+        // we have collected all methods in the hierarchy, let's collect their annotations
+        Map<TypeName, Annotation> annotations = new LinkedHashMap<>();
+        // this type
+        element.annotations().forEach(annot -> annotations.put(annot.typeName(), annot));
+        // inherited from supertype(s) and interface(s)
+        for (TypedElementInfo prototype : prototypes) {
+            prototype.annotations().forEach(annot -> annotations.putIfAbsent(annot.typeName(), annot));
+        }
+
+        // now we have a full list of annotations that are explicitly written in sources, now collect meta-annotations
+        // i.e. all annotations on the annotations we have that have @Inherited placed on them
+        processMetaAnnotations(ctx, processedTypes, annotations);
+
+        return List.copyOf(annotations.values());
+    }
+
+    /**
+     * Annotations of a parameter, taken from the full inheritance hierarchy (super type(s), interface(s).
+     *
+     * @param ctx            codegen context to obtain {@link io.helidon.common.types.TypeInfo} of types
+     * @param type           type info of the processed type
+     * @param executable     owner of the parameter (constructor or method)
+     * @param parameter      parameter info itself
+     * @param parameterIndex index of the parameter within the method (as names may be wrong at runtime)
+     * @return list of annotations on this parameter on this type, super type(s), and interface methods it implements
+     */
+    public static List<Annotation> hierarchyAnnotations(CodegenContext ctx,
+                                                        TypeInfo type,
+                                                        TypedElementInfo executable,
+                                                        TypedElementInfo parameter,
+                                                        int parameterIndex) {
+        if (parameter.kind() != ElementKind.PARAMETER) {
+            throw new CodegenException("This method only supports processing of parameter, yet kind is: " + parameter.kind());
+        }
+        if (!(executable.kind() == ElementKind.CONSTRUCTOR || executable.kind() == ElementKind.METHOD)) {
+            throw new CodegenException("This method only supports processing of parameters of methods or constructors, yet "
+                                               + "executable kind is: " + executable.kind());
+        }
+        if (executable.kind() == ElementKind.CONSTRUCTOR) {
+            // constructor parameters are not inherited
+            return parameter.annotations();
+        }
+
+        // find the same method on supertype/interfaces
+        List<TypedElementInfo> prototypes = new ArrayList<>();
+        Set<TypeName> processedTypes = new HashSet<>();
+        String packageName = type.typeName().packageName();
+        // extends
+        type.superTypeInfo().ifPresent(it -> collectInheritedMethods(
+                processedTypes,
+                prototypes,
+                it,
+                executable,
+                packageName));
+        // implements
+        type.interfaceTypeInfo().forEach(it -> collectInheritedMethods(
+                processedTypes,
+                prototypes,
+                it,
+                executable,
+                packageName));
+
+        // we have collected all methods in the hierarchy, let's collect their annotations
+        Map<TypeName, Annotation> annotations = new LinkedHashMap<>();
+        // this type
+        parameter.annotations().forEach(annot -> annotations.put(annot.typeName(), annot));
+        // inherited from supertype(s) and interface(s)
+        for (TypedElementInfo prototype : prototypes) {
+            prototype.parameterArguments()
+                    .get(parameterIndex)
+                    .annotations()
+                    .forEach(annot -> annotations.putIfAbsent(annot.typeName(), annot));
+        }
+
+        // now we have a full list of annotations that are explicitly written in sources, now collect meta-annotations
+        // i.e. all annotations on the annotations we have that have @Inherited placed on them
+        processMetaAnnotations(ctx, processedTypes, annotations);
+
+        return List.copyOf(annotations.values());
+
+    }
+
+    /**
+     * Annotations on the {@code typeInfo}, it's methods, and method parameters.
+     *
+     * @param ctx context
+     * @param typeInfo type info to check
+     * @return a set of all annotation types on any of the elements, including inherited annotations
+     */
+    public static Set<TypeName> nestedAnnotations(CodegenContext ctx, TypeInfo typeInfo) {
+        Set<TypeName> result = new HashSet<>();
+
+        // on type
+        typeInfo.annotations()
+                .stream()
+                .map(Annotation::typeName)
+                .forEach(result::add);
+        typeInfo.inheritedAnnotations()
+                .stream()
+                .map(Annotation::typeName)
+                .forEach(result::add);
+
+        // on fields, methods etc.
+        typeInfo.elementInfo()
+                .stream()
+                .map(TypedElementInfo::annotations)
+                .flatMap(List::stream)
+                .map(Annotation::typeName)
+                .forEach(result::add);
+
+        typeInfo.elementInfo()
+                .stream()
+                .map(TypedElementInfo::inheritedAnnotations)
+                .flatMap(List::stream)
+                .map(Annotation::typeName)
+                .forEach(result::add);
+
+        // on parameters
+        typeInfo.elementInfo()
+                .stream()
+                .map(TypedElementInfo::parameterArguments)
+                .flatMap(List::stream)
+                .map(TypedElementInfo::annotations)
+                .flatMap(List::stream)
+                .map(Annotation::typeName)
+                .forEach(result::add);
+        typeInfo.elementInfo()
+                .stream()
+                .map(TypedElementInfo::parameterArguments)
+                .flatMap(List::stream)
+                .map(TypedElementInfo::inheritedAnnotations)
+                .flatMap(List::stream)
+                .map(Annotation::typeName)
+                .forEach(result::add);
+
+        return result;
+        /*
+        Set<TypeName> result = new HashSet<>();
+
+        // on type
+        hierarchyAnnotations(ctx, typeInfo)
+                .stream()
+                .map(Annotation::typeName)
+                .forEach(result::add);
+
+        // on fields, methods etc.
+        typeInfo.elementInfo()
+                .stream()
+                .map(it -> hierarchyAnnotations(ctx, typeInfo, it))
+                .flatMap(List::stream)
+                .map(Annotation::typeName)
+                .forEach(result::add);
+
+        // on parameters
+        typeInfo.elementInfo()
+                .stream()
+                .forEach(it -> {
+                    int index = 0;
+                    for (var param : it.parameterArguments()) {
+                        hierarchyAnnotations(ctx, typeInfo, it, param, index++)
+                                .stream()
+                                .map(Annotation::typeName)
+                                .forEach(result::add);
+                    }
+                });
+
+        return result;
+         */
+    }
+
+    private static void processMetaAnnotations(CodegenContext ctx,
+                                               Set<TypeName> processedTypes,
+                                               Map<TypeName, Annotation> annotations) {
+
+        List<Annotation> newAnnotations = new ArrayList<>();
+
+        for (Annotation value : annotations.values()) {
+            Optional<TypeInfo> typeInfo = ctx.typeInfo(value.typeName());
+            if (typeInfo.isPresent()) {
+                // we can handle only annotations on classpath, all others are just ignored
+                TypeInfo annotationInfo = typeInfo.get();
+
+                annotationInfo
+                        .annotations()
+                        .forEach(metaAnnotation -> {
+                            collectMetaAnnotations(ctx, processedTypes, newAnnotations, metaAnnotation);
+                        });
+            }
+        }
+
+        newAnnotations.forEach(it -> annotations.putIfAbsent(it.typeName(), it));
+    }
+
+    private static void collectMetaAnnotations(CodegenContext ctx,
+                                               Set<TypeName> processedTypes,
+                                               List<Annotation> metaAnnotations,
+                                               Annotation annotation) {
+        if (!processedTypes.add(annotation.typeName())) {
+            // this annotation was already processed
+            return;
+        }
+        Optional<TypeInfo> typeInfo = ctx.typeInfo(annotation.typeName());
+        if (typeInfo.isEmpty()) {
+            return;
+        }
+        TypeInfo annotationInfo = typeInfo.get();
+        if (annotationInfo.hasAnnotation(INHERITED)) {
+            metaAnnotations.add(annotation);
+        }
+        // and check all annotations of this annotation
+        annotationInfo.annotations()
+                .forEach(metaAnnotation -> collectMetaAnnotations(ctx, processedTypes, metaAnnotations, metaAnnotation));
+    }
+
+    private static void collectInheritedMethods(Set<TypeName> processed,
+                                                List<TypedElementInfo> collected,
+                                                TypeInfo type,
+                                                TypedElementInfo method,
+                                                String currentPackage) {
+        if (!processed.add(type.typeName())) {
+            // already handled this type
+            return;
+        }
+
+        inherited(
+                type,
+                method,
+                method.parameterArguments()
+                        .stream()
+                        .map(TypedElementInfo::typeName)
+                        .collect(Collectors.toUnmodifiableList()),
+                currentPackage)
+                .ifPresent(collected::add);
+
+        type.superTypeInfo().ifPresent(it -> collectInheritedMethods(processed, collected, it, method, currentPackage));
+        for (TypeInfo typeInfo : type.interfaceTypeInfo()) {
+            collectInheritedMethods(processed, collected, typeInfo, method, currentPackage);
+        }
+    }
+
+    /**
+     * Check if the provided type declares a method that is overridden.
+     *
+     * @param type           first immediate supertype we will be checking
+     * @param method         method we are investigating
+     * @param arguments      method signature
+     * @param currentPackage package of the current type declaring the method
+     * @return overridden method element
+     */
+    private static Optional<TypedElementInfo> inherited(TypeInfo type,
+                                                        TypedElementInfo method,
+                                                        List<TypeName> arguments,
+                                                        String currentPackage) {
+
+        String methodName = method.elementName();
+        // we look only for exact match (including types)
+        Optional<TypedElementInfo> found = type.elementInfo()
+                .stream()
+                .filter(ElementInfoPredicates::isMethod)
+                .filter(not(ElementInfoPredicates::isPrivate))
+                .filter(ElementInfoPredicates.elementName(methodName))
+                .filter(ElementInfoPredicates.hasParams(arguments))
+                .findFirst();
+
+        if (found.isPresent()) {
+            TypedElementInfo superMethod = found.get();
+
+            // method has same signature, but is package local and is in a different package
+            boolean realOverride = superMethod.accessModifier() != AccessModifier.PACKAGE_PRIVATE
+                    || currentPackage.equals(type.typeName().packageName());
+
+            if (realOverride) {
+                // this is a valid method that the type overrides
+                return Optional.of(superMethod);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/common/types/src/main/java/io/helidon/common/types/Annotated.java
+++ b/common/types/src/main/java/io/helidon/common/types/Annotated.java
@@ -85,11 +85,10 @@ public interface Annotated {
      * @see #findAnnotation(TypeName)
      */
     default Annotation annotation(TypeName annotationType) {
-        return findAnnotation(annotationType).orElseThrow(() -> new NoSuchElementException("Annotation " + annotationType + " "
-                                                                                                   + "is not present. Guard "
-                                                                                                   + "with hasAnnotation(), or "
-                                                                                                   + "use findAnnotation() "
-                                                                                                   + "instead"));
+        return findAnnotation(annotationType)
+                .orElseThrow(() -> new NoSuchElementException("Annotation " + annotationType + " is not present. "
+                                                                      + "Guard with hasAnnotation(), "
+                                                                      + "or use findAnnotation() instead"));
     }
 
     /**

--- a/common/types/src/main/java/io/helidon/common/types/Annotation.java
+++ b/common/types/src/main/java/io/helidon/common/types/Annotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,7 +163,7 @@ public interface Annotation extends AnnotationBlueprint, Prototype.Api, Comparab
         }
 
         /**
-         * Update this builder from an existing prototype instance.
+         * Update this builder from an existing prototype instance. This method disables automatic service discovery.
          *
          * @param prototype existing prototype to update this builder from
          * @return updated builder instance

--- a/common/types/src/main/java/io/helidon/common/types/TypeName.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,9 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         private final List<String> typeParameters = new ArrayList<>();
         private boolean array = false;
         private boolean generic = false;
+        private boolean isEnclosingNamesMutated;
+        private boolean isTypeArgumentsMutated;
+        private boolean isTypeParametersMutated;
         private boolean primitive = false;
         private boolean wildcard = false;
         private String className;
@@ -142,7 +145,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         }
 
         /**
-         * Update this builder from an existing prototype instance.
+         * Update this builder from an existing prototype instance. This method disables automatic service discovery.
          *
          * @param prototype existing prototype to update this builder from
          * @return updated builder instance
@@ -150,12 +153,21 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         public BUILDER from(TypeName prototype) {
             packageName(prototype.packageName());
             className(prototype.className());
+            if (!isEnclosingNamesMutated) {
+                enclosingNames.clear();
+            }
             addEnclosingNames(prototype.enclosingNames());
             primitive(prototype.primitive());
             array(prototype.array());
             generic(prototype.generic());
             wildcard(prototype.wildcard());
+            if (!isTypeArgumentsMutated) {
+                typeArguments.clear();
+            }
             addTypeArguments(prototype.typeArguments());
+            if (!isTypeParametersMutated) {
+                typeParameters.clear();
+            }
             addTypeParameters(prototype.typeParameters());
             return self();
         }
@@ -169,13 +181,34 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         public BUILDER from(TypeName.BuilderBase<?, ?> builder) {
             packageName(builder.packageName());
             builder.className().ifPresent(this::className);
-            addEnclosingNames(builder.enclosingNames());
+            if (isEnclosingNamesMutated) {
+                if (builder.isEnclosingNamesMutated) {
+                    addEnclosingNames(builder.enclosingNames);
+                }
+            } else {
+                enclosingNames.clear();
+                addEnclosingNames(builder.enclosingNames);
+            }
             primitive(builder.primitive());
             array(builder.array());
             generic(builder.generic());
             wildcard(builder.wildcard());
-            addTypeArguments(builder.typeArguments());
-            addTypeParameters(builder.typeParameters());
+            if (isTypeArgumentsMutated) {
+                if (builder.isTypeArgumentsMutated) {
+                    addTypeArguments(builder.typeArguments);
+                }
+            } else {
+                typeArguments.clear();
+                addTypeArguments(builder.typeArguments);
+            }
+            if (isTypeParametersMutated) {
+                if (builder.isTypeParametersMutated) {
+                    addTypeParameters(builder.typeParameters);
+                }
+            } else {
+                typeParameters.clear();
+                addTypeParameters(builder.typeParameters);
+            }
             return self();
         }
 
@@ -227,6 +260,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          */
         public BUILDER enclosingNames(List<? extends String> enclosingNames) {
             Objects.requireNonNull(enclosingNames);
+            isEnclosingNamesMutated = true;
             this.enclosingNames.clear();
             this.enclosingNames.addAll(enclosingNames);
             return self();
@@ -243,6 +277,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          */
         public BUILDER addEnclosingNames(List<? extends String> enclosingNames) {
             Objects.requireNonNull(enclosingNames);
+            isEnclosingNamesMutated = true;
             this.enclosingNames.addAll(enclosingNames);
             return self();
         }
@@ -259,6 +294,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         public BUILDER addEnclosingName(String enclosingName) {
             Objects.requireNonNull(enclosingName);
             this.enclosingNames.add(enclosingName);
+            isEnclosingNamesMutated = true;
             return self();
         }
 
@@ -319,6 +355,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          */
         public BUILDER typeArguments(List<? extends TypeName> typeArguments) {
             Objects.requireNonNull(typeArguments);
+            isTypeArgumentsMutated = true;
             this.typeArguments.clear();
             this.typeArguments.addAll(typeArguments);
             return self();
@@ -333,6 +370,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          */
         public BUILDER addTypeArguments(List<? extends TypeName> typeArguments) {
             Objects.requireNonNull(typeArguments);
+            isTypeArgumentsMutated = true;
             this.typeArguments.addAll(typeArguments);
             return self();
         }
@@ -348,6 +386,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         public BUILDER addTypeArgument(TypeName typeArgument) {
             Objects.requireNonNull(typeArgument);
             this.typeArguments.add(typeArgument);
+            isTypeArgumentsMutated = true;
             return self();
         }
 
@@ -378,6 +417,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          */
         public BUILDER typeParameters(List<? extends String> typeParameters) {
             Objects.requireNonNull(typeParameters);
+            isTypeParametersMutated = true;
             this.typeParameters.clear();
             this.typeParameters.addAll(typeParameters);
             return self();
@@ -394,6 +434,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          */
         public BUILDER addTypeParameters(List<? extends String> typeParameters) {
             Objects.requireNonNull(typeParameters);
+            isTypeParametersMutated = true;
             this.typeParameters.addAll(typeParameters);
             return self();
         }
@@ -410,6 +451,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         public BUILDER addTypeParameter(String typeParameter) {
             Objects.requireNonNull(typeParameter);
             this.typeParameters.add(typeParameter);
+            isTypeParametersMutated = true;
             return self();
         }
 

--- a/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfigMetadataCodegenExtension.java
+++ b/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfigMetadataCodegenExtension.java
@@ -92,6 +92,10 @@ class ConfigMetadataCodegenExtension implements CodegenExtension {
     }
 
     private void storeMetadata() {
+        if (moduleTypes.isEmpty()) {
+            // only store if anything is available
+            return;
+        }
         List<Hson.Struct> root = new ArrayList<>();
 
         for (var module : moduleTypes.entrySet()) {

--- a/config/metadata/processor/src/main/java/io/helidon/config/metadata/processor/ConfigMetadataHandler.java
+++ b/config/metadata/processor/src/main/java/io/helidon/config/metadata/processor/ConfigMetadataHandler.java
@@ -49,7 +49,7 @@ import static io.helidon.config.metadata.processor.UsedTypes.META_CONFIGURED;
 /*
  * This class is separated so javac correctly reports possible errors.
  */
-class ConfigMetadataHandler {
+class  ConfigMetadataHandler {
     /*
      * Configuration metadata file location.
      */
@@ -177,6 +177,9 @@ class ConfigMetadataHandler {
     }
 
     private void storeMetadata() {
+        if (moduleTypes.isEmpty()) {
+            return;
+        }
         try (PrintWriter metaWriter = new PrintWriter(filer.createResource(StandardLocation.CLASS_OUTPUT,
                                                                            "",
                                                                            META_FILE)


### PR DESCRIPTION
### Description

APT Codegen
- removing public methods from package private class
- deprecating all public types, as these should not be used outside of this module (only the processor is public, as it is a ServiceLoader provider implmentation)
- caching TypeInfo within a single annotation processing round
- now handles all processed types, to be able to trigger based on "meta" annotations

Class model:
Bugfix in class model, where content support used deprecated (and failing) method. Added support for volatile fields

Types:
Updated with latest behavior of builder (mutated lists)

### Documentation

None.
