### PR TITLE
4.x: Fix MockBean to work with argument matchers

### DIFF
--- a/microprofile/testing/mocking/etc/spotbugs/exclude.xml
+++ b/microprofile/testing/mocking/etc/spotbugs/exclude.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <Class name="io.helidon.microprofile.testing.mocking.MockBeansCdiExtension"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    </Match>
+</FindBugsFilter>

--- a/microprofile/testing/mocking/pom.xml
+++ b/microprofile/testing/mocking/pom.xml
@@ -32,6 +32,10 @@
         Integration with Mocking to support tests with CDI injection
     </description>
 
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestMockBeanArgumentMatcher.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestMockBeanArgumentMatcher.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testing.junit5;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+import io.helidon.microprofile.testing.mocking.MockBean;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@HelidonTest
+@AddBean(TestMockBeanArgumentMatcher.Resource.class)
+@AddBean(TestMockBeanArgumentMatcher.Service.class)
+class TestMockBeanArgumentMatcher {
+
+    @MockBean
+    private Service service;
+
+    @Test
+    void testArgumentMatcher(WebTarget target) {
+        Mockito.when(service.test(anyString())).thenReturn("Mocked");
+        String response = target.path("/test")
+                .queryParam("str", "anything")
+                .request()
+                .get(String.class);
+        assertThat(response, is("Mocked"));
+    }
+
+    @Path("/test")
+    public static class Resource {
+
+        @Inject
+        private Service service;
+
+        @GET
+        public String post(@QueryParam("str") String str) {
+            return service.test(str);
+        }
+    }
+
+    @ApplicationScoped
+    static class Service {
+
+        String test(String str) {
+            return "Not Mocked: " + str;
+        }
+    }
+}

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestMockBeanArgumentMatcher.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestMockBeanArgumentMatcher.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testing.testng;
+
+import io.helidon.microprofile.testing.mocking.MockBean;
+import io.helidon.microprofile.testing.testng.AddBean;
+import io.helidon.microprofile.testing.testng.HelidonTest;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.client.WebTarget;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@HelidonTest
+@AddBean(TestMockBeanArgumentMatcher.Resource.class)
+@AddBean(TestMockBeanArgumentMatcher.Service.class)
+class TestMockBeanArgumentMatcher {
+
+    @MockBean
+    private Service service;
+
+    @Inject
+    private WebTarget target;
+
+    @Test
+    void testArgumentMatcher() {
+        Mockito.when(service.test(anyString())).thenReturn("Mocked");
+        String response = target.path("/test")
+                .queryParam("str", "anything")
+                .request()
+                .get(String.class);
+        assertThat(response, is("Mocked"));
+    }
+
+    @Path("/test")
+    public static class Resource {
+
+        @Inject
+        private Service service;
+
+        @GET
+        public String post(@QueryParam("str") String str) {
+            return service.test(str);
+        }
+    }
+
+    @ApplicationScoped
+    static class Service {
+
+        String test(String str) {
+            return "Not Mocked: " + str;
+        }
+    }
+}


### PR DESCRIPTION
### Description

- Call toString() to force initialization of the mocked instances
- Use produceWith instead of createWith
- Use addTransitiveTypeClosure instead of addType to support more than just one type
- Minor refactoring of the processMockBean method
- Re-work HelidonTestNgListener to initialize the testInstance with an extension
- Add tests

Fixes #9397
Fixes #9411

### Documentation

None.
