### PR TITLE
gRPC compatiblity fixes

### DIFF
--- a/webserver/grpc/pom.xml
+++ b/webserver/grpc/pom.xml
@@ -150,6 +150,23 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${version.lib.google-protobuf}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${version.lib.grpc}:exe:${os.detected.classifier}
+                    </pluginArtifact>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandlerNotFound.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandlerNotFound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.webserver.grpc;
 
 import io.helidon.common.buffers.BufferData;
+import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.FlowControl;
 import io.helidon.http.http2.Http2Flag;
@@ -45,6 +46,7 @@ class GrpcProtocolHandlerNotFound implements Http2SubProtocolSelector.SubProtoco
     @Override
     public void init() {
         WritableHeaders<?> writable = WritableHeaders.create();
+        writable.set(Http2Headers.STATUS_NAME, Status.NOT_FOUND_404.code());
         writable.set(GrpcStatus.NOT_FOUND);
         Http2Headers http2Headers = Http2Headers.create(writable);
         streamWriter.writeHeaders(http2Headers,
@@ -70,5 +72,4 @@ class GrpcProtocolHandlerNotFound implements Http2SubProtocolSelector.SubProtoco
     @Override
     public void data(Http2FrameHeader header, BufferData data) {
     }
-
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouteHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouteHandler.java
@@ -120,8 +120,14 @@ class GrpcRouteHandler<ReqT, ResT> extends GrpcRoute {
                                                                   String methodName,
                                                                   ServerCallHandler<ReqT, ResT> callHandler) {
         Descriptors.ServiceDescriptor svc = proto.findServiceByName(serviceName);
+        if (svc == null) {
+            throw new IllegalArgumentException("Unable to find gRPC service '" + serviceName + "'");
+        }
         Descriptors.MethodDescriptor mtd = svc.findMethodByName(methodName);
-
+        if (mtd == null) {
+            throw new IllegalArgumentException("Unable to find gRPC method '" + methodName
+                    + "' in service '" + serviceName + "'");
+        }
         String path = svc.getFullName() + "/" + methodName;
 
         /*

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerNotFoundTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerNotFoundTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.grpc;
+
+import io.helidon.http.Status;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2StreamState;
+import io.helidon.http.http2.Http2StreamWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+class GrpcProtocolHandlerNotFoundTest {
+
+    private boolean validateHeaders;
+
+    @Test
+    void testNotFoundHeaders() {
+        Http2StreamWriter writer = new Http2StreamWriter() {
+            @Override
+            public void write(Http2FrameData frame) {
+                throw new UnsupportedOperationException("Unsupported");
+            }
+
+            @Override
+            public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+                throw new UnsupportedOperationException("Unsupported");
+
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers, int streamId, Http2Flag.HeaderFlags flags, FlowControl.Outbound flowControl) {
+                validateHeaders = (headers.status() == Status.NOT_FOUND_404);
+                try {
+                    headers.validateResponse();
+                } catch (Exception e) {
+                    validateHeaders = false;
+                }
+                return 0;
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers, int streamId, Http2Flag.HeaderFlags flags, Http2FrameData dataFrame, FlowControl.Outbound flowControl) {
+                throw new UnsupportedOperationException("Unsupported");
+            }
+        };
+        GrpcProtocolHandlerNotFound handler = new GrpcProtocolHandlerNotFound(writer, 1, Http2StreamState.OPEN);
+        assertThat(validateHeaders, is(false));
+        handler.init();
+        assertThat(validateHeaders, is(true));
+    }
+}

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.grpc;
+
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2StreamState;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+class GrpcProtocolHandlerTest {
+
+    private static final HeaderName GRPC_ACCEPT_ENCODING = HeaderNames.create("grpc-accept-encoding");
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testIdentityCompressorFlag() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(GRPC_ACCEPT_ENCODING, "identity");
+        GrpcProtocolHandler handler = new GrpcProtocolHandler(null,
+                Http2Headers.create(headers),
+                null,
+                1,
+                Http2Settings.builder().build(),
+                Http2Settings.builder().build(),
+                null,
+                Http2StreamState.OPEN,
+                null);
+        handler.initCompression(null, headers);
+        assertThat(handler.isIdentityCompressor(), is(true));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testGzipCompressor() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(GRPC_ACCEPT_ENCODING, "gzip");
+        GrpcProtocolHandler handler = new GrpcProtocolHandler(null,
+                Http2Headers.create(headers),
+                null,
+                1,
+                Http2Settings.builder().build(),
+                Http2Settings.builder().build(),
+                null,
+                Http2StreamState.OPEN,
+                null);
+        handler.initCompression(null, headers);
+        assertThat(handler.isIdentityCompressor(), is(false));
+    }
+}

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcRouteHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcRouteHandlerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.grpc;
+
+import com.google.protobuf.Descriptors;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class GrpcRouteHandlerTest {
+
+    @Test
+    void testBadServiceNames() throws Descriptors.DescriptorValidationException {
+        assertThrows(IllegalArgumentException.class,
+                () -> GrpcRouteHandler.unary(Strings.getDescriptor(), "foo", "Upper", null));
+        assertThrows(IllegalArgumentException.class,
+                () -> GrpcRouteHandler.unary(Strings.getDescriptor(), "StringService", "foo", null));
+    }
+}

--- a/webserver/grpc/src/test/proto/strings.proto
+++ b/webserver/grpc/src/test/proto/strings.proto
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+syntax = "proto3";
+option java_package = "io.helidon.webserver.grpc";
+
+service StringService {
+  rpc Upper (StringMessage) returns (StringMessage) {}
+}
+
+message StringMessage {
+  string text = 1;
+}


### PR DESCRIPTION
### Description

- Special handling for identity compressor to ensure compress flag is not turned on. Identity compression is a special case, and for compatibility it should not be treated as a normal compressor.
- If a gRPC service is not found, include ":status" header in response to comply with gRPC spec
- A few null checks were missing in GrpcRouteHandler
- New tests for all the changes above
- Fixes issue #9452 

### Documentation

None