### PR TITLE
Fix MP telemetry config setting typo

### DIFF
--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -319,7 +319,7 @@ Add these lines to `META-INF/microprofile-config.properties`:
 ----
 otel.sdk.disabled=false     <1>
 otel.traces.exporter=jaeger <2>
-otel.exporter.name=greeting-service <3>
+otel.service.name=greeting-service <3>
 ----
 <1> Enable MicroProfile Telemetry.
 <2> Set exporter to Jaeger.


### PR DESCRIPTION
### Description
This PR corrects a typo which misstates the config setting to use in assigning an OpenTelemetry service name.

### Documentation
This is a doc fix.