### PR TITLE
Increases default value of write-buffer-size to 4K

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -164,12 +164,12 @@ interface ListenerConfigBlueprint {
 
     /**
      * Initial buffer size in bytes of {@link java.io.BufferedOutputStream} created internally to
-     * write data to a socket connection. Default is {@code 512}.
+     * write data to a socket connection. Default is {@code 4096}.
      *
      * @return initial buffer size used for writing
      */
     @Option.Configured
-    @Option.DefaultInt(512)
+    @Option.DefaultInt(4096)
     int writeBufferSize();
 
     /**

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public class ListenerConfigTest {
         Config config = Config.create();
         var webServerConfig = WebServer.builder().config(config.get("server")).buildPrototype();
         assertThat(webServerConfig.writeQueueLength(), is(0));         // default
-        assertThat(webServerConfig.writeBufferSize(), is(512));        // default
+        assertThat(webServerConfig.writeBufferSize(), is(4096));       // default
         assertThat(webServerConfig.shutdownGracePeriod().toMillis(), is(500L));   // default
         ListenerConfig listenerConfig2 = webServerConfig.sockets().get("other");
         assertThat(listenerConfig2.writeQueueLength(), is(64));


### PR DESCRIPTION
### Description

Increases default value of write-buffer-size to 4K. This change provides a better out-of-the-box buffering strategy for chunked encoded HTTP responses. See issue #9189 for some testing results.
