### PR TITLE
Add new `helidon-microprofile-rest-client-metrics` component to all/pom.xml

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -560,6 +560,10 @@
             <artifactId>helidon-microprofile-rest-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.microprofile.rest-client-metrics</groupId>
+            <artifactId>helidon-microprofile-rest-client-metrics</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.microprofile.reactive-streams</groupId>
             <artifactId>helidon-microprofile-reactive-streams</artifactId>
         </dependency>


### PR DESCRIPTION
### Description
Follow-up to PR #9534 for issue #6057 

The PR added a new component but I forgot to add it to `all/pom.xml`. This PR does that.

### Documentation
No impact.