### PR TITLE
Update sampler type options in JaegerTracerBuilder.

### DIFF
--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -646,7 +646,7 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
 
     /**
      * Sampler type definition.
-     * Available options are "const", "probabilistic", "ratelimiting" and "remote".
+     * Available options are "const" and "ratio".
      */
     public enum SamplerType {
         /**


### PR DESCRIPTION
### Description
Revised the sampler type options to include only "const" and "ratio," removing "probabilistic," "ratelimiting," and "remote." This change aligns the code with the latest feature specifications and simplifies the available configurations for users.
### Documentation

If enhancement: provide description with example code/config snippet or pointer to issue with the description

If feature: summarize feature and provide pointer to doc issue

If no doc impact: None
