### PR TITLE
2.x: Remove version for protobuf-java and leave to Helidon dependency-management

### DIFF
--- a/integrations/graal/native-image-extension/pom.xml
+++ b/integrations/graal/native-image-extension/pom.xml
@@ -36,7 +36,6 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <version.lib.lz4>1.3.0</version.lib.lz4>
         <version.lib.jboss-marshalling>2.1.1.Final</version.lib.jboss-marshalling>
-        <version.lib.google-protobuf>3.21.7</version.lib.google-protobuf>
         <version.lib.jzlib>1.1.3</version.lib.jzlib>
         <version.lib.zstd-jni>1.5.6-2</version.lib.zstd-jni>
     </properties>
@@ -79,7 +78,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${version.lib.google-protobuf}</version>
         </dependency>
         <dependency>
             <groupId>net.jpountz.lz4</groupId>


### PR DESCRIPTION
### Description

Remove version for protobuf-java in graal native-image-extension and leave to Helidon dependency-management
