### PR TITLE
4.1.5: Enables support to turn on/off proxy protocol in config

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -366,6 +366,7 @@ interface ListenerConfigBlueprint {
      *
      * @return proxy support status
      */
+    @Option.Configured
     @Option.Default("false")
     boolean enableProxyProtocol();
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ListenerConfigTest.java
@@ -57,4 +57,24 @@ public class ListenerConfigTest {
         assertThat(listenerConfig.shutdownGracePeriod().toMillis(), is(2000L));
     }
 
+    @Test
+    void testEnableProxyProtocolConfig() {
+        Config config = Config.create();
+
+        // default is false in default socket
+        var webServerConfig = WebServer.builder().config(config.get("server")).buildPrototype();
+        assertThat(webServerConfig.enableProxyProtocol(), is(false));
+        ListenerConfig otherConfig = webServerConfig.sockets().get("other");
+        assertThat(otherConfig.enableProxyProtocol(), is(false));
+
+        // set to true in default socket
+        var webServerConfig2 = WebServer.builder().config(config.get("server2")).buildPrototype();
+        assertThat(webServerConfig2.enableProxyProtocol(), is(true));
+
+        // set to true in non-default socket
+        var webServerConfig3 = WebServer.builder().config(config.get("server3")).buildPrototype();
+        assertThat(webServerConfig3.enableProxyProtocol(), is(false));
+        ListenerConfig graceConfig = webServerConfig3.sockets().get("grace");
+        assertThat(graceConfig.enableProxyProtocol(), is(true));
+    }
 }

--- a/webserver/webserver/src/test/resources/application.yaml
+++ b/webserver/webserver/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ server2:
   port: 8079
   host: 127.0.0.1
   shutdown-grace-period: PT1S
+  enable-proxy-protocol: true
 
   connection-providers-discover-services: false
   media-context:
@@ -57,6 +58,7 @@ server3:
   sockets:
     - name: "grace"
       shutdown-grace-period: PT2S
+      enable-proxy-protocol: true
 
 inject:
   permits-dynamic: true


### PR DESCRIPTION

Backport #9577 to Helidon 4.1.5

### Description
Enables support to turn on/off proxy protocol in config. Issue #9576.

### Documentation
Documentation is correct.
