### PR TITLE
4.1.3: Ensures there is no trailing whitespace in Java properties lines in persistence.adoc with Asciidoctor callouts at the expense of visual cleanliness

### DIFF
--- a/docs/src/main/asciidoc/mp/persistence.adoc
+++ b/docs/src/main/asciidoc/mp/persistence.adoc
@@ -327,7 +327,7 @@ the `test` data source's associated connection pool or vendor-specific
 
 [source,properties]
 ----
-javax.sql.DataSource.test.foo.bar=baz # <1> <2> <3>
+javax.sql.DataSource.test.foo.bar=baz# <1><2><3>
 ----
 <1> The *_objecttype_* portion of the configuration property name is
     `javax.sql.DataSource`.
@@ -434,8 +434,8 @@ a service name of `XE`, a `user` of `scott`, and a `password` of
 
 [source,properties]
 ----
-javax.sql.DataSource.main.connectionFactoryClassName = oracle.jdbc.pool.OracleDataSource # <1>
-javax.sql.DataSource.main.url = jdbc:oracle:thin://@localhost:1521/XE # <2>
+javax.sql.DataSource.main.connectionFactoryClassName = oracle.jdbc.pool.OracleDataSource# <1>
+javax.sql.DataSource.main.URL = jdbc:oracle:thin:@//localhost:1521/XE# <2>
 javax.sql.DataSource.main.user = scott
 javax.sql.DataSource.main.password = tiger
 ----
@@ -488,8 +488,8 @@ password:
 
 [source,properties]
 ----
-javax.sql.DataSource.test.dataSourceClassName = org.h2.jdbcx.JdbcDataSource # <1>
-javax.sql.DataSource.test.dataSource.url = jdbc:h2:mem:unit-testing;DB_CLOSE_DELAY=-1 # <2> <3>
+javax.sql.DataSource.test.dataSourceClassName = org.h2.jdbcx.JdbcDataSource# <1>
+javax.sql.DataSource.test.dataSource.url = jdbc:h2:mem:unit-testing;DB_CLOSE_DELAY=-1# <2><3>
 javax.sql.DataSource.test.dataSource.user = sa
 javax.sql.DataSource.test.dataSource.password =
 ----


### PR DESCRIPTION
Backports #9352 to Helidon 4.1.3

This PR updates the Persistence Guide so that a copy and paste of Java properties excerpts does not include trailing whitespace at the end of the line. (It also corrects a data source property, `url`, which should have been `URL`. See #9348.)

The tradeoff is that the Asciidoctor callout glyph is now smashed up against the end of the line.

<img width="866" alt="Screenshot 2024-10-09 at 2 56 29 PM" src="https://github.com/user-attachments/assets/5b298b04-073a-4be5-b812-7a5d7f12eed0">

Closes #9350.

Closes #9348.