### PR TITLE
Adopt MP metrics 5.1.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -111,7 +111,7 @@
         <version.lib.microprofile-graphql>2.0</version.lib.microprofile-graphql>
         <version.lib.microprofile-health>4.0.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>2.1</version.lib.microprofile-jwt>
-        <version.lib.microprofile-metrics-api>5.1.1</version.lib.microprofile-metrics-api>
+        <version.lib.microprofile-metrics-api>5.1.2</version.lib.microprofile-metrics-api>
         <version.lib.microprofile-openapi-api>3.1.1</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-reactive-messaging-api>3.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>3.0</version.lib.microprofile-reactive-streams-operators-api>

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/CustomSnapshot.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/CustomSnapshot.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import java.io.OutputStream;
+
+import org.eclipse.microprofile.metrics.Snapshot;
+
+/**
+ * Make sure subclass of {@link org.eclipse.microprofile.metrics.Snapshot} without a {@link #bucketValues()} implementation
+ * compiles correctly.
+ */
+class CustomSnapshot extends Snapshot {
+    @Override
+    public long size() {
+        return 0;
+    }
+
+    @Override
+    public double getMax() {
+        return 0;
+    }
+
+    @Override
+    public double getMean() {
+        return 0;
+    }
+
+    @Override
+    public PercentileValue[] percentileValues() {
+        return new PercentileValue[0];
+    }
+
+    @Override
+    public void dump(OutputStream outputStream) {
+
+    }
+}


### PR DESCRIPTION
### Description
Resolves #9264 

MP Metrics released 5.1.2 today which resolves the backward-incompatible API change in the `Snapshot` abstract class.

This PR adopts MP Metrics 5.1.2 and adds a test class which extends `Snapshot` but purposely does not implement `bucketValues` to make sure the API is now backward-compatible.

### Documentation
Bug fix; no doc impact.