### PR TITLE
4.1.2: Adds support to iterate over URIs when connecting to a gRPC service

### DIFF
--- a/webclient/grpc/etc/spotbugs/exclude.xml
+++ b/webclient/grpc/etc/spotbugs/exclude.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+    <Match>
+        <Class name="io.helidon.webclient.grpc.ClientUriSuppliers$RoundRobinSupplier" />
+        <Bug pattern="IT_NO_SUCH_ELEMENT" />
+    </Match>
+    <Match>
+        <Class name="io.helidon.webclient.grpc.ClientUriSuppliers$SingleSupplier" />
+        <Bug pattern="IT_NO_SUCH_ELEMENT" />
+    </Match>
+    <Match>
+        <Class name="io.helidon.webclient.grpc.ClientUriSuppliers$RandomSupplier" />
+        <Bug pattern="IT_NO_SUCH_ELEMENT" />
+    </Match>
+</FindBugsFilter>

--- a/webclient/grpc/pom.xml
+++ b/webclient/grpc/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>helidon-webclient-grpc</artifactId>
     <name>Helidon WebClient gRPC</name>
 
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/ClientUriSupplier.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/ClientUriSupplier.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.grpc;
+
+import java.util.Iterator;
+
+import io.helidon.webclient.api.ClientUri;
+
+/**
+ * Interface implemented by all client URI suppliers.
+ */
+public interface ClientUriSupplier extends Iterator<ClientUri>, Iterable<ClientUri> {
+
+    @Override
+    default Iterator<ClientUri> iterator() {
+        return this;
+    }
+}

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/ClientUriSuppliers.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/ClientUriSuppliers.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.grpc;
+
+import java.net.URI;
+import java.security.SecureRandom;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import io.helidon.webclient.api.ClientUri;
+
+/**
+ * Some popular implementations of the {@link io.helidon.webclient.grpc.ClientUriSupplier}
+ * interface.
+ */
+public class ClientUriSuppliers {
+
+    /**
+     * Supplies an iterator that returns URIs chosen in order from
+     * first to last.
+     */
+    public static class OrderedSupplier implements ClientUriSupplier {
+
+        private final Iterator<ClientUri> clientUris;
+
+        /**
+         * Creates an ordered supplier.
+         *
+         * @param clientUris array of client URIs
+         * @return new supplier
+         */
+        public static OrderedSupplier create(ClientUri... clientUris) {
+            return new OrderedSupplier(List.of(clientUris));
+        }
+
+        /**
+         * Creates an ordered supplier.
+         *
+         * @param clientUris collection of client URIs
+         * @return new supplier
+         */
+        public static OrderedSupplier create(Collection<ClientUri> clientUris) {
+            return new OrderedSupplier(clientUris);
+        }
+
+        protected OrderedSupplier(Collection<ClientUri> clientUris) {
+            this.clientUris = List.copyOf(clientUris).iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return clientUris.hasNext();
+        }
+
+        @Override
+        public ClientUri next() {
+            return clientUris.next();
+        }
+    }
+
+    /**
+     * Supplies a neven-ending iterator that returns URIs chosen using
+     * a round-robin strategy.
+     */
+    public static class RoundRobinSupplier implements ClientUriSupplier {
+
+        private int next;
+        private final ClientUri[] clientUris;
+
+        /**
+         * Creates a round-robin supplier.
+         *
+         * @param clientUris array of client URIs
+         * @return new supplier
+         */
+        public static RoundRobinSupplier create(ClientUri... clientUris) {
+            return new RoundRobinSupplier(clientUris);
+        }
+
+        /**
+         * Creates a round-robin supplier.
+         *
+         * @param clientUris collection of client URIs
+         * @return new supplier
+         */
+        public static RoundRobinSupplier create(Collection<ClientUri> clientUris) {
+            return new RoundRobinSupplier(clientUris.toArray(new ClientUri[]{}));
+        }
+
+        protected RoundRobinSupplier(ClientUri[] clientUris) {
+            this.clientUris = clientUris;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public ClientUri next() {
+            return clientUris[next++ % clientUris.length];
+        }
+    }
+
+    /**
+     * Supplies the same client URI over and over, never ends.
+     */
+    public static class SingleSupplier implements ClientUriSupplier {
+
+        private final ClientUri clientUri;
+
+        /**
+         * Creates a single supplier.
+         *
+         * @param clientUri the client URI as a string
+         * @return new supplier
+         */
+        public static SingleSupplier create(String clientUri) {
+            return new SingleSupplier(ClientUri.create(URI.create(clientUri)));
+        }
+
+        /**
+         * Creates a single supplier.
+         *
+         * @param clientUri the client URI
+         * @return new supplier
+         */
+        public static SingleSupplier create(ClientUri clientUri) {
+            return new SingleSupplier(clientUri);
+        }
+
+        protected SingleSupplier(ClientUri clientUri) {
+            this.clientUri = clientUri;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public ClientUri next() {
+            return clientUri;
+        }
+    }
+
+    /**
+     * Supplies an iterator that returns a URI chosen at random, never ends.
+     */
+    public static class RandomSupplier implements ClientUriSupplier {
+
+        private final ClientUri[] clientUris;
+        private final SecureRandom random = new SecureRandom();
+
+        /**
+         * Creates a random supplier.
+         *
+         * @param clientUris array of client URIs
+         * @return new supplier
+         */
+        public static RandomSupplier create(ClientUri... clientUris) {
+            return new RandomSupplier(clientUris);
+        }
+
+        /**
+         * Creates a random supplier.
+         *
+         * @param clientUris collection of client URIs
+         * @return new supplier
+         */
+        public static RandomSupplier create(Collection<ClientUri> clientUris) {
+            return new RandomSupplier(clientUris.toArray(new ClientUri[]{}));
+        }
+
+        protected RandomSupplier(ClientUri[] clientUris) {
+            this.clientUris = clientUris;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return true;
+        }
+
+        @Override
+        public ClientUri next() {
+            return clientUris[random.nextInt(clientUris.length)];
+        }
+    }
+}

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -66,12 +66,14 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
     protected static final BufferData EMPTY_BUFFER_DATA = BufferData.empty();
 
     private final GrpcClientImpl grpcClient;
+    private final GrpcChannel grpcChannel;
     private final MethodDescriptor<ReqT, ResT> methodDescriptor;
     private final CallOptions callOptions;
     private final int initBufferSize;
     private final Duration pollWaitTime;
     private final boolean abortPollTimeExpired;
     private final Duration heartbeatPeriod;
+    private final ClientUriSupplier clientUriSupplier;
 
     private final MethodDescriptor.Marshaller<ReqT> requestMarshaller;
     private final MethodDescriptor.Marshaller<ResT> responseMarshaller;
@@ -81,8 +83,9 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
     private volatile Listener<ResT> responseListener;
     private volatile HelidonSocket socket;
 
-    GrpcBaseClientCall(GrpcClientImpl grpcClient, MethodDescriptor<ReqT, ResT> methodDescriptor, CallOptions callOptions) {
-        this.grpcClient = grpcClient;
+    GrpcBaseClientCall(GrpcChannel grpcChannel, MethodDescriptor<ReqT, ResT> methodDescriptor, CallOptions callOptions) {
+        this.grpcClient = (GrpcClientImpl) grpcChannel.grpcClient();
+        this.grpcChannel = grpcChannel;
         this.methodDescriptor = methodDescriptor;
         this.callOptions = callOptions;
         this.requestMarshaller = methodDescriptor.getRequestMarshaller();
@@ -91,6 +94,7 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         this.pollWaitTime = grpcClient.prototype().protocolConfig().pollWaitTime();
         this.abortPollTimeExpired = grpcClient.prototype().protocolConfig().abortPollTimeExpired();
         this.heartbeatPeriod = grpcClient.prototype().protocolConfig().heartbeatPeriod();
+        this.clientUriSupplier = grpcClient.prototype().clientUriSupplier().orElse(null);
     }
 
     @Override
@@ -100,10 +104,11 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         this.responseListener = responseListener;
 
         // obtain HTTP2 connection
-        ClientConnection clientConnection = clientConnection();
+        ClientUri clientUri = nextClientUri();
+        ClientConnection clientConnection = clientConnection(clientUri);
         socket = clientConnection.helidonSocket();
         connection = Http2ClientConnection.create((Http2ClientImpl) grpcClient.http2Client(),
-                clientConnection, true);
+                                                  clientConnection, true);
 
         // create HTTP2 stream from connection
         clientStream = new GrpcClientStream(
@@ -134,7 +139,6 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         startStreamingThreads();
 
         // send HEADERS frame
-        ClientUri clientUri = grpcClient.prototype().baseUri().orElseThrow();
         WritableHeaders<?> headers = WritableHeaders.create();
         headers.add(Http2Headers.AUTHORITY_NAME, clientUri.authority());
         headers.add(Http2Headers.METHOD_NAME, "POST");
@@ -165,11 +169,13 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         }
     }
 
-    protected ClientConnection clientConnection() {
-        GrpcClientConfig clientConfig = grpcClient.prototype();
-        ClientUri clientUri = clientConfig.baseUri().orElseThrow();
-        WebClient webClient = grpcClient.webClient();
+    protected GrpcClientImpl grpcClient() {
+        return grpcClient;
+    }
 
+    protected ClientConnection clientConnection(ClientUri clientUri) {
+        WebClient webClient = grpcClient.webClient();
+        GrpcClientConfig clientConfig = grpcClient.prototype();
         ConnectionKey connectionKey = new ConnectionKey(
                 clientUri.scheme(),
                 clientUri.host(),
@@ -179,13 +185,12 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
                 DefaultDnsResolver.create(),
                 DnsAddressLookup.defaultLookup(),
                 Proxy.noProxy());
-
         return TcpClientConnection.create(webClient,
-                connectionKey,
-                Collections.emptyList(),
-                connection -> false,
-                connection -> {
-                }).connect();
+                                          connectionKey,
+                                          Collections.emptyList(),
+                                          connection -> false,
+                                          connection -> {
+                                          }).connect();
     }
 
     protected boolean isRemoteOpen() {
@@ -244,5 +249,17 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
 
     protected HelidonSocket socket() {
         return socket;
+    }
+
+    /**
+     * Retrieves the next URI either from the supplier or directly from config. If
+     * a supplier is provided, it will take precedence.
+     *
+     * @return the next {@link ClientUri}
+     * @throws java.util.NoSuchElementException if supplier has been exhausted
+     */
+    private ClientUri nextClientUri() {
+        return clientUriSupplier == null ? grpcClient.prototype().baseUri().orElseThrow()
+                : clientUriSupplier.next();
     }
 }

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcChannel.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcChannel.java
@@ -53,8 +53,8 @@ public class GrpcChannel extends Channel {
             MethodDescriptor<ReqT, ResT> methodDescriptor, CallOptions callOptions) {
         MethodDescriptor.MethodType methodType = methodDescriptor.getType();
         return methodType == MethodDescriptor.MethodType.UNARY
-                ? new GrpcUnaryClientCall<>(grpcClient, methodDescriptor, callOptions)
-                : new GrpcClientCall<>(grpcClient, methodDescriptor, callOptions);
+                ? new GrpcUnaryClientCall<>(this, methodDescriptor, callOptions)
+                : new GrpcClientCall<>(this, methodDescriptor, callOptions);
     }
 
     @Override

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
@@ -60,9 +60,9 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
     private volatile Future<?> writeStreamFuture;
     private volatile Future<?> heartbeatFuture;
 
-    GrpcClientCall(GrpcClientImpl grpcClient, MethodDescriptor<ReqT, ResT> methodDescriptor, CallOptions callOptions) {
-        super(grpcClient, methodDescriptor, callOptions);
-        this.executor = grpcClient.webClient().executor();
+    GrpcClientCall(GrpcChannel grpcChannel, MethodDescriptor<ReqT, ResT> methodDescriptor, CallOptions callOptions) {
+        super(grpcChannel, methodDescriptor, callOptions);
+        this.executor = grpcClient().webClient().executor();
     }
 
     @Override

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientConfigBlueprint.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientConfigBlueprint.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webclient.grpc;
 
+import java.util.Optional;
+
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.webclient.api.HttpClientConfig;
@@ -35,4 +37,13 @@ interface GrpcClientConfigBlueprint extends HttpClientConfig, Prototype.Factory<
     @Option.Default("create()")
     @Option.Configured
     GrpcClientProtocolConfig protocolConfig();
+
+    /**
+     * A {@link io.helidon.webclient.grpc.ClientUriSupplier} that can dynamically
+     * provide zero or more {@link io.helidon.webclient.api.ClientUri}s to connect.
+     *
+     * @return a supplier for zero or more client URIs
+     */
+    Optional<ClientUriSupplier> clientUriSupplier();
 }
+

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcUnaryClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcUnaryClientCall.java
@@ -42,10 +42,10 @@ class GrpcUnaryClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
     private volatile boolean requestSent;
     private volatile boolean responseSent;
 
-    GrpcUnaryClientCall(GrpcClientImpl grpcClient,
+    GrpcUnaryClientCall(GrpcChannel grpcChannel,
                         MethodDescriptor<ReqT, ResT> methodDescriptor,
                         CallOptions callOptions) {
-        super(grpcClient, methodDescriptor, callOptions);
+        super(grpcChannel, methodDescriptor, callOptions);
     }
 
     @Override

--- a/webclient/tests/grpc/pom.xml
+++ b/webclient/tests/grpc/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>helidon-webserver-testing-junit5-grpc</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.fault-tolerance</groupId>
+            <artifactId>helidon-fault-tolerance</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/ClientUriSuppliersTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/ClientUriSuppliersTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.grpc.tests;
+
+import java.net.URI;
+import java.util.stream.IntStream;
+
+import io.helidon.webclient.api.ClientUri;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.webclient.grpc.ClientUriSuppliers.OrderedSupplier;
+import static io.helidon.webclient.grpc.ClientUriSuppliers.RandomSupplier;
+import static io.helidon.webclient.grpc.ClientUriSuppliers.RoundRobinSupplier;
+import static io.helidon.webclient.grpc.ClientUriSuppliers.SingleSupplier;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsIn.isIn;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ClientUriSuppliersTest {
+
+    private static final ClientUri[] CLIENT_URIS = {
+            ClientUri.create(URI.create("http://localhost:8000")),
+            ClientUri.create(URI.create("http://localhost:8001")),
+            ClientUri.create(URI.create("http://localhost:8002"))
+    };
+
+    @Test
+    void testOrderedSupplier() {
+        OrderedSupplier supplier = OrderedSupplier.create(CLIENT_URIS);
+        assertThat(supplier.hasNext(), is(true));
+        assertThat(supplier.next(), is(CLIENT_URIS[0]));
+        assertThat(supplier.hasNext(), is(true));
+        assertThat(supplier.next(), is(CLIENT_URIS[1]));
+        assertThat(supplier.hasNext(), is(true));
+        assertThat(supplier.next(), is(CLIENT_URIS[2]));
+        assertThat(supplier.hasNext(), is(false));
+    }
+
+    @Test
+    void testRoundRobinSupplier() {
+        RoundRobinSupplier supplier = RoundRobinSupplier.create(CLIENT_URIS);
+        IntStream.range(0, 5).forEach(i -> {
+            assertThat(supplier.hasNext(), is(true));
+            assertThat(supplier.next(), is(CLIENT_URIS[0]));
+            assertThat(supplier.hasNext(), is(true));
+            assertThat(supplier.next(), is(CLIENT_URIS[1]));
+            assertThat(supplier.hasNext(), is(true));
+            assertThat(supplier.next(), is(CLIENT_URIS[2]));
+        });
+    }
+
+    @Test
+    void testSingleSupplier() {
+        SingleSupplier supplier = SingleSupplier.create(CLIENT_URIS[0]);
+        IntStream.range(0, 5).forEach(i -> {
+            assertThat(supplier.hasNext(), is(true));
+            assertThat(supplier.next(), is(CLIENT_URIS[0]));
+        });
+    }
+
+    @Test
+    void testRandomSupplier() {
+        RandomSupplier supplier = RandomSupplier.create(CLIENT_URIS);
+        IntStream.range(0, 5).forEach(i -> {
+            assertThat(supplier.hasNext(), is(true));
+            assertThat(supplier.next(), isIn(CLIENT_URIS));
+        });
+    }
+}

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcClientUriTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcClientUriTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.grpc.tests;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.tls.Tls;
+import io.helidon.faulttolerance.Retry;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.grpc.ClientUriSuppliers;
+import io.helidon.webclient.grpc.GrpcClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests client URI suppliers.
+ */
+@ServerTest
+class GrpcClientUriTest extends GrpcBaseTest {
+
+    private final WebServer server;
+    private final Tls clientTls;
+
+    GrpcClientUriTest(WebServer server) {
+        this.server = server;
+        this.clientTls = Tls.builder()
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+    }
+
+    /**
+     * Shows how each gRPC call advances the iterator in the {@code ClientUriSupplier}.
+     */
+    @Test
+    void testSupplier() {
+        CountDownLatch latch = new CountDownLatch(2);
+        ClientUri clientUri = ClientUri.create(URI.create("https://localhost:" + server.port()));
+        GrpcClient grpcClient = GrpcClient.builder()
+                .tls(clientTls)
+                .clientUriSupplier(new ClientUriSupplierTest(latch, clientUri, clientUri))
+                .build();
+        StringServiceGrpc.StringServiceBlockingStub service = StringServiceGrpc.newBlockingStub(grpcClient.channel());
+
+        Strings.StringMessage res1 = service.upper(newStringMessage("hello"));
+        assertThat(res1.getText(), is("HELLO"));
+        Strings.StringMessage res2 = service.upper(newStringMessage("hello"));
+        assertThat(res2.getText(), is("HELLO"));
+        assertThat(latch.getCount(), is(0L));
+    }
+
+    /**
+     * Should fail to connect to first URI but succeed with second after retrying.
+     */
+    @Test
+    void testSupplierWithRetries() {
+        CountDownLatch latch = new CountDownLatch(2);
+        ClientUri badUri = ClientUri.create(URI.create("https://foo:8000"));
+        ClientUri goodUri = ClientUri.create(URI.create("https://localhost:" + server.port()));
+        GrpcClient grpcClient = GrpcClient.builder()
+                .tls(clientTls)
+                .clientUriSupplier(new ClientUriSupplierTest(latch, badUri, goodUri))
+                .build();
+        StringServiceGrpc.StringServiceBlockingStub service = StringServiceGrpc.newBlockingStub(grpcClient.channel());
+
+        Retry retry = Retry.builder().calls(2).build();
+        Strings.StringMessage res = retry.invoke(() -> service.upper(newStringMessage("hello")));
+        assertThat(res.getText(), is("HELLO"));
+        assertThat(latch.getCount(), is(0L));
+    }
+
+    static class ClientUriSupplierTest extends ClientUriSuppliers.RoundRobinSupplier {
+
+        private final CountDownLatch latch;
+
+        ClientUriSupplierTest(CountDownLatch latch, ClientUri... clientUris) {
+            super(clientUris);
+            this.latch = latch;
+        }
+
+        @Override
+        public ClientUri next() {
+            latch.countDown();      // should be called twice
+            return super.next();
+        }
+    }
+}


### PR DESCRIPTION

Backport #9285 to Helidon 4.1.2 

### Description

Adds support to iterate over URIs when connecting to a gRPC service. Defines a new interface `ClientUriSupplier` that can be used to dynamically provide a list of URIs to connect to. Each gRPC call will retrieve the next URI from the supplier. See issue #9255.
