### PR TITLE
Refactor Token Length Check to Use isEmpty() Method

### DIFF
--- a/common/common/src/main/java/io/helidon/common/Errors.java
+++ b/common/common/src/main/java/io/helidon/common/Errors.java
@@ -151,11 +151,11 @@ public final class Errors extends LinkedList<Errors.ErrorMessage> {
 
                 logger.log(System.Logger.Level.ERROR, "Fatal issues found: " + fatals);
             } else {
-                if (warnings.length() > 0) {
+                if (!warnings.isEmpty()) {
                     logger.log(System.Logger.Level.WARNING, "Warnings found: \n" + warnings);
                 }
 
-                if (hints.length() > 0) {
+                if (!hints.isEmpty()) {
                     logger.log(System.Logger.Level.TRACE, "Hints found: \n" + hints);
                 }
             }

--- a/config/config/src/main/java/io/helidon/config/ConfigKeyImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigKeyImpl.java
@@ -47,7 +47,7 @@ class ConfigKeyImpl implements Config.Key {
             fullSB.append(parent.fullKey);
         }
         if (!name.isEmpty()) {
-            if (fullSB.length() > 0) {
+            if (!fullSB.isEmpty()) {
                 fullSB.append(".");
             }
             path.add(name);

--- a/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
+++ b/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
@@ -97,7 +97,7 @@ public class CorsSupportHelper<Q, R> {
         StringTokenizer tokenizer = new StringTokenizer(header, ",");
         while (tokenizer.hasMoreTokens()) {
             String value = tokenizer.nextToken().trim();
-            if (value.length() > 0) {
+            if (!value.isEmpty()) {
                 result.add(value);
             }
         }

--- a/http/http/src/main/java/io/helidon/http/HeaderHelper.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/http/src/main/java/io/helidon/http/HeaderHelper.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderHelper.java
@@ -51,7 +51,7 @@ final class HeaderHelper {
                 token.append(ch);
             } else {
                 if (ch == separator) {
-                    if (token.length() > 0) {
+                    if (!token.isEmpty()) {
                         result.add(token.toString());
                     }
                     token.setLength(0);
@@ -64,7 +64,7 @@ final class HeaderHelper {
                 }
             }
         }
-        if (token.length() > 0) {
+        if (!token.isEmpty()) {
             result.add(token.toString());
         }
         return result;

--- a/http/http/src/main/java/io/helidon/http/PathMatchers.java
+++ b/http/http/src/main/java/io/helidon/http/PathMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ public final class PathMatchers {
                     break;
                 case '{':
                     String name = parseParameter(iter, regexp, paramCounter);
-                    if (name.length() > 0) {
+                    if (!name.isEmpty()) {
                         paramToGroupName.put(name, PARAM_PREFIX + paramCounter);
                         paramCounter++;
                     }
@@ -210,13 +210,13 @@ public final class PathMatchers {
                                                             + ", index: " + (iter.index() - 1));
                 }
                 String r1 = name.toString().trim();
-                addParamRegexp(builder, r1.length() > 0 ? index : -1, parseParamRegexp(iter));
+                addParamRegexp(builder, !r1.isEmpty() ? index : -1, parseParamRegexp(iter));
                 return r1;
             }
             case '}' -> {
                 String r2 = name.toString().trim();
                 addParamRegexp(builder,
-                               r2.length() > 0 ? index : -1,
+                        !r2.isEmpty() ? index : -1,
                                greedy ? ".+" : "[^/]+");
                 return r2;
             }

--- a/http/http/src/main/java/io/helidon/http/Utils.java
+++ b/http/http/src/main/java/io/helidon/http/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ final class Utils {
                 token.append(ch);
             } else {
                 if (ch == separator) {
-                    if (includeEmptyTokens || token.length() > 0) {
+                    if (includeEmptyTokens || !token.isEmpty()) {
                         result.add(token.toString());
                     }
                     token.setLength(0);
@@ -74,7 +74,7 @@ final class Utils {
                 }
             }
         }
-        if (includeEmptyTokens || token.length() > 0) {
+        if (includeEmptyTokens || !token.isEmpty()) {
             result.add(token.toString());
         }
         return result;

--- a/inject/tools/src/main/java/io/helidon/inject/tools/ActivatorCreatorDefault.java
+++ b/inject/tools/src/main/java/io/helidon/inject/tools/ActivatorCreatorDefault.java
@@ -646,7 +646,7 @@ public class ActivatorCreatorDefault extends AbstractCreator implements Activato
     String toCodegenQualifiers(Collection<Qualifier> qualifiers) {
         StringBuilder builder = new StringBuilder();
         for (Qualifier qualifier : qualifiers) {
-            if (builder.length() > 0) {
+            if (!builder.isEmpty()) {
                 builder.append("\n\t\t\t");
             }
             builder.append(".addQualifier(").append(toCodegenQualifiers(qualifier)).append(")");

--- a/inject/tools/src/main/java/io/helidon/inject/tools/InterceptorCreatorDefault.java
+++ b/inject/tools/src/main/java/io/helidon/inject/tools/InterceptorCreatorDefault.java
@@ -1066,7 +1066,7 @@ public class InterceptorCreatorDefault extends AbstractCreator implements Interc
         String objArrayArgs = "";
         String typedElementArgs = "";
         String untypedElementArgs = "";
-        boolean hasArgs = (args.length() > 0);
+        boolean hasArgs = (!args.isEmpty());
         if (hasArgs) {
             argDecls = mi.parameterInfo().stream()
                     .map(InterceptorCreatorDefault::toDecl)

--- a/inject/tools/src/main/java/io/helidon/inject/tools/ModuleInfoItemBlueprint.java
+++ b/inject/tools/src/main/java/io/helidon/inject/tools/ModuleInfoItemBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,7 +159,7 @@ interface ModuleInfoItemBlueprint {
             assert (!isStaticUsed());
             assert (!opens());
             assert (!exports());
-            if (builder.length() > 0) {
+            if (!builder.isEmpty()) {
                 builder.append(target()).append(";");
             }
             builder.append("provides ");

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -866,7 +866,7 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension {
 
                 String explicitGaugeName = gaugeAnnotation.name();
                 String gaugeNameSuffix = (
-                        explicitGaugeName.length() > 0 ? explicitGaugeName
+                        !explicitGaugeName.isEmpty() ? explicitGaugeName
                                 : javaMethod.getName());
                 String gaugeName = (
                         gaugeAnnotation.absolute() ? gaugeNameSuffix


### PR DESCRIPTION
### Description
  - Refactored the token length check from `token.length() > 0` to `!token.isEmpty()`.
  - This change improves code readability and aligns with best practices for string operations.
### Documentation

None 