### PR TITLE
Make ClientRequestBase mock friendly

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -262,7 +262,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     }
 
     @Override
-    public final R submit(Object entity) {
+    public R submit(Object entity) {
         if (!(entity instanceof byte[] bytes && bytes.length == 0)) {
             rejectHeadWithEntity();
         }
@@ -271,7 +271,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     }
 
     @Override
-    public final R outputStream(OutputStreamHandler outputStreamConsumer) {
+    public R outputStream(OutputStreamHandler outputStreamConsumer) {
         rejectHeadWithEntity();
         additionalHeaders();
         return doOutputStream(outputStreamConsumer);
@@ -481,7 +481,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     }
 
     private void rejectHeadWithEntity() {
-        if (this.method.equals(Method.HEAD)) {
+        if (Method.HEAD.equals(this.method)) {
             throw new IllegalArgumentException("Payload in method '" + Method.HEAD + "' has no defined semantics");
         }
     }

--- a/webclient/tests/webclient/pom.xml
+++ b/webclient/tests/webclient/pom.xml
@@ -124,5 +124,10 @@
             <artifactId>helidon-logging-jul</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/WebClientMockTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/WebClientMockTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.HttpClientRequest;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.WebClient;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests WebClientMockTest.
+ */
+class WebClientMockTest {
+
+    @Test
+    public void useMock() {
+        WebClient webClient = mockWebClient(Status.OK_200);
+        HttpClientResponse response = webClient.post("http://test.com")
+                .header(HeaderNames.AUTHORIZATION, "Bearer asdsadsad")
+                .submit(new Object());
+        assertEquals(Status.OK_200, response.status());
+    }
+
+    private WebClient mockWebClient(Status status) {
+        WebClient webClient = mock(WebClient.class);
+        HttpClientRequest request = mock(HttpClientRequest.class);
+        HttpClientResponse response = mock(HttpClientResponse.class);
+        doReturn(request).when(webClient).post(anyString());
+        doReturn(request).when(request).header(any(HeaderName.class), anyString());
+        doReturn(response).when(request).submit(any(Object.class));
+        when(response.status()).thenReturn(status);
+        return webClient;
+    }
+
+}


### PR DESCRIPTION
### Description
I was mocking WebClient and I found some issues related to null pointers and unable to mock relevant methods.

This was the method I had:

```
    private WebClient mockWebClient(Status status) {
        WebClient webClient = Mockito.mock(WebClient.class);
        HttpClientRequest request = Mockito.mock(HttpClientRequest.class);
        HttpClientResponse response = Mockito.mock(HttpClientResponse.class);
        doReturn(request).when(webClient).post(anyString());
        doReturn(request).when(request).header(any(HeaderName.class), anyString());
        doReturn(response).when(request).submit(any(Object.class));
        doReturn(OpenAiChatResponse.create(null, null, 0, null, null, null, List.of(), null)).when(response).as(OpenAiChatResponse.class);
        when(response.status()).thenReturn(status);
        return webClient;
    }
```

Some issues:

```
java.lang.NullPointerException: Cannot invoke "io.helidon.http.Method.equals(Object)" because "this.method" is null
	at io.helidon.webclient.api.ClientRequestBase.rejectHeadWithEntity(ClientRequestBase.java:484)
	at io.helidon.webclient.api.ClientRequestBase.submit(ClientRequestBase.java:267)
	at io.helidon.ai.openai.OpenAiChatClientTest.mockWebClient(OpenAiChatClientTest.java:66)
```

```
Invalid use of argument matchers!
0 matchers expected, 1 recorded:
-> at io.helidon.ai.openai.OpenAiChatClientTest.mockWebClient(OpenAiChatClientTest.java:67)

This exception may occur if matchers are combined with raw values:
    //incorrect:
    someMethod(anyObject(), "raw String");
When using matchers, all arguments have to be provided by matchers.
For example:
    //correct:
    someMethod(anyObject(), eq("String by matcher"));

For more info see javadoc for Matchers class.

	at io.helidon.webclient.api.ClientRequestBase.submit(ClientRequestBase.java:269)
	at io.helidon.ai.openai.OpenAiChatClientTest.mockWebClient(OpenAiChatClientTest.java:67)
```


### Documentation
NA

