### PR TITLE
Add telemetry filter helper feature so developer code can influence automatic span creation

### DIFF
--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryClientFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryClientFilter.java
@@ -17,8 +17,12 @@ package io.helidon.microprofile.telemetry;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.Set;
 
+import io.helidon.common.HelidonServiceLoader;
+import io.helidon.common.LazyValue;
+import io.helidon.microprofile.telemetry.spi.HelidonTelemetryClientFilterHelper;
 import io.helidon.tracing.HeaderConsumer;
 import io.helidon.tracing.HeaderProvider;
 import io.helidon.tracing.Scope;
@@ -55,6 +59,11 @@ class HelidonTelemetryClientFilter implements ClientRequestFilter, ClientRespons
             Response.Status.Family.CLIENT_ERROR,
             Response.Status.Family.SERVER_ERROR);
 
+    private static final LazyValue<List<HelidonTelemetryClientFilterHelper>> HELPERS = LazyValue.create(
+            HelidonTelemetryClientFilter::helpers);
+
+    private static final String HELPER_START_SPAN_PROPERTY = HelidonTelemetryClientFilterHelper.class.getName() + ".startSpan";
+
     private final io.helidon.tracing.Tracer helidonTracer;
 
     @Inject
@@ -65,6 +74,16 @@ class HelidonTelemetryClientFilter implements ClientRequestFilter, ClientRespons
 
     @Override
     public void filter(ClientRequestContext clientRequestContext) {
+
+        boolean startSpan = HELPERS.get().stream().allMatch(h -> h.shouldStartSpan(clientRequestContext));
+        clientRequestContext.setProperty(HELPER_START_SPAN_PROPERTY, startSpan);
+        if (!startSpan) {
+            if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+                LOGGER.log(System.Logger.Level.TRACE,
+                           "Client filter helper(s) voted to not start a span for " + clientRequestContext.getUri());
+            }
+            return;
+        }
 
         if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
             LOGGER.log(System.Logger.Level.TRACE, "Starting Span in a Client Request");
@@ -103,6 +122,11 @@ class HelidonTelemetryClientFilter implements ClientRequestFilter, ClientRespons
     @Override
     public void filter(ClientRequestContext clientRequestContext, ClientResponseContext clientResponseContext) {
 
+        Boolean startSpanObj = (Boolean) clientRequestContext.getProperty(HELPER_START_SPAN_PROPERTY);
+        if (startSpanObj != null && !startSpanObj) {
+            return;
+        }
+
         if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
             LOGGER.log(System.Logger.Level.TRACE, "Closing Span in a Client Response");
         }
@@ -126,6 +150,10 @@ class HelidonTelemetryClientFilter implements ClientRequestFilter, ClientRespons
 
         clientRequestContext.removeProperty(SPAN);
         clientRequestContext.removeProperty(SPAN_SCOPE);
