### PR TITLE
4.x: Clarify description of config profiles

### DIFF
--- a/docs/src/main/asciidoc/mp/config/introduction.adoc
+++ b/docs/src/main/asciidoc/mp/config/introduction.adoc
@@ -126,9 +126,14 @@ server.host=0.0.0.0
 ==== {spec-name} Profiles [[Config-Profiles]]
 
 {spec-name} supports a concept of configuration profiles. You can define a profile using the configuration property `mp.config.profile`
-(when using default configuration, this can be defined as a system property, environment variable or as a property in `microprofile-config.properties`).
-When a profile is defined, additional config source is loaded (`microprofile-config-profile.properties`) and properties from profile have precedence over
-default properties. Profile properties can be defined using `%profile` prefix, such as `%dev.server.port`.
+This can be defined as a system property, environment variable or as a property in `microprofile-config.properties` (when default configuration is used).
+When a profile is defined, an additional config source is loaded: `microprofile-config-<profile_name>.properties` and properties in the profile
+specific config source will override properties set in the default config source.
+
+You can also use profiles on a per property level.
+Profile specific properties are defined using `%<profile_name>` prefix, such as `%dev.server.port`.
+This will override the plain property `server.port`.
+For more details see link:{microprofile-config-spec-url}#_how_config_profile_works[How Config Profiles work]
 
 === Helidon {spec-name} Features
 


### PR DESCRIPTION
### Description

Clarifies how Microprofile Config Profiles work.

Fixes #7918