### PR TITLE
4.1.5: Upgrades ojdbc to the latest version of 23 as of this writing

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/custom/database-outputs.xml
+++ b/archetypes/archetypes/src/main/archetype/mp/custom/database-outputs.xml
@@ -364,7 +364,7 @@ For details on an Oracle Docker image, see https://github.com/oracle/docker-imag
                         </map>
                         <map>
                             <value key="groupId">com.oracle.database.jdbc</value>
-                            <value key="artifactId">ucp</value>
+                            <value key="artifactId">ucp11</value>
                             <value key="scope">runtime</value>
                         </map>
                     </list>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -128,12 +128,8 @@
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.115.Final</version.lib.netty>
         <version.lib.oci>3.46.1</version.lib.oci>
-        <version.lib.ojdbc.family>21</version.lib.ojdbc.family>
-        <!--
-            UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.
-            This appears to be fixed in 21.15.0.0
-        -->
-        <version.lib.ojdbc>${version.lib.ojdbc.family}.15.0.0</version.lib.ojdbc>
+        <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
+        <version.lib.ojdbc>${version.lib.ojdbc.family}.6.0.24.10</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
         <version.lib.okio>3.4.0</version.lib.okio>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp</artifactId>
+            <artifactId>ucp11</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
+++ b/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
@@ -104,7 +104,6 @@ class TestDataSourceAcquisition {
     }
 
     private void configure(@Observes @Named("test") final PoolDataSource pds) throws SQLException {
-        assertThat(pds.getServiceName(), is("fred"));
         assertThat(pds.getDescription(), nullValue());
         assertThat(pds.getClass().isSynthetic(), is(false));
         pds.setDescription("A test datasource");

--- a/integrations/cdi/datasource-ucp/src/test/resources/application.yaml
+++ b/integrations/cdi/datasource-ucp/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ oracle:
           connectionFactoryClassName: org.h2.jdbcx.JdbcDataSource
           password: "${EMPTY}"
           user: sa
-          serviceName: fred
       PoolXADataSource:
         testxa:
           URL: jdbc:h2:mem:test

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -46,7 +46,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>com.oracle.database.jdbc</groupId>
-                    <artifactId>ucp</artifactId>
+                    <artifactId>ucp11</artifactId>
                 </exclusion>
                 <exclusion>
                     <!-- Contains JAXP impl, so we exclude it to not interfere -->

--- a/jersey/server/src/main/resources/META-INF/native-image/io.helidon.jersey/helidon-jersey-server/reflect-config.json
+++ b/jersey/server/src/main/resources/META-INF/native-image/io.helidon.jersey/helidon-jersey-server/reflect-config.json
@@ -1,0 +1,58 @@
+[
+    {
+        "name": "java.lang.Boolean",
+        "methods": [
+            { "name": "<init>", "parameterTypes": [ "java.lang.String" ] },
+            { "name": "valueOf", "parameterTypes": [ "java.lang.String" ] }
+        ]
+    },
+    {
+        "name": "java.lang.Byte",
+        "methods": [
+            { "name": "<init>", "parameterTypes": [ "java.lang.String" ] },
+            { "name": "valueOf", "parameterTypes": [ "java.lang.String" ] }
+        ]
+    },
+    {
+        "name": "java.lang.Double",
+        "methods": [
+            { "name": "<init>", "parameterTypes": [ "java.lang.String" ] },
+            { "name": "valueOf", "parameterTypes": [ "java.lang.String" ] }
+        ]
+    },
+    {
+        "name": "java.lang.Float",
+        "methods": [
+            { "name": "<init>", "parameterTypes": [ "java.lang.String" ] },
+            { "name": "valueOf", "parameterTypes": [ "java.lang.String" ] }
+        ]
+    },
+    {
+        "name": "java.lang.Integer",
+        "methods": [
+            { "name": "<init>", "parameterTypes": [ "java.lang.String" ] },
+            { "name": "valueOf", "parameterTypes": [ "java.lang.String" ] }
+        ]
+    },
+    {
+        "name": "java.lang.Long",
+        "methods": [
+            { "name": "<init>", "parameterTypes": [ "java.lang.String" ] },
+            { "name": "valueOf", "parameterTypes": [ "java.lang.String" ] }
+        ]
+    },
+    {
+        "name": "java.lang.Short",
+        "methods": [
+            { "name": "<init>", "parameterTypes": [ "java.lang.String" ] },
+            { "name": "valueOf", "parameterTypes": [ "java.lang.String" ] }
+        ]
+    },
+    {
+        "name": "java.lang.String",
+        "methods": [
+            { "name": "<init>", "parameterTypes": [ "java.lang.String" ] },
+            { "name": "valueOf", "parameterTypes": [ "java.lang.Object" ] }
+        ]
+    }
+]

--- a/messaging/connectors/aq/pom.xml
+++ b/messaging/connectors/aq/pom.xml
@@ -66,10 +66,6 @@
             <artifactId>ojdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>

--- a/tests/integration/packaging/mp-2/pom.xml
+++ b/tests/integration/packaging/mp-2/pom.xml
@@ -30,6 +30,9 @@
     <name>Helidon Tests Integration Packaging MP2</name>
 
     <properties>
+        <angus.activation.native-image.trace>false</angus.activation.native-image.trace>
+        <helidon.native.reflection.trace>false</helidon.native.reflection.trace>
+        <helidon.native.reflection.trace-parsing>false</helidon.native.reflection.trace-parsing>
         <mainClass>io.helidon.tests.integration.packaging.mp2.Mp2Main</mainClass>
         <redirectTestOutputToFile>true</redirectTestOutputToFile>
     </properties>
@@ -145,6 +148,11 @@
                         <id>build-native-image</id>
                         <configuration>
                             <quickBuild>true</quickBuild>
+                            <systemProperties>
+                                <angus.activation.native-image.trace>${angus.activation.native-image.trace}</angus.activation.native-image.trace>
+                                <helidon.native.reflection.trace>${helidon.native.reflection.trace}</helidon.native.reflection.trace>
+                                <helidon.native.reflection.trace-parsing>${helidon.native.reflection.trace-parsing}</helidon.native.reflection.trace-parsing>
+                            </systemProperties>
                         </configuration>
                     </execution>
                 </executions>

--- a/tests/integration/packaging/mp-2/src/main/resources/META-INF/native-image/io.helidon.tests.integration.packaging/helidon-tests-integration-packaging-mp2/native-image.properties
+++ b/tests/integration/packaging/mp-2/src/main/resources/META-INF/native-image/io.helidon.tests.integration.packaging/helidon-tests-integration-packaging-mp2/native-image.properties
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
-Args=--initialize-at-build-time=io.helidon.tests.integration.packaging.mp2
+Args=--initialize-at-build-time=io.helidon.tests.integration.packaging.mp2 \
+    --enable-url-protocols=http

--- a/tests/integration/packaging/mp-3/pom.xml
+++ b/tests/integration/packaging/mp-3/pom.xml
@@ -34,6 +34,9 @@
     </description>
 
     <properties>
+        <angus.activation.native-image.trace>false</angus.activation.native-image.trace>
+        <helidon.native.reflection.trace>false</helidon.native.reflection.trace>
+        <helidon.native.reflection.trace-parsing>false</helidon.native.reflection.trace-parsing>
         <mainClass>io.helidon.tests.integration.packaging.mp3.Mp3Main</mainClass>
         <redirectTestOutputToFile>true</redirectTestOutputToFile>
     </properties>
@@ -83,6 +86,11 @@
                 <artifactId>native-maven-plugin</artifactId>
                 <configuration>
                     <quickBuild>true</quickBuild>
+                    <systemProperties>
+                        <angus.activation.native-image.trace>${angus.activation.native-image.trace}</angus.activation.native-image.trace>
+                        <helidon.native.reflection.trace>${helidon.native.reflection.trace}</helidon.native.reflection.trace>
+                        <helidon.native.reflection.trace-parsing>${helidon.native.reflection.trace-parsing}</helidon.native.reflection.trace-parsing>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Backport #9441 to Helidon 4.1.5

See also: #9351. 

This PR updates Helidon's usage of the [various `ojdbc` and `ucp*` artifacts](https://search.maven.org/search?q=g:com.oracle.database.jdbc) to the latest version available from the 23 line.

Due to internal changes in the Universal Connection Pool, formerly Helidon-provided special-case support is being removed for the following properties:
* `serviceName`: Per the UCP team's instructions, the customer should use [`UCPConnectionBuilder::serviceName`](https://javadoc.io/static/com.oracle.database.jdbc/ucp/23.5.0.24.07/oracle/ucp/jdbc/UCPConnectionBuilder.html#serviceName-java.lang.String-) instead while acquiring `Connection`s
* `pdbRoles`: Per the UCP team's instructions, the customer should use [`UCPConnectionBuilder::pdbRoles`](https://javadoc.io/static/com.oracle.database.jdbc/ucp/23.5.0.24.07/oracle/ucp/jdbc/UCPConnectionBuilder.html#pdbRoles-java.util.Properties-) instead while acquiring `Connection`s
* `tnsServiceName`: There was special support for ignoring this property in prior versions of Helidon; that support is removed

It is unclear whether Helidon's special-case support for these properties was actually being used. For `serviceName` and `pdbRoles`, setting these properties would only have effect when the Universal Connection Pool's associated "connection factory" (the "real" `DataSource`, usually supplied by a database vendor) also has an equivalently-named property. Moreover, the semantics of `serviceName` appear to be valid only when the connection factory is supplied by Oracle. All other former usages of this property would have essentially no effect.