### PR TITLE
4.x: UncheckedIOException no longer a special case

### DIFF
--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/JaxRsApplicationPathTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/JaxRsApplicationPathTest.java
@@ -16,9 +16,6 @@
 
 package io.helidon.microprofile.server;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -39,8 +36,10 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriInfo;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 class JaxRsApplicationPathTest {
 
@@ -87,7 +86,8 @@ class JaxRsApplicationPathTest {
     public void testEncoded() {
         String getResponse = client.target("http://localhost:" + port)
                 .path("/ApplicationPath!/Resource/encoded").queryParam("query", "%dummy23+a")
-                .request().get(String.class);
+                .request()
+                .get(String.class);
         assertThat(getResponse, is("true:%25dummy23%2Ba"));
     }
 

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/JaxRsApplicationPathTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/JaxRsApplicationPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -412,7 +412,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         if (frameHeader.length() == 0) {
             frameInProgress = BufferData.empty();
         } else {
-                frameInProgress = reader.readBuffer(frameHeader.length());
+            frameInProgress = reader.readBuffer(frameHeader.length());
         }
 
         receiveFrameListener.frame(ctx, streamId, frameInProgress);

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -412,7 +412,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         if (frameHeader.length() == 0) {
             frameInProgress = BufferData.empty();
         } else {
-            frameInProgress = reader.readBuffer(frameHeader.length());
+                frameInProgress = reader.readBuffer(frameHeader.length());
         }
 
         receiveFrameListener.frame(ctx, streamId, frameInProgress);

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/UncheckedIoExceptionTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/UncheckedIoExceptionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.helidon.webserver.tests;
 
 import java.io.IOException;

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/UncheckedIoExceptionTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/UncheckedIoExceptionTest.java
@@ -1,0 +1,33 @@
+package io.helidon.webserver.tests;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import io.helidon.http.Status;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+public class UncheckedIoExceptionTest {
+    @SetUpRoute
+    public static void routing(HttpRules rules) {
+        rules.get("/fail", ((req, res) -> {
+            throw new UncheckedIOException("My Exception", new IOException("Outbound client failure"));
+        }));
+    }
+
+    @Test
+    public void testUncheckedIoTreatedAsAnyOther(Http1Client client) {
+        var response = client.get("/fail")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.INTERNAL_SERVER_ERROR_500));
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/UncheckedIoExceptionTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/UncheckedIoExceptionTest.java
@@ -31,16 +31,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ServerTest
-public class UncheckedIoExceptionTest {
+class UncheckedIoExceptionTest {
     @SetUpRoute
-    public static void routing(HttpRules rules) {
+    static void routing(HttpRules rules) {
         rules.get("/fail", ((req, res) -> {
             throw new UncheckedIOException("My Exception", new IOException("Outbound client failure"));
         }));
     }
 
     @Test
-    public void testUncheckedIoTreatedAsAnyOther(Http1Client client) {
+    void testUncheckedIoTreatedAsAnyOther(Http1Client client) {
         var response = client.get("/fail")
                 .request(String.class);
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver;
 
+import java.io.UncheckedIOException;
 import java.net.Socket;
 import java.util.HexFormat;
 import java.util.Iterator;
@@ -24,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
 
 import javax.net.ssl.SSLSocket;
 
@@ -129,7 +131,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
                 helidonSocket = PlainSocket.server(socket, channelId, serverChannelId);
             }
 
-            reader = new DataReader(helidonSocket);
+            reader = new DataReader(new MapExceptionDataSupplier(helidonSocket));
             writer = SocketWriter.create(listenerContext.executor(), helidonSocket,
                     listenerContext.config().writeQueueLength());
         } catch (Exception e) {
@@ -320,6 +322,23 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
             helidonSocket.close();
         } catch (Throwable e) {
             helidonSocket.log(LOGGER, TRACE, "Failed to close socket on connection close", e);
+        }
+    }
+
+    private static class MapExceptionDataSupplier implements Supplier<byte[]> {
+        private final HelidonSocket helidonSocket;
+
+        private MapExceptionDataSupplier(HelidonSocket helidonSocket) {
+            this.helidonSocket = helidonSocket;
+        }
+
+        @Override
+        public byte[] get() {
+            try {
+                return helidonSocket.get();
+            } catch (UncheckedIOException e) {
+                throw new ServerConnectionException("Failed to get data from socket", e);
+            }
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -16,7 +16,6 @@
 
 package io.helidon.webserver;
 
-import java.io.UncheckedIOException;
 import java.net.Socket;
 import java.util.HexFormat;
 import java.util.Iterator;
@@ -167,12 +166,12 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
             helidonSocket.log(LOGGER, WARNING, "escaped Request exception", e);
         } catch (HttpException e) {
             helidonSocket.log(LOGGER, WARNING, "escaped HTTP exception", e);
+        } catch (ServerConnectionException e) {
+            // socket exception - the socket failed, probably killed by OS, proxy or client
+            helidonSocket.log(LOGGER, TRACE, "server I/O issue", e);
         } catch (CloseConnectionException e) {
             // end of request stream - safe to close the connection, as it was requested by our client
             helidonSocket.log(LOGGER, TRACE, "connection close requested", e);
-        } catch (UncheckedIOException e) {
-            // socket exception - the socket failed, probably killed by OS, proxy or client
-            helidonSocket.log(LOGGER, TRACE, "received I/O exception", e);
         } catch (Exception e) {
             helidonSocket.log(LOGGER, WARNING, "unexpected exception", e);
         } finally {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConnectionException.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConnectionException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.Objects;
+
+/**
+ * An exception that was caused by server communication error (on the original client call).
+ * <p>
+ * This exception must bubble up through the error handling chain, as otherwise we would treat it
+ * as an internal exception, and may end up logging too much information.
+ */
+public class ServerConnectionException extends CloseConnectionException {
+    /**
+     * Server connection exception based on a cause.
+     *
+     * @param message descriptive message
+     * @param cause   cause of this exception
+     */
+    public ServerConnectionException(String message, Throwable cause) {
+        super(Objects.requireNonNull(message),
+              Objects.requireNonNull(cause));
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
@@ -16,7 +16,6 @@
 
 package io.helidon.webserver.http;
 
-import java.io.UncheckedIOException;
 import java.net.SocketException;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -31,6 +30,7 @@ import io.helidon.http.InternalServerException;
 import io.helidon.http.RequestException;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 
 /**
  * Http routing Error handlers.
@@ -77,7 +77,7 @@ public final class ErrorHandlers {
             if (response.hasEntity()) {
                 response.commit();
             }
-        } catch (CloseConnectionException | UncheckedIOException e) {
+        } catch (CloseConnectionException e) {
             // these errors must "bubble up"
             throw e;
         } catch (RequestException e) {
@@ -119,7 +119,7 @@ public final class ErrorHandlers {
             handleError(ctx, request, response, e);
         } catch (Throwable e) {
             if (e.getCause() instanceof SocketException se) {
-                throw new UncheckedIOException(se);
+                throw new ServerConnectionException("SocketException during routing", se);
             }
             handleError(ctx, request, response, e);
         }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -19,7 +19,6 @@ package io.helidon.webserver.http;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,6 +41,7 @@ import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.UnsupportedTypeException;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 
 /**
  * Base class for common server response tasks that can be shared across HTTP versions.
@@ -214,7 +214,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
                 os.write(entity);
                 os.close();
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                throw new ServerConnectionException("Failed to write response", e);
             }
             entity = baos.toByteArray();
             encoder.headers(headers());

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http1;
 
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -49,6 +50,7 @@ import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ProxyProtocolData;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.DirectTransportRequest;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http1.spi.Http1Upgrader;
@@ -362,7 +364,11 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         // Expect: 100-continue
         if (headers.contains(HeaderValues.EXPECT_100)) {
             if (this.http1Config.continueImmediately()) {
-                writer.writeNow(BufferData.create(CONTINUE_100));
+                try {
+                    writer.writeNow(BufferData.create(CONTINUE_100));
+                } catch (UncheckedIOException e) {
+                    throw new ServerConnectionException("Failed tow rite continue", e);
+                }
             }
             expectContinue = true;
         }
@@ -479,7 +485,11 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         sendListener.status(ctx, response.status());
         sendListener.headers(ctx, headers);
         sendListener.data(ctx, buffer);
-        writer.write(buffer);
+        try {
+            writer.write(buffer);
+        } catch (UncheckedIOException uioe) {
+            throw new ServerConnectionException("Failed to write request exception", uioe);
+        }
 
         if (response.status() == Status.INTERNAL_SERVER_ERROR_500) {
             LOGGER.log(WARNING, "Internal server error", e);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -16,7 +16,6 @@
 
 package io.helidon.webserver.http1;
 
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -207,7 +206,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                 }
 
             }
-        } catch (CloseConnectionException | UncheckedIOException e) {
+        } catch (CloseConnectionException e) {
             throw e;
         } catch (BadRequestException e) {
             handleRequestException(RequestException.builder()

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -367,7 +367,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                 try {
                     writer.writeNow(BufferData.create(CONTINUE_100));
                 } catch (UncheckedIOException e) {
-                    throw new ServerConnectionException("Failed tow rite continue", e);
+                    throw new ServerConnectionException("Failed to write continue", e);
                 }
             }
             expectContinue = true;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -19,7 +19,6 @@ package io.helidon.webserver.http1;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
@@ -45,6 +44,7 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.http.media.EntityWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.ServerResponseBase;
 import io.helidon.webserver.http.spi.Sink;
 import io.helidon.webserver.http.spi.SinkProvider;
@@ -186,7 +186,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             try (OutputStream os = outputStream(skipEncoders)) {
                 os.write(bytes);
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                throw new ServerConnectionException("Failed to write response", e);
             }
         }
     }
@@ -307,7 +307,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                 }
             }
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new ServerConnectionException("Failed to write sink data", e);
         }
     }
 
@@ -544,7 +544,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             try {
                 super.close();
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                throw new ServerConnectionException("Failed to close server response stream.", e);
             }
         }
 
@@ -764,7 +764,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             try {
                 bufferedDelegate.close();
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                throw new ServerConnectionException("Failed to close server output stream", e);
             }
         }
 
@@ -777,7 +777,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                 flush();
                 delegate.commit();
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                throw new ServerConnectionException("Failed to flush server output stream", e);
             }
         }
     }


### PR DESCRIPTION
Resolves #9192 

No longer using UncheckedIOException as a special case for the server.
Server I/O failures now throw a ServerConnectionException, and that extends the CloseConnectionException (which already has its special handling).

This change allows user to handle UncheckIOException as if it is any other throwable.

As part of this change:
- all reads on server (from server request reader) are now wrapped and no longer throw `UncheckedIOException`
- all writes on server (to server response writer) are surrounded by try/catch blocks to handle this exception.

This is a small behavior change. The original behavior was not documented, and the result was not ideal (as we would close connection even if the `UncheckedIOException` came from client call to another service).
The new behavior only closes connection with specific exception. 