### PR TITLE
4.1.3: Correct doc error: incorrect config key for compatibility of OTel span names

### DIFF
--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -83,7 +83,7 @@ MicroProfile Telemetry {mp-telemetry-version} allows for the exportation of the 
 If possible, assign the following config setting in your application's `META-INF/microprofile-config.properties` file:
 [source,properties]
 ----
-mp.telemetry.span.name-includes-method = true
+telemetry.span.name-includes-method = true
 ----
 Earlier releases of Helidon 4 implemented MicroProfile Telemetry 1.0 which was based on OpenTelemetry semantic conventions 1.22.0-alpha.
 


### PR DESCRIPTION

Backports #9373 to Helidon 4.1.3

### Description
Resolves #9368 

The config key should not have the `mp` prefix and the code does not use the `mp` prefix.

### Documentation
This is a doc bug.