### PR TITLE
2.x: Upgrade plugins to match what is used in Helidon 3

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -143,11 +143,11 @@
     </developers>
 
     <properties>
-        <version.plugin.clean>3.1.0</version.plugin.clean>
-        <version.plugin.deploy>2.8.2</version.plugin.deploy>
+        <version.plugin.clean>3.3.1</version.plugin.clean>
+        <version.plugin.deploy>3.1.1</version.plugin.deploy>
         <version.plugin.gpg>1.6</version.plugin.gpg>
-        <version.plugin.install>3.0.0-M1</version.plugin.install>
-        <version.plugin.nexus-staging>1.6.7</version.plugin.nexus-staging>
+        <version.plugin.install>3.1.1</version.plugin.install>
+        <version.plugin.nexus-staging>1.6.13</version.plugin.nexus-staging>
         <version.plugin.site>3.8.2</version.plugin.site>
         <version.plugin.versions>2.7</version.plugin.versions>
     </properties>


### PR DESCRIPTION
### Description

Older versions of the maven-deploy-plugin had issues with the `deployAtEnd` option, so this upgrades it to match what we have in Helidon 3 (needed to deploy snapshot builds).  Also upgrades a few other maven plugins to match what is used in Helidon 3. 
