### PR TITLE
Refactor assertions to use `assertThat` with appropriate matchers

### DIFF
--- a/inject/tests/resources-inject/src/test/java/io/helidon/inject/tests/inject/interceptor/InterceptorRuntimeTest.java
+++ b/inject/tests/resources-inject/src/test/java/io/helidon/inject/tests/inject/interceptor/InterceptorRuntimeTest.java
@@ -59,7 +59,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InterceptorRuntimeTest {
@@ -91,9 +90,10 @@ class InterceptorRuntimeTest {
         assertThat(file.exists(), is(true));
         String java = Files.readString(file.toPath());
         String expected = loadStringFromResource("expected/ximpl-interceptor._java_");
-        assertEquals(
-                expected.replaceFirst("#DATE#", Integer.toString(Calendar.getInstance().get(Calendar.YEAR))),
-                java);
+        assertThat(
+            java,
+            is(expected.replaceFirst("#DATE#", Integer.toString(Calendar.getInstance().get(Calendar.YEAR))))
+        );
     }
 
     @Test
@@ -104,9 +104,10 @@ class InterceptorRuntimeTest {
         assertThat(file.exists(), is(true));
         String java = Files.readString(file.toPath());
         String expected = loadStringFromResource("expected/yimpl-interceptor._java_");
-        assertEquals(
-                expected.replaceFirst("#DATE#", Integer.toString(Calendar.getInstance().get(Calendar.YEAR))),
-                java);
+        assertThat(
+            java,
+            is(expected.replaceFirst("#DATE#", Integer.toString(Calendar.getInstance().get(Calendar.YEAR))))
+        );
     }
 
     @Test

--- a/inject/tools/src/test/java/io/helidon/inject/tools/ActivatorCreatorDefaultTest.java
+++ b/inject/tools/src/test/java/io/helidon/inject/tools/ActivatorCreatorDefaultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -67,7 +66,7 @@ class ActivatorCreatorDefaultTest extends AbstractBaseCreator {
                 .build();
 
         ToolsException te = assertThrows(ToolsException.class, () -> activatorCreator.createModuleActivators(req));
-        assertEquals("Failed in create", te.getMessage());
+        assertThat(te.getMessage(), is("Failed in create"));
 
         ActivatorCreatorRequest req2 = ActivatorCreatorRequest.builder()
                 .serviceTypeNames(Collections.singletonList(TypeName.create(HelloInjectionWorldImpl.class)))

--- a/microprofile/scheduling/src/test/java/io/helidon/microprofile/scheduling/InvalidStateTest.java
+++ b/microprofile/scheduling/src/test/java/io/helidon/microprofile/scheduling/InvalidStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class InvalidStateTest {
@@ -124,7 +125,7 @@ public class InvalidStateTest {
         } catch (AssertionFailedError e) {
             throw e;
         } catch (Throwable e) {
-            assertEquals(expected, e.getClass());
+            assertThat(e, instanceOf(expected));
         }
     }
 }

--- a/tests/functional/request-scope-cdi/src/test/java/io/helidon/tests/functional/requestscopecdi/SecretTest.java
+++ b/tests/functional/request-scope-cdi/src/test/java/io/helidon/tests/functional/requestscopecdi/SecretTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @HelidonTest
 class SecretTest {
@@ -43,6 +42,6 @@ class SecretTest {
                 .get();
         assertThat(r.getStatus(), is(Response.Status.OK.getStatusCode()));
         JsonObject o = r.readEntity(JsonObject.class);
-        assertEquals(o.get("secret1"), o.get("secret2"));
+        assertThat(o.get("secret1"), is(o.get("secret2")));
     }
 }

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxyTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.http.Method.GET;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,7 +89,7 @@ class HttpProxyTest {
         try {
             ProxySelector.setDefault(ProxySelector.of(new InetSocketAddress(PROXY_HOST, proxyPort)));
             Proxy proxy = Proxy.builder().build();
-            assertEquals(ProxyType.SYSTEM, proxy.type());
+            assertThat(proxy.type(), is(ProxyType.SYSTEM));
             successVerify(proxy, clientHttp1);
         } finally {
             ProxySelector.setDefault(original);
@@ -103,7 +102,7 @@ class HttpProxyTest {
         try {
             ProxySelector.setDefault(ProxySelector.of(new InetSocketAddress(PROXY_HOST, proxyPort)));
             Proxy proxy = Proxy.builder().build();
-            assertEquals(ProxyType.SYSTEM, proxy.type());
+            assertThat(proxy.type(), is(ProxyType.SYSTEM));
             successVerify(proxy, clientHttp2);
         } finally {
             ProxySelector.setDefault(original);

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/Http2ErrorHandlingWithOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
@@ -141,7 +140,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
     void testOk() {
         var response = request("/");
 
-        assertEquals(200, response.statusCode());
+        assertThat(response.statusCode(), is(200));
         assertThat(response.body(), is("ok"));
     }
 
@@ -149,7 +148,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
     void testGetOutputStreamThenError_expect_CustomErrorHandlerMessage() {
         var response = request("/get-outputStream");
 
-        assertEquals(418, response.statusCode());
+        assertThat(response.statusCode(), is(418));
         assertThat(response.body(), is("TeaPotIAm"));
         assertThat(response.headers().firstValue(ERROR_HEADER_NAME.lowerCase()), is(Optional.of("err")));
         assertThat(response.headers().firstValue(MAIN_HEADER_NAME.lowerCase()), is(emptyOptional()));
@@ -159,7 +158,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
     void testGetOutputStreamWriteOnceThenError_expect_CustomErrorHandlerMessage() {
         var response = request("/get-outputStream-writeOnceThenError");
 
-        assertEquals(418, response.statusCode());
+        assertThat(response.statusCode(), is(418));
         assertThat(response.body(), is("TeaPotIAm"));
         assertThat(response.headers().firstValue(ERROR_HEADER_NAME.lowerCase()), is(Optional.of("err")));
         assertThat(response.headers().firstValue(MAIN_HEADER_NAME.lowerCase()), is(emptyOptional()));
@@ -185,7 +184,7 @@ class Http2ErrorHandlingWithOutputStreamTest {
     void testGetOutputStreamTryWithResourcesThenError_expect_CustomErrorHandlerMessage() {
         var response = request("/get-outputStream-tryWithResources");
 
-        assertEquals(418, response.statusCode());
+        assertThat(response.statusCode(), is(418));
         assertThat(response.body(), is("TeaPotIAm"));
         assertThat(response.headers().firstValue(ERROR_HEADER_NAME.lowerCase()), is(Optional.of("err")));
         assertThat(response.headers().firstValue(MAIN_HEADER_NAME.lowerCase()), is(emptyOptional()));

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/ErrorHandlersTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/ErrorHandlersTest.java
@@ -44,7 +44,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -138,7 +137,7 @@ class ErrorHandlersTest {
             });
             fail("It is expected a CloseConnectionException");
         } catch (CloseConnectionException e) {
-            assertEquals(OtherException.class, e.getCause().getClass());
+            assertThat(e.getCause(), instanceOf(OtherException.class));
         }
     }
 


### PR DESCRIPTION
Refactored test assertions to use assertThat instead of assertEquals to align with Helidon's convention.
