### PR TITLE
4.1.3: Allow config to set camel (default) or snake case for built-in meter names

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/BuiltInMeterNameFormat.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/BuiltInMeterNameFormat.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.api;
+
+/**
+ * Choices for the output format for built-in meter names.
+ */
+public enum BuiltInMeterNameFormat {
+    /**
+     * Snake-case.
+     */
+    SNAKE,
+
+    /**
+     * Camel-case (which is compatible with the MicroProfile Metrics spec).
+     */
+    CAMEL;
+
+    static final String DEFAULT = "CAMEL";
+}

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -220,6 +220,18 @@ interface MetricsConfigBlueprint {
     GcTimeType gcTimeType();
 
     /**
+     * Output format for built-in meter names.
+     * <p>
+     *     {@link BuiltInMeterNameFormat#SNAKE} selects "snake_case" which does not conform to the MicroProfile
+     *     Metrics specification.
+     *
+     * @return the output format for built-in meter names
+     */
+    @Option.Configured
+    @Option.Default(BuiltInMeterNameFormat.DEFAULT)
+    BuiltInMeterNameFormat builtInMeterNameFormat();
+
+    /**
      * Reports whether the specified scope is enabled, according to any scope configuration that
      * is part of this metrics configuration.
      *

--- a/metrics/system-meters/pom.xml
+++ b/metrics/system-meters/pom.xml
@@ -47,6 +47,17 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- We need a full metrics implementation to test that config affects system meter names correctly. -->
+        <dependency>
+            <groupId>io.helidon.metrics.providers</groupId>
+            <artifactId>helidon-metrics-providers-micrometer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.testing</groupId>
             <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>

--- a/metrics/system-meters/src/test/java/io/helidon/metrics/systemmeters/MeterBuilderMatcher.java
+++ b/metrics/system-meters/src/test/java/io/helidon/metrics/systemmeters/MeterBuilderMatcher.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.systemmeters;
+
+import io.helidon.metrics.api.Meter;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Hamcrest matcher for unit tests involving {@link Meter.Builder} objects.
+ */
+class MeterBuilderMatcher {
+
+    /**
+     * A matcher that checks the meter builder's name using the supplied string matcher.
+     *
+     * @param matcher string matcher to apply to the meter builder's name
+     * @return matcher applicable to a meter builder for checking the name
+     */
+    static Matcher<Meter.Builder<?, ?>> withName(Matcher<String> matcher) {
+        return new WithName(matcher);
+    }
+
+    private static class WithName extends TypeSafeMatcher<Meter.Builder<?, ?>> {
+
+        private final Matcher<? super String> matcher;
+
+        private WithName(Matcher<? super String> matcher) {
+            this.matcher = matcher;
+        }
+
+        @Override
+        protected boolean matchesSafely(Meter.Builder<?, ?> item) {
+            return matcher.matches(item.name());
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("with name ");
+            description.appendDescriptionOf(matcher);
+        }
+    }
+}

--- a/metrics/system-meters/src/test/java/io/helidon/metrics/systemmeters/TestBuiltInMeterCaseSelection.java
+++ b/metrics/system-meters/src/test/java/io/helidon/metrics/systemmeters/TestBuiltInMeterCaseSelection.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.systemmeters;
+
+import java.util.Collection;
+import java.util.Map;
+
+import io.helidon.common.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.metrics.api.Meter;
+import io.helidon.metrics.api.MetricsFactory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+class TestBuiltInMeterCaseSelection {
+
+    @Test
+    void testDefaults() {
+        SystemMetersProvider provider = new SystemMetersProvider();
+        MetricsFactory metricsFactory = MetricsFactory.getInstance(Config.empty());
+        Collection<Meter.Builder<?, ?>> meterBuilders = provider.meterBuilders(metricsFactory);
+
+        assertThat("Default used heap name", meterBuilders, allOf(
+                hasItem(MeterBuilderMatcher.withName(equalTo("memory.usedHeap"))),
+                not(hasItem(MeterBuilderMatcher.withName(equalTo("memory.used_heap"))))));
+    }
+
+    @Test
+    void testWithSnakeConfigured() {
+        SystemMetersProvider provider = new SystemMetersProvider();
+        Config config = io.helidon.config.Config.just(ConfigSources.create(Map.of("metrics.built-in-meter-name-format", "SNAKE")));
+        MetricsFactory metricsFactory = MetricsFactory.getInstance(config.get("metrics"));
+        Collection<Meter.Builder<?, ?>> meterBuilders = provider.meterBuilders(metricsFactory);
+
+        assertThat("Configured used heap name", meterBuilders, allOf(
+                hasItem(MeterBuilderMatcher.withName(equalTo("memory.used_heap"))),
+                not(hasItem(MeterBuilderMatcher.withName(equalTo("memory.usedHeap"))))));
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricIDMatcher.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricIDMatcher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+class MetricIDMatcher {
+
+    static WithName withName(Matcher<? super String> matcher) {
+        return new WithName(matcher);
+    }
+
+    private static class WithName extends TypeSafeMatcher<MetricID> {
+
+        private final Matcher<? super String> matcher;
+
+        private WithName(Matcher<? super String> matcher) {
+            this.matcher = matcher;
+        }
+
+        @Override
+        protected boolean matchesSafely(MetricID item) {
+            return matcher.matches(item.getName());
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("metric ID name");
+            description.appendDescriptionOf(matcher);
+        }
+    }
+
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestConfiguredBuiltInMeterNameFormat.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestConfiguredBuiltInMeterNameFormat.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import java.util.Map;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+@HelidonTest
+@AddConfig(key = "metrics." + MetricsCdiExtension.REST_ENDPOINTS_METRIC_ENABLED_PROPERTY_NAME, value = "true")
+@AddConfig(key = "metrics.built-in-meter-name-format", value = "SNAKE")
+@AddBean(HelloWorldResource.class)
+class TestConfiguredBuiltInMeterNameFormat {
+
+    @Inject
+    @RegistryScope(scope = MetricRegistry.BASE_SCOPE)
+    private MetricRegistry baseRegistry;
+
+    @Test
+    void checkDefaultNames() {
+        Map<MetricID, Metric> baseMetrics = baseRegistry.getMetrics();
+
+        assertThat("Built-in metrics", baseMetrics.keySet(), allOf(
+                not(hasItem(MetricIDMatcher.withName(equalTo("memory.usedHeap")))),
+                hasItem(MetricIDMatcher.withName(equalTo("memory.used_heap")))));
+
+        Map<MetricID, Metric> metrics = baseRegistry.getMetrics();
+        assertThat("REST.request unmapped exception metric", metrics.keySet(), allOf(
+                not(hasItem(MetricIDMatcher.withName(equalTo(MetricsCdiExtension.SYNTHETIC_TIMER_METRIC_UNMAPPED_EXCEPTION_NAME)))),
+                hasItem(MetricIDMatcher.withName(equalTo(MetricsCdiExtension.SYNTHETIC_TIMER_METRIC_NAME +
+                                                                 ".unmapped_exception.total")))));
+
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDefaultBuiltInMeterNameFormat.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDefaultBuiltInMeterNameFormat.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import java.util.Map;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+@HelidonTest
+@AddConfig(key = "metrics." + MetricsCdiExtension.REST_ENDPOINTS_METRIC_ENABLED_PROPERTY_NAME, value = "true")
+@AddBean(HelloWorldResource.class)
+class TestDefaultBuiltInMeterNameFormat {
+
+    @Inject
+    @RegistryScope(scope = MetricRegistry.BASE_SCOPE)
+    private MetricRegistry baseRegistry;
+
+    @Test
+    void checkDefaultNames() {
+        Map<MetricID, Metric> baseMetrics = baseRegistry.getMetrics();
+
+        assertThat("Built-in metrics", baseMetrics.keySet(), allOf(
+                hasItem(MetricIDMatcher.withName(equalTo("memory.usedHeap"))),
+                not(hasItem(MetricIDMatcher.withName(equalTo("memory.used_heap"))))));
+
+        Map<MetricID, Metric> metrics = baseRegistry.getMetrics();
+        assertThat("REST.request unmapped exception metric", metrics.keySet(), allOf(
+                hasItem(MetricIDMatcher.withName(equalTo(MetricsCdiExtension.SYNTHETIC_TIMER_METRIC_UNMAPPED_EXCEPTION_NAME))),
+                not(hasItem(MetricIDMatcher.withName(equalTo(MetricsCdiExtension.SYNTHETIC_TIMER_METRIC_NAME +
+                                                                     ".unmapped_exception.total"))))));
+
+    }
+
+}


### PR DESCRIPTION

Backport #9429 to Helidon 4.1.3

### Description
Resolves #8422 

1. Adds the metrics config  setting `built-in-meter-name-format` with choices `CAMEL` (default)` and `SNAKE`. The JavaDoc (and therefore the generated config documentation) notes that selecting `SNAKE` does not conform to the MP Metrics spec; the built-in meter names are specified there.
2. The existing system meters provider now looks at config to decide which naming scheme to use for the built-in meters (`memory.usedHeap` or `memory.used_heap` for example).
3. MP metrics now checks config to decide whether to use `REST.request.unmappedException.total` or `REST.request.unmapped_exception.total`.

The sets of names are hard-coded; the new code _does not_ try to convert "camelCase" names automatically to their "snake_case" counterparts.

### Documentation
The Javadoc for the new metrics config setting should be a good enough explanation without requiring changes to the doc page itself.