### PR TITLE
Changes dependencies on various Oracle JDBC artifacts from their compiled-with-Java-11 variants to their compiled-with-Java-17 variants

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/custom/database-outputs.xml
+++ b/archetypes/archetypes/src/main/archetype/mp/custom/database-outputs.xml
@@ -364,7 +364,7 @@ For details on an Oracle Docker image, see https://github.com/oracle/docker-imag
                         </map>
                         <map>
                             <value key="groupId">com.oracle.database.jdbc</value>
-                            <value key="artifactId">ucp11</value>
+                            <value key="artifactId">ucp17</value>
                             <value key="scope">runtime</value>
                         </map>
                     </list>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1410,6 +1410,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- The ojdbc-bom as of this writing does not "cover" ojdbc17-production:pom. Add that here temporarily. -->
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc17-production</artifactId>
+                <version>${version.lib.ojdbc}</version>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp11</artifactId>
+            <artifactId>ucp17</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -41,12 +41,12 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11-production</artifactId>
+            <artifactId>ojdbc17-production</artifactId>
             <type>pom</type>
             <exclusions>
                 <exclusion>
                     <groupId>com.oracle.database.jdbc</groupId>
-                    <artifactId>ucp11</artifactId>
+                    <artifactId>ucp17</artifactId>
                 </exclusion>
                 <exclusion>
                     <!-- Contains JAXP impl, so we exclude it to not interfere -->


### PR DESCRIPTION
This PR changes certain Oracle JDBC dependencies from their compiled-with-Java-11 variants to their compiled-with-Java-17 variants. For example, dependencies on `ucp11` are changed to be dependencies on `ucp17`.

The current version of the `ojdbc-bom` does not, because of a mistake, manage the `ojdbc17-production:pom` artifact, so this PR currently includes a stanza in `dependencies/pom.xml` to do this. This stanza should be removed if a new version of the `ojdbc-bom` (and its managed artifacts) is released, and then this PR should be modified to upgrade to that version.