### PR TITLE
3.x: Upgrade jakarta inject, interceptor and transaction apis

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -75,14 +75,14 @@
         <version.lib.jakarta.annotation-api>2.0.0</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>3.0.0</version.lib.jakarta.cdi-api>
         <version.lib.jakarta.el-api>4.0.0</version.lib.jakarta.el-api>
-        <version.lib.jakarta.inject>2.0.0</version.lib.jakarta.inject>
-        <version.lib.jakarta.interceptor-api>2.0.0</version.lib.jakarta.interceptor-api>
+        <version.lib.jakarta.inject>2.0.1</version.lib.jakarta.inject>
+        <version.lib.jakarta.interceptor-api>2.0.1</version.lib.jakarta.interceptor-api>
         <version.lib.jakarta.jaxrs-api>3.0.0</version.lib.jakarta.jaxrs-api>
         <version.lib.jakarta.jms-api>3.0.0</version.lib.jakarta.jms-api>
         <version.lib.jakarta.jsonb-api>2.0.0</version.lib.jakarta.jsonb-api>
         <version.lib.jakarta.jsonp-api>2.0.2</version.lib.jakarta.jsonp-api>
         <version.lib.jakarta.persistence-api>3.0.0</version.lib.jakarta.persistence-api>
-        <version.lib.jakarta.transaction-api>2.0.0</version.lib.jakarta.transaction-api>
+        <version.lib.jakarta.transaction-api>2.0.1</version.lib.jakarta.transaction-api>
         <version.lib.jakarta.validation-api>3.0.2</version.lib.jakarta.validation-api>
         <version.lib.jakarta.websockets-api>2.1.1</version.lib.jakarta.websockets-api>
         <!-- Check Hibernate when upgrading to ensure its supplied jaxb-runtime is compatible. -->

