### PR TITLE
4.x: Meta-configuration fixes

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -452,7 +453,11 @@ class MpConfigImpl implements Config {
         if (Enum.class.isAssignableFrom(type)) {
             return Optional.of(value -> {
                 Class<? extends Enum> enumClass = (Class<? extends Enum>) type;
-                return (T) Enum.valueOf(enumClass, value);
+                try {
+                    return (T) Enum.valueOf(enumClass, value);
+                } catch (Exception e) {
+                    return (T) Enum.valueOf(enumClass, value.toUpperCase(Locale.ROOT));
+                }
             });
         }
         // any class that has a "public static T method()"

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/config/src/main/java/io/helidon/config/BuilderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/BuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ class BuilderImpl implements Config.Builder {
     private MergingStrategy mergingStrategy = MergingStrategy.fallback();
     private boolean hasSystemPropertiesSource;
     private boolean hasEnvVarSource;
+    private boolean sourcesConfigured;
     /*
      * Config mapper providers
      */
@@ -123,6 +124,8 @@ class BuilderImpl implements Config.Builder {
         sourceSuppliers.stream()
                 .map(Supplier::get)
                 .forEach(this::addSource);
+        // this was intentional, even if empty (such as from Config.just())
+        this.sourcesConfigured = true;
 
         return this;
     }
@@ -427,7 +430,8 @@ class BuilderImpl implements Config.Builder {
             envVarAliasGeneratorEnabled = true;
         }
 
-        boolean nothingConfigured = sources.isEmpty();
+//        boolean nothingConfigured = sources.isEmpty() && !sourcesConfigured;
+        boolean nothingConfigured = false;
 
         if (nothingConfigured) {
             // use meta configuration to load all sources

--- a/config/config/src/main/java/io/helidon/config/BuilderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/BuilderImpl.java
@@ -430,15 +430,13 @@ class BuilderImpl implements Config.Builder {
             envVarAliasGeneratorEnabled = true;
         }
 
-//        boolean nothingConfigured = sources.isEmpty() && !sourcesConfigured;
-        boolean nothingConfigured = false;
+        boolean nothingConfigured = sources.isEmpty() && !sourcesConfigured;
 
         if (nothingConfigured) {
             // use meta configuration to load all sources
-            MetaConfig.configSources(mediaType -> context.findParser(mediaType).isPresent(), context.supportedSuffixes())
-                    .stream()
+            MetaConfigFinder.findConfigSource(mediaType -> context.findParser(mediaType).isPresent(), context.supportedSuffixes())
                     .map(context::sourceRuntimeBase)
-                    .forEach(targetSources::add);
+                    .ifPresent(targetSources::add);
         } else {
             // add all configured or discovered sources
 

--- a/config/config/src/main/java/io/helidon/config/BuilderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/BuilderImpl.java
@@ -434,7 +434,8 @@ class BuilderImpl implements Config.Builder {
 
         if (nothingConfigured) {
             // use meta configuration to load all sources
-            MetaConfigFinder.findConfigSource(mediaType -> context.findParser(mediaType).isPresent(), context.supportedSuffixes())
+            MetaConfigFinder.findConfigSource(mediaType -> context.findParser(mediaType).isPresent(),
+                                                     context.supportedSuffixes())
                     .map(context::sourceRuntimeBase)
                     .ifPresent(targetSources::add);
         } else {

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1635,8 +1635,14 @@ public interface Config extends io.helidon.common.config.Config {
          * @see #config(Config)
          */
         default Builder metaConfig() {
-            MetaConfig.metaConfig()
-                    .ifPresent(this::config);
+            try {
+                MetaConfig.metaConfig()
+                        .ifPresent(this::config);
+            } catch (Exception e) {
+                System.getLogger(getClass().getName())
+                        .log(System.Logger.Level.WARNING, "Failed to load SE meta-configuration,"
+                                + " please make sure it has correct format.", e);
+            }
 
             return this;
         }

--- a/config/config/src/main/java/io/helidon/config/MetaConfig.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfig.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.function.Function;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.media.type.MediaType;
@@ -239,18 +238,6 @@ public final class MetaConfig {
                 .ifPresent(list -> list.forEach(it -> configSources.addAll(MetaConfig.configSource(it))));
 
         return configSources;
-    }
-
-    // only interested in config source
-    static List<ConfigSource> configSources(Function<MediaType, Boolean> supportedMediaType, List<String> supportedSuffixes) {
-        Optional<Config> metaConfigOpt = metaConfig();
-
-        return metaConfigOpt
-                .map(MetaConfig::configSources)
-                .orElseGet(() -> MetaConfigFinder.findConfigSource(supportedMediaType, supportedSuffixes)
-                        .map(List::of)
-                        .orElseGet(List::of));
-
     }
 
     private static Config createDefault() {

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -65,5 +65,6 @@
         <module>config-metadata-builder-api</module>
         <module>test-lazy-source</module>
         <module>test-no-config-sources</module>
+        <module>test-mp-se-meta</module>
     </modules>
 </project>

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -64,5 +64,6 @@
         <module>config-metadata-meta-api</module>
         <module>config-metadata-builder-api</module>
         <module>test-lazy-source</module>
+        <module>test-no-config-sources</module>
     </modules>
 </project>

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -65,6 +65,7 @@
         <module>config-metadata-builder-api</module>
         <module>test-lazy-source</module>
         <module>test-no-config-sources</module>
+        <module>test-default-config-source</module>
         <module>test-mp-se-meta</module>
     </modules>
 </project>

--- a/config/tests/test-default-config-source/pom.xml
+++ b/config/tests/test-default-config-source/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.config.tests</groupId>
+        <artifactId>helidon-config-tests-project</artifactId>
+        <version>4.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>helidon-test-default-config-source</artifactId>
+    <name>Helidon Config Tests Default Config Source</name>
+
+    <description>
+        Test that when no config sources are configured, we do not fall to meta config, but we want to
+        use default config sources
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/config/tests/test-default-config-source/src/main/resources/application.yaml
+++ b/config/tests/test-default-config-source/src/main/resources/application.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+value: "from-file"

--- a/config/tests/test-default-config-source/src/main/resources/meta-config.yaml
+++ b/config/tests/test-default-config-source/src/main/resources/meta-config.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# MP style, which would normally fail in Helidon SE, but should be ignored, as we do not specify meta config
+add-default-sources: true
+sources:
+  - type: "properties"
+    classpath: "app.properties"

--- a/config/tests/test-default-config-source/src/test/java/io/helidon/config/tests/nosources/DefaultSourceTest.java
+++ b/config/tests/test-default-config-source/src/test/java/io/helidon/config/tests/nosources/DefaultSourceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.nosources;
+
+import java.util.Optional;
+
+import io.helidon.config.Config;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DefaultSourceTest {
+    @Test
+    public void testDefaultSource() {
+        Config config = Config.builder()
+                .disableSystemPropertiesSource()
+                .disableEnvironmentVariablesSource()
+                .build();
+
+        Optional<String> value = config.get("value")
+                .asString()
+                .asOptional();
+
+        // meta config MUST be ignored
+        assertThat("We defined not sources, we should fall back to default application.yaml",
+                   value,
+                   optionalValue(is("from-file")));
+    }
+}

--- a/config/tests/test-mp-se-meta/pom.xml
+++ b/config/tests/test-mp-se-meta/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.config.tests</groupId>
+        <artifactId>helidon-config-tests-project</artifactId>
+        <version>4.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>helidon-config-tests-mp-se-meta</artifactId>
+    <name>Helidon Config Tests MP SE Meta</name>
+
+    <description>
+        Test that when using MP config with meta-config file name that conflicts with Helidon SE, everything
+        works as expected.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/config/tests/test-mp-se-meta/src/main/resources/app.properties
+++ b/config/tests/test-mp-se-meta/src/main/resources/app.properties
@@ -1,1 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 helidon.test.value=value

--- a/config/tests/test-mp-se-meta/src/main/resources/app.properties
+++ b/config/tests/test-mp-se-meta/src/main/resources/app.properties
@@ -1,0 +1,1 @@
+helidon.test.value=value

--- a/config/tests/test-mp-se-meta/src/main/resources/application.yaml
+++ b/config/tests/test-mp-se-meta/src/main/resources/application.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+helidon.app.value: "app-value"

--- a/config/tests/test-mp-se-meta/src/main/resources/meta-config.yaml
+++ b/config/tests/test-mp-se-meta/src/main/resources/meta-config.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is an MP meta-config. It should not be named like this, but if the user does it, we should
+# honor it
+add-default-sources: true
+sources:
+  - type: "properties"
+    classpath: "app.properties"

--- a/config/tests/test-mp-se-meta/src/test/java/io/helidon/config/tests/mpsemeta/MpSeMetaTest.java
+++ b/config/tests/test-mp-se-meta/src/test/java/io/helidon/config/tests/mpsemeta/MpSeMetaTest.java
@@ -1,0 +1,39 @@
+package io.helidon.config.tests.mpsemeta;
+
+import io.helidon.common.config.GlobalConfig;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class MpSeMetaTest {
+    @Order(0)
+    @Test
+    public void testSeMeta() {
+        // this should not fail
+        io.helidon.config.Config config = io.helidon.config.Config.create();
+        assertThat(config.get("helidon.app.value").asString().asOptional(),
+                   optionalValue(is("app-value")));
+    }
+
+    @Order(1)
+    @Test
+    public void testMpMeta() {
+        System.setProperty("io.helidon.config.mp.meta-config", "meta-config.yaml");
+        Config config = ConfigProvider.getConfig();
+        assertThat(config.getValue("helidon.test.value", String.class), is("value"));
+
+        assertThat(GlobalConfig.config()
+                           .get("helidon.test.value")
+                           .asString()
+                           .asOptional(), optionalValue(is("value")));
+    }
+}

--- a/config/tests/test-mp-se-meta/src/test/java/io/helidon/config/tests/mpsemeta/MpSeMetaTest.java
+++ b/config/tests/test-mp-se-meta/src/test/java/io/helidon/config/tests/mpsemeta/MpSeMetaTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.helidon.config.tests.mpsemeta;
 
 import io.helidon.common.config.GlobalConfig;

--- a/config/tests/test-no-config-sources/pom.xml
+++ b/config/tests/test-no-config-sources/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.config.tests</groupId>
+        <artifactId>helidon-config-tests-project</artifactId>
+        <version>4.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>helidon-config-tests-no-config-sources</artifactId>
+    <name>Helidon Config Tests No Config Sources</name>
+
+    <description>
+        Test that when no config sources are defined (such as when using Config.just()), we do not
+        fallback to meta configuration.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/config/tests/test-no-config-sources/src/main/resources/application.yaml
+++ b/config/tests/test-no-config-sources/src/main/resources/application.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+value: "from-file"

--- a/config/tests/test-no-config-sources/src/main/resources/meta-config.yaml
+++ b/config/tests/test-no-config-sources/src/main/resources/meta-config.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sources:
+  - type: "inlined"
+    properties:
+      value: "from-meta-config"

--- a/config/tests/test-no-config-sources/src/test/java/io/helidon/config/tests/nosources/NoSourcesTest.java
+++ b/config/tests/test-no-config-sources/src/test/java/io/helidon/config/tests/nosources/NoSourcesTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.nosources;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.config.Config;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class NoSourcesTest {
+    @Test
+    public void testJust() {
+        Config config = Config.just();
+
+        Optional<String> value = config.get("value")
+                .asString()
+                .asOptional();
+
+        assertThat("We have used Config.just(), there should be NO config source", value, is(optionalEmpty()));
+    }
+
+    @Test
+    public void testBuilder() {
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .sources(List.of())
+                .build();
+
+        Optional<String> value = config.get("value")
+                .asString()
+                .asOptional();
+
+        assertThat("We have used Config.builder() without specifying any source, there should be NO config source",
+                   value,
+                   is(optionalEmpty()));
+    }
+
+    @Test
+    public void testMetaConfigExplicit() {
+        // a sanity check that meta configuration works when requested
+
+        Config config = Config.builder()
+                .disableEnvironmentVariablesSource()
+                .disableSystemPropertiesSource()
+                .metaConfig()
+                .build();
+
+        Optional<String> value = config.get("value")
+                .asString()
+                .asOptional();
+
+        assertThat("We have used metaConfig(), there should be the inlined config source configured",
+                   value,
+                   optionalValue(is("from-meta-config")));
+    }
+
+    @Test
+    public void testMetaConfigCreate() {
+        // a sanity check that meta configuration works when requested
+
+        Config config = Config.create();
+
+        Optional<String> value = config.get("value")
+                .asString()
+                .asOptional();
+
+        assertThat("We have used Config.create(), there should be the inlined config source configured",
+                   value,
+                   optionalValue(is("from-meta-config")));
+    }
+}

--- a/docs/src/main/asciidoc/mp/config/advanced-configuration.adoc
+++ b/docs/src/main/asciidoc/mp/config/advanced-configuration.adoc
@@ -119,7 +119,9 @@ If a file named `mp-meta-config.yaml`, or `mp-meta-config.properties` is in the 
 on the classpath, and there is no explicit setup of configuration in the code, the configuration will
 be loaded from the `meta-config` file.
 The location of the file can be overridden using system property `io.helidon.config.mp.meta-config`,
-or environment variable `HELIDON_MP_META_CONFIG`
+or environment variable `HELIDON_MP_META_CONFIG`.
+
+*Important Note:* Do not use custom files named `meta-config.*`, as even when using Micro-Profile, we still use Helidon configuration in some of our components, and this file would be recognized as a Helidon SE Meta Configuration file, which may cause erroneous behavior.
 
 [source,yaml]
 .Example of a YAML meta configuration file:


### PR DESCRIPTION
Resolves #9218 
Resolves #9220 

- make sure meta-configuration failures do not fail creation of config (such as when accidentally naming MP meta-config just `meta-config.yaml` and then SE picking it up
- set GlobalConfig from MP Config provider resolver
- do not use SE meta configuration unless explicitly requested (only in `Config.create()` and `Config.builder().metaConfig()`)

Added tests.