### PR TITLE
Correct config prefix in doc for excluding health checks

### DIFF
--- a/docs/se/health.adoc
+++ b/docs/se/health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -364,7 +364,7 @@ Built-in health checks can be configured using the config property keys
 described in this
 <<built-in-health-checks-table,table>>. Further, you can suppress one or more of the built-in
 health checks by setting the configuration item
-`helidon.health.exclude` to a comma-separated list of the health check names
+`health.exclude` to a comma-separated list of the health check names
 (from this <<built-in-health-checks-table,table>>) you want to exclude.
 
 == Examples

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.eclipse.microprofile.health.Liveness;
  * A health check that looks for thread deadlocks. Automatically created and registered via CDI.
  * <p>
  * This health check can be referred to in properties as {@code deadlock}. So for example, to exclude this
- * health check from being exposed, use {@code helidon.health.exclude: deadlock}.
+ * health check from being exposed, use {@code health.exclude: deadlock}.
  * </p>
  */
 @Liveness

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ import org.eclipse.microprofile.health.Liveness;
  *</p>
  * <p>
  * This health check can be referred to in properties as {@code diskSpace}. So for example, to exclude this
- * health check from being exposed, use {@code helidon.health.exclude: diskSpace}.
+ * health check from being exposed, use {@code health.exclude: diskSpace}.
  * </p>
  */
 @Liveness

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.eclipse.microprofile.health.Liveness;
  * </p>
  * <p>
  * This health check can be referred to in properties as {@code heapMemory}. So for example, to exclude this
- * health check from being exposed, use {@code helidon.health.exclude: heapMemory}.
+ * health check from being exposed, use {@code health.exclude: heapMemory}.
  * </p>
  */
 @Liveness


### PR DESCRIPTION
### Description
Resolves #8617 

This PR corrects the documentation errors (in an `.adoc` file and in the built-in health check Javadoc sections) which described the wrong config prefix for excluding health checks by name.

I've created a separate issue #9322 to capture the fact that a later PR should address the remaining inconsistencies described in the issue to simplify things for the user. 

### Documentation
Fixed by the PR.
