### PR TITLE
 4.1.6: Add xref to telemetry feature from tracing deprecation warning

### DIFF
--- a/docs/src/main/asciidoc/mp/tracing.adoc
+++ b/docs/src/main/asciidoc/mp/tracing.adoc
@@ -40,8 +40,10 @@ include::{rootdir}/includes/mp.adoc[]
 
 == Overview
 
-WARNING: The OpenTracing Specification that MP OpenTracing is based on is no longer maintained.
-The MP OpenTracing specification is no longer required by MicroProfile. This feature is marked as `@Deprecated` in Helidon. The specification is superseded by the link:https://github.com/eclipse/microprofile-telemetry[MicroProfile Telemetry specification].
+WARNING: This feature is marked as `@Deprecated` in Helidon. Please use the xref:{rootdir}/mp/telemetry.adoc[Telemetry] feature instead.
+The OpenTracing Specification that MP OpenTracing is based on is no longer maintained.
+The MP OpenTracing specification is no longer required by MicroProfile.
+The specification is superseded by the link:https://github.com/eclipse/microprofile-telemetry[MicroProfile Telemetry specification].
 
 Distributed tracing is a critical feature of micro-service based applications, since it traces workflow both
 within a service and across multiple services. This provides insight to sequence and timing data for specific blocks of work,


### PR DESCRIPTION

Backport #9601 to Helidon 4.1.6

### Description

Add xref to telemetry feature from tracing deprecation warning
