### PR TITLE
4.1.2: Upgrade Jersy to 3.1.8 

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -92,7 +92,7 @@
         <version.lib.jboss.classfilewriter>1.3.0.Final</version.lib.jboss.classfilewriter>
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
         <version.lib.jaxb-runtime>4.0.3</version.lib.jaxb-runtime>
-        <version.lib.jersey>3.1.7</version.lib.jersey>
+        <version.lib.jersey>3.1.8</version.lib.jersey>
         <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>
         <version.lib.kafka>3.6.2</version.lib.kafka>


### PR DESCRIPTION
Backport of #9296 to Helidon 4.1.2

### Description
Jersey upgrade.

Resolves #9251