### PR TITLE
Faster Jackson default settings

### DIFF
--- a/http/media/jackson/src/main/java/io/helidon/http/media/jackson/JacksonSupport.java
+++ b/http/media/jackson/src/main/java/io/helidon/http/media/jackson/JacksonSupport.java
@@ -29,8 +29,10 @@ import io.helidon.http.media.EntityReader;
 import io.helidon.http.media.EntityWriter;
 import io.helidon.http.media.MediaSupport;
 
+import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
@@ -75,7 +77,10 @@ public class JacksonSupport implements MediaSupport {
         Objects.requireNonNull(config);
         Objects.requireNonNull(name);
 
-        ObjectMapper objectMapper = new ObjectMapper()
+        ObjectMapper objectMapper = JsonMapper.builder()
+                .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
+                .enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)
+                .build()
                 .registerModule(new ParameterNamesModule())
                 .registerModule(new Jdk8Module())
                 .registerModule(new JavaTimeModule());


### PR DESCRIPTION
### Description

By default Jackson does not enable faster features to ensure 100% backwards compatibility. They should be safe and are already in use by many projects.

Note that `USE_FAST_DOUBLE_WRITER` has been ported to Java 20 and so has been left out.

### Documentation

None
