### PR TITLE
4.1.2: Policy validator configurable per endpoint in config (#9248)

### DIFF
--- a/docs/src/main/asciidoc/includes/security/providers/abac.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/abac.adoc
@@ -196,3 +196,15 @@ security:
 ----
 include::{sourcedir}/includes/security/providers/AbacSnippets.java[tag=snippet_4, indent=0]
 ----
+
+[source,yaml]
+.Configuration example for `JAX-RS` over the configuration
+----
+server:
+  features:
+    security:
+      endpoints:
+        - path: "/somePath"
+          config:
+            abac.policy-validator.statement: "${env.time.year >= 2017}"
+----

--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/JerseySecurityContext.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/JerseySecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ record JerseySecurityContext(io.helidon.security.SecurityContext securityContext
 
     @Override
     public boolean isUserInRole(String role) {
-        return securityContext.isUserInRole(role, methodSecurity.getAuthorizer());
+        return securityContext.isUserInRole(role, methodSecurity.authorizer());
     }
 
     @Override

--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityDefinition.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityDefinition.java
@@ -21,6 +21,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.helidon.common.config.Config;
 import io.helidon.security.AuditEvent;
 import io.helidon.security.SecurityLevel;
 import io.helidon.security.annotations.Audited;
@@ -97,7 +98,21 @@ class SecurityDefinition {
         return result;
     }
 
-    public void add(Authenticated atn) {
+    void fromConfig(Config config) {
+        config.get("authorize").as(Boolean.class).ifPresent(this::requiresAuthorization);
+        config.get("authorizer").as(String.class).ifPresent(this::authorizer);
+        config.get("authorization-explicit").as(Boolean.class).ifPresent(this::atzExplicit);
+        config.get("authenticate").as(Boolean.class).ifPresent(this::requiresAuthentication);
+        config.get("authenticator").as(String.class).ifPresent(this::authenticator);
+        config.get("authentication-optional").as(Boolean.class).ifPresent(this::authenticationOptional);
+        config.get("audit").as(Boolean.class).ifPresent(this::audited);
+        config.get("audit-event-type").as(String.class).ifPresent(this::auditEventType);
+        config.get("audit-message-format").as(String.class).ifPresent(this::auditMessageFormat);
+        config.get("audit-ok-severity").as(AuditEvent.AuditSeverity.class).ifPresent(this::auditOkSeverity);
+        config.get("audit-error-severity").as(AuditEvent.AuditSeverity.class).ifPresent(this::auditErrorSeverity);
+    }
+
+    void add(Authenticated atn) {
         if (null == atn) {
             return;
         }
@@ -106,7 +121,7 @@ class SecurityDefinition {
         this.authenticator = "".equals(atn.provider()) ? null : atn.provider();
     }
 
-    public void add(Authorized atz) {
+    void add(Authorized atz) {
         if (null == atz) {
             return;
         }
@@ -130,7 +145,7 @@ class SecurityDefinition {
         this.requiresAuthentication = atn;
     }
 
-    void setRequiresAuthorization(boolean atz) {
+    void requiresAuthorization(boolean atz) {
         this.requiresAuthorization = atz;
     }
 
@@ -154,8 +169,16 @@ class SecurityDefinition {
         return authnOptional;
     }
 
+    void authenticationOptional(boolean authnOptional) {
+        this.authnOptional = authnOptional;
+    }
+
     boolean failOnFailureIfOptional() {
         return failOnFailureIfOptional;
+    }
+
+    void failOnFailureIfOptional(boolean failOnFailureIfOptional) {
+        this.failOnFailureIfOptional = failOnFailureIfOptional;
     }
 
     boolean requiresAuthorization() {
@@ -171,47 +194,79 @@ class SecurityDefinition {
         return (count != 0) || authorizeByDefault;
     }
 
-    public boolean isAtzExplicit() {
+    boolean atzExplicit() {
         return atzExplicit;
     }
 
-    String getAuthenticator() {
+    void atzExplicit(boolean atzExplicit) {
+        this.atzExplicit = atzExplicit;
+    }
+
+    String authenticator() {
         return authenticator;
     }
 
-    String getAuthorizer() {
+    void authenticator(String authenticator) {
+        this.authenticator = authenticator;
+    }
+
+    String authorizer() {
         return authorizer;
     }
 
-    public List<SecurityLevel> getSecurityLevels() {
+    void authorizer(String authorizer) {
+        this.authorizer = authorizer;
+    }
+
+    List<SecurityLevel> securityLevels() {
         return securityLevels;
     }
 
-    public boolean isAudited() {
+    boolean audited() {
         return audited;
     }
 
-    public String getAuditEventType() {
+    void audited(boolean audited) {
+        this.audited = audited;
+    }
+
+    String auditEventType() {
         return auditEventType;
     }
 
-    public String getAuditMessageFormat() {
+    void auditEventType(String auditEventType) {
+        this.auditEventType = auditEventType;
+    }
+
+    String auditMessageFormat() {
         return auditMessageFormat;
     }
 
-    public AuditEvent.AuditSeverity getAuditOkSeverity() {
+    void auditMessageFormat(String auditMessageFormat) {
+        this.auditMessageFormat = auditMessageFormat;
+    }
+
+    AuditEvent.AuditSeverity auditOkSeverity() {
         return auditOkSeverity;
     }
 
-    public AuditEvent.AuditSeverity getAuditErrorSeverity() {
+    void auditOkSeverity(AuditEvent.AuditSeverity auditOkSeverity) {
+        this.auditOkSeverity = auditOkSeverity;
+    }
+
+    AuditEvent.AuditSeverity auditErrorSeverity() {
         return auditErrorSeverity;
     }
 
-    public AnnotationAnalyzer.AnalyzerResponse analyzerResponse(AnnotationAnalyzer analyzer) {
+    void auditErrorSeverity(AuditEvent.AuditSeverity auditOkSeverity) {
+        this.auditErrorSeverity = auditOkSeverity;
+    }
+
+    AnnotationAnalyzer.AnalyzerResponse analyzerResponse(AnnotationAnalyzer analyzer) {
         return analyzerResponses.get(analyzer);
     }
 
-    public void analyzerResponse(AnnotationAnalyzer analyzer, AnnotationAnalyzer.AnalyzerResponse analyzerResponse) {
+    void analyzerResponse(AnnotationAnalyzer analyzer, AnnotationAnalyzer.AnalyzerResponse analyzerResponse) {
         analyzerResponses.put(analyzer, analyzerResponse);
 
         switch (analyzerResponse.authenticationResponse()) {

--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityFilterContext.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityFilterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,9 @@ import org.glassfish.jersey.server.ContainerRequest;
  */
 public class SecurityFilterContext {
     private String resourceName;
+    private String fullResourceName;
+    private String resourceMethod;
+    private String fullResourceMethod;
     private String resourcePath;
     private String method;
     private Map<String, List<String>> headers;
@@ -60,113 +63,137 @@ public class SecurityFilterContext {
                 + '}';
     }
 
-    String getResourceName() {
+    String resourceName() {
         return resourceName;
     }
 
-    void setResourceName(String resourceName) {
+    void resourceName(String resourceName) {
         this.resourceName = resourceName;
     }
 
-    String getResourcePath() {
+    String fullResourceName() {
+        return fullResourceName;
+    }
+
+    void fullResourceName(String fullResourceName) {
+        this.fullResourceName = fullResourceName;
+    }
+
+    String resourceMethod() {
+        return resourceMethod;
+    }
+
+    void resourceMethod(String resourceMethod) {
+        this.resourceMethod = resourceMethod;
+    }
+
+    String fullResourceMethod() {
+        return fullResourceMethod;
+    }
+
+    void fullResourceMethod(String fullResourceMethod) {
+        this.fullResourceMethod = fullResourceMethod;
+    }
+
+    String resourcePath() {
         return resourcePath;
     }
 
-    void setResourcePath(String resourcePath) {
+    void resourcePath(String resourcePath) {
         this.resourcePath = resourcePath;
     }
 
-    String getMethod() {
+    String method() {
         return method;
     }
 
-    void setMethod(String method) {
+    void method(String method) {
         this.method = method;
     }
 
-    Map<String, List<String>> getHeaders() {
+    Map<String, List<String>> headers() {
         return headers;
     }
 
-    void setHeaders(Map<String, List<String>> headers) {
+    void headers(Map<String, List<String>> headers) {
         this.headers = headers;
     }
 
-    URI getTargetUri() {
+    URI targetUri() {
         return targetUri;
     }
 
-    void setTargetUri(URI targetUri) {
+    void targetUri(URI targetUri) {
         this.targetUri = targetUri;
     }
 
-    ContainerRequest getJerseyRequest() {
+    ContainerRequest jerseyRequest() {
         return jerseyRequest;
     }
 
-    void setJerseyRequest(ContainerRequest jerseyRequest) {
+    void jerseyRequest(ContainerRequest jerseyRequest) {
         this.jerseyRequest = jerseyRequest;
     }
 
-    boolean isShouldFinish() {
+    boolean shouldFinish() {
         return shouldFinish;
     }
 
-    void setShouldFinish(boolean shouldFinish) {
+    void shouldFinish(boolean shouldFinish) {
         this.shouldFinish = shouldFinish;
     }
 
-    SecurityDefinition getMethodSecurity() {
+    SecurityDefinition methodSecurity() {
         return methodSecurity;
     }
 
-    void setMethodSecurity(SecurityDefinition methodSecurity) {
+    void methodSecurity(SecurityDefinition methodSecurity) {
         this.methodSecurity = methodSecurity;
     }
 
-    boolean isExplicitAtz() {
+    boolean explicitAtz() {
         return explicitAtz;
     }
 
-    void setExplicitAtz(boolean explicitAtz) {
+    void explicitAtz(boolean explicitAtz) {
         this.explicitAtz = explicitAtz;
     }
 
-    boolean isTraceSuccess() {
+    boolean traceSuccess() {
         return traceSuccess;
     }
 
-    void setTraceSuccess(boolean traceSuccess) {
+    void traceSuccess(boolean traceSuccess) {
         this.traceSuccess = traceSuccess;
     }
 
-    String getTraceDescription() {
+    String traceDescription() {
         return traceDescription;
     }
 
-    void setTraceDescription(String traceDescription) {
+    void traceDescription(String traceDescription) {
         this.traceDescription = traceDescription;
     }
 
-    Throwable getTraceThrowable() {
+    Throwable traceThrowable() {
         return traceThrowable;
     }
 
-    void setTraceThrowable(Throwable traceThrowable) {
+    void traceThrowable(Throwable traceThrowable) {
         this.traceThrowable = traceThrowable;
     }
 
-    UriQuery getQueryParams() {
+    UriQuery queryParams() {
         return queryParams;
     }
 
-    void setQueryParams(UriQuery queryParams) {
+    void queryParams(UriQuery queryParams) {
         this.queryParams = queryParams;
     }
 
     void clearTrace() {
-        setTraceSuccess(true);
-        setTraceDescription(null);
-        setTraceThrowable(null);
+        traceSuccess(true);
+        traceDescription(null);
+        traceThrowable(null);
     }
 }

--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityPreMatchingFilter.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityPreMatchingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,10 +97,10 @@ class SecurityPreMatchingFilter extends SecurityFilterCommon implements Containe
         // when I reach this point, I am sure we should at least authenticate in prematching filter
         authenticate(filterContext, securityContext, tracing.atnTracing());
 
-        LOGGER.log(Level.TRACE, () -> "Filter after authentication. Should finish: " + filterContext.isShouldFinish());
+        LOGGER.log(Level.TRACE, () -> "Filter after authentication. Should finish: " + filterContext.shouldFinish());
 
         // authentication failed
-        if (filterContext.isShouldFinish()) {
+        if (filterContext.shouldFinish()) {
             return;
         }
 
@@ -122,9 +122,9 @@ class SecurityPreMatchingFilter extends SecurityFilterCommon implements Containe
 
         SecurityDefinition methodDef = new SecurityDefinition(false, false);
         methodDef.requiresAuthentication(true);
-        methodDef.setRequiresAuthorization(featureConfig().shouldUsePrematchingAuthorization());
-        context.setMethodSecurity(methodDef);
-        context.setResourceName("jax-rs");
+        methodDef.requiresAuthorization(featureConfig().shouldUsePrematchingAuthorization());
+        context.methodSecurity(methodDef);
+        context.resourceName("jax-rs");
 
         return configureContext(context, requestContext, uriInfo);
     }

--- a/microprofile/security/src/main/java/module-info.java
+++ b/microprofile/security/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module io.helidon.microprofile.security {
 
+    requires io.helidon.config.mp;
     requires io.helidon.jersey.common;
     requires io.helidon.microprofile.cdi;
     requires io.helidon.microprofile.server;

--- a/microprofile/security/src/test/java/io/helidon/microprofile/security/OptionalSecurityTest.java
+++ b/microprofile/security/src/test/java/io/helidon/microprofile/security/OptionalSecurityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ class OptionalSecurityTest {
          */
         securityFilter.processAuthentication(filterContext, clientBuilder, methodSecurity, tracing.atnTracing());
 
-        assertThat(filterContext.isShouldFinish(), is(false));
+        assertThat(filterContext.shouldFinish(), is(false));
         assertThat(securityContext.user(), is(Optional.empty()));
     }
 
@@ -108,7 +108,7 @@ class OptionalSecurityTest {
     void testNotOptional() {
         SecurityContext securityContext = security.createContext("context_id");
         SecurityFilterContext filterContext = new SecurityFilterContext();
-        filterContext.setJerseyRequest(mock(ContainerRequest.class));
+        filterContext.jerseyRequest(mock(ContainerRequest.class));
         SecurityDefinition methodSecurity = mock(SecurityDefinition.class);
         when(methodSecurity.authenticationOptional()).thenReturn(false);
 
@@ -123,7 +123,7 @@ class OptionalSecurityTest {
          */
         securityFilter.processAuthentication(filterContext, clientBuilder, methodSecurity, tracing.atnTracing());
 
-        assertThat(filterContext.isShouldFinish(), is(true));
+        assertThat(filterContext.shouldFinish(), is(true));
         assertThat(securityContext.user(), is(Optional.empty()));
     }
 

--- a/microprofile/security/src/test/java/io/helidon/microprofile/security/SecurityFilterTest.java
+++ b/microprofile/security/src/test/java/io/helidon/microprofile/security/SecurityFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ class SecurityFilterTest {
         ContainerRequest request = mock(ContainerRequest.class);
 
         SecurityFilterContext filterContext = new SecurityFilterContext();
-        filterContext.setJerseyRequest(request);
+        filterContext.jerseyRequest(request);
 
         SecurityDefinition methodSecurity = mock(SecurityDefinition.class);
 
@@ -74,7 +74,7 @@ class SecurityFilterTest {
         when(clientBuilder.submit()).thenReturn(AuthenticationResponse.failed("Unit-test"));
 
         sf.processAuthentication(filterContext, clientBuilder, methodSecurity, tracing.atnTracing());
-        assertThat(filterContext.isShouldFinish(), is(true));
+        assertThat(filterContext.shouldFinish(), is(true));
 
         verify(request).abortWith(argThat(response -> response.getStatus() == 401));
     }
@@ -94,7 +94,7 @@ class SecurityFilterTest {
         ContainerRequest request = mock(ContainerRequest.class);
 
         SecurityFilterContext filterContext = new SecurityFilterContext();
-        filterContext.setJerseyRequest(request);
+        filterContext.jerseyRequest(request);
 
         SecurityDefinition methodSecurity = mock(SecurityDefinition.class);
 
@@ -125,7 +125,7 @@ class SecurityFilterTest {
         ContainerRequest request = mock(ContainerRequest.class);
 
         SecurityFilterContext filterContext = new SecurityFilterContext();
-        filterContext.setJerseyRequest(request);
+        filterContext.jerseyRequest(request);
 
         SecurityClientBuilder<AuthorizationResponse> clientBuilder = mock(SecurityClientBuilder.class);
         when(clientBuilder.submit()).thenReturn(AuthorizationResponse.builder()
@@ -134,7 +134,7 @@ class SecurityFilterTest {
                                                              .build());
 
         sf.processAuthorization(filterContext, clientBuilder);
-        assertThat(filterContext.isShouldFinish(), is(true));
+        assertThat(filterContext.shouldFinish(), is(true));
 
         verify(request).abortWith(argThat(response -> response.getStatus() == 403));
     }
@@ -154,7 +154,7 @@ class SecurityFilterTest {
         ContainerRequest request = mock(ContainerRequest.class);
 
         SecurityFilterContext filterContext = new SecurityFilterContext();
-        filterContext.setJerseyRequest(request);
+        filterContext.jerseyRequest(request);
 
         SecurityClientBuilder<AuthorizationResponse> clientBuilder = mock(SecurityClientBuilder.class);
         when(clientBuilder.submit()).thenReturn(AuthorizationResponse.builder()

--- a/tests/integration/security/abac-policy/pom.xml
+++ b/tests/integration/security/abac-policy/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration-security</artifactId>
+        <version>4.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-security-abac-policy</artifactId>
+    <name>Helidon Tests Integration ABAC Policy Validator</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.security.abac</groupId>
+            <artifactId>helidon-security-abac-policy-el</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tests/integration/security/abac-policy/pom.xml
+++ b/tests/integration/security/abac-policy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration-security</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-tests-integration-security-abac-policy</artifactId>

--- a/tests/integration/security/abac-policy/src/main/java/io/helidon/tests/integration/security/abac/policy/PolicyStatementExplicitResource.java
+++ b/tests/integration/security/abac-policy/src/main/java/io/helidon/tests/integration/security/abac/policy/PolicyStatementExplicitResource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.security.abac.policy;
+
+import io.helidon.security.AuthorizationResponse;
+import io.helidon.security.SecurityContext;
+import io.helidon.security.abac.policy.PolicyValidator;
+import io.helidon.security.annotations.Authorized;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * A resource with explicit authorization.
+ */
+@Path("/explicit")
+public class PolicyStatementExplicitResource {
+
+    /**
+     * Policy statement and explicit authorization is set via annotations and not overridden.
+     *
+     * @param context security context to perform an explicit authorization
+     * @return result of the authorization
+     */
+    @GET
+    @Path("annotation")
+    @Authorized(explicit = true)
+    @PolicyValidator.PolicyStatement("${env.time.year >= 2017}")
+    public Response annotation(@Context SecurityContext context) {
+        AuthorizationResponse atzResponse = context.authorize();
+
+        if (atzResponse.isPermitted()) {
+            return Response.ok().entity("passed").build();
+        } else {
+            return Response.status(Response.Status.FORBIDDEN)
+                    .entity(atzResponse.description().orElse("Access not granted"))
+                    .build();
+        }
+    }
+
+    /**
+     * Policy statement and explicit authorization is set via configuration.
+     *
+     * @param context security context to perform an explicit authorization
+     * @return result of the authorization
+     */
+    @GET
+    @Path("configuration")
+    @Authorized
+    @PolicyValidator.PolicyStatement("${env.time.year < 2017}")
+    public Response configuration(@Context SecurityContext context) {
+        AuthorizationResponse atzResponse = context.authorize();
+
+        if (atzResponse.isPermitted()) {
+            return Response.ok().entity("passed").build();
+        } else {
+            return Response.status(Response.Status.FORBIDDEN)
+                    .entity(atzResponse.description().orElse("Access not granted"))
+                    .build();
+        }
+    }
+
+}

--- a/tests/integration/security/abac-policy/src/main/java/io/helidon/tests/integration/security/abac/policy/PolicyStatementResource.java
+++ b/tests/integration/security/abac-policy/src/main/java/io/helidon/tests/integration/security/abac/policy/PolicyStatementResource.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.security.abac.policy;
+
+import io.helidon.security.abac.policy.PolicyValidator;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * A resource with abac policy statements.
+ */
+@Path("/policy")
+public class PolicyStatementResource {
+
+    /**
+     * Policy statement configured via annotation.
+     *
+     * @return passed value
+     */
+    @GET
+    @Path("/annotation")
+    @PolicyValidator.PolicyStatement("${env.time.year >= 2017}")
+    public String annotation() {
+        return "passed";
+    }
+
+    /**
+     * Policy statement overridden by the config.
+     *
+     * @return passed value
+     */
+    @GET
+    @Path("/override")
+    @PolicyValidator.PolicyStatement("${env.time.year <= 2017}")
+    public String override() {
+        return "passed";
+    }
+
+    /**
+     * Policy statement should not be overridden by the config.
+     *
+     * @return passed value
+     */
+    @GET
+    @Path("/override2")
+    @PolicyValidator.PolicyStatement("${env.time.year <= 2017}")
+    public String override2() {
+        return "should not pass";
+    }
+
+    /**
+     * Policy statement overridden by the config with asterisk present in path.
+     *
+     * @return passed value
+     */
+    @GET
+    @Path("/asterisk")
+    @PolicyValidator.PolicyStatement("${env.time.year <= 2017}")
+    public String asterisk() {
+        return "passed";
+    }
+
+    /**
+     * Policy statement overridden by the config with asterisk present in path.
+     *
+     * @return passed value
+     */
+    @GET
+    @Path("/asterisk2")
+    @PolicyValidator.PolicyStatement("${env.time.year <= 2017}")
+    public String asterisk2() {
+        return "passed";
+    }
+
+    /**
+     * Policy statement not overridden by configuration and should not let anyone in.
+     *
+     * @return should not pass value
+     */
+    @GET
+    @Path("/notOverride")
+    @PolicyValidator.PolicyStatement("${env.time.year <= 2017}")
+    public String notOverride() {
+        return "should not pass";
+    }
+
+}

--- a/tests/integration/security/abac-policy/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/security/abac-policy/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/security/abac-policy/src/main/resources/application.yaml
+++ b/tests/integration/security/abac-policy/src/main/resources/application.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+server:
+  port: 0
+  features:
+    security:
+      endpoints:
+        - path: "/policy/override"
+          config:
+            abac.policy-validator.statement: "${env.time.year >= 2017}"
+        - path: "/policy/asterisk*"
+          config:
+            abac.policy-validator.statement: "${env.time.year >= 2017}"
+        - path: "/explicit/configuration"
+          config:
+            authorize: true
+            authorization-explicit: true
+            abac.policy-validator.statement: "${env.time.year >= 2017}"
+
+security:
+  providers:
+    - abac:

--- a/tests/integration/security/abac-policy/src/main/resources/logging.properties
+++ b/tests/integration/security/abac-policy/src/main/resources/logging.properties
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+

--- a/tests/integration/security/abac-policy/src/test/java/io/helidon/tests/integration/security/abac/policy/ExplicitPolicyTest.java
+++ b/tests/integration/security/abac-policy/src/test/java/io/helidon/tests/integration/security/abac/policy/ExplicitPolicyTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.security.abac.policy;
+
+import io.helidon.http.Status;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+class ExplicitPolicyTest {
+
+    @Test
+    void testAnnotation(WebTarget target) {
+        try (Response response = target.path("/explicit/annotation")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Status.OK_200.code()));
+            assertThat(response.readEntity(String.class), is("passed"));
+        }
+    }
+
+    @Test
+    void testConfiguration(WebTarget target) {
+        try (Response response = target.path("/explicit/configuration")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Status.OK_200.code()));
+            assertThat(response.readEntity(String.class), is("passed"));
+        }
+    }
+
+}

--- a/tests/integration/security/abac-policy/src/test/java/io/helidon/tests/integration/security/abac/policy/PolicyTest.java
+++ b/tests/integration/security/abac-policy/src/test/java/io/helidon/tests/integration/security/abac/policy/PolicyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.security.abac.policy;
+
+import io.helidon.http.Status;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+class PolicyTest {
+
+    @Test
+    void testAnnotation(WebTarget target) {
+        try (Response response = target.path("/policy/annotation")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Status.OK_200.code()));
+            assertThat(response.readEntity(String.class), is("passed"));
+        }
+    }
+
+    @Test
+    void testExplicitOverride(WebTarget target) {
+        try (Response response = target.path("/policy/override")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Status.OK_200.code()));
+            assertThat(response.readEntity(String.class), is("passed"));
+        }
+        try (Response response = target.path("/policy/override2")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Status.FORBIDDEN_403.code()));
+        }
+    }
+
+    @Test
+    void testAsteriskOverride(WebTarget target) {
+        try (Response response = target.path("/policy/asterisk")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Status.OK_200.code()));
+            assertThat(response.readEntity(String.class), is("passed"));
+        }
+        try (Response response = target.path("/policy/asterisk2")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Status.OK_200.code()));
+            assertThat(response.readEntity(String.class), is("passed"));
+        }
+    }
+
+    @Test
+    void testNotOverride(WebTarget target) {
+        try (Response response = target.path("/policy/notOverride")
+                .request()
+                .get()) {
+            assertThat(response.getStatus(), is(Status.FORBIDDEN_403.code()));
+        }
+    }
+}

--- a/tests/integration/security/pom.xml
+++ b/tests/integration/security/pom.xml
@@ -42,5 +42,6 @@
         <module>path-params</module>
         <module>security-response-mapper</module>
         <module>security-annotation</module>
+        <module>abac-policy</module>
     </modules>
 </project>


### PR DESCRIPTION
Backport of #9248 to Helidon 4.1.2

### Description
Fixes #8948

### Documentation

Example for adding JAX-RS endpoint policy validator via config added
Fixed several legacy configurations in the same document