### PR TITLE
Update the version of the SmallRye OpenAPI UI library

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -149,6 +149,7 @@
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>2.0.9</version.lib.slf4j>
         <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>
+        <version.lib.smallrye-openapi-ui>3.13.0</version.lib.smallrye-openapi-ui>
         <version.lib.snakeyaml>2.2</version.lib.snakeyaml>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>
         <version.lib.tyrus>2.1.5</version.lib.tyrus>

--- a/integrations/openapi-ui/pom.xml
+++ b/integrations/openapi-ui/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api-ui</artifactId>
-            <version>${version.lib.smallrye-openapi}</version>
+            <version>${version.lib.smallrye-openapi-ui}</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>


### PR DESCRIPTION
### Description
Updates the version of the OpenAPI UI library.

`dependencies/pom.xml`now contains separate version settings for SmallRye OpenAPI and the UI library and the `integrations/openapi-ui` component uses a newer release.

(Note that the SmallRye OpenAPI UI library does not depend on anything else in SmallRye.)

### Documentation
No doc impact.