### PR TITLE
Allows the creation of empty SSE events

### DIFF
--- a/http/sse/src/main/java/io/helidon/http/sse/SseEvent.java
+++ b/http/sse/src/main/java/io/helidon/http/sse/SseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,11 @@ import io.helidon.http.media.MediaContext;
  * An SSE event.
  */
 public class SseEvent {
+
+    /**
+     * Value returned by {@link #data()} when no data has been set.
+     */
+    public static final Object NO_DATA = new Object();
 
     private static final WritableHeaders<?> EMPTY_HEADERS = WritableHeaders.create();
 
@@ -91,7 +96,7 @@ public class SseEvent {
     /**
      * Get data for this event.
      *
-     * @return the data
+     * @return the data or {@link #NO_DATA}
      */
     public Object data() {
         return data;
@@ -218,7 +223,7 @@ public class SseEvent {
 
         private String id;
         private String name;
-        private Object data;
+        private Object data = NO_DATA;
         private String comment;
         private MediaType mediaType;
         private Duration reconnectMillis;
@@ -229,9 +234,6 @@ public class SseEvent {
 
         @Override
         public SseEvent build() {
-            if (data == null) {
-                throw new IllegalArgumentException("Event must include some data");
-            }
             return new SseEvent(this);
         }
 

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/SseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/SseSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public class SseSink implements Sink<SseEvent> {
                 outputStream.write(SSE_NL);
             }
             Object data = sseEvent.data();
-            if (data != null) {
+            if (data != SseEvent.NO_DATA) {
                 outputStream.write(SSE_DATA);
                 eventConsumer.accept(data, sseEvent.mediaType().orElse(MediaTypes.TEXT_PLAIN));
                 outputStream.write(SSE_NL);

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseEventTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,5 +89,21 @@ class SseEventTest extends SseBaseTest {
         HelloWorld json = event.data(HelloWorld.class, MediaTypes.APPLICATION_JSON);
         assertThat(json, is(notNullValue()));
         assertThat(json.getHello(), is("world"));
+    }
+
+    @Test
+    void testNoData() {
+        SseEvent event = SseEvent.builder().build();
+        assertThat(event, is(notNullValue()));
+        assertThat(event.data(), is(SseEvent.NO_DATA));
+    }
+
+    @Test
+    void testConvertNoData() {
+        SseEvent event = SseEvent.builder()
+                .mediaContext(mediaContext)
+                .build();
+        assertThrows(IllegalStateException.class, () -> event.data(Object.class));
+        assertThrows(IllegalStateException.class, () -> event.data(Object.class, MediaTypes.TEXT_PLAIN));
     }
 }


### PR DESCRIPTION
### Description

Allows an SSE event to be created using no data. Uses a static constant SseEvent.NO_DATA to avoid returning null in getters. Updates serialization code and tests. See issue #9165.
