### PR TITLE
Handles special case of an unquoted string containing an unresolved variable reference

### DIFF
--- a/config/hocon/pom.xml
+++ b/config/hocon/pom.xml
@@ -74,6 +74,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <environmentVariables>
+                        <VAR1>foo</VAR1>
                         <HOCON_TEST_PROPERTY>This Is My ENV VARS Value.</HOCON_TEST_PROPERTY>
                     </environmentVariables>
                 </configuration>

--- a/config/hocon/src/test/java/io/helidon/config/hocon/SubstitutionTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/SubstitutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,12 @@ package io.helidon.config.hocon;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import io.helidon.config.ClasspathConfigSource;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
@@ -54,5 +57,19 @@ class SubstitutionTest {
                 .orElse(Collections.emptyList());
         assertThat(list, Matchers.<Collection<String>> allOf(
                 hasSize(2), hasItem(is("Hello"))));
+    }
+
+    @Test
+    void testHoconExpansion() {
+        Config config = Config.create(
+                ConfigSources.create("foo: ${VAR1}/bar", "application/hocon"));
+        assertThat(config.get("foo").asString().orElseThrow(NoSuchElementException::new), is("foo/bar"));
+    }
+
+    @Test
+    void testHoconExpansionQuotes() {
+        Config config = Config.create(
+                ConfigSources.create("foo: \"${VAR1}/bar\"", "application/hocon"));
+        assertThat(config.get("foo").asString().orElseThrow(NoSuchElementException::new), is("foo/bar"));
     }
 }


### PR DESCRIPTION
### Description

Handles special case of an unquoted string containing an unresolved variable reference next to some text. The rendering call from the parser will wrap the string in double quotes if it contains special characters. Since we resolve references at a later time in Helidon config, we need to drop the quotes to avoid altering the config value. See issue #9254.

