### PR TITLE
feat: Jwt -- don't force "upn" claim

### DIFF
--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -307,9 +307,7 @@ public class Jwt {
         this.cHash = JwtUtil.getByteArray(payloadJson, C_HASH, "c_hash value");
         this.nonce = JwtUtil.getString(payloadJson, NONCE);
         this.scopes = JwtUtil.toScopes(payloadJson);
-        this.userPrincipal = JwtUtil.getString(payloadJson, USER_PRINCIPAL)
-                .or(() -> preferredUsername)
-                .or(() -> subject);
+        this.userPrincipal = JwtUtil.getString(payloadJson, USER_PRINCIPAL);
     }
 
     private Jwt(Builder builder) {
@@ -357,9 +355,7 @@ public class Jwt {
         this.scopes = builder.scopes;
 
         this.userPrincipal = builder.userPrincipal
-                .or(() -> toOptionalString(builder.payloadClaims, USER_PRINCIPAL))
-                .or(() -> preferredUsername)
-                .or(() -> subject);
+                .or(() -> toOptionalString(builder.payloadClaims, USER_PRINCIPAL));
 
         this.userGroups = builder.userGroups;
     }
@@ -662,12 +658,15 @@ public class Jwt {
     }
 
     /**
-     * User principal claim ("upn" from microprofile specification).
+     * User principal claim ("upn" from microprofile specification). Falls back to
+     * "preferred_username" then "sub" claim.
      *
-     * @return user principal or empty if claim is not defined
+     * @return user principal or empty if claim and fallbacks are not defined
      */
     public Optional<String> userPrincipal() {
-        return userPrincipal;
+        return userPrincipal
+                .or(() -> preferredUsername)
+                .or(() -> subject);
     }
 
     /**
@@ -1682,8 +1681,7 @@ public class Jwt {
          * User principal claim as defined by Microprofile JWT Auth spec.
          * Uses "upn" claim.
          *
-         * @param principal name of the principal, falls back to {@link #preferredUsername(String)} and then to
-         *                  {@link #subject(String)}
+         * @param principal name of the principal
          * @return updated builder instance
          */
         public Builder userPrincipal(String principal) {

--- a/security/jwt/src/test/java/io/helidon/security/jwt/JwtTest.java
+++ b/security/jwt/src/test/java/io/helidon/security/jwt/JwtTest.java
@@ -28,7 +28,9 @@ import io.helidon.security.jwt.jwk.JwkRSA;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -110,5 +112,17 @@ public class JwtTest {
         errors = jwtValidator.validate(jwt);
         errors.log(LOGGER);
         errors.checkValid();
+    }
+
+    @Test
+    public void testUpnNotAddedAutomatically() {
+        String json = Jwt.builder().subject("a").build().payloadJson().toString();
+        assertThat(json, not(containsString("\"upn\"")));
+    }
+
+    @Test
+    public void testUserPrincipalFallsbackToSub() {
+        Jwt jwt = Jwt.builder().subject("a").build();
+        assertThat(jwt.userPrincipal(), is(Optional.of("a")));
     }
 }


### PR DESCRIPTION
### Description

Fixes #5151

Adjusts the `Jwt` class so that `userPrincipal()` returns the value of a `upn`, `preferred_username`, or `sub` claim in that order of preference; but the class does not automatically insert a `upn` claim whenever a `preferred_username` or `sub` is present. This means `userPrincipal()` returns a value to satisfy the [Eclipse MicroProfile Interoperable JWT RBAC](https://download.eclipse.org/microprofile/microprofile-jwt-auth-2.1/microprofile-jwt-auth-spec-2.1.html). But the `Jwt` class is still usable for use-cases beyond that very specific profile where a `upn` claims in not required, not desired, and may even be forbidden.

A `upn` claim can still be set.

Unit tests are added to confirm that `Jwt.userPrincipal()` falls back to `sub` if `upn` is absent; and to confirm that `upn` is no longer automatically (and unexpectedly) added just because `sub` is set.

All the existing unit tests still pass.

### Documentation

The javadoc for `Jwt.userPrincipal()` and `Jwt.Builder.userPrincipal(String)` is adjusted.
