### PR TITLE
2.x: Upgrade Jackson to 2.18.1 and ojdbc to 21.15.0.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -72,7 +72,7 @@
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
         <version.lib.inject>1.0</version.lib.inject>
         <version.lib.interceptor-api>1.2.5</version.lib.interceptor-api>
-        <version.lib.jackson>2.15.2</version.lib.jackson>
+        <version.lib.jackson>2.18.1</version.lib.jackson>
         <version.lib.jaegertracing>1.8.1</version.lib.jaegertracing>
         <version.lib.jandex>2.3.1.Final</version.lib.jandex>
         <version.lib.jaxb-api>2.3.3</version.lib.jaxb-api>
@@ -126,7 +126,7 @@
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.46.1</version.lib.oci>
         <version.lib.oci-java-sdk-objectstorage>${version.lib.oci}</version.lib.oci-java-sdk-objectstorage>
-        <version.lib.ojdbc8>21.3.0.0</version.lib.ojdbc8>
+        <version.lib.ojdbc8>21.15.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <!-- Manage okio version for dependency convergence -->
         <version.lib.okio>3.6.0</version.lib.okio>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -85,21 +85,6 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
 </suppress>
 
 <!--
-   This CVE is being disputed by the Jackson project and the community seems in agreement that this
-   CVE should be rejected. We are suppressing this for now to reduce noise in our scan and will
-   continue to monitor progress.
-   https://nvd.nist.gov/vuln/detail/CVE-2023-35116
-   https://github.com/FasterXML/jackson-databind/issues/3972
--->
-<suppress>
-   <notes><![CDATA[
-   file name: jackson-databind-2.15.2.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-   <cve>CVE-2023-35116</cve>
-</suppress>
-
-<!--
     This is a FP. We have upgrade jgit to a fixed version, but it is still getting flagged.
     Probably due to the funky version string used by jgit. See
     https://github.com/jeremylong/DependencyCheck/issues/5943
@@ -174,5 +159,34 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <packageUrl regex="true">^pkg:maven/org\.graalvm\.compiler/compiler@.*$</packageUrl>
    <vulnerabilityName>CVE-2024-21138</vulnerabilityName>
 </suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: compiler-21.3.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.compiler/compiler@.*$</packageUrl>
+   <vulnerabilityName>CVE-2024-21235</vulnerabilityName>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: graal-sdk-21.3.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.sdk/graal-sdk@.*$</packageUrl>
+   <vulnerabilityName>CVE-2024-21235</vulnerabilityName>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: graal-sdk-21.3.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.sdk/graal-sdk@.*$</packageUrl>
+   <vulnerabilityName>CVE-2024-21094</vulnerabilityName>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: graal-sdk-21.3.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.sdk/graal-sdk@.*$</packageUrl>
+   <vulnerabilityName>CVE-2023-22045</vulnerabilityName>
+</suppress>
+
 
 </suppressions>

--- a/integrations/oci/sdk/cdi/pom.xml
+++ b/integrations/oci/sdk/cdi/pom.xml
@@ -73,6 +73,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- To satisfy jackson-module-jaxb-annotations 2.18.1 module dependency on java.xml.bind  -->
+        <!-- Somehow this got messed up in Jackson 2.18 via PR https://github.com/FasterXML/jackson-modules-base/pull/235 -->
+        <!-- Which changed the jaxb dependency to javax.xml.bind which did not provide a module name -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>


### PR DESCRIPTION
- Upgrade jackson to 2.18.1. 
- Upgrade ojdbc to 21.15.0.0
- Remove Jackson CVE supression. Suppress more graalvm warnings

The Jackson upgrade requires a work-around due to a module issue introduced in jackson-module-jaxb-annotations 2.18