### PR TITLE
Makes ApplicationPath a bean defining annotation

### DIFF
--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
@@ -151,6 +151,7 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
         LOGGER.fine(() -> "Initializing CDI container " + id);
 
         addHelidonBeanDefiningAnnotations("jakarta.ws.rs.Path",
+                                          "jakarta.ws.rs.ApplicationPath",
                                           "jakarta.ws.rs.ext.Provider",
                                           "jakarta.websocket.server.ServerEndpoint",
                                           "org.eclipse.microprofile.graphql.GraphQLApi",

--- a/tests/functional/jax-rs-bda/pom.xml
+++ b/tests/functional/jax-rs-bda/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.tests</groupId>
+        <artifactId>helidon-tests-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.helidon.webserver.tests</groupId>
+    <artifactId>helidon-tests-functional-jax-rs-bda</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorld1.java
+++ b/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorld1.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.bda;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/greet1")
+public class HelloWorld1 {
+
+    @GET
+    public String hello() {
+        return "hello1";
+    }
+}

--- a/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorld2.java
+++ b/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorld2.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.bda;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/greet2")
+public class HelloWorld2 {
+
+    @GET
+    public String hello() {
+        return "hello2";
+    }
+}

--- a/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorld3.java
+++ b/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorld3.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.bda;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+/**
+ * This resource will not be available given that a synthetic app is not
+ * created when other apps exist. Note that {@link Path} is also a BDA.
+ */
+@Path("/greet3")
+public class HelloWorld3 {
+
+    @GET
+    public String hello() {
+        return "hello3";
+    }
+}

--- a/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorldApp1.java
+++ b/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorldApp1.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.bda;
+
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * Use {@link ApplicationPath} as a bean-defining annotation (BDA). Note that
+ * there is no CDI scope annotation on the class.
+ */
+@ApplicationPath("app1")
+public class HelloWorldApp1 extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(HelloWorld1.class);
+    }
+}

--- a/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorldApp2.java
+++ b/tests/functional/jax-rs-bda/src/main/java/io/helidon/tests/functional/bda/HelloWorldApp2.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.bda;
+
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * Even though {@link ApplicationPath} is a bean-defining annotation, this
+ * class is also given an explicit application scope.
+ */
+@ApplicationScoped
+@ApplicationPath("app2")
+public class HelloWorldApp2 extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(HelloWorld2.class);
+    }
+}

--- a/tests/functional/jax-rs-bda/src/main/resources/META-INF/beans.xml
+++ b/tests/functional/jax-rs-bda/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/functional/jax-rs-bda/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/functional/jax-rs-bda/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server.host=0.0.0.0

--- a/tests/functional/jax-rs-bda/src/test/java/io/helidon/tests/functional/bda/ResourcesTest.java
+++ b/tests/functional/jax-rs-bda/src/test/java/io/helidon/tests/functional/bda/ResourcesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.bda;
+
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+class ResourcesTest {
+
+    @Inject
+    private WebTarget target;
+
+    /**
+     * Test that resource {@code "app1/greet1"} exists as part of
+     * {@link io.helidon.tests.functional.bda.HelloWorld1}.
+     */
+    @Test
+    void testHelloWorld1() {
+        Response response = target.path("app1")
+                .path("greet1")
+                .request()
+                .get();
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.readEntity(String.class), is("hello1"));
+    }
+
+    /**
+     * Test that resource {@code "app2/greet2"} exists as part of
+     * {@link io.helidon.tests.functional.bda.HelloWorld2}.
+     */
+    @Test
+    void testHelloWorld2() {
+        Response response = target.path("app2")
+                .path("greet2")
+                .request()
+                .get();
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.readEntity(String.class), is("hello2"));
+    }
+
+    /**
+     * Test that resource {@code "app3/greet3"} does not exist since no
+     * synthetic app shall be created in this case.
+     */
+    @Test
+    void testHelloWorld3() {
+        Response response = target.path("/")
+                .path("greet3")
+                .request()
+                .get();
+        assertThat(response.getStatus(), is(404));
+    }
+}


### PR DESCRIPTION
### Description

Makes ApplicationPath a bean defining annotation. New functional test that shows support for this new feature.

### Documentation

Needs to be updated.