### PR TITLE
4.1.4: clean up warning messages from archetype generated projects 

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/common/files/src/main/resources/logging.properties.mustache
+++ b/archetypes/archetypes/src/main/archetype/mp/common/files/src/main/resources/logging.properties.mustache
@@ -20,6 +20,9 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 # Quiet Weld
 org.jboss.level=WARNING
 
+# Quiet Jersey wadl support
+org.glassfish.jersey.server.wadl.level=SEVERE
+
 # Component specific log levels
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
@@ -81,7 +81,7 @@ public final class OpenApiFeature implements Weighted, ServerFeature, RuntimeTyp
             }
             if (defaultContent == null) {
                 defaultContent = "";
-                LOGGER.log(Level.WARNING, "Static OpenAPI file not found, checked: {0}", DEFAULT_FILE_PATHS);
+                LOGGER.log(Level.DEBUG, "Static OpenAPI file not found, checked: {0}", DEFAULT_FILE_PATHS);
             }
         }
         content = defaultContent;


### PR DESCRIPTION
Backport #9451 to Helidon 4.1.4

Clean up warning messages from archetype generated projects:

1. Change a log message in `OpenApiFeature` from WARNING to DEBUG
2. Update archetype's `logging.properties` to silence warning from Jersey's wadl support

See #9019 