### PR TITLE
4.1.4: Update jackson to 2.18.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -68,7 +68,7 @@
         <version.lib.hibernate-validator>7.0.5.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.15.2</version.lib.jackson>
+        <version.lib.jackson>2.18.1</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.1.3</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.1.1</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>4.0.1</version.lib.jakarta.cdi-api>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -45,22 +45,6 @@
    <vulnerabilityName>CVE-2021-26291</vulnerabilityName>
 </suppress>
 
-<!--
-    This CVE is being disputed by the Jackson project and the community seems in agreement that this
-    CVE should be rejected. We are suppressing this for now to reduce noise in our scan and will
-    continue to monitor progress.
-    https://nvd.nist.gov/vuln/detail/CVE-2023-35116
-    https://github.com/FasterXML/jackson-databind/issues/3972
-
--->
-<suppress>
-   <notes><![CDATA[
-   file name: jackson-databind-2.15.2.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-   <cve>CVE-2023-35116</cve>
-</suppress>
-
 <!-- False Positive. This does not apply to server Java deployment and certainly not to our use of graalvm SDK.
     This vulnerability applies to Java deployments, typically in clients running sandboxed
     Java Web Start applications or sandboxed Java applets, that load and run untrusted code


### PR DESCRIPTION
Backport  #9456 to 4.1.4

### Description

Update jackson to 2.18.1

Allows use to remove the dependency scan suppression