### PR TITLE
4.1.5: Fully initialize OpenTelemetry items during start-up 

### DIFF
--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryCdiExtension.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryCdiExtension.java
@@ -15,13 +15,19 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import io.helidon.tracing.Tracer;
+
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
 import jakarta.enterprise.inject.spi.WithAnnotations;
 import jakarta.enterprise.inject.spi.configurator.AnnotatedMethodConfigurator;
+import jakarta.interceptor.Interceptor;
 
 /**
  * CDI extension for Microprofile Telemetry implementation.
@@ -61,5 +67,14 @@ public class TelemetryCdiExtension implements Extension {
                 method.add(HelidonWithSpan.Literal.INSTANCE);
             }
         }
+    }
+
+    void finish(@Observes @Priority(Interceptor.Priority.LIBRARY_BEFORE) @Initialized(ApplicationScoped.class) Object startup,
+                Tracer tracer) {
+        // Forcing CDI to get us a tracer and then invoking one of the bean's methods triggers the producer to do its
+        // initialization, including setting the global tracer as part of start up.
+        tracer.enabled();
+        LOGGER.log(System.Logger.Level.TRACE,
+                   () -> "Global tracer set to " + tracer.unwrap(io.opentelemetry.api.trace.Tracer.class));
     }
 }

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestExtension.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestExtension.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.tracing.Tracer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.Extension;
+
+public class TestExtension implements Extension {
+
+    static Tracer globalTracerAtStartup;
+
+    void startup(@Observes @Initialized(ApplicationScoped.class) Object startup) {
+        globalTracerAtStartup = Tracer.global();
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestTracerAtStartup.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestTracerAtStartup.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@HelidonTest
+@AddConfig(key = "otel.sdk.disabled", value = "false")
+class TestTracerAtStartup {
+
+    @Test
+    void checkForFullFeaturedTracerAtStartup() {
+        assertThat("Global tracer from start-up extension",
+                   TestExtension.globalTracerAtStartup.unwrap(io.opentelemetry.api.trace.Tracer.class).getClass().getName(),
+                   not(containsString("Default")));
+    }
+}

--- a/microprofile/telemetry/src/test/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/microprofile/telemetry/src/test/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+io.helidon.microprofile.telemetry.TestExtension


### PR DESCRIPTION
Backport #9489 to Helidon 4.1.5

### Description
Resolves #9488 

The `helidon-microprofile-telemetry` component includes CDI producer methods for OpenTelemetry tracing types and the Helidon tracing counterparts backed by our OTel implementation.

Helidon provides these producer methods on an app-scoped bean. This works fine in a pure CDI world; the first time CDI needs to produce a tracer (for example), it prepares the `OpenTelemetryProducer` app-scoped bean which contains the producer methods. Part of that bean's post-construct code assigns the newly-created OTel tracer as the Helidon global tracer and subsequent retrievals of the global tracer return the correct, fully-featured tracer.

A problem can arise if user code accesses the global tracer _before_ CDI has had to prepare the producer. In that case the code that accesses the global tracer triggers the creation of the default, no-op OTel tracer and assigns that to the global tracer.

This PR adds an observer method to the existing Helidon OTel telemetry CDI extension which forces CDI to create the producer bean during start-up. This ensures that the global tracer is set correctly before any user code gains control and potentially accesses the global tracer.

The PR also includes a test which reproduced the problem and ensures that the global tracer is set correctly as part of start-up, before user code gains control.

### Documentation
No impact.