### PR TITLE
deprecate old injection integration for oci

### DIFF
--- a/integrations/oci/sdk/processor/src/main/java/io/helidon/integrations/oci/sdk/processor/OciInjectionProcessorObserver.java
+++ b/integrations/oci/sdk/processor/src/main/java/io/helidon/integrations/oci/sdk/processor/OciInjectionProcessorObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/oci/sdk/processor/src/main/java/io/helidon/integrations/oci/sdk/processor/OciInjectionProcessorObserver.java
+++ b/integrations/oci/sdk/processor/src/main/java/io/helidon/integrations/oci/sdk/processor/OciInjectionProcessorObserver.java
@@ -86,7 +86,10 @@ import static java.util.function.Predicate.not;
  *     comma-delimited, and each token will be treated as a fully qualified type name to signal that the type should be
  *     not be processed.</li>
  * </ul>
+ *
+ * @deprecated replaced with {@code helidon-integrations-oci} module
  */
+@Deprecated(forRemoval = true, since = "4.1.0")
 public class OciInjectionProcessorObserver implements InjectionAnnotationProcessorObserver {
     static final String OCI_ROOT_PACKAGE_NAME_PREFIX = "com.oracle.bmc.";
 

--- a/integrations/oci/sdk/processor/src/main/java/io/helidon/integrations/oci/sdk/processor/OciModuleComponentNamer.java
+++ b/integrations/oci/sdk/processor/src/main/java/io/helidon/integrations/oci/sdk/processor/OciModuleComponentNamer.java
@@ -27,7 +27,10 @@ import static java.util.function.Predicate.not;
 
 /**
  * Avoids using any OCI SDK package name(s) as the {@link ModuleComponent} name that is code-generated.
+ *
+ * @deprecated replaced with {@code helidon-integrations-oci} module
  */
+@Deprecated(forRemoval = true, since = "4.1.0")
 public class OciModuleComponentNamer implements ModuleComponentNamer {
 
     /**

--- a/integrations/oci/sdk/processor/src/main/java/io/helidon/integrations/oci/sdk/processor/OciModuleComponentNamer.java
+++ b/integrations/oci/sdk/processor/src/main/java/io/helidon/integrations/oci/sdk/processor/OciModuleComponentNamer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/oci/sdk/processor/src/main/java/module-info.java
+++ b/integrations/oci/sdk/processor/src/main/java/module-info.java
@@ -16,7 +16,10 @@
 
 /**
  * Helidon Injection Integrations for OCI SDK.
+ *
+ * @deprecated replaced with {@code helidon-integrations-oci} module
  */
+@Deprecated(forRemoval = true, since = "4.1.0")
 module io.helidon.integrations.oci.sdk.processor {
 
     requires handlebars;

--- a/integrations/oci/sdk/processor/src/main/java/module-info.java
+++ b/integrations/oci/sdk/processor/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Deprecating old injection based integration support for OCI SDK in favor of new one.

### Documentation

None
