### PR TITLE
Remove headers that do not affect CORS decision-making from request adapter logging output

### DIFF
--- a/microprofile/cors/pom.xml
+++ b/microprofile/cors/pom.xml
@@ -85,5 +85,10 @@
             <artifactId>helidon-microprofile-tests-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package io.helidon.microprofile.cors;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -147,7 +149,17 @@ class CorsSupportMp extends CorsSupportBase<ContainerRequestContext, Response, C
         @Override
         public String toString() {
             return String.format("RequestAdapterMp{path=%s, method=%s, headers=%s}", path(), method(),
-                    requestContext.getHeaders());
+                    filteredHeaders());
+        }
+
+        private Map<String, List<String>> filteredHeaders() {
+            MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
+            for (Map.Entry<String, List<String>> header : requestContext.getHeaders().entrySet()) {
+                if (HEADERS_FOR_CORS_DIAGNOSTICS.contains(header.getKey().toLowerCase(Locale.getDefault()))) {
+                    result.put(header.getKey(), header.getValue());
+                }
+            }
+            return result;
         }
     }
 

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/HeadersTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/HeadersTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cors;
+
+import java.net.URI;
+import java.util.Map;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HeadersTest {
+    @Test
+    void checkHeaders() {
+
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getRequestUri()).thenReturn(URI.create("http://myhost.com/testpath"));
+        ContainerRequestContext context = mock(ContainerRequestContext.class);
+        when(context.getHeaders()).thenReturn(new MultivaluedHashMap<>(Map.of("Origin", "http://myhost.com",
+                                                                              "Host", "otherhost",
+                                                                              "Authorization", "some-auth",
+                                                                              "X-Custom", "myValue")));
+        when(context.getMethod()).thenReturn("POST");
+        when(context.getUriInfo()).thenReturn(uriInfo);
+
+        CorsSupportMp.RequestAdapterMp requestAdapterMp = new CorsSupportMp.RequestAdapterMp(context);
+
+        assertThat("Headers",
+                   requestAdapterMp.toString(),
+                   allOf(
+                           containsString("path=/testpath"),
+                           containsString("method=POST"),
+                           containsString("Origin=[http://myhost.com]"),
+                           containsString("Host=[otherhost]"),
+                           not(containsString("Authorization")),
+                           not(containsString("X-Custom"))));
+    }
+}

--- a/webserver/cors/pom.xml
+++ b/webserver/cors/pom.xml
@@ -66,6 +66,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.webserver.cors;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -270,6 +271,13 @@ public abstract class CorsSupportBase<Q, R, T extends CorsSupportBase<Q, R, T, B
      * @param <T> type of the request wrapped by the adapter
      */
     protected interface RequestAdapter<T> {
+
+        /**
+         * Header names useful for CORS diagnostic logging messages.
+         */
+        Set<String> HEADERS_FOR_CORS_DIAGNOSTICS = Set.of("origin",
+                                                          "host",
+                                                          "access-control-request-method");
 
         /**
          *

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/RequestAdapterSe.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/RequestAdapterSe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,10 @@
  */
 package io.helidon.webserver.cors;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import io.helidon.webserver.ServerRequest;
@@ -68,6 +71,16 @@ class RequestAdapterSe implements CorsSupportBase.RequestAdapter<ServerRequest> 
 
     @Override
     public String toString() {
-        return String.format("RequestAdapterSe{path=%s, method=%s, headers=%s}", path(), method(), request.headers().toMap());
+        return String.format("RequestAdapterSe{path=%s, method=%s, headers=%s}", path(), method(), headersDisplay());
+    }
+
+    private Map<String, List<String>> headersDisplay() {
+        Map<String, List<String>> result = new HashMap<>();
+        for (Map.Entry<String, List<String>> header : request.headers().toMap().entrySet()) {
+            if (HEADERS_FOR_CORS_DIAGNOSTICS.contains(header.getKey().toLowerCase(Locale.getDefault()))) {
+                result.put(header.getKey(), header.getValue());
+            }
+        }
+        return result;
     }
 }

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/HeadersTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/HeadersTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.cors;
+
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.common.http.Http;
+import io.helidon.common.http.HttpRequest;
+import io.helidon.webserver.RequestHeaders;
+import io.helidon.webserver.ServerRequest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HeadersTest {
+
+    @Test
+    void checkHeaders() {
+        HttpRequest.Path path = mock(HttpRequest.Path.class);
+        when(path.toString())
+                .thenReturn("/testpath");
+
+        RequestHeaders requestHeaders = mock(RequestHeaders.class);
+        when(requestHeaders.toMap())
+                .thenReturn(Map.of("Origin", List.of("http://myhost.com"),
+                                   "Host", List.of("otherhost"),
+                                   "Authorization", List.of("some-auth"),
+                                   "X-Custom", List.of("myValue")));
+
+        Http.RequestMethod requestMethod = mock(Http.RequestMethod.class);
+        when(requestMethod.name()).thenReturn("POST");
+
+        ServerRequest serverRequest = mock(ServerRequest.class);
+        when(serverRequest.path()).thenReturn(path);
+        when(serverRequest.method()).thenReturn(requestMethod);
+        when(serverRequest.headers()).thenReturn(requestHeaders);
+
+        RequestAdapterSe requestAdapterSe = new RequestAdapterSe(serverRequest);
+        assertThat("Headers",
+                   requestAdapterSe.toString(),
+                   allOf(
+                           containsString("path=/testpath"),
+                           containsString("method=POST"),
+                           containsString("Origin=[http://myhost.com]"),
+                           containsString("Host=[otherhost]"),
+                           not(containsString("Authorization")),
+                           not(containsString("X-Custom"))));
+    }
+}


### PR DESCRIPTION
### Description
Resolves #9171 

CORS processing uses only a few headers to make its decisions. This PR streamlines which headers are logged (at FINE level) to track the CORS decisions.

### Documentation
No doc impact.