### PR TITLE
Add metrics tests for disabling using config

### DIFF
--- a/metrics/provider-tests/src/main/java/io/helidon/metrics/provider/tests/SimpleMeterRegistryTests.java
+++ b/metrics/provider-tests/src/main/java/io/helidon/metrics/provider/tests/SimpleMeterRegistryTests.java
@@ -16,10 +16,16 @@
 package io.helidon.metrics.provider.tests;
 
 import java.util.List;
+import java.util.Map;
 
+import io.helidon.common.testing.junit5.OptionalMatcher;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsConfig;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 
@@ -28,7 +34,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -77,5 +85,38 @@ class SimpleMeterRegistryTests {
         Counter counter2 = meterRegistry.getOrCreate(Counter.builder("c")
                                                              .tags(tags));
         assertThat("Counter with same name, same two tags", counter1, is(sameInstance(counter2)));
+    }
+
+    @Test
+    void testDisabledYieldsNoOp() {
+        // Disable metrics using config.
+        Config metricsDisabledConfig = Config.just(ConfigSources.create(Map.of("enabled", "false")));
+        MeterRegistry shouldBeNoOp = MetricsFactory.getInstance().createMeterRegistry(MetricsConfig.create(metricsDisabledConfig));
+
+        Counter shouldBeNoOpCounter = shouldBeNoOp.getOrCreate(Counter.builder("shouldBeNoOpCounter"));
+        assertThat("Counters after registration", shouldBeNoOp.meters(), is(emptyIterable()));
+
+        shouldBeNoOpCounter.increment();
+        assertThat("Counter value after increment", shouldBeNoOpCounter.count(), is(0L));
+    }
+
+    @Test
+    void testDisabledMeters() {
+        Config config = Config.just(ConfigSources.create(Map.of("scoping.scopes.0.name", "application",
+                                                                 "scoping.scopes.0.filter.exclude", ".*Ignore.*")));
+        MeterRegistry selectiveRegistry = MetricsFactory.getInstance().createMeterRegistry(MetricsConfig.create(config));
+
+        Counter shouldBeNoOpCounter = selectiveRegistry.getOrCreate(Counter.builder("pleaseIgnoreThis"));
+        Counter shouldBeLive = selectiveRegistry.getOrCreate(Counter.builder("pleaseIncludeThis"));
+        assertThat("Counters after ignored registration", selectiveRegistry.meters(), hasSize(1));
+        assertThat("Counter retrieved",
+                   selectiveRegistry.counter("pleaseIncludeThis", List.of()),
+                   OptionalMatcher.optionalPresent());
+
+        shouldBeNoOpCounter.increment();
+        shouldBeLive.increment();
+
+        assertThat("Incremented disabled counter", shouldBeNoOpCounter.count(), is(0L));
+        assertThat("Incremented live counter", shouldBeLive.count(), is(1L));
     }
 }

--- a/metrics/provider-tests/src/main/java/io/helidon/metrics/provider/tests/SimpleMeterRegistryTests.java
+++ b/metrics/provider-tests/src/main/java/io/helidon/metrics/provider/tests/SimpleMeterRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,8 @@ class SimpleMeterRegistryTests {
     void testDisabledYieldsNoOp() {
         // Disable metrics using config.
         Config metricsDisabledConfig = Config.just(ConfigSources.create(Map.of("enabled", "false")));
-        MeterRegistry shouldBeNoOp = MetricsFactory.getInstance().createMeterRegistry(MetricsConfig.create(metricsDisabledConfig));
+        MeterRegistry shouldBeNoOp = MetricsFactory.getInstance()
+                .createMeterRegistry(MetricsConfig.create(metricsDisabledConfig));
 
         Counter shouldBeNoOpCounter = shouldBeNoOp.getOrCreate(Counter.builder("shouldBeNoOpCounter"));
         assertThat("Counters after registration", shouldBeNoOp.meters(), is(emptyIterable()));


### PR DESCRIPTION
### Description
The metrics code supports disabling the entire metrics subsystem or disabling meters by meter name.

This PR adds tests for these features.

(I did not bother to create an issue for this.)

### Documentation
No doc impact.
