### PR TITLE
Http/2 revamp

### DIFF
--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
@@ -164,10 +164,12 @@ abstract class WindowSizeImpl implements WindowSize {
         @Override
         public void blockTillUpdate() {
             var startTime = System.currentTimeMillis();
+            int backoff = 50;
             while (getRemainingWindowSize() < 1) {
                 try {
                     updatedSemaphore.drainPermits();
-                    var ignored = updatedSemaphore.tryAcquire(timeoutMillis / 4, TimeUnit.MILLISECONDS);
+                    var ignored = updatedSemaphore.tryAcquire(Math.min(backoff, 5000), TimeUnit.MILLISECONDS);
+                    backoff *= 2;
                 } catch (InterruptedException e) {
                     debugLog("%s OFC STR %d: Window depleted, waiting for update interrupted.", e);
                     throw new Http2Exception(Http2ErrorCode.FLOW_CONTROL, "Flow control update wait interrupted.");

--- a/http/tests/media/multipart/pom.xml
+++ b/http/tests/media/multipart/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>helidon-http-media-multipart</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>

--- a/http/tests/media/multipart/src/test/resources/logging-test.properties
+++ b/http/tests/media/multipart/src/test/resources/logging-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
 java.util.logging.ConsoleHandler.level=FINEST
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS %4$s %3$s %5$s%6$s%n

--- a/tests/integration/h2spec/Dockerfile
+++ b/tests/integration/h2spec/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM container-registry.oracle.com/os/oraclelinux:9-slim AS build
+ENV GO111MODULE=on
+ENV GOPROXY=https://proxy.golang.org
+ENV CGO_ENABLED=0
+ENV VERSION=2.6.1-SNAPSHOT
+ENV COMMIT=af83a65f0b6273ef38bf778d400d98892e7653d8
+
+RUN microdnf install go-toolset git -y
+
+WORKDIR /workspace
+RUN git clone https://github.com/summerwind/h2spec.git
+
+WORKDIR /workspace/h2spec
+RUN git checkout ${COMMIT}
+RUN go build -ldflags "-X main.VERSION=${VERSION} -X main.COMMIT=${COMMIT}" ./cmd/h2spec
+
+FROM container-registry.oracle.com/os/oraclelinux:9-slim
+ARG PORT=8080
+ARG HOST=localhost
+ENV PORT=${PORT}
+ENV HOST=${HOST}
+COPY --from=build /workspace/h2spec/h2spec /usr/local/bin/h2spec
+CMD ["/usr/local/bin/h2spec", "-h", "${HOST}", "-p", "${PORT}"]

--- a/tests/integration/h2spec/pom.xml
+++ b/tests/integration/h2spec/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.tests.integration.h2spec</groupId>
+    <artifactId>helidon-tests-integration-h2spec</artifactId>
+    <name>Helidon Tests Integration Http/2 h2spec</name>
+
+    <properties>
+        <mainClass>io.helidon.webserver.h2spec.Main</mainClass>
+        <redirectTestOutputToFile>true</redirectTestOutputToFile>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-http2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--suppress VulnerableLibrariesLocal -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*IT</exclude>
+                    </excludes>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>
+                            ${project.build.outputDirectory}/logging.properties
+                        </java.util.logging.config.file>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>
+                            ${project.build.outputDirectory}/logging.properties
+                        </java.util.logging.config.file>
+                    </systemPropertyVariables>
+                    <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/h2spec/pom.xml
+++ b/tests/integration/h2spec/pom.xml
@@ -23,6 +23,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
         <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration.h2spec</groupId>
     <artifactId>helidon-tests-integration-h2spec</artifactId>

--- a/tests/integration/h2spec/pom.xml
+++ b/tests/integration/h2spec/pom.xml
@@ -23,7 +23,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
         <version>4.2.0-SNAPSHOT</version>
-        <relativePath>../../../../applications/mp/pom.xml</relativePath>
+        <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
     <groupId>io.helidon.tests.integration.h2spec</groupId>
     <artifactId>helidon-tests-integration-h2spec</artifactId>

--- a/tests/integration/h2spec/src/test/java/H2SpecIT.java
+++ b/tests/integration/h2spec/src/test/java/H2SpecIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2Route;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import static io.helidon.http.Method.GET;
+import static io.helidon.http.Method.POST;
+
+@Testcontainers(disabledWithoutDocker = true)
+class H2SpecIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(H2SpecIT.class);
+
+    @ParameterizedTest(name = "{0}: {1}")
+    @MethodSource("runH2Spec")
+    void h2spec(String caseName, String desc, String id, String err, String skipped) {
+        LOGGER.info("{}: \n - {} \nID: {}", caseName, desc, id);
+        if (err != null) {
+            Assertions.fail(err);
+        }
+        if (skipped != null) {
+            Assumptions.abort(skipped);
+        }
+    }
+
+    private static Stream<Arguments> runH2Spec() {
+
+        HttpRouting.Builder router = HttpRouting.builder();
+        router.route(Http2Route.route(GET, "/", (req, res) -> {
+            res.send("Hi Frank!");
+        }));
+
+        router.route(Http2Route.route(POST, "/", (req, res) -> {
+            req.content().consume();
+            res.send("pong");
+        }));
+
+        WebServer server = WebServer.builder()
+                .addProtocol(Http2Config.builder()
+                                     .sendErrorDetails(true)
+                                     // 5.1.2 https://github.com/summerwind/h2spec/issues/136
+                                     .maxConcurrentStreams(10)
+                                     .build())
+                .routing(router)
+                .build();
+
+        int port = server.start().port();
+
+        try (var cont = new GenericContainer<>(
+                new ImageFromDockerfile().withDockerfile(Path.of("./Dockerfile")))
+                .withAccessToHost(true)
+                .withImagePullPolicy(PullPolicy.ageBased(Duration.ofDays(365)))
+                .withLogConsumer(outputFrame -> LOGGER.info(outputFrame.getUtf8StringWithoutLineEnding()))
+                .waitingFor(Wait.forLogMessage(".*Finished in.*", 1))) {
+
+            org.testcontainers.Testcontainers.exposeHostPorts(port);
+            cont.withCommand("/usr/local/bin/h2spec "
+                                     + "-h host.testcontainers.internal "
+                                     + "--junit-report junit-report.xml "
+                                     // h2spec creates dummy test headers x-dummy0 with generated content of length configured by parameter --max-header-length
+                                     // default value is 4000 to fit just under the default protocol max table size(4096) with margin of 96
+                                     // as we are using custom host name 'host.testcontainers.internal' authority header is longer than usual 'localhost'
+                                     // also random port can have more chars than the usual 8080
+                                     + "--max-header-length " + (4000
+                                                - ("host.testcontainers.internal".length() - "localhost".length())
+                                                - (String.valueOf(port).length() - "8080".length()))
+                                     + " -p " + port)
+                    .withStartupAttempts(1)
+                    .start();
+
+            cont.copyFileFromContainer("/junit-report.xml", "./target/h2spec-report.xml");
+            return cont.copyFileFromContainer("/junit-report.xml", H2SpecIT::parseReport);
+        } finally {
+            server.stop();
+        }
+
+    }
+
+    private static Stream<Arguments> parseReport(InputStream is) throws Exception {
+        var a = new ArrayList<Arguments>();
+        var dom = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+        var suitList = dom.getDocumentElement()
+                .getElementsByTagName("testsuite");
+
+        for (int i = 0; i < suitList.getLength(); i++) {
+            var suitEl = (Element) suitList.item(i);
+            var suitName = suitEl.getAttribute("name");
+            var caseList = suitEl.getElementsByTagName("testcase");
+            for (int j = 0; j < caseList.getLength(); j++) {
+                var caseEl = (Element) caseList.item(j);
+                var className = caseEl.getAttribute("classname");
+                var id = caseEl.getAttribute("package");
+                a.add(Arguments.of(suitName,
+                                   className,
+                                   id,
+                                   getChildElValue(caseEl, "error", "failure"),
+                                   getChildElValue(caseEl, "skipped")));
+            }
+        }
+        return a.stream();
+    }
+
+    private static String getChildElValue(Element caseEl, String... nodeNames) {
+        for (int k = 0; k < caseEl.getChildNodes().getLength(); k++) {
+            Node node = caseEl.getChildNodes().item(k);
+            for (var nodeName : nodeNames) {
+                if (nodeName.equals(node.getNodeName())) {
+                    return node.getTextContent();
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -66,6 +66,7 @@
         <module>vault</module>
         <module>zipkin-mp-2.2</module>
         <module>tls-revocation-config</module>
+        <module>h2spec</module>
     </modules>
 
     <dependencyManagement>

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientProtocolConfigBlueprint.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientProtocolConfigBlueprint.java
@@ -89,12 +89,12 @@ interface Http2ClientProtocolConfigBlueprint extends ProtocolConfig {
     int initialWindowSize();
 
     /**
-     * Timeout for blocking between windows size check iterations.
+     * Timeout for blocking while waiting for window update when window is depleted.
      *
      * @return timeout
      */
     @Option.Configured
-    @Option.Default("PT0.1S")
+    @Option.Default("PT15S")
     Duration flowControlBlockTimeout();
 
     /**

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConfigBlueprint.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConfigBlueprint.java
@@ -82,9 +82,8 @@ interface Http2ConfigBlueprint extends ProtocolConfig {
     /**
      * Outbound flow control blocking timeout configured as {@link java.time.Duration}
      * or text in ISO-8601 format.
-     * Blocking timeout defines an interval to wait for the outbound window size changes(incoming window updates)
-     * before the next blocking iteration.
-     * Default value is {@code PT0.1S}.
+     * Blocking timeout defines an interval to wait for the outbound window size changes(incoming window updates).
+     * Default value is {@code PT15S}.
      *
      * <table>
      *     <caption><b>ISO_8601 format examples:</b></caption>
@@ -97,7 +96,7 @@ interface Http2ConfigBlueprint extends ProtocolConfig {
      * @see <a href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO_8601 Durations</a>
      */
     @Option.Configured
-    @Option.Default("PT0.1S")
+    @Option.Default("PT15S")
     Duration flowControlTimeout();
 
     /**

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -610,7 +610,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         int streamId = frameHeader.streamId();
         StreamContext streamContext = stream(streamId);
 
-        streamContext.stream().checkHeadersReceivable();
+        boolean trailers = streamContext.stream().checkHeadersReceivable();
 
         // first frame, expecting continuation
         if (frameHeader.type() == Http2FrameType.HEADERS && !frameHeader.flags(Http2FrameTypes.HEADERS).endOfHeaders()) {
@@ -665,6 +665,18 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         }
 
         receiveFrameListener.headers(ctx, streamId, headers);
+
+
+        if (trailers) {
+            if (!endOfStream) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received trailers without endOfStream flag " + streamId);
+            }
+            stream.closeFromRemote();
+            state = State.READ_FRAME;
+            // Client's trailers are ignored, we don't provide any API to consume them yet
+            return;
+        }
+
         headers.validateRequest();
         String path = headers.path();
         Method method = headers.method();

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -30,7 +30,9 @@ import io.helidon.http.HeaderValues;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.ServerResponseTrailers;
 import io.helidon.http.Status;
+import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Headers;
+import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.ServerResponseBase;
@@ -121,6 +123,8 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             }
 
             afterSend();
+        } catch (Http2Exception e) {
+            throw new CloseConnectionException("Failed writing entity", e);
         } catch (UncheckedIOException e) {
             throw new ServerConnectionException("Failed writing entity", e);
         }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -448,7 +448,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     void write100Continue() {
-        if (WriteState.EXPECTED_100 == writeState.updateAndGet(s -> {
+        if (WriteState.EXPECTED_100 == writeState.getAndUpdate(s -> {
             if (WriteState.EXPECTED_100 == s) {
                 return s.checkAndMove(WriteState.CONTINUE_100_SENT);
             }

--- a/webserver/testing/junit5/http2/src/main/java/io/helidon/webserver/testing/junit5/http2/Http2TestClient.java
+++ b/webserver/testing/junit5/http2/src/main/java/io/helidon/webserver/testing/junit5/http2/Http2TestClient.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.testing.junit5.http2;
+
+import java.net.URI;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Http/2 low-level testing client.
+ */
+public class Http2TestClient implements AutoCloseable {
+
+    private final URI uri;
+    private final ConcurrentLinkedQueue<Http2TestConnection> testConnections = new ConcurrentLinkedQueue<>();
+
+    Http2TestClient(URI uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * Create new low-level http/2 connection.
+     * @return new connection
+     */
+    public Http2TestConnection createConnection() {
+        var testConnection = new Http2TestConnection(uri);
+        testConnections.add(testConnection);
+        return testConnection;
+    }
+
+    @Override
+    public void close() {
+        testConnections.forEach(Http2TestConnection::close);
+    }
+}
+

--- a/webserver/testing/junit5/http2/src/main/java/io/helidon/webserver/testing/junit5/http2/Http2TestConnection.java
+++ b/webserver/testing/junit5/http2/src/main/java/io/helidon/webserver/testing/junit5/http2/Http2TestConnection.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.testing.junit5.http2;
+
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2ConnectionWriter;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2FrameTypes;
+import io.helidon.http.http2.Http2GoAway;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2HuffmanDecoder;
+import io.helidon.http.http2.Http2RstStream;
+import io.helidon.http.http2.Http2Setting;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2Util;
+import io.helidon.http.http2.Http2WindowUpdate;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.ConnectionKey;
+import io.helidon.webclient.api.DefaultDnsResolver;
+import io.helidon.webclient.api.DnsAddressLookup;
+import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.api.TcpClientConnection;
+import io.helidon.webclient.api.WebClient;
+
+import org.hamcrest.Matchers;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Http/2 low-level testing client connection.
+ */
+public class Http2TestConnection implements AutoCloseable {
+
+    private static final System.Logger LOGGER = System.getLogger(Http2TestConnection.class.getName());
+    private static final int FRAME_HEADER_LENGTH = 9;
+
+    private final TcpClientConnection conn;
+    private final Http2ConnectionWriter dataWriter;
+    private final DataReader reader;
+    private final ArrayBlockingQueue<Http2FrameData> readQueue = new ArrayBlockingQueue<>(100);
+    private final Thread readThread;
+    private final ClientUri clientUri;
+    private final Http2Headers.DynamicTable requestDynamicTable =
+            Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+    private final Http2HuffmanDecoder requestHuffman = Http2HuffmanDecoder.create();
+
+    Http2TestConnection(URI uri) {
+        clientUri = ClientUri.create(uri);
+        ConnectionKey connectionKey = new ConnectionKey(clientUri.scheme(),
+                                                        clientUri.host(),
+                                                        clientUri.port(),
+                                                        Duration.ZERO,
+                                                        Tls.builder().enabled(false).build(),
+                                                        DefaultDnsResolver.create(),
+                                                        DnsAddressLookup.defaultLookup(),
+                                                        Proxy.noProxy());
+
+        conn = TcpClientConnection.create(WebClient.builder()
+                                                  .baseUri(clientUri)
+                                                  .build(),
+                                          connectionKey,
+                                          List.of(),
+                                          connection -> false,
+                                          connection -> {
+                                          })
+                .connect();
+
+        conn.writer().writeNow(Http2Util.prefaceData());
+        reader = conn.reader();
+        dataWriter = new Http2ConnectionWriter(conn.helidonSocket(), conn.writer(), List.of());
+        readThread = Thread
+                .ofVirtual()
+                .start(() -> {
+                    try {
+                        for (;;) {
+                            if (Thread.interrupted()) {
+                                return;
+                            }
+                            BufferData frameHeaderBuffer = reader.readBuffer(FRAME_HEADER_LENGTH);
+                            Http2FrameHeader frameHeader = Http2FrameHeader.create(frameHeaderBuffer);
+                            LOGGER.log(DEBUG, () -> "<-- " + frameHeader);
+                            readQueue.add(new Http2FrameData(frameHeader, reader.readBuffer(frameHeader.length())));
+                        }
+                    } catch (DataReader.InsufficientDataAvailableException | UncheckedIOException e) {
+                        // closed connection
+                    }
+                });
+
+        sendSettings(Http2Settings.builder()
+                             .add(Http2Setting.INITIAL_WINDOW_SIZE, 65535L)
+                             .add(Http2Setting.MAX_FRAME_SIZE, 16384L)
+                             .add(Http2Setting.ENABLE_PUSH, false)
+                             .build());
+    }
+
+    /**
+     * Send settings frame.
+     *
+     * @param http2Settings frame to send
+     * @return this connection
+     */
+    public Http2TestConnection sendSettings(Http2Settings http2Settings) {
+        Http2Flag.SettingsFlags flags = Http2Flag.SettingsFlags.create(0);
+        Http2FrameData frameData = http2Settings.toFrameData(null, 0, flags);
+        writer().write(frameData);
+        return this;
+    }
+
+    /**
+     * Return connection writer for direct frame sending.
+     *
+     * @return connection writer
+     */
+    public Http2ConnectionWriter writer() {
+        return dataWriter;
+    }
+
+    /**
+     * Send HTTP request with given stream id with single data frame created from supplied buffer data,
+     * dataframe has end of stream flag.
+     *
+     * @param streamId send request as given stream id
+     * @param method   http method
+     * @param path     context path
+     * @param headers  http headers
+     * @param payload  payload data which has to fit in single frame
+     * @return this connection
+     */
+    public Http2TestConnection request(int streamId, Method method, String path, WritableHeaders<?> headers, BufferData payload) {
+        Http2Headers h2Headers = Http2Headers.create(headers);
+        h2Headers.method(method);
+        h2Headers.path(path);
+        h2Headers.scheme(clientUri().scheme());
+
+        writer().writeHeaders(h2Headers,
+                              streamId,
+                              Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                              FlowControl.Outbound.NOOP);
+
+        Http2FrameData frameDataData =
+                new Http2FrameData(Http2FrameHeader.create(payload.available(),
+                                                           Http2FrameTypes.DATA,
+                                                           Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                           streamId),
+                                   payload);
+        writer().writeData(frameDataData, FlowControl.Outbound.NOOP);
+        return this;
+    }
+
+    /**
+     * Await next frame, blocks until next frame arrive.
+     *
+     * @param timeout timeout for blocking
+     * @return next frame in order of reading from socket
+     */
+    public Http2FrameData awaitNextFrame(Duration timeout) {
+        try {
+            return readQueue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Wait for the next frame and assert its frame type to be RST_STREAM.
+     * @param streamId stream id asserted from retrieved RST_STREAM frame.
+     * @param timeout timeout for blocking
+     * @return the frame
+     */
+    public Http2RstStream assertRstStream(int streamId, Duration timeout) {
+        Http2FrameData frame = assertNextFrame(Http2FrameType.RST_STREAM, timeout);
+        assertThat("Stream ID doesn't match.", frame.header().streamId(), Matchers.equalTo(streamId));
+        return Http2RstStream.create(frame.data());
+    }
+
+    /**
+     * Wait for the next frame and assert its frame type to be SETTINGS.
+     * @param timeout timeout for blocking
+     * @return the frame
+     */
+    public Http2Settings assertSettings(Duration timeout) {
+        Http2FrameData frame = assertNextFrame(Http2FrameType.SETTINGS, timeout);
+        return Http2Settings.create(frame.data());
+    }
+
+    /**
+     * Wait for the next frame and assert its frame type to be WINDOWS_UPDATE.
+     * @param streamId stream id asserted from retrieved WINDOWS_UPDATE frame.
+     * @param timeout timeout for blocking
+     * @return the frame
+     */
+    public Http2WindowUpdate assertWindowsUpdate(int streamId, Duration timeout) {
+        Http2FrameData frame = assertNextFrame(Http2FrameType.WINDOW_UPDATE, timeout);
+        assertThat(frame.header().streamId(), Matchers.equalTo(streamId));
+        return Http2WindowUpdate.create(frame.data());
+    }
+
+    /**
+     * Wait for the next frame and assert its frame type to be HEADERS.
+     * @param streamId stream id asserted from retrieved HEADERS frame.
+     * @param timeout timeout for blocking
+     * @return the frame
+     */
+    public Http2Headers assertHeaders(int streamId, Duration timeout) {
+        Http2FrameData frame = assertNextFrame(Http2FrameType.HEADERS, timeout);
+        assertThat(frame.header().streamId(), Matchers.equalTo(streamId));
+        return Http2Headers.create(null, requestDynamicTable, requestHuffman, frame);
+    }
+
+    /**
+     * Wait for the next frame and assert its frame type.
+     * @param frameType expected type of frame
+     * @param timeout timeout for blocking
+     * @return the frame
+     */
+    public Http2FrameData assertNextFrame(Http2FrameType frameType, Duration timeout) {
+        Http2FrameData frame = awaitNextFrame(timeout);
+        assertThat(frame.header().type(), Matchers.equalTo(frameType));
+        return frame;
+    }
+
+    /**
+     * Wait for the next frame and assert its frame type to be GO_AWAY.
+     * @param errorCode expected error code
+     * @param message expected go away message
+     * @param timeout timeout for blocking
+     * @return the frame
+     */
+    public Http2FrameData assertGoAway(Http2ErrorCode errorCode, String message, Duration timeout) {
+        Http2FrameData frame = assertNextFrame(Http2FrameType.GO_AWAY, timeout);
+
+        Http2GoAway goAway = Http2GoAway.create(frame.data());
+        assertThat(goAway.errorCode(), is(errorCode));
+        assertThat(frame.data().readString(frame.data().available()), is(message));
+        return frame;
+    }
+
+    @Override
+    public void close() {
+        readThread.interrupt();
+        conn.closeResource();
+    }
+
+    /**
+     * Client uri used for connection, derived from Helidon test server.
+     * @return client uri
+     */
+    public ClientUri clientUri() {
+        return clientUri;
+    }
+}

--- a/webserver/tests/http2/pom.xml
+++ b/webserver/tests/http2/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>helidon-webserver-http2</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>
@@ -61,6 +66,11 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5-http2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.RequestException;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.testing.junit5.http2.Http2TestClient;
+import io.helidon.webserver.testing.junit5.http2.Http2TestConnection;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.http.Method.POST;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@ServerTest
+class ContentLengthTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(100);
+    private static CompletableFuture<Exception> consumeExceptionFuture = new CompletableFuture<>();
+    private static CompletableFuture<Exception> sendExceptionFuture = new CompletableFuture<>();
+
+    static {
+        LogConfig.configureRuntime();
+    }
+
+    @SetUpRoute
+    static void router(HttpRouting.Builder router) {
+        router.route(Http2Route.route(POST, "/", (req, res) -> {
+            try {
+                req.content().consume();
+            } catch (Exception e) {
+                consumeExceptionFuture.complete(e);
+            }
+            try {
+                res.send("pong");
+            } catch (Exception e) {
+                sendExceptionFuture.complete(e);
+            }
+        }));
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder server) {
+        server.addProtocol(Http2Config.builder()
+                                   .sendErrorDetails(true)
+                                   .maxConcurrentStreams(5)
+                                   .build());
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        consumeExceptionFuture = new CompletableFuture<>();
+        sendExceptionFuture = new CompletableFuture<>();
+    }
+
+    @Test
+    void shorterData(Http2TestClient client) {
+        Http2TestConnection h2conn = client.createConnection();
+
+        var headers = WritableHeaders.create();
+        headers.add(HeaderNames.CONTENT_LENGTH, 5);
+        h2conn.request(1, POST, "/", headers, BufferData.create("fra"));
+
+        h2conn.assertSettings(TIMEOUT);
+        h2conn.assertWindowsUpdate(0, TIMEOUT);
+        h2conn.assertSettings(TIMEOUT);
+
+        Http2Headers http2Headers = h2conn.assertHeaders(1, TIMEOUT);
+        assertThat(http2Headers.status(), is(Status.OK_200));
+        byte[] responseBytes = h2conn.assertNextFrame(Http2FrameType.DATA, TIMEOUT).data().readBytes();
+        assertThat(new String(responseBytes), is("pong"));
+
+        assertFalse(consumeExceptionFuture.isDone());
+        assertFalse(sendExceptionFuture.isDone());
+    }
+
+    @Test
+    void longerData(Http2TestClient client) throws ExecutionException, InterruptedException, TimeoutException {
+        Http2TestConnection h2conn = client.createConnection();
+
+        assertFalse(consumeExceptionFuture.isDone());
+        assertFalse(sendExceptionFuture.isDone());
+
+        var headers = WritableHeaders.create();
+        headers.add(HeaderNames.CONTENT_LENGTH, 2);
+        h2conn.request(1, POST, "/", headers, BufferData.create("frank"));
+
+        h2conn.assertSettings(TIMEOUT);
+        h2conn.assertWindowsUpdate(0, TIMEOUT);
+        h2conn.assertSettings(TIMEOUT);
+
+        h2conn.assertRstStream(1, TIMEOUT);
+        h2conn.assertGoAway(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                            "Request data length doesn't correspond to the content-length header.",
+                            TIMEOUT);
+
+        // content length discrepancy is discovered when consuming request data
+        var e = consumeExceptionFuture.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        assertThat(e, Matchers.instanceOf(RequestException.class));
+        assertThat(e.getMessage(), is("Stream is closed."));
+
+        // stream is closed, sending is not possible
+        e = sendExceptionFuture.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        assertThat(e, Matchers.instanceOf(IllegalStateException.class));
+        assertThat(e.getMessage(), is("Stream is already closed."));
+    }
+
+    @Test
+    void longerDataSecondStream(Http2TestClient client) throws ExecutionException, InterruptedException, TimeoutException {
+        Http2TestConnection h2conn = client.createConnection();
+
+        // First send payload with proper data length
+        var headers = WritableHeaders.create();
+        headers.add(HeaderNames.CONTENT_LENGTH, 5);
+        h2conn.request(1, POST, "/", headers, BufferData.create("frank"));
+
+        h2conn.assertSettings(TIMEOUT);
+        h2conn.assertWindowsUpdate(0, TIMEOUT);
+        h2conn.assertSettings(TIMEOUT);
+
+        h2conn.assertNextFrame(Http2FrameType.HEADERS, TIMEOUT);
+        h2conn.assertNextFrame(Http2FrameType.DATA, TIMEOUT);
+
+        assertFalse(consumeExceptionFuture.isDone());
+        assertFalse(sendExceptionFuture.isDone());
+
+        // Now send payload larger than advertised data length
+        headers = WritableHeaders.create();
+        headers.add(HeaderNames.CONTENT_LENGTH, 2);
+        h2conn.request(3, POST, "/", headers, BufferData.create("frank"));
+
+        h2conn.assertRstStream(3, TIMEOUT);
+        h2conn.assertGoAway(Http2ErrorCode.ENHANCE_YOUR_CALM,
+                            "Request data length doesn't correspond to the content-length header.",
+                            TIMEOUT);
+
+        // content length discrepancy is discovered when consuming request data
+        var e = consumeExceptionFuture.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        assertThat(e, Matchers.instanceOf(RequestException.class));
+        assertThat(e.getMessage(), is("Stream is closed."));
+
+        // stream is closed, sending is not possible
+        e = sendExceptionFuture.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        assertThat(e, Matchers.instanceOf(IllegalStateException.class));
+        assertThat(e.getMessage(), is("Stream is already closed."));
+    }
+}

--- a/webserver/tests/http2/src/test/resources/logging-test.properties
+++ b/webserver/tests/http2/src/test/resources/logging-test.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,3 +20,7 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
 io.helidon.webserver.level=INFO
+
+#io.helidon.http.http2.level=FINEST
+#io.helidon.http.http2.FlowControl.ifc.level=FINEST
+#io.helidon.http.http2.FlowControl.ofc.level=FINEST


### PR DESCRIPTION
Fixes #9272, #9273 and #9282

- Add h2spec test
- Consuming request trailers
- Larger frame splitting fix
- Flow control update timeout
- Streamed payload larger than content length discovery 