### PR TITLE
4.1.3: Use a fixed version of GraalVM

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -71,10 +71,9 @@ runs:
         git config --global core.eol lf
     - name: Set up GraalVM
       if: ${{ inputs.native-image == 'true' }}
-      uses: graalvm/setup-graalvm@v1.2.1
+      uses: graalvm/setup-graalvm@v1.2.4
       with:
-        java-version: ${{ env.JAVA_VERSION }}
-        version: ${{ env.GRAALVM_VERSION }}
+        java-version: ${{ env.GRAALVM_VERSION || env.JAVA_VERSION }}
         components: ${{ env.GRAALVM_COMPONENTS }}
         check-for-updates: 'false'
         set-java-home: 'false'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,7 @@ on:
 
 env:
   JAVA_VERSION: 21
+  GRAALVM_VERSION: 21.0.3
   JAVA_DISTRO: oracle
   MAVEN_ARGS: |
     -B -fae -e


### PR DESCRIPTION

Backports #9406 to Helidon 4.1.3

As otherwise Oracle JDBC and UCP drivers fail during build.
