### PR TITLE
4.x: Replace deprecated VM memory flags in docs for building container images (#8876)

### DIFF
--- a/docs/src/main/asciidoc/guides/jib.adoc
+++ b/docs/src/main/asciidoc/guides/jib.adoc
@@ -72,9 +72,9 @@ Add the following plugin declaration to your pom.xml:
                 <jmxFlag>-Djava.awt.headless=true</jmxFlag>
                 <jmxFlag>-XX:+UnlockExperimentalVMOptions</jmxFlag>
                 <jmxFlag>-XX:+UseCGroupMemoryLimitForHeap</jmxFlag>
-                <jmxFlag>-XX:InitialRAMFraction=2</jmxFlag>
-                <jmxFlag>-XX:MinRAMFraction=2</jmxFlag>
-                <jmxFlag>-XX:MaxRAMFraction=2</jmxFlag>
+                <jmxFlag>-XX:InitialRAMPercentage=50</jmxFlag>
+                <jmxFlag>-XX:MinRAMPercentage=50</jmxFlag>
+                <jmxFlag>-XX:MaxRAMPercentage=50</jmxFlag>
                 <jmxFlag>-XX:+UseG1GC</jmxFlag>
             </jvmFlags>
             <mainClass>${mainClass}</mainClass>


### PR DESCRIPTION
### Description
Fixes #8876 

I use 50, because it was 1/2 before.