### PR TITLE
Initialize distribution customizations even before config is applied

### DIFF
--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -130,6 +130,7 @@
                                 <exclude>**/TestDisabledMetrics.java</exclude>
                                 <exclude>**/TestSelectivelyDisabledMetrics.java</exclude>
                                 <exclude>**/TestConfigProcessing.java</exclude>
+                                <exclude>**/TestDistributionCustomizationsNoInit.java</exclude>
                             </excludes>
                             <systemPropertyVariables>
                                 <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
@@ -194,6 +195,18 @@
                             <systemPropertyVariables>
                                 <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                             </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Run separately so the normal MP container start-up does not happen. -->
+                        <id>test-dist-cust-with-no-init</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestDistributionCustomizationsNoInit.java</include>
+                            </includes>
                         </configuration>
                     </execution>
                 </executions>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/DistributionCustomizations.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/DistributionCustomizations.java
@@ -62,7 +62,7 @@ class DistributionCustomizations {
     private static final Duration DEFAULT_TIMER_MIN = Duration.ofMillis(5);
     private static final Duration DEFAULT_TIMER_MAX = Duration.ofSeconds(10);
 
-    private static DistributionCustomizations instance;
+    private static DistributionCustomizations instance = new DistributionCustomizations();
     private final List<Percentiles> percentileCustomizations;
     private final List<SummaryBuckets> summaryBucketCustomizations;
     private final List<TimerBuckets> timerBucketCustomizations;
@@ -80,6 +80,13 @@ class DistributionCustomizations {
                                                      "mp.metrics.distribution.percentiles-histogram.enabled",
                                                      expression -> new SingleValuedCustomization<>(expression,
                                                                                                    Boolean::parseBoolean));
+    }
+
+    private DistributionCustomizations() {
+        percentileCustomizations = List.of();
+        summaryBucketCustomizations = List.of();
+        timerBucketCustomizations = List.of();
+        summaryBucketDefaultCustomizations = List.of();
     }
 
     static void init(Config mpConfig) {

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDistributionCustomizationsNoInit.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDistributionCustomizationsNoInit.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Timer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+class TestDistributionCustomizationsNoInit {
+
+    private static MetricRegistry metricRegistry;
+
+    @BeforeAll
+    static void initRegistry() {
+        metricRegistry = RegistryFactory.getInstance().getRegistry(MetricRegistry.APPLICATION_SCOPE);
+    }
+
+    @Test
+    void checkDistributionCustomizations() {
+        // Without the change, the following triggers an NPE because this test does not use @HelidonTest
+        // and therefore the normal metrics CDI extension initialization code --which sets up the distribution
+        // customizations -- does not run.
+        Timer timer = metricRegistry.timer("testTimer");
+        assertThat("Timer", timer, notNullValue());
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDistributionCustomizationsNoInit.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDistributionCustomizationsNoInit.java
@@ -34,9 +34,10 @@ class TestDistributionCustomizationsNoInit {
 
     @Test
     void checkDistributionCustomizations() {
-        // Without the change, the following triggers an NPE because this test does not use @HelidonTest
-        // and therefore the normal metrics CDI extension initialization code --which sets up the distribution
-        // customizations -- does not run.
+        // Without the change in the main source, the following triggers an NPE because this test does not use @HelidonTest
+        // and therefore the normal metrics CDI extension initialization code--which sets up the distribution
+        // customizations--does not run. That means the configurable distribution customizations are never set, leading
+        // to the NPE.
         Timer timer = metricRegistry.timer("testTimer");
         assertThat("Timer", timer, notNullValue());
     }


### PR DESCRIPTION
### Description
Resolves #9546 

We added a new data structure, `DistributionCustomizations`, in Helidon 4.1.4 to support an enhancement in MP metrics 5.1 to allow configuration of percentiles, buckets, etc.

Under normal conditions, the Helidon MP metrics CDI extension invokes this type's `init` method with an MP config object to prepare the various customizations and all is well.

A user wrote a test that used MP metrics (a timer specifically) but did not mark the test with `@HelidonTest` so the initialization described above did not occur. That caused an NPE.

We have also since had a report of this happening in an app, in which a CDI extension attempts to register a timer _before_ the metrics CDI extension has prepared metrics properly. As with the test use case above, this means metrics tries to use the `instance` field before it has been set. 

This PR modifies the `DistributionCustomizations` class to initialize the static (non-final) `instance` variable at load-time without using config. This resolves the problem the user encountered with the test. 

Subsequently the metrics CDI extension overwrites that initial value with one derived from configuration.

### Documentation
No impact.