### PR TITLE
2.x: Adds ability to close idle HTTP connections after a certain time

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import io.helidon.webserver.HelidonConnectionHandler.HelidonHttp2ConnectionHandl
 import io.helidon.webserver.ReferenceHoldingQueue.IndirectReference;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
@@ -51,6 +52,8 @@ import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
@@ -217,6 +220,20 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
                                         soConfig,
                                         requestDecoder,
                                         directHandlers));
+
+        // Set up idle handler to close inactive connections based on config
+        int idleTimeout = serverConfig.connectionIdleTimeout();
+        if (idleTimeout > 0) {
+            p.addLast(new IdleStateHandler(idleTimeout, idleTimeout, idleTimeout));
+            p.addLast(new ChannelDuplexHandler() {
+                @Override
+                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                    if (evt instanceof IdleStateEvent) {
+                        ctx.close();        // async close of idle connection
+                    }
+                }
+            });
+        }
 
         // Cleanup queues as part of event loop
         ch.eventLoop().execute(this::clearQueues);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,6 +211,11 @@ class ServerBasicConfig implements ServerConfiguration {
         return isRequestedUriDiscoveryEnabled;
     }
 
+    @Override
+    public int connectionIdleTimeout() {
+        return socketConfig.connectionIdleTimeout();
+    }
+
     static class SocketConfig implements SocketConfiguration {
 
         private final int port;
@@ -234,6 +239,7 @@ class ServerBasicConfig implements ServerConfiguration {
         private final List<RequestedUriDiscoveryType> requestedUriDiscoveryTypes;
         private final AllowList trustedProxies;
         private final boolean isRequestedUriDiscoveryEnabled;
+        private final int connectionIdleTimeout;
 
         /**
          * Creates new instance.
@@ -261,6 +267,7 @@ class ServerBasicConfig implements ServerConfiguration {
             this.requestedUriDiscoveryTypes = builder.requestedUriDiscoveryTypes();
             this.trustedProxies = builder.trustedProxies();
             this.isRequestedUriDiscoveryEnabled = builder.requestedUriDiscoveryEnabled();
+            this.connectionIdleTimeout = builder.connectionIdleTimeout();
         }
 
         @Override
@@ -386,6 +393,11 @@ class ServerBasicConfig implements ServerConfiguration {
         @Override
         public boolean requestedUriDiscoveryEnabled() {
             return isRequestedUriDiscoveryEnabled;
+        }
+
+        @Override
+        public int connectionIdleTimeout() {
+            return connectionIdleTimeout;
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -616,6 +616,12 @@ public interface ServerConfiguration extends SocketConfiguration {
         @Override
         public Builder trustedProxies(AllowList trustedProxies) {
             defaultSocketBuilder().trustedProxies(trustedProxies);
+            return this;
+        }
+
+        @Override
+        public Builder connectionIdleTimeout(int seconds) {
+            defaultSocketBuilder().connectionIdleTimeout(seconds);
             return this;
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -698,6 +698,12 @@ public interface WebServer {
          */
         public Builder experimental(ExperimentalConfiguration experimental) {
             configurationBuilder.experimental(experimental);
+            return this;
+        }
+
+        @Override
+        public Builder connectionIdleTimeout(int seconds) {
+            defaultSocket(it -> it.connectionIdleTimeout(seconds));
             return this;
         }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionIdleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionIdleTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.net.SocketException;
+import java.time.Duration;
+import java.util.List;
+import java.util.logging.Logger;
+
+import io.helidon.common.http.Http;
+import io.helidon.webserver.utils.SocketHttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests support for idle connection timeouts.
+ */
+public class ConnectionIdleTest {
+    private static final Logger LOGGER = Logger.getLogger(ConnectionIdleTest.class.getName());
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    private static final int IDLE_TIMEOUT = 1000;
+
+    private static WebServer webServer;
+
+    @BeforeAll
+    public static void startServer() throws Exception {
+        startServer(0);
+    }
+
+    @AfterAll
+    public static void close() throws Exception {
+        if (webServer != null) {
+            webServer.shutdown().await(TIMEOUT);
+        }
+    }
+
+    /**
+     * Start the Web Server
+     *
+     * @param port the port on which to start the server
+     */
+    private static void startServer(int port) {
+        webServer = WebServer.builder()
+                .host("localhost")
+                .port(port)
+                .connectionIdleTimeout(IDLE_TIMEOUT / 1000)     // in seconds
+                .routing(Routing.builder().get("/hello", (req, res) -> res.send("Hello World!")))
+                .build()
+                .start()
+                .await(TIMEOUT);
+
+        LOGGER.info("Started server at: https://localhost:" + webServer.port());
+    }
+
+    @Test
+    public void testIdleConnectionClosed() throws Exception {
+        try (SocketHttpClient client = new SocketHttpClient(webServer)) {
+            // initial request with keep-alive to open connection
+            client.request(Http.Method.GET,
+                    "/hello",
+                    null,
+                    List.of("Connection: keep-alive"));
+            String res = client.receive();
+            assertThat(res, containsString("Hello World!"));
+
+            // second request while connection is active
+            client.request(Http.Method.GET,
+                           "/hello",
+                           null);
+            res = client.receive();
+            assertThat(res, containsString("Hello World!"));
+
+            // wait for connection to time out due to inactivity
+            Thread.sleep(2 * IDLE_TIMEOUT);
+
+            // try again and either get nothing or an exception
+            try {
+                client.request(Http.Method.GET,
+                               "/hello",
+                               null);
+                res = client.receive();
+                assertThat(res, is(""));
+            } catch (SocketException e) {
+                // falls through as possible outcome
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Adds ability to close idle HTTP connections after a certain time using connection-idle-timeout (in seconds). New test. See issue #9163.

**Configuration**

```java
 webServer = WebServer.builder()
                      .host("localhost")
                      .port(port)
                      .connectionIdleTimeout(300)      // 5 minutes
                      ...
```

```yaml
server:
  host: localhost
  port: 0
  connection-idle-timeout: 300
```

