### PR TITLE
Remove headers from request adapter logging output that do not affect CORS decision-making

### DIFF
--- a/microprofile/cors/pom.xml
+++ b/microprofile/cors/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -82,6 +82,11 @@
         <dependency>
             <groupId>io.helidon.microprofile.tests</groupId>
             <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
@@ -16,6 +16,7 @@
 package io.helidon.microprofile.cors;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -154,7 +155,7 @@ class CorsSupportMp extends CorsSupportBase<ContainerRequestContext, Response, C
         private Map<String, List<String>> filteredHeaders() {
             MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
             for (Map.Entry<String, List<String>> header : requestContext.getHeaders().entrySet()) {
-                if (HEADERS_FOR_CORS_DIAGNOSTICS.contains(header.getKey())) {
+                if (HEADERS_FOR_CORS_DIAGNOSTICS.contains(header.getKey().toLowerCase(Locale.getDefault()))) {
                     result.put(header.getKey(), header.getValue());
                 }
             }

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.helidon.microprofile.cors;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -146,8 +147,18 @@ class CorsSupportMp extends CorsSupportBase<ContainerRequestContext, Response, C
 
         @Override
         public String toString() {
-            return String.format("RequestAdapterMp{path=%s, method=%s, headers=%s}", path(), method(),
-                    requestContext.getHeaders());
+            return String.format("RequestAdapterMp{path=%s, method=%s, CORS-related headers=%s}", path(), method(),
+                    filteredHeaders());
+        }
+
+        private Map<String, List<String>> filteredHeaders() {
+            MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
+            for (Map.Entry<String, List<String>> header : requestContext.getHeaders().entrySet()) {
+                if (HEADERS_FOR_CORS_DIAGNOSTICS.contains(header.getKey())) {
+                    result.put(header.getKey(), header.getValue());
+                }
+            }
+            return result;
         }
     }
 

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/TestHeaders.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/TestHeaders.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cors;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestHeaders {
+
+    @Test
+    void checkHeaders() {
+
+        UriInfo uriInfo = mock(UriInfo.class);
+        when (uriInfo.getRequestUri()).thenReturn(URI.create("http://myhost.com/testpath"));
+        ContainerRequestContext context = mock(ContainerRequestContext.class);
+        when(context.getHeaders()).thenReturn(new MultivaluedHashMap<>(Map.of("Origin", "http://myhost.com",
+                                                     "Host", "otherhost",
+                                                     "Authorization", "some-auth",
+                                                     "X-Custom", "myValue")));
+        when(context.getMethod()).thenReturn("POST");
+        when(context.getUriInfo()).thenReturn(uriInfo);
+
+        CorsSupportMp.RequestAdapterMp requestAdapterMp = new CorsSupportMp.RequestAdapterMp(context);
+
+        assertThat("Headers",
+                   requestAdapterMp.toString(),
+                   allOf(
+                           containsString("path=/testpath"),
+                           containsString("method=POST"),
+                           containsString("Origin=[http://myhost.com]"),
+                           containsString("Host=[otherhost]"),
+                           not(containsString("Authorization")),
+                           not(containsString("X-Custom"))));
+
+
+    }
+}

--- a/webserver/cors/pom.xml
+++ b/webserver/cors/pom.xml
@@ -63,5 +63,10 @@
             <artifactId>helidon-webclient</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
@@ -275,9 +275,9 @@ public abstract class CorsSupportBase<Q, R, T extends CorsSupportBase<Q, R, T, B
         /**
          * Header names useful for CORS diagnostic logging messages.
          */
-        Set<String> HEADERS_FOR_CORS_DIAGNOSTICS = Set.of("Origin",
-                                                          "Host",
-                                                          "Access-Control-Request-Method");
+        Set<String> HEADERS_FOR_CORS_DIAGNOSTICS = Set.of("origin",
+                                                          "host",
+                                                          "access-control-request-method");
 
         /**
          *

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.webserver.cors;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -270,6 +271,13 @@ public abstract class CorsSupportBase<Q, R, T extends CorsSupportBase<Q, R, T, B
      * @param <T> type of the request wrapped by the adapter
      */
     protected interface RequestAdapter<T> {
+
+        /**
+         * Header names useful for CORS diagnostic logging messages.
+         */
+        Set<String> HEADERS_FOR_CORS_DIAGNOSTICS = Set.of("Origin",
+                                                          "Host",
+                                                          "Access-Control-Request-Method");
 
         /**
          *

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/RequestAdapterSe.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/RequestAdapterSe.java
@@ -17,6 +17,7 @@ package io.helidon.webserver.cors;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -76,7 +77,7 @@ class RequestAdapterSe implements CorsSupportBase.RequestAdapter<ServerRequest> 
     private Map<String, List<String>> headersDisplay() {
         Map<String, List<String>> result = new HashMap<>();
         for (Map.Entry<String, List<String>> header : request.headers().toMap().entrySet()) {
-            if (HEADERS_FOR_CORS_DIAGNOSTICS.contains(header.getKey())) {
+            if (HEADERS_FOR_CORS_DIAGNOSTICS.contains(header.getKey().toLowerCase(Locale.getDefault()))) {
                 result.put(header.getKey(), header.getValue());
             }
         }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/RequestAdapterSe.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/RequestAdapterSe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 package io.helidon.webserver.cors;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import io.helidon.webserver.ServerRequest;
@@ -68,6 +70,16 @@ class RequestAdapterSe implements CorsSupportBase.RequestAdapter<ServerRequest> 
 
     @Override
     public String toString() {
-        return String.format("RequestAdapterSe{path=%s, method=%s, headers=%s}", path(), method(), request.headers().toMap());
+        return String.format("RequestAdapterSe{path=%s, method=%s, CORS-related headers=%s}", path(), method(), headersDisplay());
+    }
+
+    private Map<String, List<String>> headersDisplay() {
+        Map<String, List<String>> result = new HashMap<>();
+        for (Map.Entry<String, List<String>> header : request.headers().toMap().entrySet()) {
+            if (HEADERS_FOR_CORS_DIAGNOSTICS.contains(header.getKey())) {
+                result.put(header.getKey(), header.getValue());
+            }
+        }
+        return result;
     }
 }

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/TestHeaders.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/TestHeaders.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.cors;
+
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.common.http.Http;
+import io.helidon.common.http.HttpRequest;
+import io.helidon.webserver.RequestHeaders;
+import io.helidon.webserver.ServerRequest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestHeaders {
+
+    @Test
+    void checkHeaders() {
+        HttpRequest.Path path = mock(HttpRequest.Path.class);
+        when(path.toString())
+                .thenReturn("/testpath");
+
+        RequestHeaders requestHeaders = mock(RequestHeaders.class);
+        when(requestHeaders.toMap())
+                .thenReturn(Map.of("Origin", List.of("http://myhost.com"),
+                                   "Host", List.of("otherhost"),
+                                   "Authorization", List.of("some-auth"),
+                                   "X-Custom", List.of("myValue")));
+
+        Http.RequestMethod requestMethod = mock(Http.RequestMethod.class);
+        when(requestMethod.name()).thenReturn("POST");
+
+        ServerRequest serverRequest = mock(ServerRequest.class);
+        when(serverRequest.path()).thenReturn(path);
+        when(serverRequest.method()).thenReturn(requestMethod);
+        when(serverRequest.headers()).thenReturn(requestHeaders);
+
+        RequestAdapterSe requestAdapterSe = new RequestAdapterSe(serverRequest);
+        assertThat("Headers",
+                   requestAdapterSe.toString(),
+                   allOf(
+                           containsString("path=/testpath"),
+                           containsString("method=POST"),
+                           containsString("Origin=[http://myhost.com]"),
+                           containsString("Host=[otherhost]"),
+                           not(containsString("Authorization")),
+                           not(containsString("X-Custom"))));
+    }
+}


### PR DESCRIPTION
### Description
Resolves #9170 

CORS processing uses only a few headers to make its decisions. This PR streamlines which headers are logged (at `FINE` level) to track the CORS decisions.

### Documentation
No impact.