### PR TITLE
4.x: Replace manual casts on pattern with instanceof in helidon/config modules

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/SeConfig.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/SeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,8 +84,8 @@ class SeConfig implements Config {
         this.stringKey = prefix.child(key).toString();
         this.stringPrefix = prefix.toString();
 
-        if (delegate instanceof MpConfigImpl) {
-            this.delegateImpl = (MpConfigImpl) delegate;
+        if (delegate instanceof MpConfigImpl mpConfig) {
+            this.delegateImpl = mpConfig;
         } else {
             this.delegateImpl = null;
         }

--- a/config/config/src/main/java/io/helidon/config/ConfigDiff.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,8 +86,8 @@ class ConfigDiff {
     }
 
     private static Optional<String> value(Config node) {
-        if (node instanceof AbstractConfigImpl) {
-            return ((AbstractConfigImpl) node).value();
+        if (node instanceof AbstractConfigImpl abstractConfig) {
+            return abstractConfig.value();
         }
         return node.asString().asOptional();
     }

--- a/config/config/src/main/java/io/helidon/config/ConfigKeyImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,8 +109,8 @@ class ConfigKeyImpl implements Config.Key {
     @Override
     public ConfigKeyImpl child(io.helidon.common.config.Config.Key key) {
         final List<String> path;
-        if (key instanceof ConfigKeyImpl) {
-            path = ((ConfigKeyImpl) key).path;
+        if (key instanceof ConfigKeyImpl configKey) {
+            path = configKey.path;
         } else {
             path = new LinkedList<>();
             while (!key.isRoot()) {

--- a/config/config/src/main/java/io/helidon/config/ConfigSourceRuntimeImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSourceRuntimeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,16 +83,15 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
 
         // content source
         AtomicReference<Object> lastStamp = new AtomicReference<>();
-        if (configSource instanceof ParsableSource) {
+        if (configSource instanceof ParsableSource parsableSource) {
             // eager parsable config source
-            reloader = new ParsableConfigSourceReloader(configContext, (ParsableSource) source, lastStamp);
+            reloader = new ParsableConfigSourceReloader(configContext, parsableSource, lastStamp);
             singleNodeFunction = objectNodeToSingleNode();
-        } else if (configSource instanceof NodeConfigSource) {
+        } else if (configSource instanceof NodeConfigSource nodeConfigSource) {
             // eager node config source
-            reloader = new NodeConfigSourceReloader((NodeConfigSource) source, lastStamp);
+            reloader = new NodeConfigSourceReloader(nodeConfigSource, lastStamp);
             singleNodeFunction = objectNodeToSingleNode();
-        } else if (configSource instanceof LazyConfigSource) {
-            LazyConfigSource lazySource = (LazyConfigSource) source;
+        } else if (configSource instanceof LazyConfigSource lazySource) {
             // lazy config source
             reloader = Optional::empty;
             singleNodeFunction = lazySource::node;
@@ -143,8 +142,7 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
             }
         }
 
-        if (!changesSupported && (configSource instanceof EventConfigSource)) {
-            EventConfigSource event = (EventConfigSource) source;
+        if (!changesSupported && (configSource instanceof EventConfigSource event)) {
             changesSupported = true;
             changesRunnable = () -> event.onChange((key, config) -> listeners.forEach(it -> it.accept(key, config)));
         }
@@ -222,8 +220,8 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
         }
 
         // we may have media type mapping per node configured as well
-        if (configSource instanceof AbstractConfigSource) {
-            loadedData = loadedData.map(it -> ((AbstractConfigSource) configSource)
+        if (configSource instanceof AbstractConfigSource abstractConfigSource) {
+            loadedData = loadedData.map(it -> abstractConfigSource
                     .processNodeMapping(configContext::findParser, ConfigKeyImpl.of(), it));
         }
 

--- a/config/config/src/main/java/io/helidon/config/UrlConfigSource.java
+++ b/config/config/src/main/java/io/helidon/config/UrlConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,8 +139,8 @@ public final class UrlConfigSource extends AbstractConfigSource
         try {
             URLConnection urlConnection = url.openConnection();
 
-            if (urlConnection instanceof HttpURLConnection) {
-                return httpContent((HttpURLConnection) urlConnection);
+            if (urlConnection instanceof HttpURLConnection httpURLConnection) {
+                return httpContent(httpURLConnection);
             } else {
                 return genericContent(urlConnection);
             }

--- a/config/config/src/main/java/io/helidon/config/UrlHelper.java
+++ b/config/config/src/main/java/io/helidon/config/UrlHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,7 @@ final class UrlHelper {
         // the URL may not be an HTTP URL
         try {
             URLConnection urlConnection = url.openConnection();
-            if (urlConnection instanceof HttpURLConnection) {
-                HttpURLConnection connection = (HttpURLConnection) urlConnection;
+            if (urlConnection instanceof HttpURLConnection connection) {
                 try {
                     connection.setRequestMethod(HEAD_METHOD);
                     if (STATUS_NOT_FOUND == connection.getResponseCode()) {


### PR DESCRIPTION
### Description
Some manual casts can be replaced on pattern and `instanceof` in helidon/config modules.

- [ ] Backport 3.x (for myself)
