### PR TITLE
4.1.5: Removes repeated warning when method name cannot be determined from annotation

### DIFF
--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AbstractServiceBuilder.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AbstractServiceBuilder.java
@@ -224,7 +224,7 @@ public abstract class AbstractServiceBuilder {
             Object value = m.invoke(annotation);
             return value instanceof String s ? s : null;
         } catch (NoSuchMethodException e) {
-            LOGGER.log(Level.WARNING, () -> String.format("Annotation %s has no name() method", annotation));
+            // falls through
         } catch (IllegalAccessException | InvocationTargetException e) {
             LOGGER.log(Level.WARNING, () -> String.format("Error calling name() method on annotation %s", annotation), e);
         }


### PR DESCRIPTION
Backport #9529 to Helidon 4.1.5

### Description

Removes repeated warning when method name cannot be determined from annotation. Issue #9508.

### Documentation

None