--- a/integrations/cdi/jpa-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/module-info.java
@@ -34,7 +34,7 @@ module io.helidon.integrations.cdi.jpa {
     requires jakarta.xml.bind;
 
     requires jakarta.inject; // automatic module
-    requires jakarta.interceptor.api; // automatic module
+    requires jakarta.interceptor;
 
     requires io.helidon.integrations.cdi.delegates;
     requires io.helidon.integrations.cdi.referencecountedcontext;

--- a/integrations/cdi/jpa-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/cdi/jta-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jta-cdi/src/main/java/module-info.java
@@ -27,7 +27,7 @@ module io.helidon.integrations.jta.cdi {
     requires jakarta.annotation;
     requires java.sql;
     requires java.rmi;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires jakarta.inject;
     requires jakarta.cdi;
     requires narayana.jta.jakarta;

--- a/integrations/cdi/jta-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jta-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/jta/jdbc/pom.xml
+++ b/integrations/jta/jdbc/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test-scoped dependencies. -->
         <dependency>

--- a/integrations/micrometer/cdi/src/main/java/module-info.java
+++ b/integrations/micrometer/cdi/src/main/java/module-info.java
@@ -26,7 +26,7 @@ module io.helidon.integrations.micrometer.cdi {
     requires static jakarta.activation;
     requires static jakarta.cdi;
     requires static jakarta.inject;
-    requires static jakarta.interceptor.api;
+    requires static jakarta.interceptor;
 
     requires io.helidon.common.http;
     requires io.helidon.servicecommon.rest;

--- a/integrations/micrometer/cdi/src/main/java/module-info.java
+++ b/integrations/micrometer/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/cdi/src/main/java/module-info.java
+++ b/integrations/micronaut/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/cdi/src/main/java/module-info.java
+++ b/integrations/micronaut/cdi/src/main/java/module-info.java
@@ -27,7 +27,7 @@ module io.helidon.integrations.micronaut.cdi {
 
     requires jakarta.cdi;
     requires jakarta.inject;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
 
     requires microprofile.config.api;
 

--- a/integrations/micronaut/data/src/main/java/module-info.java
+++ b/integrations/micronaut/data/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/data/src/main/java/module-info.java
+++ b/integrations/micronaut/data/src/main/java/module-info.java
@@ -22,7 +22,7 @@ module io.helidon.integrations.micronaut.data {
     requires java.sql;
 
     requires jakarta.cdi;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
 
     requires io.micronaut.inject;
 

--- a/integrations/microstream/cdi/src/main/java/module-info.java
+++ b/integrations/microstream/cdi/src/main/java/module-info.java
@@ -27,7 +27,7 @@ module io.helidon.integrations.microstream.cdi {
     requires io.helidon.integrations.microstream.cache;
     requires transitive jakarta.cdi;
     requires transitive jakarta.inject;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires jakarta.annotation;
     requires microstream.base;
     requires microstream.cache;

--- a/integrations/microstream/cdi/src/main/java/module-info.java
+++ b/integrations/microstream/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/neo4j/metrics/src/main/java/module-info.java
+++ b/integrations/neo4j/metrics/src/main/java/module-info.java
@@ -29,7 +29,7 @@ module io.helidon.integrations.neo4j.metrics {
 
     requires static jakarta.cdi;
     requires static jakarta.inject;
-    requires static jakarta.interceptor.api;
+    requires static jakarta.interceptor;
     requires static jakarta.annotation;
 
     exports io.helidon.integrations.neo4j.metrics;

--- a/integrations/neo4j/metrics/src/main/java/module-info.java
+++ b/integrations/neo4j/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/neo4j/neo4j/src/main/java/module-info.java
+++ b/integrations/neo4j/neo4j/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/neo4j/neo4j/src/main/java/module-info.java
+++ b/integrations/neo4j/neo4j/src/main/java/module-info.java
@@ -22,7 +22,7 @@ module io.helidon.integrations.neo4j {
 
     requires static jakarta.cdi;
     requires static jakarta.inject;
-    requires static jakarta.interceptor.api;
+    requires static jakarta.interceptor;
     requires static io.helidon.config;
     requires static io.helidon.config.mp;
 

--- a/integrations/oci/metrics/cdi/src/main/java/module-info.java
+++ b/integrations/oci/metrics/cdi/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module io.helidon.integrations.oci.metrics.cdi {
 
     requires oci.java.sdk.monitoring;
 
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     provides jakarta.enterprise.inject.spi.Extension with io.helidon.integrations.oci.metrics.cdi.OciMetricsCdiExtension;
 
     opens io.helidon.integrations.oci.metrics.cdi to weld.core.impl, io.helidon.microprofile.cdi;

--- a/integrations/oci/metrics/cdi/src/main/java/module-info.java
+++ b/integrations/oci/metrics/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/oci/sdk/cdi/src/main/java/module-info.java
+++ b/integrations/oci/sdk/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/oci/sdk/cdi/src/main/java/module-info.java
+++ b/integrations/oci/sdk/cdi/src/main/java/module-info.java
@@ -29,7 +29,7 @@ module io.helidon.integrations.oci.sdk.cdi {
     requires java.logging;
     requires transitive jakarta.cdi;
     requires jakarta.inject;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires jakarta.ws.rs;
     requires microprofile.config.api;
     requires oci.java.sdk.common;

--- a/microprofile/access-log/src/main/java/module-info.java
+++ b/microprofile/access-log/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/access-log/src/main/java/module-info.java
+++ b/microprofile/access-log/src/main/java/module-info.java
@@ -22,7 +22,7 @@ module io.helidon.microprofile.accesslog {
 
     requires io.helidon.microprofile.server;
     requires io.helidon.webserver.accesslog;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
 
     exports io.helidon.microprofile.accesslog;
 

--- a/microprofile/cors/src/main/java/module-info.java
+++ b/microprofile/cors/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/cors/src/main/java/module-info.java
+++ b/microprofile/cors/src/main/java/module-info.java
@@ -34,7 +34,7 @@ module io.helidon.microprofile.cors {
     requires jersey.common;
     requires microprofile.config.api;
 
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires jakarta.cdi;
 
     exports io.helidon.microprofile.cors;

--- a/microprofile/fault-tolerance/src/main/java/module-info.java
+++ b/microprofile/fault-tolerance/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/fault-tolerance/src/main/java/module-info.java
+++ b/microprofile/fault-tolerance/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module io.helidon.microprofile.faulttolerance {
     requires java.logging;
     requires jakarta.annotation;
     requires jakarta.inject;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
 
     requires io.helidon.common.context;
     requires io.helidon.common.configurable;

--- a/microprofile/graphql/server/src/main/java/module-info.java
+++ b/microprofile/graphql/server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/graphql/server/src/main/java/module-info.java
+++ b/microprofile/graphql/server/src/main/java/module-info.java
@@ -26,7 +26,7 @@ module io.helidon.microprofile.graphql.server {
     requires jakarta.json.bind;
     requires jakarta.annotation;
     requires jakarta.cdi;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires org.eclipse.yasson;
 
     requires org.jboss.jandex;

--- a/microprofile/grpc/metrics/src/main/java/module-info.java
+++ b/microprofile/grpc/metrics/src/main/java/module-info.java
@@ -28,7 +28,7 @@ module io.helidon.microprofile.grpc.metrics {
     requires io.helidon.servicecommon.restcdi;
 
     requires java.logging;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
 
     provides io.helidon.microprofile.grpc.server.AnnotatedServiceConfigurer
             with io.helidon.microprofile.grpc.metrics.MetricsConfigurer;

--- a/microprofile/grpc/metrics/src/main/java/module-info.java
+++ b/microprofile/grpc/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/health/src/main/java/module-info.java
+++ b/microprofile/health/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/health/src/main/java/module-info.java
+++ b/microprofile/health/src/main/java/module-info.java
@@ -34,7 +34,7 @@ module io.helidon.microprofile.health {
     requires jakarta.inject;
     requires jakarta.ws.rs;
     requires jakarta.json;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires microprofile.config.api;
     requires microprofile.health.api;
     requires io.helidon.config.mp;

--- a/microprofile/jwt-auth/src/main/java/module-info.java
+++ b/microprofile/jwt-auth/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/jwt-auth/src/main/java/module-info.java
+++ b/microprofile/jwt-auth/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module io.helidon.microprofile.jwt.auth {
 
     requires jakarta.cdi;
     requires jakarta.inject;
+    requires jakarta.interceptor;
     requires jakarta.ws.rs;
     requires microprofile.config.api;
     requires transitive microprofile.jwt.auth.api;

--- a/microprofile/lra/jax-rs/src/main/java/module-info.java
+++ b/microprofile/lra/jax-rs/src/main/java/module-info.java
@@ -30,7 +30,7 @@ module io.helidon.microprofile.lra {
     requires io.helidon.microprofile.config;
     requires io.helidon.microprofile.server;
     requires microprofile.config.api;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires jersey.common;
     requires io.helidon.lra.coordinator.client;
     requires io.helidon.common.serviceloader;

--- a/microprofile/lra/jax-rs/src/main/java/module-info.java
+++ b/microprofile/lra/jax-rs/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/messaging/core/src/main/java/module-info.java
+++ b/microprofile/messaging/core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/messaging/core/src/main/java/module-info.java
+++ b/microprofile/messaging/core/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module io.helidon.microprofile.messaging {
     requires static jakarta.cdi;
     requires static jakarta.inject;
     requires static jakarta.activation;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires io.helidon.config;
     requires io.helidon.config.mp;
     requires io.helidon.microprofile.config;

--- a/microprofile/metrics/src/main/java/module-info.java
+++ b/microprofile/metrics/src/main/java/module-info.java
@@ -24,7 +24,7 @@ module io.helidon.microprofile.metrics {
 
     requires static jakarta.cdi;
     requires static jakarta.inject;
-    requires static jakarta.interceptor.api;
+    requires static jakarta.interceptor;
     requires static jakarta.annotation;
     requires static jakarta.activation;
 

--- a/microprofile/metrics/src/main/java/module-info.java
+++ b/microprofile/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/openapi/src/main/java/module-info.java
+++ b/microprofile/openapi/src/main/java/module-info.java
@@ -29,7 +29,7 @@ module io.helidon.microprofile.openapi {
     requires microprofile.config.api;
     requires io.helidon.microprofile.server;
     requires io.helidon.openapi;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires transitive microprofile.openapi.api;
 
     requires org.jboss.jandex;

--- a/microprofile/openapi/src/main/java/module-info.java
+++ b/microprofile/openapi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/scheduling/src/main/java/module-info.java
+++ b/microprofile/scheduling/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/scheduling/src/main/java/module-info.java
+++ b/microprofile/scheduling/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module io.helidon.microprofile.scheduling {
     requires java.logging;
     requires static jakarta.cdi;
     requires static jakarta.inject;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires io.helidon.common.configurable;
     requires io.helidon.config;
     requires io.helidon.config.mp;

--- a/microprofile/security/src/main/java/module-info.java
+++ b/microprofile/security/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/security/src/main/java/module-info.java
+++ b/microprofile/security/src/main/java/module-info.java
@@ -26,7 +26,7 @@ module io.helidon.microprofile.security {
     requires transitive io.helidon.security.integration.webserver;
     requires io.helidon.microprofile.server;
     requires io.helidon.microprofile.cdi;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
 
     exports io.helidon.microprofile.security;
 

--- a/microprofile/server/src/main/java/module-info.java
+++ b/microprofile/server/src/main/java/module-info.java
@@ -30,7 +30,7 @@ module io.helidon.microprofile.server {
     requires io.helidon.microprofile.config;
     requires transitive jakarta.cdi;
     requires transitive jakarta.ws.rs;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires jakarta.validation;
     requires transitive jakarta.json;
     requires io.helidon.jersey.media.jsonp;

--- a/microprofile/tracing/src/main/java/module-info.java
+++ b/microprofile/tracing/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/tracing/src/main/java/module-info.java
+++ b/microprofile/tracing/src/main/java/module-info.java
@@ -29,7 +29,7 @@ module io.helidon.microprofile.tracing {
 
     requires static jakarta.cdi;
     requires static jakarta.inject;
-    requires static jakarta.interceptor.api;
+    requires static jakarta.interceptor;
 
     requires io.helidon.microprofile.server;
     requires transitive io.helidon.microprofile.config;

--- a/microprofile/websocket/src/main/java/module-info.java
+++ b/microprofile/websocket/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/websocket/src/main/java/module-info.java
+++ b/microprofile/websocket/src/main/java/module-info.java
@@ -20,7 +20,7 @@
 module io.helidon.microprofile.tyrus {
     requires java.logging;
     requires jakarta.inject;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
 
     requires jakarta.cdi;
     requires transitive jakarta.websocket;

--- a/service-common/rest-cdi/src/main/java/module-info.java
+++ b/service-common/rest-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/service-common/rest-cdi/src/main/java/module-info.java
+++ b/service-common/rest-cdi/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module io.helidon.servicecommon.restcdi {
     requires io.helidon.servicecommon.rest;
     requires java.logging;
     requires microprofile.config.api;
-    requires jakarta.interceptor.api;
+    requires jakarta.interceptor;
     requires jakarta.inject;
     requires io.helidon.config.mp;
     requires io.helidon.microprofile.server;


### PR DESCRIPTION
### Description

Upgrades EE specs to the latest in the EE 9 platform:

* Inject: 2.0.0 to 2.0.1
* Interceptor: 2.0.0 to 2.0.1
* Transaction: 2.0.0 to 2.0.1

This results in the interceptor module name change from `jakarta.interceptor.api` to `jakarta.interceptor`

Also looks like JTA had module info changes requiring a dependency on CDI.
