### PR TITLE
3.x: Support built-in health check config at `health.checks` (retaining now-deprecated `helidon.health` for compatibility)

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/DeprecatedMpConfig.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/DeprecatedMpConfig.java
@@ -13,5 +13,62 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.helidon.config.mp;public class DeprecatedMpConfig {
+package io.helidon.config.mp;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import org.eclipse.microprofile.config.Config;
+
+/**
+ * A utility class to handle MicroProfile configuration properties that should no longer be used.
+ * <p>
+ * For one major release, the property is retrieved through this class, to warn about the usage.
+ * In next major release, the deprecated property is removed (as is use of this class).
+ * <p>
+ * This class is closely patterned after {@code io.helidon.config.DeprecatedConfig} and works whether the MP config object
+ * is proxied by CDI or not. That other class can be used in conjunction with
+ * {@link io.helidon.config.mp.MpConfig#toHelidonConfig(org.eclipse.microprofile.config.Config)} for MP
+ * config objects that <em>are not</em> injected but that does work for MP config objects proxied by CDI. This one does work for
+ * those use cases.
+ */
+public final class DeprecatedMpConfig {
+    private static final Logger LOGGER = Logger.getLogger(DeprecatedMpConfig.class.getName());
+
+    private DeprecatedMpConfig() {
+    }
+
+    /**
+     * Get a value from config, attempting to read both the keys.
+     * Warning is logged if either the current key is not defined, or both the keys are defined.
+     *
+     * @param config        configuration instance
+     * @param type          type of the retrieved value
+     * @param currentKey    key that should be used
+     * @param deprecatedKey key that should not be used
+     * @param <T>           type of the retrieved value
+     * @return config value of the current key if exists, or the deprecated key if it does not, an empty {@code Optional}
+     *         otherwise
+     */
+    public static <T> Optional<T> getConfigValue(Config config, Class<T> type, String currentKey, String deprecatedKey) {
+        Optional<T> deprecatedConfig = config.getOptionalValue(deprecatedKey, type);
+        Optional<T> currentConfig = config.getOptionalValue(currentKey, type);
+
+        if (deprecatedConfig.isPresent()) {
+            if (currentConfig.isPresent()) {
+                LOGGER.warning("You are using both a deprecated configuration and a current one. "
+                                       + "Deprecated key: \"" + deprecatedKey + "\", "
+                                       + "current key: \"" + currentKey + "\", "
+                                       + "only the current key will be used, and deprecated will be ignored.");
+                return currentConfig;
+            } else {
+                LOGGER.warning("You are using a deprecated configuration key. "
+                                       + "Deprecated key: \"" + deprecatedKey + "\", "
+                                       + "current key: \"" + currentKey + "\".");
+                return deprecatedConfig;
+            }
+        } else {
+            return currentConfig;
+        }
+    }
 }

--- a/config/config-mp/src/main/java/io/helidon/config/mp/DeprecatedMpConfig.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/DeprecatedMpConfig.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.config.mp;public class DeprecatedMpConfig {
+}

--- a/docs/se/health.adoc
+++ b/docs/se/health.adoc
@@ -23,6 +23,7 @@
 :rootdir: {docdir}/..
 
 include::{rootdir}/includes/se.adoc[]
+:built-in-health-check-config-prefix: health.checks
 
 == Contents
 
@@ -216,16 +217,14 @@ common health check statuses:
 |available disk space
 |`diskSpace`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/DiskSpaceHealthCheck.html[`DiskSpaceHealthCheck`]
-|`helidon.healthCheck.diskSpace.thresholdPercent` +
-+
-`helidon.healthCheck.diskSpace.path`
+|`{built-in-health-check-config-prefix}.diskSpace.thresholdPercent` +
+`{built-in-health-check-config-prefix}.diskSpace.path`
 | `99.999` +
-+
 `/`
 |available heap memory
 | `heapMemory`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/HeapMemoryHealthCheck.html[`HeapMemoryHealthCheck`]
-|`helidon.healthCheck.heapMemory.thresholdPercent`
+|`{built-in-health-check-config-prefix}.heapMemory.thresholdPercent`
 |`98`
 |=======
 

--- a/health/health-checks/pom.xml
+++ b/health/health-checks/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+        </dependency>
+        <dependency>
             <!-- only needed for compilation, not required in runtime -->
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
@@ -30,6 +30,7 @@ import io.helidon.health.HealthCheckException;
 import io.helidon.health.common.BuiltInHealthCheck;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
@@ -131,8 +132,8 @@ public class DiskSpaceHealthCheck implements HealthCheck {
     }
 
     @Inject
-    DiskSpaceHealthCheck(Config rootConfig) {
-        Config diskSpaceConfig = DeprecatedConfig.get(rootConfig,
+    DiskSpaceHealthCheck() {
+        Config diskSpaceConfig = DeprecatedConfig.get(config(),
                                                          HealthChecks.CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX,
                                                          HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX)
                 .get(CONFIG_KEY_DISKSPACE_PREFIX);
@@ -313,5 +314,9 @@ public class DiskSpaceHealthCheck implements HealthCheck {
 
             return this;
         }
+    }
+
+    private static Config config() {
+        return CDI.current().select(Config.class).get();
     }
 }

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
@@ -86,14 +86,20 @@ public class DiskSpaceHealthCheck implements HealthCheck {
 
     /**
      * Full configuration key for path, when configured through MicroProfile config.
+     *
+     * @deprecated The value will change to {@value CURRENT_CONFIG_KEY_PATH} in a future release
      */
+    @Deprecated(since = "3.2.11")
     public static final String CONFIG_KEY_PATH = HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX
             + "." + CONFIG_KEY_DISKSPACE_PREFIX
             + "." + CONFIG_KEY_PATH_SUFFIX;
 
     /**
      * Full configuration key for threshold percent, when configured through Microprofile config.
+     *
+     * @deprecated The value will change to {@value CURRENT_CONFIG_KEY_THRESHOLD_PERCENT} in future release
      */
+    @Deprecated(since = "3.2.11")
     public static final String CONFIG_KEY_THRESHOLD_PERCENT = HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX
             + "." + CONFIG_KEY_DISKSPACE_PREFIX
             + "." + CONFIG_KEY_THRESHOLD_PERCENT_SUFFIX;

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
@@ -16,7 +16,6 @@
 
 package io.helidon.health.checks;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
@@ -26,12 +25,12 @@ import java.util.Formatter;
 import java.util.Locale;
 
 import io.helidon.config.Config;
+import io.helidon.config.DeprecatedConfig;
 import io.helidon.health.HealthCheckException;
 import io.helidon.health.common.BuiltInHealthCheck;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
@@ -43,7 +42,8 @@ import org.eclipse.microprofile.health.Liveness;
  * <p>
  * By default, this health check has a threshold of 100%, meaning that it will never fail the threshold check.
  * Also, by default, it will check the root path {@code /}. These defaults can be modified using the
- * {@value CONFIG_KEY_PATH} property (default {@value DEFAULT_PATH}), and the {@value CONFIG_KEY_THRESHOLD_PERCENT}
+ * {@value CURRENT_CONFIG_KEY_PATH} property (default {@value DEFAULT_PATH}), and the
+ * {@value CURRENT_CONFIG_KEY_THRESHOLD_PERCENT}
  * property (default {@value DEFAULT_THRESHOLD}, virtually 100). The threshold should be set to a percent, such as 50 for 50% or
  * 99 for 99%. If disk usage
  * exceeds this threshold, then the health check will fail.
@@ -69,7 +69,7 @@ public class DiskSpaceHealthCheck implements HealthCheck {
      * directory as application path), use
      * {@link io.helidon.health.checks.DiskSpaceHealthCheck.Builder#path(java.nio.file.Path)}.
      * When running within a MicroProfile server, you can configure path using a configuration key
-     * {@value #CONFIG_KEY_PATH}
+     * {@value #CURRENT_CONFIG_KEY_PATH}
      * Defaults to {@value}
      */
     public static final String DEFAULT_PATH = ".";
@@ -87,14 +87,25 @@ public class DiskSpaceHealthCheck implements HealthCheck {
     /**
      * Full configuration key for path, when configured through MicroProfile config.
      */
-    public static final String CONFIG_KEY_PATH = HealthChecks.CONFIG_KEY_HEALTH_PREFIX
+    public static final String CONFIG_KEY_PATH = HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX
             + "." + CONFIG_KEY_DISKSPACE_PREFIX
             + "." + CONFIG_KEY_PATH_SUFFIX;
 
     /**
      * Full configuration key for threshold percent, when configured through Microprofile config.
      */
-    public static final String CONFIG_KEY_THRESHOLD_PERCENT = HealthChecks.CONFIG_KEY_HEALTH_PREFIX
+    public static final String CONFIG_KEY_THRESHOLD_PERCENT = HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX
+            + "." + CONFIG_KEY_DISKSPACE_PREFIX
+            + "." + CONFIG_KEY_THRESHOLD_PERCENT_SUFFIX;
+
+    // The following two constants are used in the Javadoc to nudge users toward using the config key prefix "health.checks"
+    // rather than the obsolete "helidon.health". Because the original public constants above have always referred to the
+    // now-deprecated config prefixes, those values are unchanged to preserve backward compatibility.
+    private static final String CURRENT_CONFIG_KEY_PATH = HealthChecks.CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX
+            + "." + CONFIG_KEY_DISKSPACE_PREFIX
+            + "." + CONFIG_KEY_PATH_SUFFIX;
+
+    private static final String CURRENT_CONFIG_KEY_THRESHOLD_PERCENT = HealthChecks.CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX
             + "." + CONFIG_KEY_DISKSPACE_PREFIX
             + "." + CONFIG_KEY_THRESHOLD_PERCENT_SUFFIX;
 
@@ -114,16 +125,22 @@ public class DiskSpaceHealthCheck implements HealthCheck {
     }
 
     @Inject
-    DiskSpaceHealthCheck(
-            @ConfigProperty(name = CONFIG_KEY_PATH, defaultValue = DEFAULT_PATH) File path,
-            @ConfigProperty(name = CONFIG_KEY_THRESHOLD_PERCENT, defaultValue = "99.999") double thresholdPercent
-    ) {
+    DiskSpaceHealthCheck(Config rootConfig) {
+        Config diskSpaceConfig = DeprecatedConfig.get(rootConfig,
+                                                         HealthChecks.CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX,
+                                                         HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX)
+                .get(CONFIG_KEY_DISKSPACE_PREFIX);
+        Path path = diskSpaceConfig.get(CONFIG_KEY_PATH_SUFFIX)
+                .as(Path.class)
+                .orElse(Paths.get("."));
+        thresholdPercent = diskSpaceConfig.get(CONFIG_KEY_THRESHOLD_PERCENT_SUFFIX)
+                .asDouble()
+                .orElse(99.999d);
         try {
-            this.fileStore = Files.getFileStore(path.toPath());
+            this.fileStore = Files.getFileStore(path);
         } catch (IOException e) {
-            throw new HealthCheckException("Failed to obtain file store for path " + path.getAbsolutePath(), e);
+            throw new HealthCheckException("Failed to obtain file store for path " + path, e);
         }
-        this.thresholdPercent = thresholdPercent;
     }
 
     private DiskSpaceHealthCheck(Builder builder) {

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HealthChecks.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HealthChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ import org.eclipse.microprofile.health.HealthCheck;
  */
 public final class HealthChecks {
 
-    static final String CONFIG_KEY_HEALTH_PREFIX = "helidon.health";
+    static final String CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX = "health.checks";
+    static final String DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX = "helidon.health";
 
     private HealthChecks() {
     }
@@ -114,9 +115,10 @@ public final class HealthChecks {
     }
 
     /**
-     * Built-in health checks, set up using "helidon.health" configuration.
+     * Built-in health checks, set up using configuration at {@value CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX} or the deprecated
+     * {@value DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX}.
      *
-     * @param config configuration rooted at "helidon.health"
+     * @param config configuration at the node containing health checks config
      * @return built-in health checks, set up using the provided configuration
      * @see io.helidon.health.HealthSupport.Builder#addLiveness(org.eclipse.microprofile.health.HealthCheck...)
      */

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
@@ -24,6 +24,7 @@ import io.helidon.config.DeprecatedConfig;
 import io.helidon.health.common.BuiltInHealthCheck;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
@@ -84,9 +85,8 @@ public class HeapMemoryHealthCheck implements HealthCheck {
     // this will be ignored if not within CDI
     @Inject
     HeapMemoryHealthCheck(
-            Runtime runtime,
-            Config rootConfig) {
-        this(runtime, DeprecatedConfig.get(rootConfig,
+            Runtime runtime) {
+        this(runtime, DeprecatedConfig.get(config(),
                                            HealthChecks.CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX,
                                            HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX)
                 .get(CONFIG_KEY_HEAP_PREFIX)
@@ -98,6 +98,10 @@ public class HeapMemoryHealthCheck implements HealthCheck {
     HeapMemoryHealthCheck(Runtime runtime, double thresholdPercent) {
         this.rt = runtime;
         this.thresholdPercent = thresholdPercent;
+    }
+
+    private static Config config() {
+        return CDI.current().select(Config.class).get();
     }
 
     private HeapMemoryHealthCheck(Builder builder) {

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
@@ -62,7 +62,10 @@ public class HeapMemoryHealthCheck implements HealthCheck {
 
     /**
      * Config property key for heap memory threshold.
+     *
+     * @deprecated The value will change to {@value #CURRENT_CONFIG_KEY_THRESHOLD_PERCENT} in a future release
      */
+    @Deprecated(since = "3.2.11")
     public static final String CONFIG_KEY_THRESHOLD_PERCENT = HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX
             + "." + CONFIG_KEY_HEAP_PREFIX
             + "." + CONFIG_KEY_THRESHOLD_PERCENT_SUFFIX;

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
@@ -19,13 +19,13 @@ package io.helidon.health.checks;
 import java.util.Formatter;
 import java.util.Locale;
 
-import io.helidon.config.Config;
 import io.helidon.config.DeprecatedConfig;
+import io.helidon.config.mp.MpConfig;
 import io.helidon.health.common.BuiltInHealthCheck;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
@@ -85,8 +85,9 @@ public class HeapMemoryHealthCheck implements HealthCheck {
     // this will be ignored if not within CDI
     @Inject
     HeapMemoryHealthCheck(
+            Config config,
             Runtime runtime) {
-        this(runtime, DeprecatedConfig.get(config(),
+        this(runtime, DeprecatedConfig.get(MpConfig.toHelidonConfig(config),
                                            HealthChecks.CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX,
                                            HealthChecks.DEPRECATED_CONFIG_KEY_BUILT_IN_HEALTH_CHECKS_PREFIX)
                 .get(CONFIG_KEY_HEAP_PREFIX)
@@ -98,10 +99,6 @@ public class HeapMemoryHealthCheck implements HealthCheck {
     HeapMemoryHealthCheck(Runtime runtime, double thresholdPercent) {
         this.rt = runtime;
         this.thresholdPercent = thresholdPercent;
-    }
-
-    private static Config config() {
-        return CDI.current().select(Config.class).get();
     }
 
     private HeapMemoryHealthCheck(Builder builder) {
@@ -199,7 +196,7 @@ public class HeapMemoryHealthCheck implements HealthCheck {
          * @param config {@code Config} node for heap memory
          * @return updated builder instance
          */
-        public Builder config(Config config) {
+        public Builder config(io.helidon.config.Config config) {
             config.get(CONFIG_KEY_THRESHOLD_PERCENT_SUFFIX)
                     .asDouble()
                     .ifPresent(this::thresholdPercent);

--- a/health/health-checks/src/main/java/module-info.java
+++ b/health/health-checks/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ module io.helidon.health.checks {
 
     requires io.helidon.common;
     requires io.helidon.config;
+    requires io.helidon.config.mp;
     requires io.helidon.health;
     requires io.helidon.health.common;
     requires static microprofile.config.api;

--- a/health/health-checks/src/test/resources/testConfig.yaml
+++ b/health/health-checks/src/test/resources/testConfig.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-bothFail:
+bothFailWithDeprecatedPrefix:
   helidon:
     health:
       diskSpace:
         thresholdPercent: 0.0
       heapMemory:
         thresholdPercent: 0.0
-bothPass:
+bothPassWithDeprecatedPrefix:
   helidon:
     health:
       diskSpace:
         thresholdPercent: 98.1
       heapMemory:
         thresholdPercent: 98.1
+# Following are set to zero to avoid the defaults and force a DOWN state the test can easily detect.
+bothFailWithoutDeprecatedHelidonPrefix:
+  health:
+    checks:
+      diskSpace:
+        thresholdPercent: 0.0
+      heapMemory:
+        thresholdPercent: 0.0

--- a/microprofile/health/pom.xml
+++ b/microprofile/health/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>helidon-service-common-rest-cdi</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.health</groupId>
+            <artifactId>helidon-health-checks</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/TestConfigPrefix.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/TestConfigPrefix.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.health;
+
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the config prefix.
+ * <p>
+ * We specify 0 values to force the statuses to DOWN. The default config settings cause the checks to return UP, so if we
+ * detect DOWN statuses we know the config has been found and applied correctly.
+ */
+@HelidonTest
+@AddConfig(key = "health.checks.diskSpace.thresholdPercent", value = "0.0")
+@AddConfig(key = "health.checks.heapMemory.thresholdPercent", value = "0.0")
+class TestConfigPrefix {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void testConfig() {
+        TestUtils.checkForFailure(webTarget);
+    }
+}

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/TestDeprecatedConfigPrefix.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/TestDeprecatedConfigPrefix.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.health;
+
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the deprecated config prefix.
+ * <p>
+ *     We specify 0 values to force the statuses to DOWN. The default config settings cause the checks to return UP, so if we
+ *     detect DOWN statuses we know the config has been found and applied correctly.
+ */
+@HelidonTest
+@AddConfig(key = "helidon.health.diskSpace.thresholdPercent", value = "0.0")
+@AddConfig(key = "helidon.health.heapMemory.thresholdPercent", value = "0.0")
+class TestDeprecatedConfigPrefix {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void testConfig() {
+        TestUtils.checkForFailure(webTarget);
+    }
+}

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/TestUtils.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/TestUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.health;
+
+import io.helidon.common.http.Http;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+class TestUtils {
+    static JsonObject getLivenessCheck(JsonObject health, String checkName) {
+        return health.getJsonArray("checks").stream()
+                .map(JsonValue::asJsonObject)
+                .filter(jo -> jo.getString("name").equals(checkName))
+                .findFirst()
+                .orElse(null);
+    }
+
+    static void checkForFailure(WebTarget webTarget) {
+        Response response = webTarget.path("/health")
+                .request()
+                .get();
+
+        assertThat("Health endpoint status", response.getStatus(), is(Http.Status.SERVICE_UNAVAILABLE_503.code()));
+
+        JsonObject healthJson = response.readEntity(JsonObject.class);
+        JsonObject diskSpace = TestUtils.getLivenessCheck(healthJson, "diskSpace");
+        JsonObject heapMemory = TestUtils.getLivenessCheck(healthJson, "heapMemory");
+        assertThat("Disk space liveness return data", diskSpace, is(notNullValue()));
+        assertThat("Disk space liveness check status", diskSpace.getString("status"), is("DOWN"));
+        assertThat("Heap memory liveness return data", heapMemory, is(notNullValue()));
+        assertThat("Heap memory liveness check status", heapMemory.getString("status"), is("DOWN"));
+    }
+}


### PR DESCRIPTION
### Description
Resolves #9322 

The PR allows (and encourages, through changes in the doc and Javadoc) the use of `health.checks` (preferred over `helidon.health`) as the prefix for config keys to control the built-in health checks.

The now-deprecated `helidon.health` prefix still works although its use triggers a warning courtesy of the new utility class `DeprecatedMpConfig`. (This is patterned closely after the existing `DeprecatedConfig` class but that does not work with proxied MP `Config` objects.)

There are some public constants which retain their old values (even though the syntax for how they are computed has changed) so any user code relying on the previous values will continue to work unchanged.

The Javadoc and the `.adoc` doc now refer to `health.checks` as the config prefix.

A few tests added.

### Documentation
Doc is updated.