### PR TITLE
4.1.3: Concurrency limits module, and support in Helidon WebServer

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -464,6 +464,10 @@
             <artifactId>helidon-common-features</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.concurrency</groupId>
+            <artifactId>helidon-common-concurrency-limits</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.dbclient</groupId>
             <artifactId>helidon-dbclient</artifactId>
         </dependency>
@@ -995,6 +999,10 @@
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-service-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-concurrency-limits</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -610,6 +610,11 @@
                 <artifactId>helidon-common-features</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.helidon.common.concurrency</groupId>
+                <artifactId>helidon-common-concurrency-limits</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
 
             <!-- db client -->
             <dependency>
@@ -1311,6 +1316,11 @@
             <dependency>
                 <groupId>io.helidon.webserver</groupId>
                 <artifactId>helidon-webserver-service-common</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.webserver</groupId>
+                <artifactId>helidon-webserver-concurrency-limits</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>

--- a/common/concurrency/limits/README.md
+++ b/common/concurrency/limits/README.md
@@ -1,0 +1,37 @@
+Concurrency Limits
+-----
+
+This module provides concurrency limits, so we can limit the number of concurrent, in-progress operations (for example in WebServer).
+
+The implemented concurrency limits are:
+
+| Key     | Weight | Description                                                  |
+|---------|--------|--------------------------------------------------------------|
+| `fixed` | `90`   | Semaphore based concurrency limit, supports queueing         |
+| `aimd`  | `80`   | AIMD based limit (additive-increase/multiplicative-decrease) |
+
+Current usage: `helidon-webserver`
+
+The weight is not significant (unless you want to override an implementation using your own Limit with a higher weight), as the usages in Helidon use a single (optional) implementation that must be correctly typed in 
+configuration.
+
+# Fixed concurrency limit
+
+The fixed concurrency limit is based on a semaphore behavior. 
+You can define the number of available permits, then each time a token is requested, a permit (if available) is returned.
+When the token is finished (through one of its lifecycle operations), the permit is returned.
+
+When the limit is set to 0, an unlimited implementation is used.
+
+The fixed limit also provides support for defining a queue. If set to a value above `0`, queuing is enabled. In such a case we enqueue a certain number of requests (with a configurable timeout). 
+
+Defaults are:
+- `permits: 0` - unlimited permits (no limit)
+- `queue-length: 0` - no queuing
+- `queue-timeout: PT1S` - 1 second timout in queue, if queuing is enabled
+
+# AIMD concurrency limit
+
+The additive-increase/multiplicative-decrease (AIMD) algorithm is a feedback control algorithm best known for its use in TCP congestion control. AIMD combines linear growth of the congestion window when there is no congestion with an exponential reduction when congestion is detected.
+
+This implementation provides variable concurrency limit with fixed minimal/maximal number of permits.

