### PR TITLE
4.1.5: Upgrade ASM and Byte Buddy for Java 24 support (#9571)

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -58,7 +58,7 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate-enhance}</version>
-                    <!-- Force upgrade for Java 22 support. Should remove after Hibernate upgrade -->
+                    <!-- Force upgrade for latest Java support. -->
                     <dependencies>
                         <dependency>
                             <groupId>net.bytebuddy</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -40,7 +40,7 @@
         <version.lib.animal-sniffer>1.18</version.lib.animal-sniffer>
         <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
-        <version.lib.bytebuddy>1.14.18</version.lib.bytebuddy>
+        <version.lib.bytebuddy>1.15.10</version.lib.bytebuddy>
         <version.lib.commons-codec>1.16.0</version.lib.commons-codec>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.2.1</version.lib.cron-utils>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.arquillian>1.7.0.Final</version.lib.arquillian>
-        <version.lib.asm>9.7</version.lib.asm>
+        <version.lib.asm>9.7.1</version.lib.asm>
         <version.lib.checkstyle>10.12.5</version.lib.checkstyle>
         <version.lib.commons-io>2.11.0</version.lib.commons-io>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
@@ -703,7 +703,7 @@
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
                     <version>${version.plugin.hibernate-enhance}</version>
-                    <!-- Force upgrade for Java 22 support. Should remove after Hibernate upgrade -->
+                    <!-- Force upgrade for latest Java support -->
                     <dependencies>
                         <dependency>
                             <groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
Backport #9571 to Helidon 4.1.5

### Description

Upgrades ASM to 9.7.1
Upgrades Byte Buddy to 1.15.10

### Documentation

No impact
