### PR TITLE
Fix DbClient PostgreSQL tests

### DIFF
--- a/tests/integration/dbclient/pgsql/etc/docker/Dockerfile
+++ b/tests/integration/dbclient/pgsql/etc/docker/Dockerfile
@@ -17,8 +17,9 @@
 FROM oraclelinux:9-slim
 
 RUN microdnf install postgresql-server && microdnf clean all
+RUN mkdir -p /var/run/postgresql && \
+    chown postgres:postgres /var/run/postgresql
 ADD entrypoint.sh /usr/local/bin/
-
 ENV PGDATA /var/lib/pgsql/data
 USER postgres
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
### Description

The OEL package for PostgreSQL has been updated and broke the Dockerfile used in the DbClient integration tests.

### Documentation

None.
