### PR TITLE
Update Slack link to use HTTPS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We welcome your contributions! There are multiple ways to contribute.
 
 ## Discussion
 
-Join us at [#helidon-users](http://slack.helidon.io) and participate in discussions.
+Join us at [#helidon-users](https://slack.helidon.io) and participate in discussions.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ but a couple are handy to use on your desktop to verify your changes.
 
 * See the [Helidon FAQ](https://github.com/oracle/helidon/wiki/FAQ)
 * Ask questions on Stack Overflow using the [helidon tag](https://stackoverflow.com/tags/helidon)
-* Join us on Slack: [#helidon-users](http://slack.helidon.io)
+* Join us on Slack: [#helidon-users](https://slack.helidon.io)
 
 ## Get Involved
 

--- a/docs/src/main/asciidoc/community.adoc
+++ b/docs/src/main/asciidoc/community.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ creating issues, or submitting pull requests.
 
 Have a question?
 
-* Ask them in in Slack at http://slack.helidon.io[#helidon-user]
+* Ask them in in Slack at https://slack.helidon.io[#helidon-user]
 * Or on https://stackoverflow.com/questions/tagged/helidon[Stack Overflow] using the `helidon` tag
 * Read the https://github.com/oracle/helidon/wiki/FAQ[Helidon FAQ]
 


### PR DESCRIPTION
Can I have a review on this very small change by updating the Slack link from `http://slack.helidon.io` to `https://slack.helidon.io` in the following files:
- `README.md`
- `CONTRIBUTING.md`
- `docs/src/main/asciidoc/community.adoc`

This change ensures a secure connection when users join the Helidon Slack channel.
