### PR TITLE
3.x: netty 4.1.115, grpc-java 1.65.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -61,7 +61,7 @@
         <version.lib.graphql-java>22.1</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>22.0</version.lib.graphql-java.extended.scalars>
         <version.lib.gson>2.9.0</version.lib.gson>
-        <version.lib.grpc>1.60.0</version.lib.grpc>
+        <version.lib.grpc>1.65.1</version.lib.grpc>
         <version.lib.guava>32.0.1-jre</version.lib.guava>
         <version.lib.h2>2.1.212</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -128,7 +128,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
-        <version.lib.netty>4.1.108.Final</version.lib.netty>
+        <version.lib.netty>4.1.115.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.46.1</version.lib.oci>
         <version.lib.ojdbc8>21.15.0.0</version.lib.ojdbc8>

--- a/grpc/core/pom.xml
+++ b/grpc/core/pom.xml
@@ -59,6 +59,10 @@
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
+            <artifactId>grpc-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
         </dependency>
         <dependency>

--- a/grpc/core/src/main/java/io/helidon/grpc/core/MarshallerSupplier.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/MarshallerSupplier.java
@@ -16,9 +16,9 @@
 
 package io.helidon.grpc.core;
 
-import com.google.protobuf.MessageLite;
+import com.google.protobuf.Message;
 import io.grpc.MethodDescriptor;
-import io.grpc.protobuf.lite.ProtoLiteUtils;
+import io.grpc.protobuf.ProtoUtils;
 import jakarta.inject.Named;
 
 /**
@@ -68,7 +68,7 @@ public interface MarshallerSupplier {
 
         @Override
         public <T> MethodDescriptor.Marshaller<T> get(Class<T> clazz) {
-            if (MessageLite.class.isAssignableFrom(clazz)) {
+            if (Message.class.isAssignableFrom(clazz)) {
                 return proto.get(clazz);
             }
             String msg = String.format(
@@ -91,9 +91,9 @@ public interface MarshallerSupplier {
         public <T> MethodDescriptor.Marshaller<T> get(Class<T> clazz) {
             try {
                 java.lang.reflect.Method getDefaultInstance = clazz.getDeclaredMethod("getDefaultInstance");
-                MessageLite instance = (MessageLite) getDefaultInstance.invoke(clazz);
+                Message instance = (Message) getDefaultInstance.invoke(clazz);
 
-                return (MethodDescriptor.Marshaller<T>) ProtoLiteUtils.marshaller(instance);
+                return (MethodDescriptor.Marshaller<T>) ProtoUtils.marshaller(instance);
             } catch (Exception e) {
                 String msg = String.format(
                         "Attempting to use class %s, which is not a valid Protocol buffer message, with a default marshaller",

--- a/grpc/core/src/main/java/io/helidon/grpc/core/MarshallerSupplier.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/MarshallerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/core/src/main/java/module-info.java
+++ b/grpc/core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/core/src/main/java/module-info.java
+++ b/grpc/core/src/main/java/module-info.java
@@ -33,7 +33,6 @@ module io.helidon.grpc.core {
 
     requires io.grpc.netty;
     requires transitive io.grpc.protobuf;
-    requires io.grpc.protobuf.lite;
     requires transitive io.grpc.stub;
     requires transitive io.grpc;
     requires io.netty.handler;

--- a/microprofile/grpc/server/src/main/java/module-info.java
+++ b/microprofile/grpc/server/src/main/java/module-info.java
@@ -27,7 +27,6 @@ module io.helidon.microprofile.grpc.server {
     requires io.helidon.microprofile.server;
     requires io.helidon.config.mp;
 
-    requires io.grpc.protobuf.lite;
     requires com.google.protobuf;
 
     requires java.logging;

--- a/microprofile/grpc/server/src/main/java/module-info.java
+++ b/microprofile/grpc/server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.plugin.source>3.3.0</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>10.0.4</version.plugin.dependency-check>
+        <version.plugin.dependency-check>11.1.0</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>

--- a/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
@@ -27,6 +27,7 @@ Args=--initialize-at-run-time=io.netty.buffer.UnpooledByteBufAllocator$Instrumen
   --initialize-at-run-time=io.netty.handler.codec.compression.Lz4FrameDecoder \
   --initialize-at-run-time=io.netty.handler.codec.compression.Lz4FrameEncoder \
   --initialize-at-run-time=io.netty.handler.codec.compression.LzmaFrameEncoder \
+  --initialize-at-run-time=io.netty.handler.codec.compression.Zstd \
   --initialize-at-run-time=io.netty.handler.codec.compression.ZstdOptions \
   --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder \
   --initialize-at-run-time=io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler \


### PR DESCRIPTION
## Description

- Upgrade Netty to 4.1.115
- Upgrade grpc-java to 1.65.1 (matches what is currently in main. See #9105). Required by Netty upgrade.
- google-protobuf is already at 3.25.5 (matches what is in main)
- Drops dependency on protobuf lite in favor of the full version which we already depended on (like main).
- Upgrade dependency check plugin to 11.1.0
