### PR TITLE
4.x: Use newly defined exception to report problems while processing meta config

### DIFF
--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1638,7 +1638,7 @@ public interface Config extends io.helidon.common.config.Config {
             try {
                 MetaConfig.metaConfig()
                         .ifPresent(this::config);
-            } catch (Exception e) {
+            } catch (MetaConfigException e) {
                 System.getLogger(getClass().getName())
                         .log(System.Logger.Level.WARNING, "Failed to load SE meta-configuration,"
                                 + " please make sure it has correct format.", e);

--- a/config/config/src/main/java/io/helidon/config/MetaConfigException.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfigException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+/**
+ * Exception is thrown if problems are found while processing meta config.
+ */
+public class MetaConfigException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor with the detailed message.
+     *
+     * @param message the message
+     */
+    public MetaConfigException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor with the detailed message.
+     *
+     * @param message the message
+     * @param cause   the cause
+     */
+    public MetaConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/config/config/src/main/java/io/helidon/config/MetaConfigException.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfigException.java
@@ -28,7 +28,7 @@ class MetaConfigException extends RuntimeException {
      *
      * @param message the message
      */
-    public MetaConfigException(String message) {
+    MetaConfigException(String message) {
         super(message);
     }
 
@@ -38,7 +38,7 @@ class MetaConfigException extends RuntimeException {
      * @param message the message
      * @param cause   the cause
      */
-    public MetaConfigException(String message, Throwable cause) {
+    MetaConfigException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/config/config/src/main/java/io/helidon/config/MetaConfigException.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfigException.java
@@ -19,7 +19,7 @@ package io.helidon.config;
 /**
  * Exception is thrown if problems are found while processing meta config.
  */
-public class MetaConfigException extends RuntimeException {
+class MetaConfigException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 

--- a/config/config/src/main/java/io/helidon/config/MetaProviders.java
+++ b/config/config/src/main/java/io/helidon/config/MetaProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,7 @@ final class MetaProviders {
                 .filter(provider -> provider.supports(type))
                 .findFirst()
                 .map(provider -> provider.create(type, config))
-                .orElseThrow(() -> new IllegalArgumentException("Config source of type " + type + " is not supported."
+                .orElseThrow(() -> new MetaConfigException("Config source of type " + type + " is not supported."
                                                                         + " Supported types: " + SUPPORTED_CONFIG_SOURCES));
     }
 
@@ -122,7 +122,7 @@ final class MetaProviders {
                 .filter(provider -> provider.supports(type))
                 .findFirst()
                 .map(provider -> provider.createMulti(type, sourceProperties))
-                .orElseThrow(() -> new IllegalArgumentException("Config source of type " + type + " is not supported."
+                .orElseThrow(() -> new MetaConfigException("Config source of type " + type + " is not supported."
                                                                         + " Supported types: " + SUPPORTED_CONFIG_SOURCES));
     }
 
@@ -131,7 +131,7 @@ final class MetaProviders {
                 .filter(provider -> provider.supports(type))
                 .findFirst()
                 .map(provider -> provider.create(type, config))
-                .orElseThrow(() -> new IllegalArgumentException("Config source of type " + type + " is not supported."
+                .orElseThrow(() -> new MetaConfigException("Config source of type " + type + " is not supported."
                                                                         + " Supported types: " + SUPPORTED_OVERRIDE_SOURCES));
     }
 
@@ -140,7 +140,7 @@ final class MetaProviders {
                 .filter(provider -> provider.supports(type))
                 .findFirst()
                 .map(provider -> provider.create(type, config))
-                .orElseThrow(() -> new IllegalArgumentException("Polling strategy of type " + type + " is not supported."
+                .orElseThrow(() -> new MetaConfigException("Polling strategy of type " + type + " is not supported."
                                                                         + " Supported types: " + SUPPORTED_POLLING_STRATEGIES));
     }
 
@@ -149,7 +149,7 @@ final class MetaProviders {
                 .filter(provider -> provider.supports(type))
                 .findFirst()
                 .map(provider -> provider.create(type, config))
-                .orElseThrow(() -> new IllegalArgumentException("Retry policy of type " + type + " is not supported."
+                .orElseThrow(() -> new MetaConfigException("Retry policy of type " + type + " is not supported."
                                                                         + " Supported types: " + SUPPORTED_RETRY_POLICIES));
     }
 
@@ -158,7 +158,7 @@ final class MetaProviders {
                 .filter(provider -> provider.supports(type))
                 .findFirst()
                 .map(provider -> provider.create(type, config))
-                .orElseThrow(() -> new IllegalArgumentException("Change watcher of type " + type + " is not supported."
+                .orElseThrow(() -> new MetaConfigException("Change watcher of type " + type + " is not supported."
                                                                 + " Supported types: " + SUPPORTED_CHANGE_WATCHERS));
     }
 

--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -59,6 +59,7 @@
         <module>test-mappers-1-common</module>
         <module>test-mappers-2-complex</module>
         <module>test-meta-source</module>
+        <module>test-meta-source-fail</module>
         <module>test-parsers-1-complex</module>
         <module>service-registry</module>
         <module>config-metadata-meta-api</module>

--- a/config/tests/test-meta-source-fail/pom.xml
+++ b/config/tests/test-meta-source-fail/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.config.tests</groupId>
+        <artifactId>helidon-config-tests-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-config-tests-test-meta-source-fail</artifactId>
+    <name>Helidon Config Tests Meta Source Failure</name>
+
+    <description>
+        Integration tests to verify meta source failures.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/config/tests/test-meta-source-fail/src/main/java/io/helidon/config/tests/fail/CustomConfigSourceProvider.java
+++ b/config/tests/test-meta-source-fail/src/main/java/io/helidon/config/tests/fail/CustomConfigSourceProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.fail;
+
+import java.util.Collections;
+import java.util.Set;
+
+import io.helidon.config.Config;
+import io.helidon.config.spi.ConfigSource;
+import io.helidon.config.spi.ConfigSourceProvider;
+
+/**
+ * Provider for type {@link #SOURCE_TYPE} that fails on creation.
+ */
+public class CustomConfigSourceProvider implements ConfigSourceProvider {
+
+    private static final String SOURCE_TYPE = "custom-provider";
+
+    @Override
+    public boolean supports(String type) {
+        return SOURCE_TYPE.equals(type);
+    }
+
+    @Override
+    public ConfigSource create(String s, Config config) {
+        throw new RuntimeException("Oops");
+    }
+
+    @Override
+    public Set<String> supported() {
+        return Collections.singleton(SOURCE_TYPE);
+    }
+}

--- a/config/tests/test-meta-source-fail/src/main/java/io/helidon/config/tests/fail/package-info.java
+++ b/config/tests/test-meta-source-fail/src/main/java/io/helidon/config/tests/fail/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.fail;

--- a/config/tests/test-meta-source-fail/src/main/resources/META-INF/services/io.helidon.config.spi.ConfigSourceProvider
+++ b/config/tests/test-meta-source-fail/src/main/resources/META-INF/services/io.helidon.config.spi.ConfigSourceProvider
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.config.tests.fail.CustomConfigSourceProvider

--- a/config/tests/test-meta-source-fail/src/test/java/io/helidon/config/tests/fail/CustomConfigSourceFailTest.java
+++ b/config/tests/test-meta-source-fail/src/test/java/io/helidon/config/tests/fail/CustomConfigSourceFailTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.fail;
+
+import io.helidon.config.Config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verify failure if config source provider throws an exception.
+ */
+public class CustomConfigSourceFailTest {
+
+    @Test
+    public void testCustomSourceFail() {
+        assertThrows(RuntimeException.class, Config::create);
+    }
+}

--- a/config/tests/test-meta-source-fail/src/test/resources/meta-config.yaml
+++ b/config/tests/test-meta-source-fail/src/test/resources/meta-config.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sources:
+  - type: "custom-provider"


### PR DESCRIPTION
### Description

Use newly defined exception to report problems while processing meta config configuration. This enables special handling of this exception without interfering with any exceptions that may be thrown in custom config sources. See issue #9383.

