### PR TITLE
4.x Allow users to direct Helidon to use an existing global `OpenTelemetry` instance rather than create its own

### DIFF
--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/OpenTelemetryProducer.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/OpenTelemetryProducer.java
@@ -90,8 +90,8 @@ class OpenTelemetryProducer {
 
         mpConfig.getOptionalValue(EXPORTER_NAME_PROPERTY, String.class).ifPresent(e -> exporterName = e);
 
-        // If there is an OTEL Agent – delegate everything to it.
-        if (HelidonOpenTelemetry.AgentDetector.isAgentPresent(config)) {
+        // If there is an OTEL Agent – or otherwise we should use a pre-existing global OTel instance - delegate to it.
+        if (HelidonOpenTelemetry.AgentDetector.useExistingGlobalOpenTelemetry(config)) {
             openTelemetry =  GlobalOpenTelemetry.get();
         } else {
 

--- a/tracing/providers/opentelemetry/pom.xml
+++ b/tracing/providers/opentelemetry/pom.xml
@@ -84,6 +84,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
@@ -51,7 +51,7 @@ public final class HelidonOpenTelemetry {
     public static final String IO_OPENTELEMETRY_JAVAAGENT = "io.opentelemetry.javaagent";
 
     static final String UNSUPPORTED_OPERATION_MESSAGE = "Span listener attempted to invoke an illegal operation";
-    static final String USE_EXISTING_OTEL = "io.helidon.tracing.otel.use-existing";
+    static final String USE_EXISTING_OTEL = "io.helidon.tracing.otel.use-existing-instance";
 
     private static final System.Logger LOGGER = System.getLogger(HelidonOpenTelemetry.class.getName());
     private static final LazyValue<List<SpanListener>> SPAN_LISTENERS =

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
@@ -51,7 +51,7 @@ public final class HelidonOpenTelemetry {
     public static final String IO_OPENTELEMETRY_JAVAAGENT = "io.opentelemetry.javaagent";
 
     static final String UNSUPPORTED_OPERATION_MESSAGE = "Span listener attempted to invoke an illegal operation";
-    static final String USE_EXISTING_OTEL = "io.helidon.tracing.otel.use-existing-instance";
+    static final String USE_EXISTING_OTEL = "io.helidon.telemetry.otel.use-existing-instance";
 
     private static final System.Logger LOGGER = System.getLogger(HelidonOpenTelemetry.class.getName());
     private static final LazyValue<List<SpanListener>> SPAN_LISTENERS =

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
@@ -51,6 +51,7 @@ public final class HelidonOpenTelemetry {
     public static final String IO_OPENTELEMETRY_JAVAAGENT = "io.opentelemetry.javaagent";
 
     static final String UNSUPPORTED_OPERATION_MESSAGE = "Span listener attempted to invoke an illegal operation";
+    static final String USE_EXISTING_OTEL = "io.helidon.tracing.otel.use-existing";
 
     private static final System.Logger LOGGER = System.getLogger(HelidonOpenTelemetry.class.getName());
     private static final LazyValue<List<SpanListener>> SPAN_LISTENERS =
@@ -142,6 +143,18 @@ public final class HelidonOpenTelemetry {
                 return true;
             }
             return false;
+        }
+
+        /**
+         * Return whether the user has requested that Helidon use an existing global OpenTelemetry instance rather than
+         * creating one itself; specifying that the OpenTelemetry agent is present automatically implies using the agent's
+         * existing instance.
+         *
+         * @param config configuration potentially containing the setting
+         * @return true if Helidon is configured to use an existing global OpenTelemetry instance; false otherwise
+         */
+        public static boolean useExistingGlobalOpenTelemetry(Config config) {
+            return isAgentPresent(config) || config.get(USE_EXISTING_OTEL).asBoolean().orElse(false);
         }
 
         private static boolean checkSystemProperties() {


### PR DESCRIPTION
### Description
Resolves #9204 

This PR adds the ability of Helidon MP users to indicate that some code _other than_ Helidon will create the global OpenTelemetry instance and Helidon MP should simply use that instance rather than trying to create it.

This PR affects the public API of Helidon in these ways:
* New config setting `io.helidon.telemetry.otel.use-existing-instance` indicating whether Helidon MP should use the global instance of OTel which some other code has already created. Defaults to `false` so Helidon MP creates the global OTel instance itself.
* The pre-existing public type`HelidonOpenTelemetry.AgentDetector` has a new public method `useExistingGlobalOpenTelemetry`. This method combines the results of the existing `isAgentPresent` method with a check of the new config setting. If `isAgentPresent` returns `true` then this new method returns true regardless of the config setting. Otherwise the method essentially returns the config setting (which, as mentioned above, defaults to `false`).
* `OpenTelemetryProducer` now invokes the new `AgentDetector#useExistingGlobalOpenTelemetry` method (instead of `isAgentPresent` as it used to) to decide whether to create a new global OTel instance or use whatever existing one is present.

If `otel.agent.present` is `true` and `io.helidon.telemetry.otel.use-existing-instance` is `false` the agent setting takes precedence and Helidon uses the global OTel instance which the agent provided.

The PR also includes some new tests. 

### Documentation
There is no doc impact currently but, at some point, we need to add documentation for the OpenTelemetry tracing provider and this enhancement would be discussed there.