### PR TITLE
2.x: netty 4.1.115, grpc-java 1.65.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -60,10 +60,10 @@
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.google-protobuf>3.25.5</version.lib.google-protobuf>
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
-	<version.lib.graphql-java>22.1</version.lib.graphql-java>
+        <version.lib.graphql-java>22.1</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>22.0</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
-        <version.lib.grpc>1.60.0</version.lib.grpc>
+        <version.lib.grpc>1.65.1</version.lib.grpc>
         <version.lib.guava>32.0.1-jre</version.lib.guava>
         <version.lib.h2>1.4.200</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -122,7 +122,7 @@
         <version.lib.hibernate-validator>6.2.5.Final</version.lib.hibernate-validator>
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
-        <version.lib.netty>4.1.108.Final</version.lib.netty>
+        <version.lib.netty>4.1.115.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.46.1</version.lib.oci>
         <version.lib.oci-java-sdk-objectstorage>${version.lib.oci}</version.lib.oci-java-sdk-objectstorage>

--- a/grpc/core/pom.xml
+++ b/grpc/core/pom.xml
@@ -55,6 +55,10 @@
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
+            <artifactId>grpc-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
         </dependency>
         <dependency>

--- a/grpc/core/src/main/java/io/helidon/grpc/core/MarshallerSupplier.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/MarshallerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package io.helidon.grpc.core;
 
 import javax.inject.Named;
 
-import com.google.protobuf.MessageLite;
+import com.google.protobuf.Message;
 import io.grpc.MethodDescriptor;
-import io.grpc.protobuf.lite.ProtoLiteUtils;
+import io.grpc.protobuf.ProtoUtils;
 
 /**
  * A supplier of {@link MethodDescriptor.Marshaller} instances for specific
@@ -69,7 +69,7 @@ public interface MarshallerSupplier {
 
         @Override
         public <T> MethodDescriptor.Marshaller<T> get(Class<T> clazz) {
-            if (MessageLite.class.isAssignableFrom(clazz)) {
+            if (Message.class.isAssignableFrom(clazz)) {
                 return proto.get(clazz);
             }
             return JavaMarshaller.instance();
@@ -89,9 +89,9 @@ public interface MarshallerSupplier {
         public <T> MethodDescriptor.Marshaller<T> get(Class<T> clazz) {
             try {
                 java.lang.reflect.Method getDefaultInstance = clazz.getDeclaredMethod("getDefaultInstance");
-                MessageLite instance = (MessageLite) getDefaultInstance.invoke(clazz);
+                Message instance = (Message) getDefaultInstance.invoke(clazz);
 
-                return (MethodDescriptor.Marshaller<T>) ProtoLiteUtils.marshaller(instance);
+                return (MethodDescriptor.Marshaller<T>) ProtoUtils.marshaller(instance);
             } catch (Exception e) {
                 String msg = String.format(
                         "Attempting to use class %s, which is not a valid Protocol buffer message, with a default marshaller",

--- a/grpc/core/src/main/java/module-info.java
+++ b/grpc/core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ module io.helidon.grpc.core {
 
     requires io.grpc.netty;
     requires transitive io.grpc.protobuf;
-    requires io.grpc.protobuf.lite;
     requires transitive io.grpc.stub;
     requires transitive io.grpc;
     requires io.netty.handler;

--- a/microprofile/grpc/server/src/main/java/module-info.java
+++ b/microprofile/grpc/server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ module io.helidon.microprofile.grpc.server {
     requires io.helidon.microprofile.server;
     requires io.helidon.config.mp;
 
-    requires io.grpc.protobuf.lite;
     requires com.google.protobuf;
 
     requires java.logging;

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>10.0.4</version.plugin.dependency-check>
+        <version.plugin.dependency-check>11.1.0</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0-M5</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>

--- a/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
@@ -28,6 +28,7 @@ Args=--allow-incomplete-classpath \
   --initialize-at-run-time=io.netty.handler.codec.compression.Lz4FrameDecoder \
   --initialize-at-run-time=io.netty.handler.codec.compression.Lz4FrameEncoder \
   --initialize-at-run-time=io.netty.handler.codec.compression.LzmaFrameEncoder \
+  --initialize-at-run-time=io.netty.handler.codec.compression.Zstd \
   --initialize-at-run-time=io.netty.handler.codec.compression.ZstdOptions \
   --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder \
   --initialize-at-run-time=io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler \


### PR DESCRIPTION
## Description

- Upgrade Netty to 4.1.115
- Upgrade grpc-java to 1.65.1 (matches what is currently in main. See #9105). Required by Netty upgrade.
- google-protobuf is already at 3.25.5 (matches what is in main)
- Drops dependency on protobuf lite in favor of the full version which we already depended on (like main).
- Upgrade dependency check plugin to 11.1.0