### PR TITLE
Grouping Executors related methods into a single class

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
-/** Encapsulates operations with {@link Executors}. Helps to workaround
+/** 
+ * Encapsulates operations with {@link Executors}. Helps to workaround
  * limitations of GraalVM for JDK21 which doesn't support execution of
  * virtual threads and Graal.js code together. New versions of GraalVM
  * don't have this limitation, but for those who stick with JDK21, this

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
@@ -16,12 +16,13 @@
 
 package io.helidon.webserver;
 
-import io.helidon.common.task.HelidonTaskExecutor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
-/** 
+import io.helidon.common.task.HelidonTaskExecutor;
+
+/**
  * Encapsulates operations with {@link Executors}. Helps to workaround
  * limitations of GraalVM for JDK21 which doesn't support execution of
  * virtual threads and Graal.js code together. New versions of GraalVM
@@ -38,7 +39,8 @@ final class ExecutorsFactory {
     private ExecutorsFactory() {
     }
 
-    /** Used by {@link LoomServer} to allocate its executor service.
+    /**
+     * Used by {@link LoomServer} to allocate its executor service.
      *
      * @return {@link Executors#newVirtualThreadPerTaskExecutor()}
      */
@@ -46,7 +48,8 @@ final class ExecutorsFactory {
         return Executors.newVirtualThreadPerTaskExecutor();
     }
 
-    /** Used by {@link ServerListener} to allocate its reader executor.
+    /**
+     * Used by {@link ServerListener} to allocate its reader executor.
      *
      * @return {@link ThreadPerTaskExecutor#create(java.util.concurrent.ThreadFactory)}
      */
@@ -54,14 +57,14 @@ final class ExecutorsFactory {
         return ThreadPerTaskExecutor.create(virtualThreadFactory());
     }
 
-    /** Used by {@link ServerListener} to allocate its shared executor.
+    /**
+     * Used by {@link ServerListener} to allocate its shared executor.
      *
      * @return {@link Executors#newThreadPerTaskExecutor(java.util.concurrent.ThreadFactory)}.
      */
     static ExecutorService newServerListenerSharedExecutor() {
         return Executors.newThreadPerTaskExecutor(virtualThreadFactory());
     }
-
 
     private static ThreadFactory virtualThreadFactory() {
         return Thread.ofVirtual().factory();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ExecutorsFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import io.helidon.common.task.HelidonTaskExecutor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/** Encapsulates operations with {@link Executors}. Helps to workaround
+ * limitations of GraalVM for JDK21 which doesn't support execution of
+ * virtual threads and Graal.js code together. New versions of GraalVM
+ * don't have this limitation, but for those who stick with JDK21, this
+ * is a serious limitations in using Helidon 4.0.x
+ * <p>
+ * By moving these <em>"factories"</em> into separate class, it is easier
+ * to use GraalVM's `@Substitute` mechanism and get Helidon and Graal.js working
+ * on GraalVM for JDK21. More info
+ * <a href="https://github.com/enso-org/enso/pull/10783#discussion_r1768000821">available in PR-10783</a>.
+ */
+final class ExecutorsFactory {
+
+    private ExecutorsFactory() {
+    }
+
+    /** Used by {@link LoomServer} to allocate its executor service.
+     *
+     * @return {@link Executors#newVirtualThreadPerTaskExecutor()}
+     */
+    static ExecutorService newLoomServerVirtualThreadPerTaskExecutor() {
+        return Executors.newVirtualThreadPerTaskExecutor();
+    }
+
+    /** Used by {@link ServerListener} to allocate its reader executor.
+     *
+     * @return {@link ThreadPerTaskExecutor#create(java.util.concurrent.ThreadFactory)}
+     */
+    static HelidonTaskExecutor newServerListenerReaderExecutor() {
+        return ThreadPerTaskExecutor.create(virtualThreadFactory());
+    }
+
+    /** Used by {@link ServerListener} to allocate its shared executor.
+     *
+     * @return {@link Executors#newThreadPerTaskExecutor(java.util.concurrent.ThreadFactory)}.
+     */
+    static ExecutorService newServerListenerSharedExecutor() {
+        return Executors.newThreadPerTaskExecutor(virtualThreadFactory());
+    }
+
+
+    private static ThreadFactory virtualThreadFactory() {
+        return Thread.ofVirtual().factory();
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -71,7 +71,7 @@ class LoomServer implements WebServer {
                         .id("web-" + WEBSERVER_COUNTER.getAndIncrement())
                         .build());
         this.serverConfig = serverConfig;
-        this.executorService = Executors.newVirtualThreadPerTaskExecutor();
+        this.executorService = ExecutorsFactory.newLoomServerVirtualThreadPerTaskExecutor();
 
         Map<String, ListenerConfig> sockets = new HashMap<>(serverConfig.sockets());
         sockets.put(DEFAULT_SOCKET_NAME, serverConfig);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -60,6 +60,7 @@ import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
+import java.util.concurrent.ThreadFactory;
 
 class ServerListener implements ListenerContext {
     private static final System.Logger LOGGER = System.getLogger(ServerListener.class.getName());
@@ -143,12 +144,10 @@ class ServerListener implements ListenerContext {
                 .unstarted(this::listen);
 
         // to read requests and execute tasks
-        this.readerExecutor = ThreadPerTaskExecutor.create(Thread.ofVirtual()
-                                                                   .factory());
+        this.readerExecutor = ExecutorsFactory.newServerListenerReaderExecutor();
 
         // to do anything else (writers etc.)
-        this.sharedExecutor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
-                                                                         .factory());
+        this.sharedExecutor = ExecutorsFactory.newServerListenerSharedExecutor();
 
         this.closeFuture = new CompletableFuture<>();
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import java.util.Timer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +59,6 @@ import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
-import java.util.concurrent.ThreadFactory;
 
 class ServerListener implements ListenerContext {
     private static final System.Logger LOGGER = System.getLogger(ServerListener.class.getName());


### PR DESCRIPTION
### Description

Enso has decided to use Helidon 4.0.x to emulate `WebSocket` on Graal.js. However we have problems to run our code on _native image_ with GraalVM for JDK21. [More info](https://github.com/enso-org/enso/pull/10783#discussion_r1768000821) available - in short: there is a bug in GraalVM for JDK21 that prevents usage of virtual threads and Graal.js. 

The bug was fixed in newer versions of GraalVM, but [backport is complicated](https://github.com/oracle/graal/pull/9516) and we don't have a workaround for the bug on the GraalVM side and we'd like to stick with JDK 21.

### Documentation

We have [experimentally verified](https://github.com/enso-org/enso/pull/10783/commits/c032d9db5c0e083a7c1e0f9cfd68e8312c8e96d3#r1770787594) that with small changes in Helidon code we can use `@Substitute` mechanism of GraalVM _native image_ to switch to _platform threads_. As we don't care about massive performance, but just want to get things work, it is a sufficient solution for us.

Can you accept this little refactoring into next version of Helidon, please? Thank you very much.
