### PR TITLE
Renames package-private Grpc type to GrpcRouteHandler

### DIFF
--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -80,7 +80,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private final int streamId;
     private final Http2Settings serverSettings;
     private final Http2Settings clientSettings;
-    private final Grpc<REQ, RES> route;
+    private final GrpcRouteHandler<REQ, RES> route;
     private final AtomicInteger numMessages = new AtomicInteger();
     private final LinkedBlockingQueue<REQ> listenerQueue = new LinkedBlockingQueue<>();
     private final StreamFlowControl flowControl;
@@ -99,7 +99,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                         Http2Settings clientSettings,
                         StreamFlowControl flowControl,
                         Http2StreamState currentStreamState,
-                        Grpc<REQ, RES> route) {
+                        GrpcRouteHandler<REQ, RES> route) {
         this.prologue = prologue;
         this.headers = headers;
         this.streamWriter = streamWriter;

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
@@ -71,7 +71,7 @@ public class GrpcProtocolSelector implements Http2SubProtocolSelector {
             if (contentType.startsWith("application/grpc")) {
                 GrpcRouting routing = router.routing(GrpcRouting.class, GrpcRouting.empty());
 
-                Grpc<?, ?> route = routing.findRoute(prologue);
+                GrpcRouteHandler<?, ?> route = routing.findRoute(prologue);
 
                 if (route == null) {
                     return new SubProtocolResult(true,

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRoute.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,20 @@ import io.helidon.http.PathMatchers;
 import io.helidon.webserver.Route;
 
 abstract class GrpcRoute implements Route {
-    abstract Grpc<?, ?> toGrpc(HttpPrologue grpcPrologue);
 
+    /**
+     * Finds a match for an HTTP prologue.
+     *
+     * @param prologue the prologue
+     * @return the match result
+     */
     abstract PathMatchers.MatchResult accepts(HttpPrologue prologue);
+
+    /**
+     * Obtains a handler from an HTTP prologue.
+     *
+     * @param grpcPrologue the prologue
+     * @return the handler
+     */
+    abstract GrpcRouteHandler<?, ?> handler(HttpPrologue grpcPrologue);
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouteHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouteHandler.java
@@ -29,77 +29,77 @@ import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.stub.ServerCalls;
 
-class Grpc<ReqT, ResT> extends GrpcRoute {
+class GrpcRouteHandler<ReqT, ResT> extends GrpcRoute {
 
     private final MethodDescriptor<ReqT, ResT> method;
     private final PathMatcher pathMatcher;
     private final ServerCallHandler<ReqT, ResT> callHandler;
 
-    private Grpc(MethodDescriptor<ReqT, ResT> method,
-                 PathMatcher pathMatcher,
-                 ServerCallHandler<ReqT, ResT> callHandler) {
+    private GrpcRouteHandler(MethodDescriptor<ReqT, ResT> method,
+                             PathMatcher pathMatcher,
+                             ServerCallHandler<ReqT, ResT> callHandler) {
         this.method = method;
         this.pathMatcher = pathMatcher;
         this.callHandler = callHandler;
     }
 
-    static <ReqT, ResT> Grpc<ReqT, ResT> unary(Descriptors.FileDescriptor proto,
-                                               String serviceName,
-                                               String methodName,
-                                               ServerCalls.UnaryMethod<ReqT, ResT> method) {
+    static <ReqT, ResT> GrpcRouteHandler<ReqT, ResT> unary(Descriptors.FileDescriptor proto,
+                                                           String serviceName,
+                                                           String methodName,
+                                                           ServerCalls.UnaryMethod<ReqT, ResT> method) {
         return grpc(proto, serviceName, methodName, ServerCalls.asyncUnaryCall(method));
     }
 
-    static <ReqT, ResT> Grpc<ReqT, ResT> bidi(Descriptors.FileDescriptor proto,
-                                              String serviceName,
-                                              String methodName,
-                                              ServerCalls.BidiStreamingMethod<ReqT, ResT> method) {
+    static <ReqT, ResT> GrpcRouteHandler<ReqT, ResT> bidi(Descriptors.FileDescriptor proto,
+                                                          String serviceName,
+                                                          String methodName,
+                                                          ServerCalls.BidiStreamingMethod<ReqT, ResT> method) {
         return grpc(proto, serviceName, methodName, ServerCalls.asyncBidiStreamingCall(method));
     }
 
-    static <ReqT, ResT> Grpc<ReqT, ResT> serverStream(Descriptors.FileDescriptor proto,
-                                                      String serviceName,
-                                                      String methodName,
-                                                      ServerCalls.ServerStreamingMethod<ReqT, ResT> method) {
+    static <ReqT, ResT> GrpcRouteHandler<ReqT, ResT> serverStream(Descriptors.FileDescriptor proto,
+                                                                  String serviceName,
+                                                                  String methodName,
+                                                                  ServerCalls.ServerStreamingMethod<ReqT, ResT> method) {
         return grpc(proto, serviceName, methodName, ServerCalls.asyncServerStreamingCall(method));
     }
 
-    static <ReqT, ResT> Grpc<ReqT, ResT> clientStream(Descriptors.FileDescriptor proto,
-                                                      String serviceName,
-                                                      String methodName,
-                                                      ServerCalls.ClientStreamingMethod<ReqT, ResT> method) {
+    static <ReqT, ResT> GrpcRouteHandler<ReqT, ResT> clientStream(Descriptors.FileDescriptor proto,
+                                                                  String serviceName,
+                                                                  String methodName,
+                                                                  ServerCalls.ClientStreamingMethod<ReqT, ResT> method) {
         return grpc(proto, serviceName, methodName, ServerCalls.asyncClientStreamingCall(method));
     }
 
     /**
-     * Create a {@link io.helidon.webserver.grpc.Grpc gRPC route} from a {@link ServerMethodDefinition}.
+     * Create a {@link GrpcRouteHandler gRPC route} from a {@link ServerMethodDefinition}.
      *
      * @param definition the {@link ServerMethodDefinition} representing the method to execute
      * @param proto an optional protocol buffer {@link com.google.protobuf.Descriptors.FileDescriptor}
      * containing the service definition
      * @param <ReqT> the request type
      * @param <ResT> the response type
-     * @return a {@link io.helidon.webserver.grpc.Grpc gRPC route} created
+     * @return a {@link GrpcRouteHandler gRPC route} created
      * from the {@link ServerMethodDefinition}
      */
-    static <ReqT, ResT> Grpc<ReqT, ResT> methodDefinition(ServerMethodDefinition<ReqT, ResT> definition,
-                                                          Descriptors.FileDescriptor proto) {
+    static <ReqT, ResT> GrpcRouteHandler<ReqT, ResT> methodDefinition(ServerMethodDefinition<ReqT, ResT> definition,
+                                                                      Descriptors.FileDescriptor proto) {
         return grpc(definition.getMethodDescriptor(), definition.getServerCallHandler(), proto);
     }
 
     @SuppressWarnings("unchecked")
-    public static <ReqT, ResT> Grpc<ReqT, ResT> bindableMethod(BindableService service,
-                                                               ServerMethodDefinition<?, ?> method) {
+    public static <ReqT, ResT> GrpcRouteHandler<ReqT, ResT> bindableMethod(BindableService service,
+                                                                           ServerMethodDefinition<?, ?> method) {
         ServerServiceDefinition definition = service.bindService();
         String path = definition.getServiceDescriptor().getName() + "/"
                 + method.getMethodDescriptor().getBareMethodName();
-        return new Grpc<>((MethodDescriptor<ReqT, ResT>) method.getMethodDescriptor(),
-                PathMatchers.exact(path),
-                (ServerCallHandler<ReqT, ResT>) method.getServerCallHandler());
+        return new GrpcRouteHandler<>((MethodDescriptor<ReqT, ResT>) method.getMethodDescriptor(),
+                                      PathMatchers.exact(path),
+                                      (ServerCallHandler<ReqT, ResT>) method.getServerCallHandler());
     }
 
     @Override
-    Grpc<?, ?> toGrpc(HttpPrologue grpcPrologue) {
+    GrpcRouteHandler<?, ?> handler(HttpPrologue grpcPrologue) {
         return this;
     }
 
@@ -115,10 +115,10 @@ class Grpc<ReqT, ResT> extends GrpcRoute {
         return callHandler;
     }
 
-    private static <ResT, ReqT> Grpc<ReqT, ResT> grpc(Descriptors.FileDescriptor proto,
-                                                      String serviceName,
-                                                      String methodName,
-                                                      ServerCallHandler<ReqT, ResT> callHandler) {
+    private static <ResT, ReqT> GrpcRouteHandler<ReqT, ResT> grpc(Descriptors.FileDescriptor proto,
+                                                                  String serviceName,
+                                                                  String methodName,
+                                                                  ServerCallHandler<ReqT, ResT> callHandler) {
         Descriptors.ServiceDescriptor svc = proto.findServiceByName(serviceName);
         Descriptors.MethodDescriptor mtd = svc.findMethodByName(methodName);
 
@@ -140,12 +140,12 @@ class Grpc<ReqT, ResT> extends GrpcRoute {
                 .setType(getMethodType(mtd)).setFullMethodName(path).setRequestMarshaller(reqMarshaller)
                 .setResponseMarshaller(resMarshaller).setSampledToLocalTracing(true);
 
-        return new Grpc<>(grpcDesc.build(), PathMatchers.exact(path), callHandler);
+        return new GrpcRouteHandler<>(grpcDesc.build(), PathMatchers.exact(path), callHandler);
     }
 
 
     /**
-     * Create a {@link io.helidon.webserver.grpc.Grpc gRPC route} from a {@link MethodDescriptor}.
+     * Create a {@link GrpcRouteHandler gRPC route} from a {@link MethodDescriptor}.
      *
      * @param grpcDesc the {@link MethodDescriptor} describing the method to execute
      * @param callHandler the {@link io.grpc.ServerCallHandler} that will execute the method
@@ -153,13 +153,13 @@ class Grpc<ReqT, ResT> extends GrpcRoute {
      * the service definition
      * @param <ReqT> the request type
      * @param <ResT> the response type
-     * @return a {@link io.helidon.webserver.grpc.Grpc gRPC route} created
+     * @return a {@link GrpcRouteHandler gRPC route} created
      * from the {@link io.grpc.ServerMethodDefinition}
      */
-    private static <ResT, ReqT> Grpc<ReqT, ResT> grpc(MethodDescriptor<ReqT, ResT> grpcDesc,
-                                                      ServerCallHandler<ReqT, ResT> callHandler,
-                                                      Descriptors.FileDescriptor proto) {
-        return new Grpc<>(grpcDesc, PathMatchers.exact(grpcDesc.getFullMethodName()), callHandler);
+    private static <ResT, ReqT> GrpcRouteHandler<ReqT, ResT> grpc(MethodDescriptor<ReqT, ResT> grpcDesc,
+                                                                  ServerCallHandler<ReqT, ResT> callHandler,
+                                                                  Descriptors.FileDescriptor proto) {
+        return new GrpcRouteHandler<>(grpcDesc, PathMatchers.exact(grpcDesc.getFullMethodName()), callHandler);
     }
 
     private static String getClassName(Descriptors.Descriptor descriptor) {
@@ -173,7 +173,7 @@ class Grpc<ReqT, ResT> extends GrpcRoute {
     @SuppressWarnings("unchecked")
     private static <T> Class<T> load(String className) {
         try {
-            return (Class<T>) Grpc.class.getClassLoader().loadClass(className);
+            return (Class<T>) GrpcRouteHandler.class.getClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException("Failed to load class \"" + className + "\" for grpc", e);
         }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouting.java
@@ -109,11 +109,11 @@ public class GrpcRouting implements Routing {
         return services;
     }
 
-    Grpc<?, ?> findRoute(HttpPrologue prologue) {
+    GrpcRouteHandler<?, ?> findRoute(HttpPrologue prologue) {
         for (GrpcRoute route : routes) {
             PathMatchers.MatchResult accepts = route.accepts(prologue);
             if (accepts.accepted()) {
-                return route.toGrpc(prologue);
+                return route.handler(prologue);
             }
         }
 
@@ -219,7 +219,7 @@ public class GrpcRouting implements Routing {
                                           String serviceName,
                                           String methodName,
                                           ServerCalls.UnaryMethod<ReqT, ResT> method) {
-            return route(Grpc.unary(proto, serviceName, methodName, method));
+            return route(GrpcRouteHandler.unary(proto, serviceName, methodName, method));
         }
 
         /**
@@ -237,7 +237,7 @@ public class GrpcRouting implements Routing {
                                          String serviceName,
                                          String methodName,
                                          ServerCalls.BidiStreamingMethod<ReqT, ResT> method) {
-            return route(Grpc.bidi(proto, serviceName, methodName, method));
+            return route(GrpcRouteHandler.bidi(proto, serviceName, methodName, method));
         }
 
         /**
@@ -255,7 +255,7 @@ public class GrpcRouting implements Routing {
                                                  String serviceName,
                                                  String methodName,
                                                  ServerCalls.ServerStreamingMethod<ReqT, ResT> method) {
-            return route(Grpc.serverStream(proto, serviceName, methodName, method));
+            return route(GrpcRouteHandler.serverStream(proto, serviceName, methodName, method));
         }
 
         /**
@@ -273,7 +273,7 @@ public class GrpcRouting implements Routing {
                                                  String serviceName,
                                                  String methodName,
                                                  ServerCalls.ClientStreamingMethod<ReqT, ResT> method) {
-            return route(Grpc.clientStream(proto, serviceName, methodName, method));
+            return route(GrpcRouteHandler.clientStream(proto, serviceName, methodName, method));
         }
 
         /**
@@ -285,7 +285,7 @@ public class GrpcRouting implements Routing {
          */
         public Builder service(Descriptors.FileDescriptor proto, BindableService service) {
             for (ServerMethodDefinition<?, ?> method : service.bindService().getMethods()) {
-                route(Grpc.methodDefinition(method, proto));
+                route(GrpcRouteHandler.methodDefinition(method, proto));
             }
             return this;
         }
@@ -298,7 +298,7 @@ public class GrpcRouting implements Routing {
          */
         public Builder service(ServerServiceDefinition service) {
             for (ServerMethodDefinition<?, ?> method : service.getMethods()) {
-                route(Grpc.methodDefinition(method, null));
+                route(GrpcRouteHandler.methodDefinition(method, null));
             }
             return this;
         }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServiceRoute.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServiceRoute.java
@@ -32,9 +32,9 @@ import io.grpc.stub.ServerCalls;
 class GrpcServiceRoute extends GrpcRoute {
 
     private final String serviceName;
-    private final List<Grpc<?, ?>> routes;
+    private final List<GrpcRouteHandler<?, ?>> routes;
 
-    private GrpcServiceRoute(String serviceName, List<Grpc<?, ?>> routes) {
+    private GrpcServiceRoute(String serviceName, List<GrpcRouteHandler<?, ?>> routes) {
         this.serviceName = serviceName;
         this.routes = routes;
     }
@@ -62,9 +62,9 @@ class GrpcServiceRoute extends GrpcRoute {
     static GrpcRoute create(BindableService service) {
         ServerServiceDefinition definition = service.bindService();
         String serviceName = definition.getServiceDescriptor().getName();
-        List<Grpc<?, ?>> routes = new LinkedList<>();
+        List<GrpcRouteHandler<?, ?>> routes = new LinkedList<>();
         service.bindService().getMethods().forEach(
-                method -> routes.add(Grpc.bindableMethod(service, method)));
+                method -> routes.add(GrpcRouteHandler.bindableMethod(service, method)));
         return new GrpcServiceRoute(serviceName, routes);
     }
 
@@ -82,8 +82,8 @@ class GrpcServiceRoute extends GrpcRoute {
     }
 
     @Override
-    Grpc<?, ?> toGrpc(HttpPrologue prologue) {
-        for (Grpc<?, ?> route : routes) {
+    GrpcRouteHandler<?, ?> handler(HttpPrologue prologue) {
+        for (GrpcRouteHandler<?, ?> route : routes) {
             PathMatchers.MatchResult accepts = route.accepts(prologue);
             if (accepts.accepted()) {
                 return route;
@@ -94,7 +94,7 @@ class GrpcServiceRoute extends GrpcRoute {
     }
 
     PathMatchers.MatchResult accepts(HttpPrologue prologue) {
-        for (Grpc<?, ?> route : routes) {
+        for (GrpcRouteHandler<?, ?> route : routes) {
             PathMatchers.MatchResult accepts = route.accepts(prologue);
             if (accepts.accepted()) {
                 return accepts;
@@ -104,7 +104,7 @@ class GrpcServiceRoute extends GrpcRoute {
     }
 
     static class Routing implements GrpcService.Routing {
-        private final List<Grpc<?, ?>> routes = new LinkedList<>();
+        private final List<GrpcRouteHandler<?, ?>> routes = new LinkedList<>();
         private final Descriptors.FileDescriptor proto;
         private final String serviceName;
 
@@ -115,27 +115,27 @@ class GrpcServiceRoute extends GrpcRoute {
 
         @Override
         public <ReqT, ResT> GrpcService.Routing unary(String methodName, ServerCalls.UnaryMethod<ReqT, ResT> method) {
-            routes.add(Grpc.unary(proto, serviceName, methodName, method));
+            routes.add(GrpcRouteHandler.unary(proto, serviceName, methodName, method));
             return this;
         }
 
         @Override
         public <ReqT, ResT> GrpcService.Routing bidi(String methodName, ServerCalls.BidiStreamingMethod<ReqT, ResT> method) {
-            routes.add(Grpc.bidi(proto, serviceName, methodName, method));
+            routes.add(GrpcRouteHandler.bidi(proto, serviceName, methodName, method));
             return this;
         }
 
         @Override
         public <ReqT, ResT> GrpcService.Routing serverStream(String methodName,
                                                              ServerCalls.ServerStreamingMethod<ReqT, ResT> method) {
-            routes.add(Grpc.serverStream(proto, serviceName, methodName, method));
+            routes.add(GrpcRouteHandler.serverStream(proto, serviceName, methodName, method));
             return this;
         }
 
         @Override
         public <ReqT, ResT> GrpcService.Routing clientStream(String methodName,
                                                              ServerCalls.ClientStreamingMethod<ReqT, ResT> method) {
-            routes.add(Grpc.clientStream(proto, serviceName, methodName, method));
+            routes.add(GrpcRouteHandler.clientStream(proto, serviceName, methodName, method));
             return this;
         }
 

--- a/webserver/grpc/src/main/java/module-info.java
+++ b/webserver/grpc/src/main/java/module-info.java
@@ -35,6 +35,10 @@ module io.helidon.webserver.grpc {
     requires io.helidon.tracing;
     requires io.helidon.common.config;
 
+    requires io.grpc;
+    requires io.grpc.stub;
+    requires com.google.protobuf;
+
     requires transitive io.helidon.grpc.core;
 
     requires static io.helidon.common.features.api;


### PR DESCRIPTION
### Description

Renames package-private Grpc type to GrpcRouteHandler. The name Grpc is too generic and is also used in the API. Adds missing requires in module-info.java.

### Documentation

None