### PR TITLE
4.1.2: New implementation for SSE in webserver

### DIFF
--- a/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/SocketHttpClient.java
+++ b/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/SocketHttpClient.java
@@ -606,6 +606,15 @@ public class SocketHttpClient implements AutoCloseable {
     }
 
     /**
+     * Provides access to underlying socket reader.
+     *
+     * @return the reader
+     */
+    public BufferedReader socketReader() {
+        return socketReader;
+    }
+
+    /**
      * Override this to send a specific payload.
      *
      * @param pw      the print writer where to write the payload

--- a/webclient/sse/src/main/java/io/helidon/webclient/sse/SseSourceHandlerProvider.java
+++ b/webclient/sse/src/main/java/io/helidon/webclient/sse/SseSourceHandlerProvider.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 import io.helidon.common.GenericType;
+import io.helidon.common.buffers.DataReader;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.sse.SseEvent;
@@ -93,6 +94,9 @@ public class SseSourceHandlerProvider implements SourceHandlerProvider<SseEvent>
                 }
             }
 
+            source.onClose();
+        } catch (DataReader.InsufficientDataAvailableException e) {
+            // normal SSE termination when connection closed by server
             source.onClose();
         } catch (IOException e) {
             source.onError(e);

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.sse;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.media.type.MediaType;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.DateTime;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HttpMediaType;
+import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.MediaContext;
+import io.helidon.http.sse.SseEvent;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http.spi.SinkProviderContext;
+
+import static io.helidon.http.HeaderValues.CONTENT_TYPE_EVENT_STREAM;
+import static io.helidon.http.HeaderValues.create;
+
+/**
+ * Implementation of an SSE sink. Emits {@link SseEvent}s.
+ */
+class DataWriterSseSink implements SseSink {
+
+    /**
+     * Type of SSE event sinks.
+     */
+    public static final GenericType<DataWriterSseSink> TYPE = GenericType.create(DataWriterSseSink.class);
+
+    private static final Header CACHE_NO_CACHE_ONLY = create(HeaderNames.CACHE_CONTROL, "no-cache");
+    private static final byte[] SSE_NL = "\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SSE_ID = "id:".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SSE_DATA = "data:".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SSE_EVENT = "event:".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SSE_COMMENT = ":".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] OK_200 = "HTTP/1.1 200 OK\r\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] DATE = "Date: ".getBytes(StandardCharsets.UTF_8);
+    private static final WritableHeaders<?> EMPTY_HEADERS = WritableHeaders.create();
+
+    private final ServerResponse response;
+    private final ConnectionContext ctx;
+    private final MediaContext mediaContext;
+    private final Runnable closeRunnable;
+
+    DataWriterSseSink(SinkProviderContext context) {
+        this.response = context.serverResponse();
+        this.ctx = context.connectionContext();
+        this.mediaContext = ctx.listenerContext().mediaContext();
+        this.closeRunnable = context.closeRunnable();
+        writeStatusAndHeaders();
+    }
+
+    @Override
+    public DataWriterSseSink emit(SseEvent sseEvent) {
+        BufferData bufferData = BufferData.growing(512);
+
+        Optional<String> comment = sseEvent.comment();
+        if (comment.isPresent()) {
+            bufferData.write(SSE_COMMENT);
+            bufferData.write(comment.get().getBytes(StandardCharsets.UTF_8));
+            bufferData.write(SSE_NL);
+        }
+        Optional<String> id = sseEvent.id();
+        if (id.isPresent()) {
+            bufferData.write(SSE_ID);
+            bufferData.write(id.get().getBytes(StandardCharsets.UTF_8));
+            bufferData.write(SSE_NL);
+        }
+        Optional<String> name = sseEvent.name();
+        if (name.isPresent()) {
+            bufferData.write(SSE_EVENT);
+            bufferData.write(name.get().getBytes(StandardCharsets.UTF_8));
+            bufferData.write(SSE_NL);
+        }
+        Object data = sseEvent.data();
+        if (data != null) {
+            bufferData.write(SSE_DATA);
+            byte[] bytes = serializeData(data, sseEvent.mediaType().orElse(MediaTypes.TEXT_PLAIN));
+            bufferData.write(bytes);
+            bufferData.write(SSE_NL);
+        }
+        bufferData.write(SSE_NL);
+
+        // write event to the network
+        ctx.dataWriter().writeNow(bufferData);
+        return this;
+    }
+
+    @Override
+    public void close() {
+        closeRunnable.run();
+        ctx.serverSocket().close();
+    }
+
+    void writeStatusAndHeaders() {
+        ServerResponseHeaders headers = response.headers();
+
+        // verify response has no status or content type
+        HttpMediaType ct = headers.contentType().orElse(null);
+        if (response.status().code() != Status.OK_200.code()
+                || ct != null && !CONTENT_TYPE_EVENT_STREAM.values().equals(ct.mediaType().text())) {
+            throw new IllegalStateException("ServerResponse instance cannot be used to create SseSink");
+        }
+
+        // start writing status line
+        BufferData buffer = BufferData.growing(256);
+        buffer.write(OK_200);
+
+        // serialize a date header if not included
+        if (!headers.contains(HeaderNames.DATE)) {
+            buffer.write(DATE);
+            byte[] dateBytes = DateTime.http1Bytes();
+            buffer.write(dateBytes);
+        }
+
+        // set up and write headers
+        if (ct == null) {
+            headers.add(CONTENT_TYPE_EVENT_STREAM);
+        }
+        headers.set(CACHE_NO_CACHE_ONLY);
+        for (Header header : headers) {
+            header.writeHttp1Header(buffer);
+        }
+
+        // complete heading
+        buffer.write('\r');        // "\r\n" - empty line after headers
+        buffer.write('\n');
+
+        // write response heading to the network
+        ctx.dataWriter().writeNow(buffer);
+    }
+
+    private byte[] serializeData(Object object, MediaType mediaType) {
+        if (object instanceof byte[] bytes) {
+            return bytes;
+        } else if (mediaContext != null) {
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                if (object instanceof String str && mediaType.equals(MediaTypes.TEXT_PLAIN)) {
+                    EntityWriter<String> writer = mediaContext.writer(GenericType.STRING, EMPTY_HEADERS, EMPTY_HEADERS);
+                    writer.write(GenericType.STRING, str, baos, EMPTY_HEADERS, EMPTY_HEADERS);
+                } else {
+                    GenericType<Object> type = GenericType.create(object);
+                    WritableHeaders<?> resHeaders = WritableHeaders.create();
+                    resHeaders.set(HeaderNames.CONTENT_TYPE, mediaType.text());
+                    EntityWriter<Object> writer = mediaContext.writer(type, EMPTY_HEADERS, resHeaders);
+                    writer.write(type, object, baos, EMPTY_HEADERS, resHeaders);
+                }
+                return baos.toByteArray();
+            } catch (IOException e) {
+                throw new ServerConnectionException("Failed to write SSE event", e);
+
+            }
+        }
+        throw new IllegalStateException("Unable to serialize SSE event without a media context");
+    }
+}

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/OutputStreamSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/OutputStreamSseSink.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.sse;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.media.type.MediaType;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HttpMediaType;
+import io.helidon.http.Status;
+import io.helidon.http.sse.SseEvent;
+import io.helidon.webserver.http.ServerResponse;
+
+import static io.helidon.http.HeaderValues.CONTENT_TYPE_EVENT_STREAM;
+
+/**
+ * Deprecated implementation of an SSE sink. Emits {@link SseEvent}s.
+ *
+ * @deprecated Should use {@link io.helidon.webserver.sse.DataWriterSseSink}.
+ */
+@Deprecated(since = "4.1.2", forRemoval = true)
+class OutputStreamSseSink implements SseSink {
+
+    /**
+     * Type of SSE event sinks.
+     */
+    public static final GenericType<DataWriterSseSink> TYPE = GenericType.create(DataWriterSseSink.class);
+
+    private static final byte[] SSE_NL = "\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SSE_ID = "id:".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SSE_DATA = "data:".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SSE_EVENT = "event:".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SSE_COMMENT = ":".getBytes(StandardCharsets.UTF_8);
+
+    private final BiConsumer<Object, MediaType> eventConsumer;
+    private final Runnable closeRunnable;
+    private final OutputStream outputStream;
+
+    OutputStreamSseSink(ServerResponse serverResponse, BiConsumer<Object, MediaType> eventConsumer, Runnable closeRunnable) {
+        // Verify response has no status or content type
+        HttpMediaType ct = serverResponse.headers().contentType().orElse(null);
+        if (serverResponse.status().code() != Status.OK_200.code()
+                || ct != null && !CONTENT_TYPE_EVENT_STREAM.values().equals(ct.mediaType().text())) {
+            throw new IllegalStateException("ServerResponse instance cannot be used to create SseResponse");
+        }
+
+        // Ensure content type set for SSE
+        if (ct == null) {
+            serverResponse.headers().add(CONTENT_TYPE_EVENT_STREAM);
+        }
+
+        this.outputStream = serverResponse.outputStream();
+        this.eventConsumer = eventConsumer;
+        this.closeRunnable = closeRunnable;
+    }
+
+    @Override
+    public OutputStreamSseSink emit(SseEvent sseEvent) {
+        try {
+            Optional<String> comment = sseEvent.comment();
+            if (comment.isPresent()) {
+                outputStream.write(SSE_COMMENT);
+                outputStream.write(comment.get().getBytes(StandardCharsets.UTF_8));
+                outputStream.write(SSE_NL);
+            }
+            Optional<String> id = sseEvent.id();
+            if (id.isPresent()) {
+                outputStream.write(SSE_ID);
+                outputStream.write(id.get().getBytes(StandardCharsets.UTF_8));
+                outputStream.write(SSE_NL);
+            }
+            Optional<String> name = sseEvent.name();
+            if (name.isPresent()) {
+                outputStream.write(SSE_EVENT);
+                outputStream.write(name.get().getBytes(StandardCharsets.UTF_8));
+                outputStream.write(SSE_NL);
+            }
+            Object data = sseEvent.data();
+            if (data != SseEvent.NO_DATA) {
+                outputStream.write(SSE_DATA);
+                eventConsumer.accept(data, sseEvent.mediaType().orElse(MediaTypes.TEXT_PLAIN));
+                outputStream.write(SSE_NL);
+            }
+            outputStream.write(SSE_NL);
+            outputStream.flush();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return this;
+    }
+
+    @Override
+    public void close() {
+        closeRunnable.run();
+    }
+}

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/SseSinkProvider.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/SseSinkProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,12 @@ import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http.spi.Sink;
 import io.helidon.webserver.http.spi.SinkProvider;
+import io.helidon.webserver.http.spi.SinkProviderContext;
 
 /**
  * Sink provider for SSE type.
+ *
+ * @see io.helidon.webserver.http.spi.SinkProvider
  */
 public class SseSinkProvider implements SinkProvider<SseEvent> {
 
@@ -37,10 +40,34 @@ public class SseSinkProvider implements SinkProvider<SseEvent> {
         return SseSink.TYPE.equals(type) && request.headers().isAccepted(MediaTypes.TEXT_EVENT_STREAM);
     }
 
+    /**
+     * Creates a Sink for SSE events.
+     *
+     * @param context the context
+     * @return newly created sink
+     * @param <X> type of sink
+     */
     @Override
     @SuppressWarnings("unchecked")
-    public <X extends Sink<SseEvent>> X create(ServerResponse response, BiConsumer<Object, MediaType> eventConsumer,
-                                        Runnable closeRunnable) {
-        return (X) new SseSink(response, eventConsumer, closeRunnable);
+    public <X extends Sink<SseEvent>> X create(SinkProviderContext context) {
+        return (X) new DataWriterSseSink(context);
+    }
+
+    /**
+     * Creates a Sink for SSE events.
+     *
+     * @param response the HTTP response
+     * @param eventConsumer an event consumer
+     * @param closeRunnable a runnable to call on close
+     * @param <X> type of sink
+     * @return newly created sink
+     * @deprecated replaced by {@link #create(SinkProviderContext)}
+     */
+    @Override
+    @Deprecated(since = "4.1.2", forRemoval = true)
+    public <X extends Sink<SseEvent>> X create(ServerResponse response,
+                                               BiConsumer<Object, MediaType> eventConsumer,
+                                               Runnable closeRunnable) {
+        return (X) new OutputStreamSseSink(response, eventConsumer, closeRunnable);
     }
 }

--- a/webserver/sse/src/main/java/module-info.java
+++ b/webserver/sse/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ module io.helidon.webserver.sse {
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.common;
+    requires transitive io.helidon.common.socket;
     requires transitive io.helidon.http.sse;
     requires transitive io.helidon.webserver;
 

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/DirectClientServerContext.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/DirectClientServerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,5 +137,10 @@ class DirectClientServerContext implements ConnectionContext, ListenerContext {
     @Override
     public ListenerConfig config() {
         return listenerConfiguration;
+    }
+
+    @Override
+    public HelidonSocket serverSocket() {
+        return serverSocket;
     }
 }

--- a/webserver/tests/sse/pom.xml
+++ b/webserver/tests/sse/pom.xml
@@ -28,11 +28,18 @@
     <name>Helidon WebServer Tests SSE</name>
     <description>WebServer SSE tests</description>
 
+    <properties>
+        <mainClass>io.helidon.webserver.tests.sse.Main</mainClass>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-sse</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>
@@ -70,4 +77,51 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${version.plugin.resources}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${version.plugin.dependency}</version>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${version.plugin.jar}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>libs</classpathPrefix>
+                            <mainClass>${mainClass}</mainClass>
+                            <useUniqueVersions>false</useUniqueVersions>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/webserver/tests/sse/src/main/java/io/helidon/webserver/tests/sse/Main.java
+++ b/webserver/tests/sse/src/main/java/io/helidon/webserver/tests/sse/Main.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.sse;
+
+import java.util.stream.IntStream;
+
+import io.helidon.http.sse.SseEvent;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.sse.SseSink;
+
+/**
+ * Simple SSE server that can be used to manually test interop with other
+ * clients such as Postman.
+ */
+public class Main {
+
+    static void sse(ServerRequest req, ServerResponse res) {
+        try (SseSink sseSink = res.sink(SseSink.TYPE)) {
+            IntStream.range(0, 1000).forEach(i -> sseSink.emit(SseEvent.create("hello world " + i)));
+        }
+    }
+
+    public static void main(String[] args) {
+        WebServer.builder()
+                .port(8080)
+                .routing(HttpRouting.builder().get("/sse", Main::sse))
+                .build()
+                .start();
+    }
+}

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SimpleSseClient.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SimpleSseClient.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.tests.sse;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.http.Method;
+
+class SimpleSseClient implements AutoCloseable {
+
+    public enum State {
+        DISCONNECTED,
+        CONNECTED,
+        HEADERS_READ,
+        ERROR
+    }
+
+    private State state = State.DISCONNECTED;
+    private BufferedReader reader;
+    private final String path;
+    private final SocketHttpClient client;
+
+    public static SimpleSseClient create(int port, String path) {
+        return create("localhost", port, path, Duration.ofSeconds(10));
+    }
+
+    public static SimpleSseClient create(int port, String path, Duration timeout) {
+        return create("localhost", port, path, timeout);
+    }
+
+    public static SimpleSseClient create(String host, int port, String path, Duration timeout) {
+        return new SimpleSseClient("localhost", port, path, timeout);
+    }
+
+    private SimpleSseClient(String host, int port, String path, Duration timeout) {
+        this.path = path;
+        this.client = SocketHttpClient.create(host, port, timeout);
+    }
+
+    public String nextEvent() {
+        ensureConnected();
+        ensureHeadersRead();
+
+        try {
+            String line;
+            StringBuilder event = new StringBuilder();
+            while ((line = reader.readLine()) != null) {
+                if (line.isEmpty()) {
+                    return event.toString();
+                }
+                if (!event.isEmpty()) {
+                    event.append("\n");
+                }
+                event.append(line);
+            }
+            if (event.isEmpty()) {
+                return null;
+            }
+            state = State.ERROR;
+            throw new RuntimeException("Unable to parse response");
+        } catch (IOException e) {
+            state = State.ERROR;
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        client.close();
+        state = State.DISCONNECTED;
+
+    }
+
+    public State state() {
+        return state;
+    }
+
+    private void ensureConnected() {
+        if (state == State.DISCONNECTED) {
+            client.request(Method.GET.toString(),
+                           path,
+                           "HTTP/1.1",
+                           "localhost",
+                           Collections.emptyList(),
+                           null);
+            reader = client.socketReader();
+            state = State.CONNECTED;
+        }
+    }
+
+    private void ensureHeadersRead() {
+        if (state == State.CONNECTED) {
+            try {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.isEmpty()) {
+                        state = State.HEADERS_READ;
+                        return;
+                    }
+                    line = line.toLowerCase();
+                    if (line.contains("http/1.1") && !line.contains("200")) {
+                        throw new RuntimeException("Invalid status code in response");
+                    } else if (line.contains("content-type") && !line.contains("text/event-stream")) {
+                        throw new RuntimeException("Invalid content-type in response");
+                    }
+                }
+                state = State.ERROR;
+                throw new RuntimeException("Unable to parse response");
+            } catch (IOException e) {
+                state = State.ERROR;
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseClientTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import io.helidon.http.sse.SseEvent;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webclient.sse.SseSource;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
@@ -44,7 +45,8 @@ class SseClientTest extends SseBaseTest {
 
     private final Http1Client client;
 
-    SseClientTest(Http1Client client) {
+    SseClientTest(WebServer webServer, Http1Client client) {
+        super(webServer);
         this.client = client;
     }
 

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ package io.helidon.webserver.tests.sse;
 import io.helidon.http.Status;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import org.junit.jupiter.api.Test;
 
-import static io.helidon.http.HeaderValues.ACCEPT_EVENT_STREAM;
 import static io.helidon.http.HeaderValues.ACCEPT_JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,10 +33,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @ServerTest
 class SseServerTest extends SseBaseTest {
 
-    private final Http1Client client;
-
-    SseServerTest(Http1Client client) {
-        this.client = client;
+    SseServerTest(WebServer webServer) {
+        super(webServer);
     }
 
     @SetUpRoute
@@ -50,49 +48,43 @@ class SseServerTest extends SseBaseTest {
     }
 
     @Test
-    void testSseString1() {
-        testSse("/sseString1", "data:hello\n\ndata:world\n\n");
+    void testSseString1() throws Exception {
+        testSse("/sseString1", "data:hello", "data:world");
     }
 
     @Test
-    void testSseString2() {
-        testSse("/sseString2", "data:1\n\ndata:2\n\ndata:3\n\n");
+    void testSseString2() throws Exception {
+        testSse("/sseString2", "data:1", "data:2", "data:3");
     }
 
     @Test
-    void testSseJson1() {
-        testSse("/sseJson1", "data:{\"hello\":\"world\"}\n\n");
+    void testSseJson1() throws Exception {
+        testSse("/sseJson1", "data:{\"hello\":\"world\"}");
     }
 
     @Test
-    void testSseJson2() {
-        testSse("/sseJson2", "data:{\"hello\":\"world\"}\n\n");
+    void testSseJson2() throws Exception {
+        testSse("/sseJson2", "data:{\"hello\":\"world\"}");
     }
 
     @Test
-    void testSseMixed() {
-        testSse("/sseMixed",
-                "data:hello\n\ndata:world\n\n" +
-                        "data:{\"hello\":\"world\"}\n\n" +
-                        "data:{\"hello\":\"world\"}\n\n");
+    void testSseMixed() throws Exception {
+        testSse("/sseMixed", "data:hello", "data:world",
+                "data:{\"hello\":\"world\"}", "data:{\"hello\":\"world\"}");
     }
 
     @Test
-    void testIdComment() {
-        testSse("/sseIdComment", ":This is a comment\nid:1\ndata:hello\n\n");
+    void testIdComment() throws Exception {
+        testSse("/sseIdComment", ":This is a comment\nid:1\ndata:hello");
     }
 
     @Test
     void testWrongAcceptType() {
+        Http1Client client = Http1Client.builder()
+                .baseUri("http://localhost:" + webServer().port())
+                .build();
         try (Http1ClientResponse response = client.get("/sseString1").header(ACCEPT_JSON).request()) {
             assertThat(response.status(), is(Status.NOT_ACCEPTABLE_406));
-        }
-    }
-
-    private void testSse(String path, String result) {
-        try (Http1ClientResponse response = client.get(path).header(ACCEPT_EVENT_STREAM).request()) {
-            assertThat(response.status(), is(Status.OK_200));
-            assertThat(response.as(String.class), is(result));
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.SocketContext;
 
 /**
@@ -58,7 +59,7 @@ public interface ConnectionContext extends SocketContext {
     /**
      * Router that may contain routings of different types (HTTP, WebSocket, grpc).
      *
-     * @return rouer
+     * @return the router
      */
     Router router();
 
@@ -70,5 +71,14 @@ public interface ConnectionContext extends SocketContext {
      */
     default Optional<ProxyProtocolData> proxyProtocolData() {
         return Optional.empty();
+    }
+
+    /**
+     * The underlying network socket for the connection.
+     *
+     * @return the socket
+     */
+    default HelidonSocket serverSocket() {
+        throw new UnsupportedOperationException("Not supported");
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -244,6 +244,11 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         return Optional.ofNullable(proxyProtocolData);
     }
 
+    @Override
+    public HelidonSocket serverSocket() {
+        return helidonSocket;
+    }
+
     private ServerConnection identifyConnection() {
         // if just one candidate, take a chance with it
         if (providerCandidates.size() == 1) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/SinkProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/SinkProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,12 +42,26 @@ public interface SinkProvider<T> {
     /**
      * Creates a sink using this provider.
      *
+     * @param context a context for a sync provider
+     * @param <X> type of sink
+     * @return newly created sink
+     */
+    default <X extends Sink<T>> X create(SinkProviderContext context) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
+     * Creates a sink using this provider.
+     *
      * @param response the HTTP response
      * @param eventConsumer an event consumer
      * @param closeRunnable a runnable to call on close
      * @param <X> type of sink
      * @return newly created sink
+     * @deprecated replaced by {@link #create(SinkProviderContext)}
      */
-    <X extends Sink<T>> X create(ServerResponse response, BiConsumer<Object, MediaType> eventConsumer,
+    @Deprecated(since = "4.1.2", forRemoval = true)
+    <X extends Sink<T>> X create(ServerResponse response,
+                                 BiConsumer<Object, MediaType> eventConsumer,
                                  Runnable closeRunnable);
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/SinkProviderContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/SinkProviderContext.java
@@ -13,34 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.helidon.webserver.sse;
+package io.helidon.webserver.http.spi;
 
-import io.helidon.common.GenericType;
-import io.helidon.http.sse.SseEvent;
-import io.helidon.webserver.http.spi.Sink;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.http.ServerResponse;
 
 /**
- * A sink for SSE events.
+ * A context for {@link io.helidon.webserver.http.spi.SinkProvider}s supplied
+ * at creation time.
  */
-public interface SseSink extends Sink<SseEvent> {
+public interface SinkProviderContext {
 
     /**
-     * Type of SSE event sinks.
-     */
-    GenericType<SseSink> TYPE = GenericType.create(SseSink.class);
-
-    /**
-     * Emits an event using to the sink.
+     * Obtains the server response associated with this context.
      *
-     * @param event the event to emit
-     * @return this sink
+     * @return the server response
      */
-    @Override
-    SseSink emit(SseEvent event);
+    ServerResponse serverResponse();
 
     /**
-     * Close SSE sink.
+     * Obtains access to the connection context.
+     *
+     * @return the connection context
      */
-    @Override
-    void close();
+    ConnectionContext connectionContext();
+
+    /**
+     * Runnable to execute to close the response.
+     *
+     * @return the close runnable
+     */
+    Runnable closeRunnable();
 }


### PR DESCRIPTION

Backport of #9224 to Helidon 4.1.2

### Description

Provides a new implementation for SSE in webserver. This implementation does not use the normal output stream to serialize the events to avoid problems with buffering and chunked encoding. Instead, it writes directly to the underlying socket writer and flushes data as needed. As a result, chunked encoding is no longer used for SSE. Several tests have been updated. Fixes #9164.

#### Summary of Changes

1. New `create` method in `SinkProvider` that deprecates the old one. This change is required for the new implementation. Not a very popular SPI, but we shall continue to support the old method (and continue to include the old implemtnation) for some time. Class `Http1ServerResponse` updated accordingly.
2. New SSE implementation in `SseSink` that writes directly to a writer. Also needs to write response status line and headers. No longer uses the output stream from the response.
3. New `SimpleSseClient` class to test SSE endpoints without using `WebClient`. This is required because we don't use chunked encoding anymore. Related tests have been updated.
