### PR TITLE
4.1.5: Upgrade kafka-clients to 3.8.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -95,7 +95,7 @@
         <version.lib.jersey>3.1.9</version.lib.jersey>
         <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>
-        <version.lib.kafka>3.6.2</version.lib.kafka>
+        <version.lib.kafka>3.8.1</version.lib.kafka>
         <version.lib.log4j>2.21.1</version.lib.log4j>
         <version.lib.logback>1.4.14</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>


### PR DESCRIPTION
Backport #9527 to Helidon 4.1.5

### Description

4.x: Upgrade kafka-clients to 3.8.1
