### PR TITLE
4.x: Amends datasource-ucp to depend on ucp11 instead of ucp

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/custom/database-outputs.xml
+++ b/archetypes/archetypes/src/main/archetype/mp/custom/database-outputs.xml
@@ -362,11 +362,6 @@ For details on an Oracle Docker image, see https://github.com/oracle/docker-imag
                             <value key="artifactId">ojdbc</value>
                             <value key="scope">runtime</value>
                         </map>
-                        <map>
-                            <value key="groupId">com.oracle.database.jdbc</value>
-                            <value key="artifactId">ucp</value>
-                            <value key="scope">runtime</value>
-                        </map>
                     </list>
                     <value key="jdbcDataSource">oracle.jdbc.pool.OracleDataSource</value>
                     <value key="databaseUrl">jdbc:oracle:thin:@localhost:1521:XE</value>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp</artifactId>
+            <artifactId>ucp11</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -41,11 +41,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.integrations.db</groupId>
-            <artifactId>ojdbc</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ucp11</artifactId>
             <scope>compile</scope>
@@ -75,10 +70,9 @@
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>jandex</artifactId>
+            <groupId>io.helidon.integrations.db</groupId>
+            <artifactId>ojdbc</artifactId>
             <scope>runtime</scope>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
@@ -86,6 +80,13 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test-scoped dependencies. -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/integrations/cdi/datasource-ucp/src/main/java/module-info.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/module-info.java
@@ -23,10 +23,9 @@
  * @see
  * io.helidon.integrations.datasource.ucp.cdi.UCPBackedDataSourceExtension
  */
-@SuppressWarnings({ "requires-automatic"})
+@SuppressWarnings({ "requires-automatic" })
 module io.helidon.integrations.datasource.ucp.cdi {
 
-    requires com.oracle.database.jdbc; // com.oracle.database.ucp needs this (!)
     requires com.oracle.database.ucp;
     requires java.desktop; // For java.beans
     requires java.naming; // PoolDataSourceImpl implements javax.naming.Referenceable

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -45,10 +45,6 @@
             <type>pom</type>
             <exclusions>
                 <exclusion>
-                    <groupId>com.oracle.database.jdbc</groupId>
-                    <artifactId>ucp</artifactId>
-                </exclusion>
-                <exclusion>
                     <!-- Contains JAXP impl, so we exclude it to not interfere -->
                     <groupId>com.oracle.database.xml</groupId>
                     <artifactId>xmlparserv2</artifactId>

--- a/messaging/connectors/aq/pom.xml
+++ b/messaging/connectors/aq/pom.xml
@@ -66,10 +66,6 @@
             <artifactId>ojdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>


### PR DESCRIPTION
This PR changes `integrations/cdi/datasource-ucp/pom.xml` to depend on `ucp11` instead of `ucp`, since the `pom.xml` was [previously amended](https://github.com/helidon-io/helidon/blob/4.1.2/integrations/cdi/datasource-ucp/pom.xml#L43-L47) (via https://github.com/helidon-io/helidon/commit/ef6649f236ecd3d35ec96a138c0735ad7a54856f) to include a dependency on our `ojdbc` integration rather than on the Oracle JDBC driver directly&mdash;a decision which had some unintended ripple effects. 

Part of this change seems to have been to [include the full production suite of artifacts related to the driver](https://github.com/helidon-io/helidon/blob/4.1.2/integrations/db/ojdbc/pom.xml#L42-L45). Notably, the suite of artifacts also includes `ucp11`, along with several other jars related to observability and so on.

Our `ojdbc` integration excludes `ucp` from its dependency tree. But that dependency is never included (despite the [Developers Guide For Oracle JDBC on Maven Central](https://www.oracle.com/database/technologies/maven-central-guide.html) claiming (incorrectly) that it is (see "Use Case 1: I Want the Production Jars", second bullet point, and contrast with what [the relevant `pom.xml` actually says](https://search.maven.org/artifact/com.oracle.database.jdbc/ojdbc11-production/21.9.0.0/pom))), so the exclusion is effectively a no-op. I'll fix this in a subsequent PR (though I'm not the original author, it seems simple enough).

Anyway, the net effect of all this, as #9349 indicates, is that a user of this project will currently end up with two copies of UCP on the classpath: one compiled with JDK 8 (`ucp`) dragged in by `integrations/cdi/datasource-ucp`, and another compiled with JDK 11 (`ucp11`) (dragged in by `integrations/db/ojdbc`).  The intent of this PR is to fix this problem and remove at least some of this confusion.

Closes #9349.