### PR TITLE
3.x: Replace deprecated VM memory flags in docs for building container images (#9480)

### DIFF
--- a/docs/guides/jib.adoc
+++ b/docs/guides/jib.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -72,9 +72,9 @@ Add the following plugin declaration to your pom.xml:
                 <jmxFlag>-Djava.awt.headless=true</jmxFlag>
                 <jmxFlag>-XX:+UnlockExperimentalVMOptions</jmxFlag>
                 <jmxFlag>-XX:+UseCGroupMemoryLimitForHeap</jmxFlag>
-                <jmxFlag>-XX:InitialRAMFraction=2</jmxFlag>
-                <jmxFlag>-XX:MinRAMFraction=2</jmxFlag>
-                <jmxFlag>-XX:MaxRAMFraction=2</jmxFlag>
+                <jmxFlag>-XX:InitialRAMPercentage=50</jmxFlag>
+                <jmxFlag>-XX:MinRAMPercentage=50</jmxFlag>
+                <jmxFlag>-XX:MaxRAMPercentage=50</jmxFlag>
                 <jmxFlag>-XX:+UseG1GC</jmxFlag>
             </jvmFlags>
             <mainClass>${mainClass}</mainClass>


### PR DESCRIPTION
### Description
Fixes #9480 

[The same](https://github.com/helidon-io/helidon/pull/9479) was done for 4.x