+    }
+
+    private static List<HelidonTelemetryClientFilterHelper> helpers() {
+        return HelidonServiceLoader.create(ServiceLoader.load(HelidonTelemetryClientFilterHelper.class)).asList();
     }
 
     private static class RequestContextHeaderInjector implements HeaderConsumer {

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/spi/HelidonTelemetryClientFilterHelper.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/spi/HelidonTelemetryClientFilterHelper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry.spi;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+
+/**
+ * Service-loaded type applied while the Helidon-provided client filter executes.
+ */
+public interface HelidonTelemetryClientFilterHelper {
+
+    /**
+     * Invoked to see if this helper votes to create and start a new span for the outgoing client request reflected
+     * in the provided client request context.
+     *
+     * @param clientRequestContext the {@link jakarta.ws.rs.client.ClientRequestContext} passed to the filter
+     * @return true to vote to start a span; false to vote not to start a span
+     */
+    boolean shouldStartSpan(ClientRequestContext clientRequestContext);
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/spi/HelidonTelemetryContainerFilterHelper.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/spi/HelidonTelemetryContainerFilterHelper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry.spi;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+
+/**
+ * Service-loaded type applied while the Helidon-provided container filter executes.
+ */
+public interface HelidonTelemetryContainerFilterHelper {
+
+    /**
+     * Invoked to see if this helper votes to create and start a new span for the incoming
+     * request reflected in the provided container request context.
+     *
+     * @param containerRequestContext the {@link jakarta.ws.rs.container.ContainerRequestContext} passed to the filter
+     * @return true to vote to start a span; false to vote not to start a span
+     */
+    boolean shouldStartSpan(ContainerRequestContext containerRequestContext);
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/spi/package-info.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/spi/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * SPI interfaces open to developer implementation as needed.
+ */
+package io.helidon.microprofile.telemetry.spi;

--- a/microprofile/telemetry/src/main/java/module-info.java
+++ b/microprofile/telemetry/src/main/java/module-info.java
@@ -17,8 +17,6 @@
 import io.helidon.common.features.api.Feature;
 import io.helidon.common.features.api.HelidonFlavor;
 import io.helidon.common.features.api.Preview;
-import io.helidon.microprofile.telemetry.TelemetryAutoDiscoverable;
-import io.helidon.microprofile.telemetry.TelemetryCdiExtension;
 
 /**
  * MicroProfile Telemetry support for Helidon.
@@ -57,11 +55,15 @@ module io.helidon.microprofile.telemetry {
     requires transitive jersey.common;
 
     exports io.helidon.microprofile.telemetry;
+    exports io.helidon.microprofile.telemetry.spi;
+
+    uses io.helidon.microprofile.telemetry.spi.HelidonTelemetryClientFilterHelper;
+    uses io.helidon.microprofile.telemetry.spi.HelidonTelemetryContainerFilterHelper;
 
     provides jakarta.enterprise.inject.spi.Extension
-            with TelemetryCdiExtension;
+            with io.helidon.microprofile.telemetry.TelemetryCdiExtension;
 
     provides org.glassfish.jersey.internal.spi.AutoDiscoverable
-            with TelemetryAutoDiscoverable;
+            with io.helidon.microprofile.telemetry.TelemetryAutoDiscoverable;
 
 }

--- a/tests/integration/mp-telemetry/pom.xml
+++ b/tests/integration/mp-telemetry/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../../../applications/mp/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.tests.integration</groupId>
+    <artifactId>helidon-tests-integration-mp-telemetry</artifactId>
+    <name>Helidon Tests Integration MP Telemetry</name>
+
+    <properties>
+        <!-- The default for the following is 5000 ms. Reducing it speeds up tests significantly. -->
+        <otel.bsp.schedule.delay>100</otel.bsp.schedule.delay>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.telemetry</groupId>
+            <artifactId>helidon-microprofile-telemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <otel.bsp.schedule.delay>${otel.bsp.schedule.delay}</otel.bsp.schedule.delay>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+    </build>
+</project>

--- a/tests/integration/mp-telemetry/src/main/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/FilterSelectorSuppressPersonalizedGreetingSpan.java
+++ b/tests/integration/mp-telemetry/src/main/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/FilterSelectorSuppressPersonalizedGreetingSpan.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.telemetry.mp.filterselectivity;
+
+import io.helidon.microprofile.telemetry.spi.HelidonTelemetryContainerFilterHelper;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+
+public class FilterSelectorSuppressPersonalizedGreetingSpan implements HelidonTelemetryContainerFilterHelper {
+
+    @Override
+    public boolean shouldStartSpan(ContainerRequestContext containerRequestContext) {
+        // Suppress spans for the personalized greeting endpoint.
+        return containerRequestContext.getUriInfo().getPath().endsWith("greet");
+    }
+}

--- a/tests/integration/mp-telemetry/src/main/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/GreetResource.java
+++ b/tests/integration/mp-telemetry/src/main/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/GreetResource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.telemetry.mp.filterselectivity;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/greet")
+public class GreetResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getDefaultMessage() {
+        return createResponse("World");
+    }
+
+    @Path("/{name}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getMessage(@PathParam("name") String name) {
+        return createResponse(name);
+    }
+
+    private static String createResponse(String who) {
+        return "Hello " + who + "!";
+    }
+}

--- a/tests/integration/mp-telemetry/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-telemetry/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/mp-telemetry/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/mp-telemetry/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Microprofile server properties
+server.port=8080
+server.host=0.0.0.0
+

--- a/tests/integration/mp-telemetry/src/main/resources/META-INF/services/io.helidon.microprofile.telemetry.spi.HelidonTelemetryContainerFilterHelper
+++ b/tests/integration/mp-telemetry/src/main/resources/META-INF/services/io.helidon.microprofile.telemetry.spi.HelidonTelemetryContainerFilterHelper
@@ -1,0 +1,1 @@
+io.helidon.tests.integration.telemetry.mp.filterselectivity.FilterSelectorSuppressPersonalizedGreetingSpan

--- a/tests/integration/mp-telemetry/src/test/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/TestSpanExporter.java
+++ b/tests/integration/mp-telemetry/src/test/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/TestSpanExporter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.telemetry.mp.filterselectivity;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.helidon.common.testing.junit5.MatcherWithRetry;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import static org.hamcrest.Matchers.iterableWithSize;
+
+// Partially inspired by the MP Telemetry TCK InMemorySpanExporter.
+@ApplicationScoped
+public class TestSpanExporter implements SpanExporter {
+
+    private final List<SpanData> spanData = new CopyOnWriteArrayList<>();
+    private final System.Logger LOGGER = System.getLogger(TestSpanExporter.class.getName());
+
+    private final int RETRY_COUNT = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryCount", 120);
+    private final int RETRY_DELAY_MS = Integer.getInteger(TestSpanExporter.class.getName() + ".test.retryDelayMs", 500);
+
+
+    private enum State {READY, STOPPED}
+
+    private State state = State.READY;
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> collection) {
+        if (state == State.STOPPED) {
+            return CompletableResultCode.ofFailure();
+        }
+        spanData.addAll(collection);
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        state = State.STOPPED;
+        spanData.clear();
+        return CompletableResultCode.ofSuccess();
+    }
+
+    List<SpanData> spanData(int expectedCount) {
+        long startTime = 0;
+        if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+            startTime = System.currentTimeMillis();
+        }
+        var result = MatcherWithRetry.assertThatWithRetry("Expected span count",
+                                             () -> new ArrayList<>(spanData),
+                                             iterableWithSize(expectedCount),
+                                             RETRY_COUNT,
+                                             RETRY_DELAY_MS);
+        if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+            LOGGER.log(System.Logger.Level.DEBUG, "spanData waited "
+                    + (System.currentTimeMillis() - startTime)
+                    + " ms for expected spans to arrive.");
+        }
+        return result;
+    }
+
+    List<SpanData> spanData(Duration delay) throws InterruptedException {
+        Thread.sleep(delay);
+        return new ArrayList<>(spanData);
+    }
+
+    void clear() {
+        spanData.clear();
+    }
+}

--- a/tests/integration/mp-telemetry/src/test/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/TestSpanExporterProvider.java
+++ b/tests/integration/mp-telemetry/src/test/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/TestSpanExporterProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.telemetry.mp.filterselectivity;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import jakarta.enterprise.inject.spi.CDI;
+
+public class TestSpanExporterProvider implements ConfigurableSpanExporterProvider {
+
+    public TestSpanExporterProvider() {
+        System.err.println("provider ctor");
+    }
+
+    @Override
+    public SpanExporter createExporter(ConfigProperties configProperties) {
+        return CDI.current().select(TestSpanExporter.class).get();
+    }
+
+    @Override
+    public String getName() {
+        return "in-memory";
+    }
+}

--- a/tests/integration/mp-telemetry/src/test/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/TestSpanSelectivity.java
+++ b/tests/integration/mp-telemetry/src/test/java/io/helidon/tests/integration/telemetry/mp/filterselectivity/TestSpanSelectivity.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.telemetry.mp.filterselectivity;
+
+import java.time.Duration;
+import java.util.List;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.AddConfigBlock;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddBean(TestSpanExporter.class)
+@AddConfig(key = "otel.sdk.disabled", value = "false")
+@AddConfig(key = "otel.traces.exporter", value = "in-memory")
+
+class TestSpanSelectivity {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Inject
+    private TestSpanExporter testSpanExporter;
+
+    @BeforeEach
+    void clearSpanData() {
+        testSpanExporter.clear();
+    }
+
+    @Test
+    void checkSpansForDefaultGreeting() {
+        Response response = webTarget.path("/greet").request(MediaType.TEXT_PLAIN).get();
+        assertThat("Request status", response.getStatus(), is(200));
+
+        List<SpanData> spanData = testSpanExporter.spanData(2); // Automatic GET span plus the resource span
+        assertThat("Span data", spanData, hasSize(2));
+    }
+
+    @Test
+    void checkSpansForPersonalizedGreeting() throws InterruptedException {
+        Response response = webTarget.path("/greet/Joe").request(MediaType.TEXT_PLAIN).get();
+        assertThat("Request status", response.getStatus(), is(200));
+
+        List<SpanData> spanData = testSpanExporter.spanData(Duration.ofSeconds(2));
+        assertThat("Span data", spanData, hasSize(1));
+    }
+}

--- a/tests/integration/mp-telemetry/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/tests/integration/mp-telemetry/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.tests.integration.telemetry.mp.filterselectivity.TestSpanExporterProvider

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -67,6 +67,7 @@
         <module>zipkin-mp-2.2</module>
         <module>tls-revocation-config</module>
         <module>h2spec</module>
+        <module>mp-telemetry</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description
Resolves #9550 

Helidon provides container and client filters which always add spans to the incoming and outgoing calls (respectively).

As described in the related issue, sometimes developers want to be able to suppress the automatic creation of the spans by the filters.

This PR adds two new helper SPI interfaces, one for container filters and one for client filters. The new interfaces expose a single method which accepts the corresponding request context (container or client) and returns a `boolean` whether that helper votes to create the automatic span or not.

The container and client filters now check with all known helpers to find out whether to create the automatic span or not. As written, if at least one helper votes "no" then the span is _not_ created.

### Documentation
Doc page update will be in a later commit to this PR.