### PR TITLE
2.x: Uses socket config instead of server config to configure idle connection handler

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -222,7 +222,7 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
                                         directHandlers));
 
         // Set up idle handler to close inactive connections based on config
-        int idleTimeout = serverConfig.connectionIdleTimeout();
+        int idleTimeout = soConfig.connectionIdleTimeout();
         if (idleTimeout > 0) {
             p.addLast(new IdleStateHandler(idleTimeout, idleTimeout, idleTimeout));
             p.addLast(new ChannelDuplexHandler() {


### PR DESCRIPTION
### Description

Uses socket config instead of server config to configure idle connection handler. Updates test.
