### PR TITLE
4.x: Remove unused method NativeUtil.findResources

### DIFF
--- a/integrations/graal/native-image-extension/src/main/java/io/helidon/integrations/graal/nativeimage/extension/NativeUtil.java
+++ b/integrations/graal/native-image-extension/src/main/java/io/helidon/integrations/graal/nativeimage/extension/NativeUtil.java
@@ -16,11 +16,9 @@
 
 package io.helidon.integrations.graal.nativeimage.extension;
 
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,8 +39,6 @@ import io.github.classgraph.ClassRefTypeSignature;
 import io.github.classgraph.FieldInfo;
 import io.github.classgraph.MethodParameterInfo;
 import io.github.classgraph.ReferenceTypeSignature;
-import io.github.classgraph.Resource;
-import io.github.classgraph.ResourceList;
 import io.github.classgraph.ScanResult;
 import io.github.classgraph.TypeArgument;
 import io.github.classgraph.TypeSignature;
@@ -267,21 +263,6 @@ public final class NativeUtil {
         }
 
         return result;
-    }
-
-    List<String> findResources(String name) {
-        ResourceList allResources = scan.getResourcesWithPath(name);
-        List<String> list = new ArrayList<>();
-        for (Resource resource : allResources) {
-            String contentAsString = null;
-            try {
-                contentAsString = resource.getContentAsString();
-            } catch (IOException e) {
-                tracer.parsing(() -> "Failed to load resource " + resource.getPath(), e);
-            }
-            list.add(contentAsString);
-        }
-        return list;
     }
 
     void processAnnotatedFields(String annotation, BiConsumer<Class<?>, Field> fieldProcessor) {


### PR DESCRIPTION
### Description
Method `NativeUtil.findResources` is not used and can be removed without breaking compatibility

<img width="1248" alt="Screenshot 2024-12-10 at 18 24 31" src="https://github.com/user-attachments/assets/39b27520-15aa-4d08-b80b-58a8760849cb">