--- a/common/concurrency/limits/pom.xml
+++ b/common/concurrency/limits/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.common.concurrency</groupId>
+        <artifactId>helidon-common-concurrency-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>helidon-common-concurrency-limits</artifactId>
+    <name>Helidon Common Concurrency Limits</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.builder</groupId>
+            <artifactId>helidon-builder-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.config.metadata</groupId>
+                            <artifactId>helidon-config-metadata-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.config.metadata</groupId>
+                        <artifactId>helidon-config-metadata-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/common/concurrency/limits/pom.xml
+++ b/common/concurrency/limits/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.common.concurrency</groupId>
         <artifactId>helidon-common-concurrency-project</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.1.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimit.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Semaphore;
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.config.Config;
+
+/**
+ * AIMD based limiter.
+ * <p>
+ * The additive-increase/multiplicative-decrease (AIMD) algorithm is a feedback control algorithm best known for its use in TCP
+ * congestion control. AIMD combines linear growth of the congestion window when there is no congestion with an exponential
+ * reduction when congestion is detected.
+ */
+@SuppressWarnings("removal")
+@RuntimeType.PrototypedBy(AimdLimitConfig.class)
+public class AimdLimit implements Limit, SemaphoreLimit, RuntimeType.Api<AimdLimitConfig> {
+    static final String TYPE = "aimd";
+
+    private final AimdLimitConfig config;
+    private final AimdLimitImpl aimdLimitImpl;
+
+    private AimdLimit(AimdLimitConfig config) {
+        this.config = config;
+        this.aimdLimitImpl = new AimdLimitImpl(config);
+    }
+
+    /**
+     * Create a new fluent API builder to construct {@link io.helidon.common.concurrency.limits.AimdLimit}
+     * instance.
+     *
+     * @return fluent API builder
+     */
+    public static AimdLimitConfig.Builder builder() {
+        return AimdLimitConfig.builder();
+    }
+
+    /**
+     * Create a new instance with all defaults.
+     *
+     * @return a new limit instance
+     */
+    public static AimdLimit create() {
+        return builder().build();
+    }
+
+    /**
+     * Create a new instance from configuration.
+     *
+     * @param config configuration of the AIMD limit
+     * @return a new limit instance configured from {@code config}
+     */
+    public static AimdLimit create(Config config) {
+        return builder()
+                .config(config)
+                .build();
+    }
+
+    /**
+     * Create a new instance from configuration.
+     *
+     * @param config configuration of the AIMD limit
+     * @return a new limit instance configured from {@code config}
+     */
+    public static AimdLimit create(AimdLimitConfig config) {
+        return new AimdLimit(config);
+    }
+
+    /**
+     * Create a new instance customizing its configuration.
+     *
+     * @param consumer consumer of configuration builder
+     * @return a new limit instance configured from the builder
+     */
+    public static AimdLimit create(Consumer<AimdLimitConfig.Builder> consumer) {
+        return builder()
+                .update(consumer)
+                .build();
+    }
+
+    @Override
+    public <T> T invoke(Callable<T> callable) throws Exception {
+        return aimdLimitImpl.invoke(callable);
+    }
+
+    @Override
+    public void invoke(Runnable runnable) throws Exception {
+        aimdLimitImpl.invoke(runnable);
+    }
+
+    @Override
+    public Optional<Token> tryAcquire(boolean wait) {
+        return aimdLimitImpl.tryAcquire();
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public Semaphore semaphore() {
+        return aimdLimitImpl.semaphore();
+    }
+
+    @Override
+    public String name() {
+        return config.name();
+    }
+
+    @Override
+    public String type() {
+        return TYPE;
+    }
+
+    @Override
+    public AimdLimitConfig prototype() {
+        return config;
+    }
+
+    @Override
+    public Limit copy() {
+        return config.build();
+    }
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitConfigBlueprint.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitConfigBlueprint.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.concurrency.limits.spi.LimitProvider;
+
+/**
+ * Configuration of {@link io.helidon.common.concurrency.limits.AimdLimit}.
+ */
+@Prototype.Blueprint
+@Prototype.Configured(value = AimdLimit.TYPE, root = false)
+@Prototype.Provides(LimitProvider.class)
+interface AimdLimitConfigBlueprint extends Prototype.Factory<AimdLimit> {
+    /**
+     * Backoff ratio to use for the algorithm.
+     * The value must be within [0.5, 1.0).
+     *
+     * @return backoff ratio
+     */
+    @Option.Configured
+    @Option.DefaultDouble(0.9)
+    double backoffRatio();
+
+    /**
+     * Initial limit.
+     * The value must be within [{@link #minLimit()}, {@link #maxLimit()}].
+     *
+     * @return initial limit
+     */
+    @Option.Configured
+    @Option.DefaultInt(20)
+    int initialLimit();
+
+    /**
+     * Maximal limit.
+     * The value must be same or higher than {@link #minLimit()}.
+     *
+     * @return maximal limit
+     */
+    @Option.Configured
+    @Option.DefaultInt(200)
+    int maxLimit();
+
+    /**
+     * Minimal limit.
+     * The value must be same or lower than {@link #maxLimit()}.
+     *
+     * @return minimal limit
+     */
+    @Option.Configured
+    @Option.DefaultInt(20)
+    int minLimit();
+
+    /**
+     * Timeout that when exceeded is the same as if the task failed.
+     *
+     * @return task timeout, defaults to 5 seconds
+     */
+    @Option.Configured
+    @Option.Default("PT5S")
+    Duration timeout();
+
+    /**
+     * A clock that supplies nanosecond time.
+     *
+     * @return supplier of current nanoseconds, defaults to {@link java.lang.System#nanoTime()}
+     */
+    Optional<Supplier<Long>> clock();
+
+    /**
+     * Name of this instance.
+     *
+     * @return name of the instance
+     */
+    @Option.Default(AimdLimit.TYPE)
+    String name();
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitImpl.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.io.Serial;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+import io.helidon.common.config.ConfigException;
+
+class AimdLimitImpl {
+    private final double backoffRatio;
+    private final long timeoutInNanos;
+    private final int minLimit;
+    private final int maxLimit;
+
+    private final Supplier<Long> clock;
+    private final AtomicInteger concurrentRequests;
+    private final AdjustableSemaphore semaphore;
+
+    private final AtomicInteger limit;
+    private final Lock limitLock = new ReentrantLock();
+
+    AimdLimitImpl(AimdLimitConfig config) {
+        int initialLimit = config.initialLimit();
+        this.backoffRatio = config.backoffRatio();
+        this.timeoutInNanos = config.timeout().toNanos();
+        this.minLimit = config.minLimit();
+        this.maxLimit = config.maxLimit();
+        this.clock = config.clock().orElseGet(() -> System::nanoTime);
+
+        this.concurrentRequests = new AtomicInteger();
+        this.semaphore = new AdjustableSemaphore(initialLimit);
+
+        this.limit = new AtomicInteger(initialLimit);
+
+        if (!(backoffRatio < 1.0 && backoffRatio >= 0.5)) {
+            throw new ConfigException("Backoff ratio must be within [0.5, 1.0)");
+        }
+        if (maxLimit < minLimit) {
+            throw new ConfigException("Max limit must be higher than min limit, or equal to it");
+        }
+        if (initialLimit > maxLimit) {
+            throw new ConfigException("Initial limit must be lower than max limit, or equal to it");
+        }
+        if (initialLimit < minLimit) {
+            throw new ConfigException("Initial limit must be higher than minimum limit, or equal to it");
+        }
+    }
+
+    Semaphore semaphore() {
+        return semaphore;
+    }
+
+    int currentLimit() {
+        return limit.get();
+    }
+
+    Optional<Limit.Token> tryAcquire() {
+        if (!semaphore.tryAcquire()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new AimdToken(clock, concurrentRequests));
+    }
+
+    void invoke(Runnable runnable) throws Exception {
+        invoke(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    <T> T invoke(Callable<T> callable) throws Exception {
+        long startTime = clock.get();
+        int currentRequests = concurrentRequests.incrementAndGet();
+
+        if (semaphore.tryAcquire()) {
+            try {
+                T response = callable.call();
+                updateWithSample(startTime, clock.get(), currentRequests, true);
+                return response;
+            } catch (IgnoreTaskException e) {
+                return e.handle();
+            } catch (Throwable e) {
+                updateWithSample(startTime, clock.get(), currentRequests, false);
+                throw e;
+            } finally {
+                concurrentRequests.decrementAndGet();
+                semaphore.release();
+            }
+        } else {
+            throw new LimitException("No more permits available for the semaphore");
+        }
+    }
+
+    void updateWithSample(long startTime, long endTime, int currentRequests, boolean success) {
+        long rtt = endTime - startTime;
+
+        int currentLimit = limit.get();
+        if (rtt > timeoutInNanos || !success) {
+            currentLimit = (int) (currentLimit * backoffRatio);
+        } else if (currentRequests * 2 >= currentLimit) {
+            currentLimit = currentLimit + 1;
+        }
+        setLimit(Math.min(maxLimit, Math.max(minLimit, currentLimit)));
+    }
+
+    private void setLimit(int newLimit) {
+        if (newLimit == limit.get()) {
+            // already have the correct limit
+            return;
+        }
+        // now we lock, to do this only once in parallel,
+        // as otherwise we may end up in strange lands
+        limitLock.lock();
+        try {
+            int oldLimit = limit.get();
+            if (oldLimit == newLimit) {
+                // parallel thread already fixed it
+                return;
+            }
+            limit.set(newLimit);
+
+            if (newLimit > oldLimit) {
+                this.semaphore.release(newLimit - oldLimit);
+            } else {
+                this.semaphore.reducePermits(oldLimit - newLimit);
+            }
+        } finally {
+            limitLock.unlock();
+        }
+    }
+
+    private static final class AdjustableSemaphore extends Semaphore {
+        @Serial
+        private static final long serialVersionUID = 114L;
+
+        private AdjustableSemaphore(int permits) {
+            super(permits);
+        }
+
+        @Override
+        protected void reducePermits(int reduction) {
+            super.reducePermits(reduction);
+        }
+    }
+
+    private class AimdToken implements Limit.Token {
+        private final long startTime;
+        private final int currentRequests;
+
+        private AimdToken(Supplier<Long> clock, AtomicInteger concurrentRequests) {
+            startTime = clock.get();
+            currentRequests = concurrentRequests.incrementAndGet();
+        }
+
+        @Override
+        public void dropped() {
+            updateWithSample(startTime, clock.get(), currentRequests, false);
+        }
+
+        @Override
+        public void ignore() {
+            concurrentRequests.decrementAndGet();
+        }
+
+        @Override
+        public void success() {
+            updateWithSample(startTime, clock.get(), currentRequests, true);
+            concurrentRequests.decrementAndGet();
+        }
+    }
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitProvider.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/AimdLimitProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import io.helidon.common.Weight;
+import io.helidon.common.concurrency.limits.spi.LimitProvider;
+import io.helidon.common.config.Config;
+
+/**
+ * {@link java.util.ServiceLoader} service provider for {@link io.helidon.common.concurrency.limits.AimdLimit}
+ * limit implementation.
+ */
+@Weight(80)
+public class AimdLimitProvider implements LimitProvider {
+    /**
+     * Constructor required by the service loader.
+     */
+    public AimdLimitProvider() {
+    }
+
+    @Override
+    public String configKey() {
+        return AimdLimit.TYPE;
+    }
+
+    @Override
+    public Limit create(Config config, String name) {
+        return AimdLimit.builder()
+                .config(config)
+                .name(name)
+                .build();
+    }
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/FixedLimit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/FixedLimit.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.config.Config;
+
+/**
+ * Semaphore based limit, that supports queuing for a permit, and timeout on the queue.
+ * The default behavior is non-queuing.
+ *
+ * @see io.helidon.common.concurrency.limits.FixedLimitConfig
+ */
+@SuppressWarnings("removal")
+@RuntimeType.PrototypedBy(FixedLimitConfig.class)
+public class FixedLimit implements Limit, SemaphoreLimit, RuntimeType.Api<FixedLimitConfig> {
+    /**
+     * Default limit, meaning unlimited execution.
+     */
+    public static final int DEFAULT_LIMIT = 0;
+    /**
+     * Default length of the queue.
+     */
+    public static final int DEFAULT_QUEUE_LENGTH = 0;
+    /**
+     * Timeout of a request that is enqueued.
+     */
+    public static final String DEFAULT_QUEUE_TIMEOUT_DURATION = "PT1S";
+
+    static final String TYPE = "fixed";
+
+    private final FixedLimitConfig config;
+    private final LimiterHandler handler;
+    private final int initialPermits;
+
+    private FixedLimit(FixedLimitConfig config) {
+        this.config = config;
+        if (config.permits() == 0 && config.semaphore().isEmpty()) {
+            this.handler = new NoOpSemaphoreHandler();
+            this.initialPermits = 0;
+        } else {
+            Semaphore semaphore = config.semaphore().orElseGet(() -> new Semaphore(config.permits(), config.fair()));
+            this.initialPermits = semaphore.availablePermits();
+            if (config.queueLength() == 0) {
+                this.handler = new RealSemaphoreHandler(semaphore);
+            } else {
+                this.handler = new QueuedSemaphoreHandler(semaphore,
+                                                          config.queueLength(),
+                                                          config.queueTimeout());
+            }
+        }
+    }
+
+    /**
+     * Create a new fluent API builder to construct {@link FixedLimit}
+     * instance.
+     *
+     * @return fluent API builder
+     */
+    public static FixedLimitConfig.Builder builder() {
+        return FixedLimitConfig.builder();
+    }
+
+    /**
+     * Create a new instance with all defaults (no limit).
+     *
+     * @return a new limit instance
+     */
+    public static FixedLimit create() {
+        return builder().build();
+    }
+
+    /**
+     * Create an instance from the provided semaphore.
+     *
+     * @param semaphore semaphore to use
+     * @return a new fixed limit backed by the provided semaphore
+     */
+    public static FixedLimit create(Semaphore semaphore) {
+        return builder()
+                .semaphore(semaphore)
+                .build();
+    }
+
+    /**
+     * Create a new instance from configuration.
+     *
+     * @param config configuration of the fixed limit
+     * @return a new limit instance configured from {@code config}
+     */
+    public static FixedLimit create(Config config) {
+        return builder()
+                .config(config)
+                .build();
+    }
+
+    /**
+     * Create a new instance from configuration.
+     *
+     * @param config configuration of the fixed limit
+     * @return a new limit instance configured from {@code config}
+     */
+    public static FixedLimit create(FixedLimitConfig config) {
+        return new FixedLimit(config);
+    }
+
+    /**
+     * Create a new instance customizing its configuration.
+     *
+     * @param consumer consumer of configuration builder
+     * @return a new limit instance configured from the builder
+     */
+    public static FixedLimit create(Consumer<FixedLimitConfig.Builder> consumer) {
+        return builder()
+                .update(consumer)
+                .build();
+    }
+
+    @Override
+    public <T> T invoke(Callable<T> callable) throws Exception {
+        return handler.invoke(callable);
+    }
+
+    @Override
+    public void invoke(Runnable runnable) throws Exception {
+        handler.invoke(runnable);
+    }
+
+    @Override
+    public Optional<Token> tryAcquire(boolean wait) {
+        return handler.tryAcquire(wait);
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public Semaphore semaphore() {
+        return handler.semaphore();
+    }
+
+    @Override
+    public FixedLimitConfig prototype() {
+        return config;
+    }
+
+    @Override
+    public String name() {
+        return config.name();
+    }
+
+    @Override
+    public String type() {
+        return FixedLimit.TYPE;
+    }
+
+    @Override
+    public Limit copy() {
+        if (config.semaphore().isPresent()) {
+            Semaphore semaphore = config.semaphore().get();
+
+            return FixedLimitConfig.builder()
+                    .from(config)
+                    .semaphore(new Semaphore(initialPermits, semaphore.isFair()))
+                    .build();
+        }
+        return config.build();
+    }
+
+    @SuppressWarnings("removal")
+    private interface LimiterHandler extends SemaphoreLimit, LimitAlgorithm {
+    }
+
+    private static class NoOpSemaphoreHandler implements LimiterHandler {
+        private static final Token TOKEN = new Token() {
+            @Override
+            public void dropped() {
+            }
+
+            @Override
+            public void ignore() {
+            }
+
+            @Override
+            public void success() {
+            }
+        };
+
+        @Override
+        public <T> T invoke(Callable<T> callable) throws Exception {
+            try {
+                return callable.call();
+            } catch (IgnoreTaskException e) {
+                return e.handle();
+            }
+        }
+
+        @Override
+        public void invoke(Runnable runnable) {
+            runnable.run();
+        }
+
+        @Override
+        public Optional<Token> tryAcquire(boolean wait) {
+            return Optional.of(TOKEN);
+        }
+
+        @SuppressWarnings("removal")
+        @Override
+        public Semaphore semaphore() {
+            return NoopSemaphore.INSTANCE;
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static class RealSemaphoreHandler implements LimiterHandler {
+        private final Semaphore semaphore;
+
+        private RealSemaphoreHandler(Semaphore semaphore) {
+            this.semaphore = semaphore;
+        }
+
+        @Override
+        public <T> T invoke(Callable<T> callable) throws Exception {
+            if (semaphore.tryAcquire()) {
+                try {
+                    return callable.call();
+                } catch (IgnoreTaskException e) {
+                    return e.handle();
+                } finally {
+                    semaphore.release();
+                }
+            } else {
+                throw new LimitException("No more permits available for the semaphore");
+            }
+        }
+
+        @Override
+        public void invoke(Runnable runnable) throws Exception {
+            if (semaphore.tryAcquire()) {
+                try {
+                    runnable.run();
+                } catch (IgnoreTaskException e) {
+                    e.handle();
+                } finally {
+                    semaphore.release();
+                }
+            } else {
+                throw new LimitException("No more permits available for the semaphore");
+            }
+        }
+
+        @Override
+        public Optional<Token> tryAcquire(boolean wait) {
+            if (!semaphore.tryAcquire()) {
+                return Optional.empty();
+            }
+            return Optional.of(new SemaphoreToken(semaphore));
+        }
+
+        @Override
+        public Semaphore semaphore() {
+            return semaphore;
+        }
+    }
+
+    private static class QueuedSemaphoreHandler implements LimiterHandler {
+        private final Semaphore semaphore;
+        private final int queueLength;
+        private final long timeoutMillis;
+
+        private QueuedSemaphoreHandler(Semaphore semaphore, int queueLength, Duration queueTimeout) {
+            this.semaphore = semaphore;
+            this.queueLength = queueLength;
+            this.timeoutMillis = queueTimeout.toMillis();
+        }
+
+        @Override
+        public Optional<Token> tryAcquire(boolean wait) {
+            if (semaphore.getQueueLength() >= this.queueLength) {
+                // this is an estimate - we do not promise to be precise here
+                return Optional.empty();
+            }
+
+            try {
+                if (wait) {
+                    if (!semaphore.tryAcquire(timeoutMillis, TimeUnit.MILLISECONDS)) {
+                        return Optional.empty();
+                    }
+                } else {
+                    if (!semaphore.tryAcquire()) {
+                        return Optional.empty();
+                    }
+                }
+
+            } catch (InterruptedException e) {
+                return Optional.empty();
+            }
+            return Optional.of(new SemaphoreToken(semaphore));
+        }
+
+        @Override
+        public Semaphore semaphore() {
+            return semaphore;
+        }
+    }
+
+    private static class SemaphoreToken implements Token {
+        private final Semaphore semaphore;
+
+        private SemaphoreToken(Semaphore semaphore) {
+            this.semaphore = semaphore;
+        }
+
+        @Override
+        public void dropped() {
+            semaphore.release();
+        }
+
+        @Override
+        public void ignore() {
+            semaphore.release();
+        }
+
+        @Override
+        public void success() {
+            semaphore.release();
+        }
+    }
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/FixedLimitConfigBlueprint.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/FixedLimitConfigBlueprint.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.Semaphore;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.concurrency.limits.spi.LimitProvider;
+
+/**
+ * Configuration of {@link FixedLimit}.
+ *
+ * @see #permits()
+ * @see #queueLength()
+ * @see #queueTimeout()
+ */
+@Prototype.Blueprint
+@Prototype.Configured(value = FixedLimit.TYPE, root = false)
+@Prototype.Provides(LimitProvider.class)
+interface FixedLimitConfigBlueprint extends Prototype.Factory<FixedLimit> {
+    /**
+     * Number of permit to allow.
+     * Defaults to {@value FixedLimit#DEFAULT_LIMIT}.
+     * When set to {@code 0}, we switch to unlimited.
+     *
+     * @return number of permits
+     */
+    @Option.Configured
+    @Option.DefaultInt(FixedLimit.DEFAULT_LIMIT)
+    int permits();
+
+    /**
+     * Whether the {@link java.util.concurrent.Semaphore} should be {@link java.util.concurrent.Semaphore#isFair()}.
+     * Defaults to {@code false}.
+     *
+     * @return whether this should be a fair semaphore
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean fair();
+
+    /**
+     * How many requests can be enqueued waiting for a permit.
+     * Note that this may not be an exact behavior due to concurrent invocations.
+     * We use {@link java.util.concurrent.Semaphore#getQueueLength()} in the
+     * {@link io.helidon.common.concurrency.limits.FixedLimit} implementation.
+     * Default value is {@value FixedLimit#DEFAULT_QUEUE_LENGTH}.
+     * If set to {code 0}, there is no queueing.
+     *
+     * @return number of requests to enqueue
+     */
+    @Option.Configured
+    @Option.DefaultInt(FixedLimit.DEFAULT_QUEUE_LENGTH)
+    int queueLength();
+
+    /**
+     * How long to wait for a permit when enqueued.
+     * Defaults to {@value FixedLimit#DEFAULT_QUEUE_TIMEOUT_DURATION}
+     *
+     * @return duration of the timeout
+     */
+    @Option.Configured
+    @Option.Default(FixedLimit.DEFAULT_QUEUE_TIMEOUT_DURATION)
+    Duration queueTimeout();
+
+    /**
+     * Name of this instance.
+     *
+     * @return name of the instance
+     */
+    @Option.Default(FixedLimit.TYPE)
+    String name();
+
+    /**
+     * Explicitly configured semaphore.
+     * Note that if this is set, all other configuration is ignored.
+     *
+     * @return semaphore instance
+     */
+    Optional<Semaphore> semaphore();
+
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/FixedLimitProvider.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/FixedLimitProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import io.helidon.common.Weight;
+import io.helidon.common.concurrency.limits.spi.LimitProvider;
+import io.helidon.common.config.Config;
+
+/**
+ * {@link java.util.ServiceLoader} service provider for {@link FixedLimit}
+ * limit implementation.
+ */
+@Weight(90)
+public class FixedLimitProvider implements LimitProvider {
+    /**
+     * Constructor required by the service loader.
+     */
+    public FixedLimitProvider() {
+    }
+
+    @Override
+    public String configKey() {
+        return FixedLimit.TYPE;
+    }
+
+    @Override
+    public Limit create(Config config, String name) {
+        return FixedLimit.builder()
+                .config(config)
+                .name(name)
+                .build();
+    }
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/IgnoreTaskException.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/IgnoreTaskException.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.util.Objects;
+
+/**
+ * If this exception is thrown from a limited task within
+ * {@link Limit#invoke(java.util.concurrent.Callable)}, the
+ * invocation will be ignored by possible algorithms (for example when considering round-trip timing).
+ * <p>
+ * This should be used for cases where we never got to execute the intended task.
+ * This exception should never be thrown by {@link Limit}, it should always
+ * be translated to a proper return type, or actual exception.
+ */
+public class IgnoreTaskException extends RuntimeException {
+    /**
+     * Desired return value, if we want to ignore the result, yet we still provide valid response.
+     */
+    private final Object returnValue;
+    /**
+     * Exception to throw to the user. This is to allow throwing an exception while ignoring it for limits algorithm.
+     */
+    private final Exception exception;
+
+    /**
+     * Create a new instance with a cause.
+     *
+     * @param cause the cause of this exception
+     */
+    public IgnoreTaskException(Exception cause) {
+        super(Objects.requireNonNull(cause));
+
+        this.exception = cause;
+        this.returnValue = null;
+    }
+
+    /**
+     * Create a new instance with a return value.
+     *
+     * @param returnValue value to return, even though this invocation should be ignored
+     *                    return value may be {@code null}.
+     */
+    public IgnoreTaskException(Object returnValue) {
+        this.exception = null;
+        this.returnValue = returnValue;
+    }
+
+    /**
+     * This is used by limit implementations to either return the value, or throw an exception.
+     *
+     * @return the value provided to be the return value
+     * @param <T> type of the return value
+     * @throws Exception exception provided by the task
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T handle() throws Exception {
+        if (returnValue == null && exception != null) {
+            throw exception;
+        }
+        return (T) returnValue;
+    }
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/Limit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/Limit.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import io.helidon.common.config.NamedService;
+import io.helidon.service.registry.Service;
+
+/**
+ * Contract for a concurrency limiter.
+ */
+@Service.Contract
+public interface Limit extends LimitAlgorithm, NamedService {
+    /**
+     * Create a copy of this limit with the same configuration.
+     *
+     * @return a copy of this limit
+     */
+    Limit copy();
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/LimitAlgorithm.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/LimitAlgorithm.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+/**
+ * Concurrency limit algorithm.
+ * <p>
+ * There are two options how to use a limit - by handling a token provided by {@link #tryAcquire()},
+ * or by invoking a callable or runnable through one of the invoke methods (such as {@link #invoke(Runnable)}.
+ * <p>
+ * The invoke methods are backed by the same {@link #tryAcquire()} methods, so behavior is consistent.
+ */
+public interface LimitAlgorithm {
+    /**
+     * Invoke a callable within the limits of this limiter.
+     * <p>
+     * {@link io.helidon.common.concurrency.limits.Limit} implementors note:
+     * Make sure to catch {@link io.helidon.common.concurrency.limits.IgnoreTaskException} from the
+     * callable, and call its {@link IgnoreTaskException#handle()} to either return the provided result,
+     * or throw the exception after ignoring the timing for future decisions.
+     *
+     * @param callable callable to execute within the limit
+     * @param <T>      the callable return type
+     * @return result of the callable
+     * @throws LimitException      in case the limiter did not have an available permit
+     * @throws java.lang.Exception in case the task failed with an exception
+     */
+    default <T> T invoke(Callable<T> callable) throws LimitException, Exception {
+        Optional<Token> token = tryAcquire();
+        if (token.isEmpty()) {
+            throw new LimitException("No token available.");
+        }
+        Token permit = token.get();
+        try {
+            T response = callable.call();
+            permit.success();
+            return response;
+        } catch (IgnoreTaskException e) {
+            permit.ignore();
+            return e.handle();
+        } catch (Exception e) {
+            permit.dropped();
+            throw e;
+        }
+    }
+
+    /**
+     * Invoke a runnable within the limits of this limiter.
+     * <p>
+     * {@link io.helidon.common.concurrency.limits.Limit} implementors note:
+     * Make sure to catch {@link io.helidon.common.concurrency.limits.IgnoreTaskException} from the
+     * runnable, and call its {@link IgnoreTaskException#handle()} to either return the provided result,
+     * or throw the exception after ignoring the timing for future decisions.
+     *
+     * @param runnable runnable to execute within the limit
+     * @throws LimitException      in case the limiter did not have an available permit
+     * @throws java.lang.Exception in case the task failed with an exception
+     */
+    default void invoke(Runnable runnable) throws LimitException, Exception {
+        Optional<Token> token = tryAcquire();
+        if (token.isEmpty()) {
+            throw new LimitException("No token available.");
+        }
+        Token permit = token.get();
+        try {
+            runnable.run();
+            permit.success();
+        } catch (IgnoreTaskException e) {
+            permit.ignore();
+            e.handle();
+        } catch (Exception e) {
+            permit.dropped();
+            throw e;
+        }
+    }
+
+    /**
+     * Try to acquire a token, waiting for available permits for the configured amount of time, if queuing is enabled.
+     * <p>
+     * If acquired, the caller must call one of the {@link io.helidon.common.concurrency.limits.Limit.Token}
+     * operations to release the token.
+     * If the response is empty, the limit does not have an available token.
+     *
+     * @return acquired token, or empty if there is no available token
+     */
+    default Optional<Token> tryAcquire() {
+        return tryAcquire(true);
+    }
+
+    /**
+     * Try to acquire a token, waiting for available permits for the configured amount of time, if
+     * {@code wait} is enabled, returning immediately otherwise.
+     * <p>
+     * If acquired, the caller must call one of the {@link io.helidon.common.concurrency.limits.Limit.Token}
+     * operations to release the token.
+     * If the response is empty, the limit does not have an available token.
+     *
+     * @param wait whether to wait in the queue (if one is configured/available in the limit), or to return immediately
+     * @return acquired token, or empty if there is no available token
+     */
+    Optional<Token> tryAcquire(boolean wait);
+
+    /**
+     * When a token is retrieved from {@link #tryAcquire()}, one of its methods must be called when the task
+     * is over, to release the token back to the pool (such as a permit returned to a {@link java.util.concurrent.Semaphore}).
+     * <p>
+     * Choice of method to invoke may influence the algorithm used for determining number of available permits.
+     */
+    interface Token {
+        /**
+         * Operation was dropped, for example because it hit a timeout, or was rejected by other limits.
+         * Loss based {@link io.helidon.common.concurrency.limits.Limit} implementations will likely do an aggressive
+         * reducing in limit when this happens.
+         */
+        void dropped();
+
+        /**
+         * The operation failed before any meaningful RTT measurement could be made and should be ignored to not
+         * introduce an artificially low RTT.
+         */
+        void ignore();
+
+        /**
+         * Notification that the operation succeeded and internally measured latency should be used as an RTT sample.
+         */
+        void success();
+    }
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/LimitException.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/LimitException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.util.Objects;
+
+/**
+ * A limit was reached and the submitted task cannot be executed.
+ *
+ * @see io.helidon.common.concurrency.limits.Limit#invoke(java.util.concurrent.Callable)
+ * @see io.helidon.common.concurrency.limits.Limit#invoke(Runnable)
+ */
+public class LimitException extends RuntimeException {
+    /**
+     * A new limit exception with a cause.
+     *
+     * @param cause cause of the limit reached
+     */
+    public LimitException(Exception cause) {
+        super(Objects.requireNonNull(cause));
+    }
+
+    /**
+     * A new limit exception with a message.
+     *
+     * @param message description of why the limit was reached
+     */
+    public LimitException(String message) {
+        super(Objects.requireNonNull(message));
+    }
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/NoopSemaphore.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/NoopSemaphore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,28 @@
  * limitations under the License.
  */
 
-package io.helidon.webserver;
+package io.helidon.common.concurrency.limits;
 
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-/*
+/**
  * A semaphore that does nothing.
+ * Use {@link #INSTANCE} to get an instance of this semaphore.
+ *
+ * @deprecated this is only provided for backward compatibility and will be removed, use
+ *         {@link FixedLimit#create()} to get unlimited limit
  */
-class NoopSemaphore extends Semaphore {
-    NoopSemaphore() {
+@Deprecated(forRemoval = true, since = "4.2.0")
+public class NoopSemaphore extends Semaphore {
+    /**
+     * Singleton instance to be used whenever needed.
+     */
+    public static final Semaphore INSTANCE = new NoopSemaphore();
+
+    private NoopSemaphore() {
         super(0);
     }
 

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreLimit.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/SemaphoreLimit.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * The {@link io.helidon.common.concurrency.limits.Limit} is backed by a semaphore, and this provides
+ * direct access to the semaphore.
+ * Note that this usage may bypass calculation of limits if the semaphore is used directly.
+ * This is for backward compatibility only, and will be removed.
+ *
+ * @deprecated DO NOT USE except for backward compatibility with semaphore based handling
+ */
+@Deprecated(since = "4.2.0", forRemoval = true)
+public interface SemaphoreLimit {
+    /**
+     * Underlying semaphore of this limit.
+     *
+     * @return the semaphore instance
+     * @deprecated this only exists for backward compatibility of Helidon WebServer and will be removed
+     */
+    @Deprecated(forRemoval = true, since = "4.2.0")
+    Semaphore semaphore();
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/package-info.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Concurrency limits API and default implementations.
+ *
+ * @see io.helidon.common.concurrency.limits.Limit
+ * @see io.helidon.common.concurrency.limits.FixedLimit
+ */
+package io.helidon.common.concurrency.limits;

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/spi/LimitProvider.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/spi/LimitProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits.spi;
+
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.config.ConfiguredProvider;
+import io.helidon.service.registry.Service;
+
+/**
+ * A {@link java.util.ServiceLoader} (and service registry) service provider to discover rate limits.
+ */
+@Service.Contract
+public interface LimitProvider extends ConfiguredProvider<Limit> {
+}

--- a/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/spi/package-info.java
+++ b/common/concurrency/limits/src/main/java/io/helidon/common/concurrency/limits/spi/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Extension points to create custom concurrency rate limits.
+ */
+package io.helidon.common.concurrency.limits.spi;

--- a/common/concurrency/limits/src/main/java/module-info.java
+++ b/common/concurrency/limits/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Concurrency limits.
+ *
+ * @see io.helidon.common.concurrency.limits
+ */
+module io.helidon.common.concurrency.limits {
+    requires static io.helidon.service.registry;
+
+    requires io.helidon.builder.api;
+    requires io.helidon.common;
+    requires io.helidon.common.config;
+
+    exports io.helidon.common.concurrency.limits;
+    exports io.helidon.common.concurrency.limits.spi;
+
+    provides io.helidon.common.concurrency.limits.spi.LimitProvider
+            with io.helidon.common.concurrency.limits.FixedLimitProvider,
+                    io.helidon.common.concurrency.limits.AimdLimitProvider;
+}

--- a/common/concurrency/limits/src/main/resources/META-INF/helidon/service.loader
+++ b/common/concurrency/limits/src/main/resources/META-INF/helidon/service.loader
@@ -1,0 +1,2 @@
+# List of service contracts we want to support either from service registry, or from service loader
+io.helidon.common.concurrency.limits.spi.LimitProvider

--- a/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/AimdLimitTest.java
+++ b/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/AimdLimitTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class AimdLimitTest {
+    @Test
+    void decreaseOnDrops() {
+        AimdLimitConfig config = AimdLimitConfig.builder()
+                .initialLimit(30)
+                .buildPrototype();
+
+        AimdLimitImpl limiter = new AimdLimitImpl(config);
+
+        assertThat(limiter.currentLimit(), is(30));
+        limiter.updateWithSample(0, 0, 0, false);
+        assertThat(limiter.currentLimit(), is(27));
+    }
+
+    @Test
+    void decreaseOnTimeoutExceeded() {
+        Duration timeout = Duration.ofSeconds(1);
+        AimdLimitConfig config = AimdLimitConfig.builder()
+                .initialLimit(30)
+                .timeout(timeout)
+                .buildPrototype();
+        AimdLimitImpl limiter = new AimdLimitImpl(config);
+        limiter.updateWithSample(0, timeout.toNanos() + 1, 0, true);
+        assertThat(limiter.currentLimit(), is(27));
+    }
+
+    @Test
+    void increaseOnSuccess() {
+        AimdLimitConfig config = AimdLimitConfig.builder()
+                .initialLimit(20)
+                .buildPrototype();
+        AimdLimitImpl limiter = new AimdLimitImpl(config);
+        limiter.updateWithSample(0, Duration.ofMillis(1).toNanos(), 10, true);
+        assertThat(limiter.currentLimit(), is(21));
+    }
+
+    @Test
+    void successOverflow() {
+        AimdLimitConfig config = AimdLimitConfig.builder()
+                .initialLimit(21)
+                .maxLimit(21)
+                .minLimit(0)
+                .buildPrototype();
+        AimdLimitImpl limiter = new AimdLimitImpl(config);
+        limiter.updateWithSample(0, Duration.ofMillis(1).toNanos(), 10, true);
+        // after success limit should still be at the max.
+        assertThat(limiter.currentLimit(), is(21));
+    }
+
+    @Test
+    void testDefault() {
+        AimdLimitConfig config = AimdLimitConfig.builder()
+                .minLimit(10)
+                .initialLimit(10)
+                .buildPrototype();
+        AimdLimitImpl limiter = new AimdLimitImpl(config);
+        assertThat(limiter.currentLimit(), is(10));
+    }
+
+    @Test
+    void concurrentUpdatesAndReads() throws InterruptedException {
+        AimdLimitConfig config = AimdLimitConfig.builder()
+                .initialLimit(1)
+                .backoffRatio(0.9)
+                .timeout(Duration.ofMillis(100))
+                .minLimit(1)
+                .maxLimit(200)
+                .buildPrototype();
+        AimdLimitImpl limit = new AimdLimitImpl(config);
+
+        int threadCount = 100;
+        int operationsPerThread = 1_000;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger timeoutCount = new AtomicInteger(0);
+        AtomicInteger dropCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await(); // Wait for all threads to be ready
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        long startTime = System.nanoTime();
+                        long rtt = (long) (Math.random() * 200_000_000); // 0-200ms
+                        int concurrentRequests = (int) (Math.random() * limit.currentLimit() * 2);
+                        boolean didDrop = Math.random() < 0.01; // 1% chance of drop
+
+                        limit.updateWithSample(startTime, rtt, concurrentRequests, !didDrop);
+
+                        if (didDrop) {
+                            dropCount.incrementAndGet();
+                        } else if (rtt > config.timeout().toNanos()) {
+                            timeoutCount.incrementAndGet();
+                        } else {
+                            successCount.incrementAndGet();
+                        }
+
+                        // Read the current limit
+                        int currentLimit = limit.currentLimit();
+                        assertThat(currentLimit, is(greaterThanOrEqualTo(config.minLimit())));
+                        assertThat(currentLimit, is(lessThanOrEqualTo(config.maxLimit())));
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown(); // Start all threads
+        boolean finished = endLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertThat("Test did not complete in time", finished, is(true));
+
+        assertThat("Total operations mismatch",
+                   threadCount * operationsPerThread,
+                   is(successCount.get() + timeoutCount.get() + dropCount.get()));
+    }
+
+    @Test
+    public void testSemaphoreReleased() throws Exception {
+        Limit limit = AimdLimit.builder()
+                .minLimit(5)
+                .initialLimit(5)
+                .build();
+
+        for (int i = 0; i < 5000; i++) {
+            limit.invoke(() -> {});
+        }
+    }
+}

--- a/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/ConfiguredLimitTest.java
+++ b/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/ConfiguredLimitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.helidon.config.Config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConfiguredLimitTest {
+    private static Config config;
+
+    @BeforeAll
+    public static void init() {
+        config = Config.create();
+    }
+
+    @Test
+    public void testFixed() {
+        LimitUsingConfig limitConfig = LimitUsingConfig.create(config.get("first"));
+        Optional<Limit> configuredLimit = limitConfig.concurrencyLimit();
+        assertThat(configuredLimit, not(Optional.empty()));
+        Limit limit = configuredLimit.get();
+
+        assertThat(limit.name(), is("server-listener"));
+        assertThat(limit.type(), is("fixed"));
+
+        FixedLimitConfig prototype = ((FixedLimit) limit).prototype();
+        assertThat("Permits", prototype.permits(), is(1));
+        assertThat("Queue length", prototype.queueLength(), is(20));
+        assertThat("Should be fair", prototype.fair(), is(true));
+        assertThat("Queue timeout", prototype.queueTimeout(), is(Duration.ofSeconds(42)));
+    }
+
+    @Test
+    public void testAimd() {
+        LimitUsingConfig limitConfig = LimitUsingConfig.create(config.get("second"));
+        Optional<Limit> configuredLimit = limitConfig.concurrencyLimit();
+        assertThat(configuredLimit, not(Optional.empty()));
+        Limit limit = configuredLimit.get();
+
+        assertThat(limit.name(), is("aimd"));
+        assertThat(limit.type(), is("aimd"));
+
+        AimdLimitConfig prototype = ((AimdLimit) limit).prototype();
+        assertThat("Timeout", prototype.timeout(), is(Duration.ofSeconds(42)));
+        assertThat("Min limit", prototype.minLimit(), is(11));
+        assertThat("Max limit", prototype.maxLimit(), is(22));
+        assertThat("Initial limit", prototype.initialLimit(), is(14));
+        assertThat("Backoff ratio", prototype.backoffRatio(), is(0.74));
+    }
+}

--- a/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/FixedLimitTest.java
+++ b/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/FixedLimitTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class FixedLimitTest {
+    @Test
+    public void testUnlimited() throws InterruptedException {
+        FixedLimit limiter = FixedLimit.create();
+        int concurrency = 5;
+        CountDownLatch cdl = new CountDownLatch(1);
+        CountDownLatch threadsCdl = new CountDownLatch(concurrency);
+
+        Lock lock = new ReentrantLock();
+        List<String> result = new ArrayList<>(concurrency);
+
+        Thread[] threads = new Thread[concurrency];
+        for (int i = 0; i < concurrency; i++) {
+            int index = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    limiter.invoke(() -> {
+                        threadsCdl.countDown();
+                        cdl.await(10, TimeUnit.SECONDS);
+                        lock.lock();
+                        try {
+                            result.add("result_" + index);
+                        } finally {
+                            lock.unlock();
+                        }
+                        return null;
+                    });
+                } catch (Exception e) {
+                    threadsCdl.countDown();
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        for (Thread thread : threads) {
+            thread.start();
+        }
+        threadsCdl.await();
+        cdl.countDown();
+        for (Thread thread : threads) {
+            thread.join(Duration.ofSeconds(5));
+        }
+        assertThat(result, hasSize(concurrency));
+    }
+
+    @Test
+    public void testLimit() throws Exception {
+        FixedLimit limiter = FixedLimit.builder()
+                .permits(1)
+                .build();
+
+        int concurrency = 5;
+        CountDownLatch cdl = new CountDownLatch(1);
+        CountDownLatch threadsCdl = new CountDownLatch(concurrency);
+
+        Lock lock = new ReentrantLock();
+        List<String> result = new ArrayList<>(concurrency);
+        AtomicInteger failures = new AtomicInteger();
+
+        Thread[] threads = new Thread[concurrency];
+        for (int i = 0; i < concurrency; i++) {
+            int index = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    limiter.invoke(() -> {
+                        threadsCdl.countDown();
+                        cdl.await(10, TimeUnit.SECONDS);
+                        lock.lock();
+                        try {
+                            result.add("result_" + index);
+                        } finally {
+                            lock.unlock();
+                        }
+                        return null;
+                    });
+                } catch (LimitException e) {
+                    threadsCdl.countDown();
+                    failures.incrementAndGet();
+                } catch (Exception e) {
+                    threadsCdl.countDown();
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+        // wait for all threads to reach appropriate destination
+        threadsCdl.await();
+        cdl.countDown();
+        for (Thread thread : threads) {
+            thread.join(Duration.ofSeconds(5));
+        }
+        assertThat(failures.get(), is(concurrency - 1));
+        assertThat(result.size(), is(1));
+    }
+
+    @Test
+    public void testLimitWithQueue() throws Exception {
+        FixedLimit limiter = FixedLimit.builder()
+                .permits(1)
+                .queueLength(1)
+                .queueTimeout(Duration.ofSeconds(5))
+                .build();
+
+        int concurrency = 5;
+        CountDownLatch cdl = new CountDownLatch(1);
+
+        Lock lock = new ReentrantLock();
+        List<String> result = new ArrayList<>(concurrency);
+        AtomicInteger failures = new AtomicInteger();
+
+        Thread[] threads = new Thread[concurrency];
+        for (int i = 0; i < concurrency; i++) {
+            int index = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    limiter.invoke(() -> {
+                        cdl.await(10, TimeUnit.SECONDS);
+                        lock.lock();
+                        try {
+                            result.add("result_" + index);
+                        } finally {
+                            lock.unlock();
+                        }
+                        return null;
+                    });
+                } catch (LimitException e) {
+                    failures.incrementAndGet();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+        // wait for the threads to reach their destination (either failed, or on cdl, or in queue)
+        TimeUnit.MILLISECONDS.sleep(100);
+        cdl.countDown();
+        for (Thread thread : threads) {
+            thread.join(Duration.ofSeconds(5));
+        }
+        // 1 submitted, 1 in queue (may be less failures, as the queue length is not guaranteed to be atomic
+        assertThat(failures.get(), lessThanOrEqualTo(concurrency - 2));
+        // may be 2 or more (1 submitted, 1 or more queued)
+        assertThat(result.size(), greaterThanOrEqualTo(2));
+    }
+
+    @Test
+    public void testSemaphoreReleased() throws Exception {
+        Limit limit = FixedLimit.builder()
+                .permits(5)
+                .build();
+
+        for (int i = 0; i < 5000; i++) {
+            limit.invoke(() -> {
+            });
+        }
+    }
+
+    @Test
+    public void testSemaphoreReleasedWithQueue() throws Exception {
+        Limit limit = FixedLimit.builder()
+                .permits(5)
+                .queueLength(10)
+                .queueTimeout(Duration.ofMillis(100))
+                .build();
+
+        for (int i = 0; i < 5000; i++) {
+            limit.invoke(() -> {
+            });
+        }
+    }
+}

--- a/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitUsingConfigBlueprint.java
+++ b/common/concurrency/limits/src/test/java/io/helidon/common/concurrency/limits/LimitUsingConfigBlueprint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.concurrency.limits;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.concurrency.limits.spi.LimitProvider;
+
+@Prototype.Blueprint
+@Prototype.Configured
+interface LimitUsingConfigBlueprint {
+    @Option.Provider(value = LimitProvider.class, discoverServices = false)
+    @Option.Configured
+    Optional<Limit> concurrencyLimit();
+}

--- a/common/concurrency/limits/src/test/resources/application.yaml
+++ b/common/concurrency/limits/src/test/resources/application.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+first:
+  concurrency-limit:
+    - type: "fixed"
+      name: "server-listener"
+      fair: true
+      permits: 1
+      queue-length: 20
+      queue-timeout: "PT42S"
+second:
+  concurrency-limit:
+    aimd:
+      timeout: "PT42S"
+      min-limit: 11
+      max-limit: 22
+      initial-limit: 14
+      backoff-ratio: 0.74

--- a/common/concurrency/pom.xml
+++ b/common/concurrency/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.common</groupId>
         <artifactId>helidon-common-project</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.1.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/concurrency/pom.xml
+++ b/common/concurrency/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.common</groupId>
+        <artifactId>helidon-common-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.helidon.common.concurrency</groupId>
+    <artifactId>helidon-common-concurrency-project</artifactId>
+    <name>Helidon Common Concurrency Project</name>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>limits</module>
+    </modules>
+</project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -55,6 +55,7 @@
         <module>tls</module>
         <module>types</module>
         <module>uri</module>
+        <module>concurrency</module>
     </modules>
 
     <build>

--- a/microprofile/websocket/pom.xml
+++ b/microprofile/websocket/pom.xml
@@ -77,6 +77,10 @@
             <artifactId>jakarta.websocket-client-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.concurrency</groupId>
+            <artifactId>helidon-common-concurrency-limits</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusConnection.java
+++ b/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusConnection.java
@@ -25,8 +25,12 @@ import java.util.concurrent.Semaphore;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.concurrency.limits.FixedLimit;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.LimitException;
 import io.helidon.common.socket.SocketContext;
 import io.helidon.http.DateTime;
+import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.spi.ServerConnection;
 import io.helidon.websocket.WsCloseCodes;
@@ -67,33 +71,45 @@ class TyrusConnection implements ServerConnection, WsSession {
     }
 
     @Override
-    public void handle(Semaphore requestSemaphore) {
+    public void handle(Limit limit) {
         myThread = Thread.currentThread();
         DataReader dataReader = ctx.dataReader();
-        listener.onOpen(this);
-        if (requestSemaphore.tryAcquire()) {
-            try {
-                while (canRun) {
-                    try {
-                        readingNetwork = true;
-                        BufferData buffer = dataReader.readBuffer();
-                        readingNetwork = false;
-                        lastRequestTimestamp = DateTime.timestamp();
-                        listener.onMessage(this, buffer, true);
-                        lastRequestTimestamp = DateTime.timestamp();
-                    } catch (Exception e) {
-                        listener.onError(this, e);
-                        listener.onClose(this, WsCloseCodes.UNEXPECTED_CONDITION, e.getMessage());
-                        return;
-                    }
-                }
-                listener.onClose(this, WsCloseCodes.NORMAL_CLOSE, "Idle timeout");
-            } finally {
-                requestSemaphore.release();
-            }
-        } else {
-            listener.onClose(this, WsCloseCodes.TRY_AGAIN_LATER, "Too Many Concurrent Requests");
+
+        try {
+            limit.invoke(() -> listener.onOpen(this));
+        } catch (LimitException e) {
+            listener.onError(this, e);
+            throw new CloseConnectionException("Too many concurrent requests");
+        } catch (Exception e) {
+            listener.onError(this, e);
+            listener.onClose(this, WsCloseCodes.UNEXPECTED_CONDITION, e.getMessage());
+            return;
         }
+
+        while (canRun) {
+            try {
+                readingNetwork = true;
+                BufferData buffer = dataReader.readBuffer();
+                readingNetwork = false;
+                lastRequestTimestamp = DateTime.timestamp();
+                limit.invoke(() -> listener.onMessage(this, buffer, true));
+                lastRequestTimestamp = DateTime.timestamp();
+            } catch (LimitException e) {
+                listener.onClose(this, WsCloseCodes.TRY_AGAIN_LATER, "Too Many Concurrent Requests");
+                return;
+            } catch (Exception e) {
+                listener.onError(this, e);
+                listener.onClose(this, WsCloseCodes.UNEXPECTED_CONDITION, e.getMessage());
+                return;
+            }
+        }
+        listener.onClose(this, WsCloseCodes.NORMAL_CLOSE, "Idle timeout");
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public void handle(Semaphore requestSemaphore) {
+        handle(FixedLimit.create(requestSemaphore));
     }
 
     @Override

--- a/microprofile/websocket/src/main/java/module-info.java
+++ b/microprofile/websocket/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ module io.helidon.microprofile.tyrus {
     requires static io.helidon.common.features.api;
 
     requires transitive jakarta.websocket;
+    requires transitive io.helidon.common.concurrency.limits;
 
     exports io.helidon.microprofile.tyrus;
 

--- a/webserver/concurrency-limits/pom.xml
+++ b/webserver/concurrency-limits/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.webserver</groupId>
+        <artifactId>helidon-webserver-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-webserver-concurrency-limits</artifactId>
+    <name>Helidon WebServer Concurrency Limits</name>
+    <description>Feature that adds filters for concurrency limits</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.concurrency</groupId>
+            <artifactId>helidon-common-concurrency-limits</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
+            <artifactId>helidon-builder-api</artifactId>
+            <groupId>io.helidon.builder</groupId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.config.metadata</groupId>
+                            <artifactId>helidon-config-metadata-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.config.metadata</groupId>
+                        <artifactId>helidon-config-metadata-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/webserver/concurrency-limits/pom.xml
+++ b/webserver/concurrency-limits/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.webserver</groupId>
         <artifactId>helidon-webserver-project</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+        <version>4.1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-webserver-concurrency-limits</artifactId>

--- a/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsFeature.java
+++ b/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsFeature.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.concurrency.limits;
+
+import java.util.Set;
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Weighted;
+import io.helidon.common.config.Config;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.spi.ServerFeature;
+
+/**
+ * Server feature that adds limits as filters.
+ * <p>
+ * When using this feature, the limits operation is enforced within a filter, i.e. after the request
+ * is accepted. This means it is used only for HTTP requests.
+ */
+@RuntimeType.PrototypedBy(LimitsFeatureConfig.class)
+public class LimitsFeature implements ServerFeature, Weighted, RuntimeType.Api<LimitsFeatureConfig> {
+    /**
+     * Default weight of this feature. It is the first feature to be registered (above context and access log).
+     * <p>
+     * Context: 1100
+     * <p>
+     * Access Log: 1000
+     * <p>
+     * This feature: {@value}
+     */
+    public static final double WEIGHT = 2000;
+    static final String ID = "limits";
+
+    private final LimitsFeatureConfig config;
+
+    private LimitsFeature(LimitsFeatureConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * Fluent API builder to set up an instance.
+     *
+     * @return a new builder
+     */
+    public static LimitsFeatureConfig.Builder builder() {
+        return LimitsFeatureConfig.builder();
+    }
+
+    /**
+     * Create a new instance from its configuration.
+     *
+     * @param config configuration
+     * @return a new feature
+     */
+    public static LimitsFeature create(LimitsFeatureConfig config) {
+        return new LimitsFeature(config);
+    }
+
+    /**
+     * Create a new instance customizing its configuration.
+     *
+     * @param builderConsumer consumer of configuration
+     * @return a new feature
+     */
+    public static LimitsFeature create(Consumer<LimitsFeatureConfig.Builder> builderConsumer) {
+        return builder()
+                .update(builderConsumer)
+                .build();
+    }
+
+    /**
+     * Create a new limits feature with default setup, but enabled.
+     *
+     * @return a new feature
+     */
+    public static LimitsFeature create() {
+        return builder()
+                .enabled(true)
+                .build();
+    }
+
+    /**
+     * Create a new context feature with custom setup.
+     *
+     * @param config configuration
+     * @return a new configured feature
+     */
+    public static LimitsFeature create(Config config) {
+        return builder()
+                .config(config)
+                .build();
+    }
+
+    @Override
+    public void setup(ServerFeatureContext featureContext) {
+        double featureWeight = config.weight();
+        // all sockets
+        Set<String> sockets = config.sockets();
+        if (sockets.isEmpty()) {
+            // configure on default only
+            featureContext.socket(WebServer.DEFAULT_SOCKET_NAME)
+                    .httpRouting()
+                    .addFeature(new LimitsRoutingFeature(config, featureWeight));
+        } else {
+            // configure on all configured
+            for (String socket : sockets) {
+                featureContext.socket(socket)
+                        .httpRouting()
+                        .addFeature(new LimitsRoutingFeature(config, featureWeight));
+            }
+        }
+    }
+
+    @Override
+    public String name() {
+        return config.name();
+    }
+
+    @Override
+    public String type() {
+        return ID;
+    }
+
+    @Override
+    public double weight() {
+        return config.weight();
+    }
+
+    @Override
+    public LimitsFeatureConfig prototype() {
+        return config;
+    }
+}

--- a/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsFeatureConfigBlueprint.java
+++ b/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsFeatureConfigBlueprint.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.concurrency.limits;
+
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.spi.LimitProvider;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+@Prototype.Blueprint
+@Prototype.Configured(value = LimitsFeature.ID, root = false)
+@Prototype.Provides(ServerFeatureProvider.class)
+interface LimitsFeatureConfigBlueprint extends Prototype.Factory<LimitsFeature> {
+    /**
+     * Weight of the context feature. As it is used by other features, the default is quite high:
+     * {@value LimitsFeature#WEIGHT}.
+     *
+     * @return weight of the feature
+     */
+    @Option.DefaultDouble(LimitsFeature.WEIGHT)
+    @Option.Configured
+    double weight();
+
+    /**
+     * List of sockets to register this feature on. If empty, it would get registered on all sockets.
+     *
+     * @return socket names to register on, defaults to empty (all available sockets)
+     */
+    @Option.Configured
+    Set<String> sockets();
+
+    /**
+     * Name of this instance.
+     *
+     * @return instance name
+     */
+    @Option.Default(LimitsFeature.ID)
+    String name();
+
+    /**
+     * Concurrency limit to use to limit concurrent execution of incoming requests.
+     * The default is to have unlimited concurrency.
+     *
+     * @return concurrency limit
+     */
+    @Option.Provider(value = LimitProvider.class, discoverServices = false)
+    @Option.Configured
+    Optional<Limit> concurrencyLimit();
+
+    /**
+     * Whether this feature is enabled, defaults to {@code true}.
+     *
+     * @return whether to enable this feature
+     */
+    @Option.DefaultBoolean(true)
+    @Option.Configured
+    boolean enabled();
+}

--- a/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsFeatureProvider.java
+++ b/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsFeatureProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.concurrency.limits;
+
+import io.helidon.common.Weight;
+import io.helidon.common.config.Config;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+/**
+ * {@link java.util.ServiceLoader} provider implementation to automatically register this service.
+ * <p>
+ * The required configuration (disabled by default):
+ * <pre>
+ * server:
+ *   features:
+ *     limits:
+ *       enabled: true
+ *       limit:
+ *         bulkhead:
+ *         limit: 10
+ *         queue: 100
+ * </pre>
+ */
+@Weight(LimitsFeature.WEIGHT)
+public class LimitsFeatureProvider implements ServerFeatureProvider<LimitsFeature> {
+    /**
+     * Public constructor required by {@link java.util.ServiceLoader}.
+     */
+    public LimitsFeatureProvider() {
+    }
+
+    @Override
+    public String configKey() {
+        return LimitsFeature.ID;
+    }
+
+    @Override
+    public LimitsFeature create(Config config, String name) {
+        return LimitsFeature.builder()
+                .config(config)
+                .name(name)
+                .build();
+    }
+}

--- a/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsRoutingFeature.java
+++ b/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/LimitsRoutingFeature.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.concurrency.limits;
+
+import java.util.Optional;
+
+import io.helidon.common.Weighted;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.LimitAlgorithm;
+import io.helidon.http.HttpException;
+import io.helidon.http.Status;
+import io.helidon.webserver.http.FilterChain;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.RoutingRequest;
+import io.helidon.webserver.http.RoutingResponse;
+
+class LimitsRoutingFeature implements HttpFeature, Weighted {
+    private final double featureWeight;
+    private final Limit limits;
+    private final boolean enabled;
+
+    LimitsRoutingFeature(LimitsFeatureConfig config, double featureWeight) {
+        this.featureWeight = featureWeight;
+        this.limits = config.concurrencyLimit().orElse(null);
+        this.enabled = config.enabled();
+    }
+
+    @Override
+    public void setup(HttpRouting.Builder builder) {
+        if (enabled && limits != null) {
+            builder.addFilter(this::filter);
+        }
+    }
+
+    @Override
+    public double weight() {
+        return featureWeight;
+    }
+
+    private void filter(FilterChain chain, RoutingRequest req, RoutingResponse res) {
+        Optional<LimitAlgorithm.Token> token = limits.tryAcquire();
+
+        if (token.isEmpty()) {
+            throw new HttpException("Limit exceeded", Status.SERVICE_UNAVAILABLE_503);
+        }
+
+        LimitAlgorithm.Token permit = token.get();
+        try {
+            chain.proceed();
+            permit.success();
+        } catch (Throwable e) {
+            permit.dropped();
+            throw e;
+        }
+    }
+}

--- a/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/package-info.java
+++ b/webserver/concurrency-limits/src/main/java/io/helidon/webserver/concurrency/limits/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An implementation of a feature to protect all server requests with a limit.
+ */
+package io.helidon.webserver.concurrency.limits;

--- a/webserver/concurrency-limits/src/main/java/module-info.java
+++ b/webserver/concurrency-limits/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Limits feature for Helidon WebServer.
+ */
+module io.helidon.webserver.concurrency.limits {
+    requires io.helidon.common;
+    requires io.helidon.http;
+    requires io.helidon.webserver;
+
+    requires transitive io.helidon.builder.api;
+    requires transitive io.helidon.common.config;
+    requires transitive io.helidon.common.concurrency.limits;
+
+    exports io.helidon.webserver.concurrency.limits;
+
+    provides io.helidon.webserver.spi.ServerFeatureProvider
+            with io.helidon.webserver.concurrency.limits.LimitsFeatureProvider;
+
+    uses io.helidon.common.concurrency.limits.spi.LimitProvider;
+}

--- a/webserver/concurrency-limits/src/test/java/io/helidon/webserver/concurrency/limits/FixedLimitTest.java
+++ b/webserver/concurrency-limits/src/test/java/io/helidon/webserver/concurrency/limits/FixedLimitTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.concurrency.limits;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+public class FixedLimitTest {
+    private static final CountDownLatch FIRST_ENCOUNTER = new CountDownLatch(1);
+    private static final CountDownLatch FINISH_LATCH = new CountDownLatch(1);
+
+    private final Http1Client client;
+
+    public FixedLimitTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    public static void route(HttpRules rules) {
+        rules.get("/greet", (req, res) -> res.send("Hello"))
+                .get("/wait", (req, res) -> {
+                    FIRST_ENCOUNTER.countDown();
+                    FINISH_LATCH.await();
+                    res.send("finished");
+                });
+    }
+
+    @Test
+    public void testRequest() {
+        var response = client.get("/greet")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("Hello"));
+    }
+
+    @Test
+    public void testLimits() throws Exception {
+        Callable<ClientResponseTyped<String>> callable = () -> {
+            return client.get("/wait")
+                    .request(String.class);
+        };
+        try (ExecutorService es = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory())) {
+            var first = es.submit(callable);
+            FIRST_ENCOUNTER.await();
+            var secondResponse = es.submit(callable)
+                    .get(5, TimeUnit.SECONDS);
+
+            assertThat(secondResponse.status(), is(Status.SERVICE_UNAVAILABLE_503));
+            FINISH_LATCH.countDown();
+            var firstResponse = first.get(5, TimeUnit.SECONDS);
+            assertThat(firstResponse.status(), is(Status.OK_200));
+            assertThat(firstResponse.entity(), is("finished"));
+
+        }
+    }
+}

--- a/webserver/concurrency-limits/src/test/resources/application.yaml
+++ b/webserver/concurrency-limits/src/test/resources/application.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  features:
+    limits:
+      concurrency-limit:
+        fixed:
+          permits: 1
+          queue-length: 0
+

--- a/webserver/concurrency-limits/src/test/resources/logging.properties
+++ b/webserver/concurrency-limits/src/test/resources/logging.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+io.helidon.webserver.level=INFO

--- a/webserver/http2/pom.xml
+++ b/webserver/http2/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.concurrency</groupId>
+            <artifactId>helidon-common-concurrency-limits</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -27,6 +27,8 @@ import java.util.concurrent.Semaphore;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.concurrency.limits.FixedLimit;
+import io.helidon.common.concurrency.limits.Limit;
 import io.helidon.common.task.InterruptableTask;
 import io.helidon.common.tls.TlsUtils;
 import io.helidon.http.DateTime;
@@ -172,9 +174,9 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     }
 
     @Override
-    public void handle(Semaphore requestSemaphore) throws InterruptedException {
+    public void handle(Limit limit) throws InterruptedException {
         try {
-            doHandle(requestSemaphore);
+            doHandle(limit);
         } catch (Http2Exception e) {
             if (state == State.FINISHED) {
                 // already handled
@@ -207,6 +209,12 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             state = State.FINISHED;
             throw e;
         }
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public void handle(Semaphore requestSemaphore) throws InterruptedException {
+        handle(FixedLimit.create(requestSemaphore));
     }
 
     /**
@@ -326,7 +334,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         return clientSettings;
     }
 
-    private void doHandle(Semaphore requestSemaphore) throws InterruptedException {
+    private void doHandle(Limit limit) throws InterruptedException {
         myThread = Thread.currentThread();
         while (canRun && state != State.FINISHED) {
             if (expectPreface && state != State.WRITE_SERVER_SETTINGS) {
@@ -341,10 +349,9 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                     // no data to read -> connection is closed
                     throw new CloseConnectionException("Connection closed by client", e);
                 }
-                dispatchHandler(requestSemaphore);
-            } else {
-                dispatchHandler(requestSemaphore);
             }
+
+            dispatchHandler(limit);
         }
         if (state != State.FINISHED) {
             Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.NO_ERROR, "Idle timeout");
@@ -352,7 +359,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         }
     }
 
-    private void dispatchHandler(Semaphore requestSemaphore) {
+    private void dispatchHandler(Limit limit) {
         switch (state) {
         case CONTINUATION -> doContinuation();
         case WRITE_SERVER_SETTINGS -> writeServerSettings();
@@ -360,7 +367,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         case SETTINGS -> doSettings();
         case ACK_SETTINGS -> ackSettings();
         case DATA -> dataFrame();
-        case HEADERS -> doHeaders(requestSemaphore);
+        case HEADERS -> doHeaders(limit);
         case PRIORITY -> doPriority();
         case READ_PUSH_PROMISE -> throw new Http2Exception(Http2ErrorCode.REFUSED_STREAM, "Push promise not supported");
         case PING -> pingFrame();
@@ -606,7 +613,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         state = State.READ_FRAME;
     }
 
-    private void doHeaders(Semaphore requestSemaphore) {
+    private void doHeaders(Limit limit) {
         int streamId = frameHeader.streamId();
         StreamContext streamContext = stream(streamId);
 
@@ -675,7 +682,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                                                         path,
                                                         http2Config.validatePath());
         stream.prologue(httpPrologue);
-        stream.requestSemaphore(requestSemaphore);
+        stream.requestLimit(limit);
         stream.headers(headers, endOfStream);
         state = State.READ_FRAME;
 

--- a/webserver/http2/src/main/java/module-info.java
+++ b/webserver/http2/src/main/java/module-info.java
@@ -40,6 +40,7 @@ module io.helidon.webserver.http2 {
     requires transitive io.helidon.http.media;
     requires transitive io.helidon.http;
     requires transitive io.helidon.webserver;
+    requires transitive io.helidon.common.concurrency.limits;
 
     exports io.helidon.webserver.http2;
     exports io.helidon.webserver.http2.spi;

--- a/webserver/pom.xml
+++ b/webserver/pom.xml
@@ -46,6 +46,7 @@
         <module>testing</module>
         <module>webserver</module>
         <module>websocket</module>
+        <module>concurrency-limits</module>
     </modules>
 
     <profiles>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>helidon-common-features</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.concurrency</groupId>
+            <artifactId>helidon-common-concurrency-limits</artifactId>
+        </dependency>
+        <dependency>
             <!--
             This dependency is not required, yet a lot of examples depend on it. Kept in for backward compatibility.
             This used to be a transitive dependency of another module.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -28,6 +28,8 @@ import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.spi.LimitProvider;
 import io.helidon.common.context.Context;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.tls.Tls;
@@ -255,12 +257,27 @@ interface ListenerConfigBlueprint {
      * Defaults to {@code -1}, meaning "unlimited" - what the system allows.
      * Also make sure that this number is higher than the expected time it takes to handle a single request in your application,
      * as otherwise you may stop in-progress requests.
+     * <p>
+     * Setting this option will always ignore {@link #concurrencyLimit()} and will use
+     * the {@link io.helidon.common.concurrency.limits.FixedLimit}.
      *
      * @return number of requests that can be processed on this listener, regardless of protocol
      */
     @Option.Configured
     @Option.DefaultInt(-1)
     int maxConcurrentRequests();
+
+    /**
+     * Concurrency limit to use to limit concurrent execution of incoming requests.
+     * The default is to have unlimited concurrency.
+     * <p>
+     * Note that if {@link #maxConcurrentRequests()} is configured, this is ignored.
+     *
+     * @return concurrency limit
+     */
+    @Option.Provider(value = LimitProvider.class, discoverServices = false)
+    @Option.Configured
+    Optional<Limit> concurrencyLimit();
 
     /**
      * How long should we wait before closing a connection that has no traffic on it.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/spi/ServerConnection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/spi/ServerConnection.java
@@ -19,6 +19,9 @@ package io.helidon.webserver.spi;
 import java.time.Duration;
 import java.util.concurrent.Semaphore;
 
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.NoopSemaphore;
+
 /**
  * Server connection abstraction, used by any provider to handle a socket connection.
  */
@@ -32,8 +35,30 @@ public interface ServerConnection {
      *                         releasing it when the request ends; please be very careful, as this may lead to complete stop
      *                         of the server if incorrectly implemented
      * @throws InterruptedException to interrupt any waiting state and terminate this connection
+     * @deprecated implement {@link #handle(io.helidon.common.concurrency.limits.Limit)} instead
      */
-    void handle(Semaphore requestSemaphore) throws InterruptedException;
+    @Deprecated(forRemoval = true, since = "4.2.0")
+    default void handle(Semaphore requestSemaphore) throws InterruptedException {
+        throw new IllegalStateException("This method must be implemented, unless handle(Limit) is implemented");
+    }
+
+    /**
+     * Start handling the connection. Data is provided through
+     * {@link ServerConnectionSelector#connection(io.helidon.webserver.ConnectionContext)}.
+     *
+     * @param limit that is responsible for maximal concurrent request limit, the connection implementation
+     *              is responsible invoking each request within the limit's
+     *              {@link io.helidon.common.concurrency.limits.Limit#invoke(java.util.concurrent.Callable)}
+     * @throws InterruptedException to interrupt any waiting state and terminate this connection
+     */
+    @SuppressWarnings("removal") // usage will be removed with the deprecated types
+    default void handle(Limit limit) throws InterruptedException {
+        if (limit instanceof io.helidon.common.concurrency.limits.SemaphoreLimit sl) {
+            handle(sl.semaphore());
+        } else {
+            handle(NoopSemaphore.INSTANCE);
+        }
+    }
 
     /**
      * How long is this connection idle. This is a duration from the last request to now.

--- a/webserver/webserver/src/main/java/module-info.java
+++ b/webserver/webserver/src/main/java/module-info.java
@@ -43,6 +43,7 @@ module io.helidon.webserver {
     requires transitive io.helidon.config;
     requires transitive io.helidon.http.encoding;
     requires transitive io.helidon.http.media;
+    requires transitive io.helidon.common.concurrency.limits;
 
     // provides multiple packages due to intentional cyclic dependency
     // we want to support HTTP/1.1 by default (we could fully separate it, but the API would be harder to use
@@ -60,7 +61,7 @@ module io.helidon.webserver {
     uses io.helidon.webserver.spi.ServerFeatureProvider;
     uses io.helidon.webserver.http.spi.SinkProvider;
     uses io.helidon.webserver.http1.spi.Http1UpgradeProvider;
-
+    uses io.helidon.common.concurrency.limits.spi.LimitProvider;
 
     provides io.helidon.webserver.spi.ProtocolConfigProvider
             with io.helidon.webserver.http1.Http1ProtocolConfigProvider;

--- a/webserver/websocket/pom.xml
+++ b/webserver/websocket/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.concurrency</groupId>
+            <artifactId>helidon-common-concurrency-limits</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
@@ -25,6 +25,9 @@ import java.util.concurrent.Semaphore;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.concurrency.limits.FixedLimit;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.concurrency.limits.LimitException;
 import io.helidon.common.socket.SocketContext;
 import io.helidon.http.DateTime;
 import io.helidon.http.Headers;
@@ -124,39 +127,51 @@ public class WsConnection implements ServerConnection, WsSession {
         return new WsConnection(ctx, prologue, upgradeHeaders, wsKey, wsRoute.listener());
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void handle(Semaphore requestSemaphore) {
-        myThread = Thread.currentThread();
-        listener.onOpen(this);
+        handle(FixedLimit.create(requestSemaphore));
+    }
 
-        if (requestSemaphore.tryAcquire()) {
-            try {
-                while (canRun) {
-                    readingNetwork = true;
-                    ClientWsFrame frame = readFrame();
-                    readingNetwork = false;
-                    lastRequestTimestamp = DateTime.timestamp();
-                    try {
-                        if (!processFrame(frame)) {
-                            lastRequestTimestamp = DateTime.timestamp();
-                            return;
-                        }
-                        lastRequestTimestamp = DateTime.timestamp();
-                    } catch (CloseConnectionException e) {
-                        throw e;
-                    } catch (Exception e) {
-                        listener.onError(this, e);
-                        this.close(WsCloseCodes.UNEXPECTED_CONDITION, e.getMessage());
-                        return;
-                    }
-                }
-                this.close(WsCloseCodes.NORMAL_CLOSE, "Idle timeout");
-            } finally {
-                requestSemaphore.release();
-            }
-        } else {
-            listener.onClose(this, WsCloseCodes.TRY_AGAIN_LATER, "Too Many Concurrent Requests");
+    @Override
+    public void handle(Limit limit) {
+        myThread = Thread.currentThread();
+
+        try {
+            limit.invoke(() -> listener.onOpen(this));
+        } catch (LimitException e) {
+            close(WsCloseCodes.TRY_AGAIN_LATER, "Too Many Concurrent Requests");
+            return;
+        } catch (Exception e) {
+            close(WsCloseCodes.UNEXPECTED_CONDITION, e.getMessage());
+            return;
         }
+
+        while (canRun) {
+            readingNetwork = true;
+            ClientWsFrame frame = readFrame();
+            readingNetwork = false;
+            lastRequestTimestamp = DateTime.timestamp();
+            try {
+                boolean result = limit.invoke(() -> processFrame(frame));
+                if (!result) {
+                    lastRequestTimestamp = DateTime.timestamp();
+                    return;
+                }
+                lastRequestTimestamp = DateTime.timestamp();
+            } catch (LimitException e) {
+                listener.onClose(this, WsCloseCodes.TRY_AGAIN_LATER, "Too Many Concurrent Requests");
+                close(WsCloseCodes.TRY_AGAIN_LATER, "Too Many Concurrent Requests");
+                return;
+            } catch (CloseConnectionException e) {
+                throw e;
+            } catch (Exception e) {
+                listener.onError(this, e);
+                this.close(WsCloseCodes.UNEXPECTED_CONDITION, e.getMessage());
+                return;
+            }
+        }
+        this.close(WsCloseCodes.NORMAL_CLOSE, "Idle timeout");
     }
 
     @Override

--- a/webserver/websocket/src/main/java/module-info.java
+++ b/webserver/websocket/src/main/java/module-info.java
@@ -36,6 +36,7 @@ module io.helidon.webserver.websocket {
 
     requires transitive io.helidon.webserver;
     requires transitive io.helidon.websocket;
+    requires transitive io.helidon.common.concurrency.limits;
 
     exports io.helidon.webserver.websocket;
 


### PR DESCRIPTION

Backport of #9295 to Helidon 4.1.3

### Description
Resolves #8897
Resolves #9229

### Documentation
This PR introduces 
- a new module `common/concurrency/limits` that provides API and SPI for concurrency limit implementations, and a couple of default implementations (AIMD, Fixed).
- a new module `webserver/concurrency-limits` that provides feature with a filter to impose limits within a filter in routing
- update of `webserver/webserver` to use a `Limit` instead of a `Semaphore` in connection handlers (backward compatible)

Configuration reference will be in the generated documentation.

#### Configure limits on WebServer
This will configure limit for a server listener (configurable per listener), enforced on the connection level (i.e. outside of routing and filters).

The default behavior is the same (unlimited).
If `server.max-concurrent-requests` is configured (value is not `-1`), it will be used and `concurrency-limit` configuration for the listener will be ignored.

Configuration:
```yaml
server:
  port: 8080
  concurrency-limit:
    aimd: # `limit type`
      # AIMD limit configuration
```
#### Configure limits for routing
This will configure limit for as a server feature, enforced in an HTTP filter.
Configuration:
```yaml
server:
  features:
    limits: # the feature is called `limits`
      enabled: true
      concurrency-limit: # `limit` configuration of the `limits` server feature
        fixed: # `limit type`
          permits: 1
          queue-length: 10
```
