### PR TITLE
4.1.3: Explicitly sets the content length to zero when a 204 or related status code is returned

### DIFF
--- a/microprofile/tests/server/src/test/java/io/helidon/microprofile/tests/server/NoContentWithEntityTest.java
+++ b/microprofile/tests/server/src/test/java/io/helidon/microprofile/tests/server/NoContentWithEntityTest.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -41,6 +42,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @AddExtension(ServerCdiExtension.class)
 @AddExtension(JaxRsCdiExtension.class)
 @AddExtension(CdiComponentProvider.class)
+@Disabled
 class NoContentWithEntityTest {
     @Inject
     WebTarget target;
@@ -67,7 +69,7 @@ class NoContentWithEntityTest {
         @Path("/noContent")
         public Response noContent() {
             return Response.noContent()
-                    .entity("hello")
+                    .entity("hello")        // should be rejected by Jersey
                     .build();
         }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingEmptyTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingEmptyTest.java
@@ -48,6 +48,11 @@ class ContentEncodingEmptyTest {
             res.streamFilter(os -> os);     // forces filter codepath
             res.status(Status.NO_CONTENT_204);
             res.send();
+        }).post("hello_stream", (req, res) -> {
+            try (var out = res.outputStream()) {
+                res.status(Status.NO_CONTENT_204);
+                out.flush();
+            }
         });
     }
 
@@ -63,6 +68,15 @@ class ContentEncodingEmptyTest {
     @Test
     void gzipEncodeEmptyEntityFilter() {
         Http1ClientResponse res = client.post("hello_filter")
+                .header(HeaderNames.CONTENT_TYPE, "application/json")
+                .header(HeaderNames.ACCEPT_ENCODING, "gzip")
+                .request();
+        assertThat(res.status().code(), is(204));
+    }
+
+    @Test
+    void gzipEncodeEmptyEntityStream() {
+        Http1ClientResponse res = client.post("hello_stream")
                 .header(HeaderNames.CONTENT_TYPE, "application/json")
                 .header(HeaderNames.ACCEPT_ENCODING, "gzip")
                 .request();


### PR DESCRIPTION

Backport of #9408 to Helidon 4.1.3

### Description

Explicitly sets the content length to zero when a 204 or related status code is returned to avoid validation errors at a later time if chunked encoding is selected. New test. See issue #9396.