### PR TITLE
4.1.4: Use replace instead of replaceAll for string replacement 

### DIFF
--- a/common/config/src/main/java/io/helidon/common/config/Config.java
+++ b/common/config/src/main/java/io/helidon/common/config/Config.java
@@ -383,8 +383,8 @@ public interface Config {
          * @return unescaped name
          */
         static String unescapeName(String escapedName) {
-            return escapedName.replaceAll("~1", ".")
-                    .replaceAll("~0", "~");
+            return escapedName.replace("~1", ".")
+                    .replace("~0", "~");
         }
 
         /**

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1020,8 +1020,8 @@ public interface Config extends io.helidon.common.config.Config {
          * @return unescaped name
          */
         static String unescapeName(String escapedName) {
-            return escapedName.replaceAll("~1", ".")
-                    .replaceAll("~0", "~");
+            return escapedName.replace("~1", ".")
+                    .replace("~0", "~");
         }
     }
 


### PR DESCRIPTION

Backport #9448 to Helidon 4.1.4

### Description

 (regexp not needed)

Resolves #9430 