### PR TITLE
4.x: Replace deprecated method Scheduling.fixedRateBuilder() on Scheduling.fixedRate() in CoordinatorService

### DIFF
--- a/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/CoordinatorService.java
+++ b/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/CoordinatorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/CoordinatorService.java
+++ b/lra/coordinator/server/src/main/java/io/helidon/lra/coordinator/CoordinatorService.java
@@ -165,7 +165,7 @@ public class CoordinatorService implements HttpService {
 
     private void init() {
         lraPersistentRegistry.load(this);
-        recoveryTask = Scheduling.fixedRateBuilder()
+        recoveryTask = Scheduling.fixedRate()
                 .delay(config.get("recovery-interval").asLong().orElse(200L))
                 .initialDelay(200)
                 .timeUnit(TimeUnit.MILLISECONDS)
@@ -173,7 +173,7 @@ public class CoordinatorService implements HttpService {
                 .build();
 
         if (config.get("periodical-persist").asBoolean().orElse(false)) {
-            persistTask = Scheduling.fixedRateBuilder()
+            persistTask = Scheduling.fixedRate()
                     .delay(config.get("persist-interval").asLong().orElse(5000L))
                     .initialDelay(200)
                     .timeUnit(TimeUnit.MILLISECONDS)


### PR DESCRIPTION
### Description
I've found, that the deprecated method Scheduling.fixedRateBuilder() is used in the code. The method was marked as deprecated in [this commit](https://github.com/helidon-io/helidon/commit/e492423826d003cbf328cc9a0eb37df63aad5367#diff-00241b86b77b293b3a01442977eda4462b33de67f1d1d514fb5cb26bda7517a4R53).

![image](https://github.com/user-attachments/assets/6407b021-9bc7-4a0b-a0af-d26995af4bc9)

It can be replaced on Scheduling.fixedRate()
