### PR TITLE
Allow developer to choose whether Helidon injects OTel types which notify span listeners

### DIFF
--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -204,6 +204,15 @@ include::{sourcedir}/mp/TelemetrySnippets.java[tag=snippet_6, indent=0]
 
 include::{rootdir}/includes/tracing/common-callbacks.adoc[tags=defs;detailed,leveloffset=+1]
 
+==== Using Span Listeners with Injection
+By default, Helidon _does not_ notify registered span listeners of life cycle events that involve an injected OpenTelemetry `Tracer` or `Span`.
+
+To enable this notification for injected telemetry objects configure `telemetry.injection-type` to `neutral` (overriding the default of `native`). See the <<Configuration,Configuration>> section for more information. Helidon then injects wrappers around the OpenTelemetry native objects instead of the OpenTelemetry native objects themselves. The wrappers notify registered listeners of life cycle changes.
+
+Note that although the injected neutral objects implement the corresponding OpenTelemetry interfaces, they _are not_ type-compatible with the underlying OpenTelemetry implementation types, so code that uses `instanceof` or other type-sensitive logic that refers to OpenTelemetry implementation types will not work. The injected neutral objects implement the
+link:{tracing-javadoc-base-url}/io/helidon/tracing/Wrapper.html[`io.helidon.tracing.Wrapper` interface]
+which declares the `unwrap` method. You can check and cast an injected neutral object to `Wrapper` and invokes its `unwrap` method to get access to the underlying OpenTelemetry object.
+
 === Controlling Automatic Span Creation
 By default, Helidon MP Telemetry creates a new child span for each incoming REST request and for each outgoing REST client request. You can selectively control if Helidon creates these automatic spans on a request-by-request basis by adding a very small amount of code to your project.
 
@@ -261,6 +270,12 @@ The OpenTelemetry Java Agent may influence the work of MicroProfile Telemetry, o
 `otel.agent.present=true`
 
 This way, Helidon will explicitly get all the configuration and objects from the Agent, thus allowing correct span hierarchy settings.
+
+=== Helidon Telemetry Configuration
+
+include::{rootdir}/config/io_helidon_microprofile_telemetry_TelemetryConfig.adoc[leveloffset=+1,tag=config]
+
+The <<Using Span Listeners with Injection, Using Span Listeners with Injection>> section describes the effect of this configuration.
 
 [[examples]]
 == Examples

--- a/microprofile/telemetry/etc/spotbugs/exclude.xml
+++ b/microprofile/telemetry/etc/spotbugs/exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2024 Oracle and/or its affiliates.
+    Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/microprofile/telemetry/etc/spotbugs/exclude.xml
+++ b/microprofile/telemetry/etc/spotbugs/exclude.xml
@@ -28,4 +28,9 @@
         <Method name="&lt;init&gt;"/>
         <Bug pattern = "VA_FORMAT_STRING_USES_NEWLINE"/>
     </Match>
+    <Match>
+        <!-- False positives in multiple methods - see https://github.com/spotbugs/spotbugs/issues/3235 -->
+        <Class name="io.helidon.microprofile.telemetry.WrappedProducer$WrappedSpanBuilder"/>
+        <Bug pattern = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    </Match>
 </FindBugsFilter>

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -140,12 +140,34 @@
                             <artifactId>helidon-common-features-processor</artifactId>
                             <version>${helidon.version}</version>
                         </path>
+                        <path>
+                            <!-- Codegen integration with Java annotation processing -->
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <!-- Config metadata codegen (to generate META-INF/helidon/config-metadata.json) -->
+                            <groupId>io.helidon.config.metadata</groupId>
+                            <artifactId>helidon-config-metadata-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <otel.bsp.schedule.delay>${otel.bsp.schedule.delay}</otel.bsp.schedule.delay>
+                    </systemPropertyVariables>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-test</id>
@@ -156,6 +178,7 @@
                             </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/AgentDetectorTest.java</exclude>
+                                <exclude>**/TestListenersWithInjection.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -171,6 +194,20 @@
                         <configuration>
                             <includes>
                                 <include>**/AgentDetectorTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!--
+                            Run separately so other tests do not interfere with the static information about the global tracer.
+                        -->
+                        <id>test-listeners-with-injection</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestListenersWithInjection.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/InjectionType.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/InjectionType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+/**
+ * Choices for the telemetry injection type config value.
+ */
+public enum InjectionType {
+
+    /**
+     * Inject native OpenTelemetry types.
+     */
+    NATIVE,
+
+    /**
+     * Inject Helidon neutral types which wrap the OpenTelemetry types.
+     */
+    NEUTRAL;
+
+    static final String DEFAULT = "NATIVE";
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/InjectionType.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/InjectionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/NativeOpenTelemetryProducer.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/NativeOpenTelemetryProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/NativeOpenTelemetryProducer.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/NativeOpenTelemetryProducer.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+
+/**
+ * Producer implementation which injects the native OTel objects (which do not participate in the Helidon-specific
+ * span listener feature).
+ */
+class NativeOpenTelemetryProducer implements OpenTelemetryProducer.Producer {
+
+    static NativeOpenTelemetryProducer create(Tracer nativeTracer) {
+        return new NativeOpenTelemetryProducer(nativeTracer);
+    }
+
+    private final Tracer nativeTracer;
+
+    private NativeOpenTelemetryProducer(Tracer nativeTracer) {
+        this.nativeTracer = nativeTracer;
+    }
+
+    @Override
+    public Tracer tracer() {
+        return nativeTracer;
+    }
+
+    @Override
+    public Span span() {
+        return new Span() {
+            @Override
+            public <T> Span setAttribute(AttributeKey<T> key, T value) {
+                return Span.current().setAttribute(key, value);
+            }
+
+            @Override
+            public Span addEvent(String name, Attributes attributes) {
+                return Span.current().addEvent(name, attributes);
+            }
+
+            @Override
+            public Span addEvent(String name, Attributes attributes, long timestamp, TimeUnit unit) {
+                return Span.current().addEvent(name, attributes, timestamp, unit);
+            }
+
+            @Override
+            public Span setStatus(StatusCode statusCode, String description) {
+                return Span.current().setStatus(statusCode, description);
+            }
+
+            @Override
+            public Span recordException(Throwable exception, Attributes additionalAttributes) {
+                return Span.current().recordException(exception, additionalAttributes);
+            }
+
+            @Override
+            public Span updateName(String name) {
+                return Span.current().updateName(name);
+            }
+
+            @Override
+            public void end() {
+                Span.current().end();
+            }
+
+            @Override
+            public void end(long timestamp, TimeUnit unit) {
+                Span.current().end(timestamp, unit);
+            }
+
+            @Override
+            public SpanContext getSpanContext() {
+                return Span.current().getSpanContext();
+            }
+
+            @Override
+            public boolean isRecording() {
+                return Span.current().isRecording();
+            }
+        };
+    }
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/OpenTelemetryProducer.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/OpenTelemetryProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryConfigBlueprint.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryConfigBlueprint.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Configuration for telemetry.
+ */
+@Prototype.Blueprint
+@Prototype.Configured(TelemetryConfigBlueprint.TELEMETRY_CONFIG_KEY)
+interface TelemetryConfigBlueprint {
+
+    /**
+     * The config key containing settings for all of metrics.
+     */
+    String TELEMETRY_CONFIG_KEY = "telemetry";
+
+    /**
+     * Injection type for injected OpenTelemetry objects such as {@link io.opentelemetry.api.trace.Tracer} and
+     * {@link io.opentelemetry.api.trace.Span}.
+     *
+     * @return injection type
+     */
+    @Option.Configured
+    @Option.Default(InjectionType.DEFAULT)
+    InjectionType injectionType();
+
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryConfigBlueprint.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/TelemetryConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WrappedProducer.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WrappedProducer.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.tracing.Wrapper;
+import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
+import io.helidon.tracing.providers.opentelemetry.OpenTelemetryTracerProvider;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+/**
+ * Producer implementation that returns wrappers which implement the OTel interfaces but wrap Helidon OTel implementations,
+ * thus notifying any registered span listeners of state changes.
+ * <p>
+ *     Each wrapped instance records its Helidon counterpart which in turn wraps the OTel native object. In each wrapped type,
+ *     the OTel methods which do not alter states delegate to the OTel native object, whereas for the most part those which do
+ *     change state delegate to the Helidon object thereby notifying any registered span listeners.
+ */
+class WrappedProducer implements OpenTelemetryProducer.Producer {
+
+    private static final System.Logger LOGGER = System.getLogger(WrappedProducer.class.getName());
+
+    private final io.helidon.tracing.Tracer helidonTracer;
+
+    private WrappedProducer(io.helidon.tracing.Tracer helidonTracer) {
+        this.helidonTracer = helidonTracer;
+    }
+
+    static WrappedProducer create(io.helidon.tracing.Tracer helidonTracer) {
+        return new WrappedProducer(helidonTracer);
+    }
+
+    @Override
+    public Tracer tracer() {
+        return new WrappedTracer(helidonTracer);
+    }
+
+    @Override
+    public Span span() {
+        return new WrappedSpan(helidonTracer);
+    }
+
+    static class WrappedTracer implements Tracer {
+
+        private final io.helidon.tracing.Tracer helidonTracer;
+
+        WrappedTracer(io.helidon.tracing.Tracer helidonTracer) {
+            this.helidonTracer = helidonTracer;
+        }
+
+        @Override
+        public SpanBuilder spanBuilder(String spanName) {
+            return new WrappedSpanBuilder(helidonTracer, spanName);
+        }
+    }
+
+    static class WrappedSpanBuilder implements io.opentelemetry.api.trace.SpanBuilder, Wrapper {
+
+        private final io.helidon.tracing.Span.Builder<?> helidonSpanBuilder;
+        private final SpanBuilder nativeSpanBuilder;
+
+        private WrappedSpanBuilder(io.helidon.tracing.Tracer helidonTracer, String spanName) {
+            nativeSpanBuilder = helidonTracer.unwrap(Tracer.class).spanBuilder(spanName);
+            helidonSpanBuilder = HelidonOpenTelemetry.create(nativeSpanBuilder, helidonTracer);
+            // To maintain the Helidon span lineage set the parent if one is available.
+            io.helidon.tracing.Span.current().map(io.helidon.tracing.Span::context).ifPresent(helidonSpanBuilder::parent);
+        }
+
+        @Override
+        public SpanBuilder setParent(Context context) {
+            nativeSpanBuilder.setParent(context);
+            // Generally we don't also invoke the Helidon implementation's method because most of the methods simply delegate
+            // to the native OTel counterpart method. But we need to set the parent of the Helidon span builder
+            // explicitly because the parentage is not maintained via simple delegation to the native OTel span builder.
+            helidonSpanBuilder.parent(HelidonOpenTelemetry.create(context));
+            return this;
+        }
+
+        @Override
+        public SpanBuilder setNoParent() {
+            // There is no Helidon counterpart for clearing the parent once set.
+            nativeSpanBuilder.setNoParent();
+            return this;
+        }
+
+        @Override
+        public SpanBuilder addLink(SpanContext spanContext) {
+            nativeSpanBuilder.addLink(spanContext);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder addLink(SpanContext spanContext, Attributes attributes) {
+            nativeSpanBuilder.addLink(spanContext, attributes);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder setAttribute(String key, String value) {
+            nativeSpanBuilder.setAttribute(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder setAttribute(String key, long value) {
+            nativeSpanBuilder.setAttribute(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder setAttribute(String key, double value) {
+            nativeSpanBuilder.setAttribute(key, value);
+            helidonSpanBuilder.tag(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder setAttribute(String key, boolean value) {
+            nativeSpanBuilder.setAttribute(key, value);
+            return this;
+        }
+
+        @Override
+        public <T> SpanBuilder setAttribute(AttributeKey<T> key, T value) {
+            nativeSpanBuilder.setAttribute(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder setSpanKind(SpanKind spanKind) {
+            nativeSpanBuilder.setSpanKind(spanKind);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder setStartTimestamp(long startTimestamp, TimeUnit unit) {
+            nativeSpanBuilder.setStartTimestamp(startTimestamp, unit);
+            return this;
+        }
+
+        @Override
+        public Span startSpan() {
+            return new WrappedSpan(helidonSpanBuilder.start());
+        }
+
+        @Override
+        public <R> R unwrap(Class<? extends R> c) {
+            if (c.isInstance(helidonSpanBuilder)) {
+                return c.cast(helidonSpanBuilder);
+            }
+            if (c.isInstance(nativeSpanBuilder)) {
+                return c.cast(nativeSpanBuilder);
+            }
+            throw new IllegalArgumentException("Cannot provide an instance of " + c.getName()
+                                                       + "; the wrapped telemetry span builder has type "
+                                                       + nativeSpanBuilder.getClass().getName()
+                                                       + " and the wrapped Helidon span builder has type "
+                                                       + helidonSpanBuilder.getClass().getName());
+        }
+    }
+
+    static class WrappedSpan implements io.opentelemetry.api.trace.Span, Wrapper {
+
+        private final io.helidon.tracing.Span helidonSpan;
+        private final Span nativeSpan;
+
+        private WrappedSpan(io.helidon.tracing.Span helidonSpan) {
+            this.helidonSpan = helidonSpan;
+            nativeSpan = helidonSpan.unwrap(io.opentelemetry.api.trace.Span.class);
+        }
+
+        /**
+         * Constructor for use by the injection producer method which does not have a Helidon span already.
+         *
+         * @param helidonTracer Helidon tracer
+         */
+        private WrappedSpan(io.helidon.tracing.Tracer helidonTracer) {
+            Span nativeCurrentSpan = Span.fromContextOrNull(Context.current());
+
+            nativeSpan = Span.current();
+            helidonSpan = OpenTelemetryTracerProvider.span(helidonTracer, nativeSpan, nativeCurrentSpan == null);
+        }
+
+        @Override
+        public <T> Span setAttribute(AttributeKey<T> key, T value) {
+            nativeSpan.setAttribute(key, value);
+            return this;
+        }
+
+        @Override
+        public Span addEvent(String name, Attributes attributes) {
+            nativeSpan.addEvent(name, attributes);
+            return this;
+        }
+
+        @Override
+        public Span addEvent(String name, Attributes attributes, long timestamp, TimeUnit unit) {
+            nativeSpan.addEvent(name, attributes, timestamp, unit);
+            return this;
+        }
+
+        @Override
+        public Span setStatus(StatusCode statusCode, String description) {
+            nativeSpan.setStatus(statusCode, description);
+            return this;
+        }
+
+        @Override
+        public Span recordException(Throwable exception, Attributes additionalAttributes) {
+            nativeSpan.recordException(exception, additionalAttributes);
+            return this;
+        }
+
+        @Override
+        public Span updateName(String name) {
+            nativeSpan.updateName(name);
+            return this;
+        }
+
+        @Override
+        public void end() {
+            // Invoking the Helidon end method will notify listeners as well as end its native delegate span.
+            helidonSpan.end();
+        }
+
+        @Override
+        public void end(long timestamp, TimeUnit unit) {
+            // The Helidon API does not have an end(long, TimeUnit) method. So we have to invoke the native span directly
+            // with those arguments and then invoke the listeners explicitly. We don't want to also invoke the Helidon "end()"
+            // method to accomplish the notifications because that would end the native span again.
+            nativeSpan.end(timestamp, unit);
+            HelidonOpenTelemetry.invokeListeners(helidonSpan, LOGGER, listener -> listener.ended(helidonSpan));
+        }
+
+        @Override
+        public SpanContext getSpanContext() {
+            return nativeSpan.getSpanContext();
+        }
+
+        @Override
+        public boolean isRecording() {
+            return nativeSpan.isRecording();
+        }
+
+        @Override
+        public Scope makeCurrent() {
+            return new WrappedScope(helidonSpan.activate());
+        }
+
+        @Override
+        public <R> R unwrap(Class<? extends R> c) {
+            if (c.isInstance(nativeSpan)) {
+                return c.cast(nativeSpan);
+            }
+            if (c.isInstance(helidonSpan)) {
+                return c.cast(helidonSpan);
+            }
+            throw new IllegalArgumentException("Cannot provide an instance of " + c.getName()
+                                                                   + "; the wrapped telemetry span has type "
+                                                                   + nativeSpan.getClass().getName()
+                                                                   + " and the wrapped Helidon span has type "
+                                                                   + helidonSpan.getClass().getName());
+        }
+    }
+
+    static class WrappedScope implements io.opentelemetry.context.Scope, Wrapper {
+
+        private final io.helidon.tracing.Scope helidonScope;
+
+        private WrappedScope(io.helidon.tracing.Scope helidonScope) {
+            this.helidonScope = helidonScope;
+        }
+
+        @Override
+        public void close() {
+            helidonScope.close();
+        }
+
+        @Override
+        public <R> R unwrap(Class<? extends R> c) {
+            Scope nativeScope = helidonScope.unwrap(Scope.class);
+            if (c.isInstance(nativeScope)) {
+                return c.cast(nativeScope);
+            }
+            if (c.isInstance(helidonScope)) {
+                return c.cast(helidonScope);
+            }
+            throw new IllegalArgumentException("Cannot provide an instance of " + c.getName()
+                                                       + "; the wrapped telemetry scope has type "
+                                                       + nativeScope.getClass().getName()
+                                                       + " and the wrapped Helidon scope has type "
+                                                       + helidonScope.getClass().getName());
+        }
+    }
+}

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WrappedProducer.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/WrappedProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestListenersWithInjection.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestListenersWithInjection.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanListener;
+import io.helidon.tracing.Tracer;
+import io.helidon.tracing.Wrapper;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddBean(TestListenersWithInjection.TestResource.class)
+@AddConfig(key = "otel.sdk.disabled", value = "false")
+@AddConfig(key = "telemetry.injection-type", value = "neutral")
+class TestListenersWithInjection {
+
+    private static final TestSpanListener testSpanListener = new TestSpanListener();
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Inject
+    private TestResource testResource;
+
+    @BeforeAll
+    static void prepareTracer() {
+        Tracer.global().register(testSpanListener);
+    }
+
+    @BeforeEach
+    void clear() {
+        testSpanListener.clear();
+    }
+
+    @Test
+    void checkNotifications() throws InterruptedException {
+        int startingBefore = testSpanListener.starting();
+        int startedBefore = testSpanListener.started();
+        int closedBefore = testSpanListener.closed();
+        int endedBefore = testSpanListener.ended();
+
+        testResource.go();
+
+        assertThat("Starting", testSpanListener.starting() - startingBefore, is(1));
+        assertThat("Started", testSpanListener.started() - startedBefore, is(1));
+        assertThat("Closed", testSpanListener.closed() - closedBefore, is(1));
+        assertThat("Ended", testSpanListener.ended() - endedBefore, is(1));
+
+    }
+
+    @Test
+    void checkTypesOfListenerParameters() throws InterruptedException {
+
+        int startingBefore = testSpanListener.starting();
+        int startedBefore = testSpanListener.started();
+        int closedBefore = testSpanListener.closed();
+        int endedBefore = testSpanListener.ended();
+
+        // Access the resource using HTTP so the filter will set a current span that the resource will inject.
+        Response response = webTarget.path("/test/work").request(MediaType.TEXT_PLAIN).get();
+
+        assertThat("Starting", testSpanListener.starting() - startingBefore, greaterThan(0));
+        assertThat("Started", testSpanListener.started() - startedBefore, greaterThan(0));
+        assertThat("Closed", testSpanListener.closed() - closedBefore, greaterThan(0));
+        assertThat("Ended", testSpanListener.ended() - endedBefore, greaterThan(0));
+
+        // The listener should have recorded span lifecycles for these spans:
+        // 1. outgoing client request with name HTTP GET
+        // 2. incoming server request added by the Helidon MP filter with name /test/work
+        // 3. explicitly-created span in the service REST method with name explicitSpan
+        //
+        // Further, the injected span in the REST resource should match span 2 above (the span added by the Helidon MP filter)
+
+        assertThat("Response from test resource", response.getStatus(), is(equalTo(200)));
+
+        assertThat("Number of spans recorded by listener", testSpanListener.spansStarted, hasSize(3));
+
+        Span outgoingClientSpan = testSpanListener.spansStarted.getFirst();
+        Span incomingServerSpanFromFilter = testSpanListener.spansStarted.get(1);
+        Span explicitlyCreatedSpan = testSpanListener.spansStarted.getLast();
+
+        io.opentelemetry.api.trace.SpanContext incomingServerRequestNativeSpanContextViaInjection =
+                testResource.copyOfInjectedOtelSpanContext();
+
+        io.opentelemetry.api.trace.Span incomingServerRequestNativeSpanFromFilterViaListener =
+                incomingServerSpanFromFilter.unwrap(io.opentelemetry.api.trace.Span.class);
+        assertThat("Base native span context via injection vs. via listener",
+                   incomingServerRequestNativeSpanContextViaInjection,
+                   is(equalTo(incomingServerRequestNativeSpanFromFilterViaListener.getSpanContext())));
+
+        assertThat("Parent of explicitly-created span", explicitlyCreatedSpan.unwrap(ReadableSpan.class).getParentSpanContext(),
+                   equalTo(incomingServerRequestNativeSpanContextViaInjection));
+
+    }
+
+    @Test
+    void checkTypesOfInjectedFields() {
+
+        assertThat("Injected tracer",
+                   testResource.injectedOtelTracer(),
+                   allOf(instanceOf(io.opentelemetry.api.trace.Tracer.class),
+                         instanceOf(WrappedProducer.WrappedTracer.class)));
+
+        assertThat("Injected span", testResource.injectedOtelSpan(), allOf(instanceOf(io.opentelemetry.api.trace.Span.class),
+                                                                           instanceOf(Wrapper.class)));
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        SpanContext copyOfInjectedOtelSpanContext;
+
+        @Inject
+        private io.opentelemetry.api.trace.Tracer injectedOtelTracer;
+
+        @Inject
+        private io.opentelemetry.api.trace.Span injectedOtelSpan;
+
+        @WithSpan
+        void go() throws InterruptedException {
+            Thread.sleep(500);
+        }
+
+        io.opentelemetry.api.trace.Tracer injectedOtelTracer() {
+            return injectedOtelTracer;
+        }
+
+        io.opentelemetry.api.trace.Span injectedOtelSpan() {
+            return injectedOtelSpan;
+        }
+
+        io.opentelemetry.api.trace.SpanContext copyOfInjectedOtelSpanContext() {
+            return copyOfInjectedOtelSpanContext;
+        }
+
+        @Path("/work")
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String workWithInjectedTracerAndSpan() throws InterruptedException {
+            copyOfInjectedOtelSpanContext = injectedOtelSpan.getSpanContext();
+            io.opentelemetry.api.trace.SpanBuilder otelSpanBuilder = injectedOtelTracer.spanBuilder("explicitSpan");
+            io.opentelemetry.api.trace.Span otelSpan = otelSpanBuilder.startSpan();
+
+            try (io.opentelemetry.context.Scope ignored = otelSpan.makeCurrent()) {
+                Thread.sleep(200);
+            }
+            otelSpan.end();
+
+            injectedOtelSpan.setAttribute("marker", true);
+            return "worked";
+        }
+    }
+
+    private static class TestSpanListener implements SpanListener {
+
+        private final List<Span.Builder<?>> spanBuildersStarting = new ArrayList<>();
+
+        private final List<Span> spansStarted = new ArrayList<>();
+
+        private final List<Span> spansActivated = new ArrayList<>();
+
+        private final List<Scope> scopesActivated = new ArrayList<>();
+
+        private final List<Span> spansClosed = new ArrayList<>();
+        private final List<Scope> scopesClosed = new ArrayList<>();
+
+        private final List<Span> spansEnded = new ArrayList<>();
+
+        void clear() {
+            spanBuildersStarting.clear();
+
+            spansStarted.clear();
+
+            spansActivated.clear();
+            scopesActivated.clear();
+
+            spansClosed.clear();
+            scopesClosed.clear();
+
+            spansEnded.clear();
+        }
+
+        @Override
+        public void starting(Span.Builder<?> spanBuilder) {
+            spanBuildersStarting.add(spanBuilder);
+        }
+
+        @Override
+        public void started(Span span) {
+            spansStarted.add(span);
+        }
+
+        @Override
+        public void activated(Span span, Scope scope) {
+            spansActivated.add(span);
+            scopesActivated.add(scope);
+        }
+
+        @Override
+        public void closed(Span span, Scope scope) {
+            spansClosed.add(span);
+            scopesClosed.add(scope);
+        }
+
+        @Override
+        public void ended(Span span) {
+            spansEnded.add(span);
+        }
+
+        int starting() {
+            return spanBuildersStarting.size();
+        }
+
+        List<Span.Builder<?>> spanBuilderStarting() {
+            return spanBuildersStarting;
+        }
+
+        int started() {
+            return spansStarted.size();
+        }
+
+        List<Span> spanStarted() {
+            return spansStarted;
+        }
+
+        int activated() {
+            return spansActivated.size();
+        }
+
+        List<Span> spanActivated() {
+            return spansActivated;
+        }
+
+        List<Scope> scopeActivated() {
+            return scopesActivated;
+        }
+
+        int closed() {
+            return spansClosed.size();
+        }
+
+        List<Span> spanClosed() {
+            return spansClosed;
+        }
+
+        List<Scope> scopeClosed() {
+            return scopesClosed;
+        }
+
+        int ended() {
+            return spansEnded.size();
+        }
+
+        List<Span> spanEnded() {
+            return spansEnded;
+        }
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestListenersWithInjection.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestListenersWithInjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/HelidonOpenTelemetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryScope.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryScope.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryScope.java
@@ -37,6 +37,19 @@ class OpenTelemetryScope implements Scope {
         this.spanListeners = spanListeners;
     }
 
+    /**
+     * Creates a new Helidon {@link io.helidon.tracing.Scope} which wraps an existing OTel {@link io.opentelemetry.context.Scope}.
+     *
+     * @param helidonTracer Helidon tracer
+     * @param span          Helidon span
+     * @param scope         OTel scope
+     */
+    OpenTelemetryScope(OpenTelemetryTracer helidonTracer,
+                       OpenTelemetrySpan span,
+                       io.opentelemetry.context.Scope scope) {
+        this(span, scope, helidonTracer.spanListeners());
+    }
+
     @Override
     public void close() {
         if (closed.compareAndSet(false, true) && delegate != null) {

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
@@ -169,6 +169,7 @@ public class OpenTelemetryTracerProvider implements TracerProvider {
     public void global(Tracer tracer) {
         if (tracer instanceof OpenTelemetryTracer ott) {
             globalTracer(ott);
+            return;
         }
         throw new IllegalArgumentException("Tracer must be an instance of Helidon OpenTelemetry tracer. "
                                                    + "Please use HelidonOpenTelemetry to create such instance");

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracerProvider.java
@@ -25,6 +25,7 @@ import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
+import io.helidon.tracing.Scope;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.Tracer;
 import io.helidon.tracing.TracerBuilder;
@@ -115,6 +116,45 @@ public class OpenTelemetryTracerProvider implements TracerProvider {
         return Optional.of(HelidonOpenTelemetry.create(otelSpan, otelBaggage));
     }
 
+    /**
+     * Returns a Helidon {@link io.helidon.tracing.Tracer} which wraps the provided OpenTelemetry
+     * {@link io.opentelemetry.api.trace.Tracer}.
+     *
+     * @param openTelemetryTracer native OTel tracer to wrap
+     * @return Helidon tracer wrapping the native OTel tracer
+     */
+    public static Tracer tracer(io.opentelemetry.api.trace.Tracer openTelemetryTracer) {
+        return new OpenTelemetryTracer(GlobalOpenTelemetry.get(), openTelemetryTracer, Map.of());
+    }
+
+    /**
+     * Returns a Helidon {@link io.helidon.tracing.Span} which wraps the provided OpenTelemetry
+     * {@link io.opentelemetry.api.trace.Span}.
+     *
+     * @param helidonTracer     the Helidon tracer from which to create the span
+     * @param openTelemetrySpan native OTel span to wrap
+     * @param isNoop            whether the native span is a no-op span
+     * @return Helidon span wrapping the native OTel span
+     */
+    public static Span span(Tracer helidonTracer, io.opentelemetry.api.trace.Span openTelemetrySpan, boolean isNoop) {
+        return new OpenTelemetrySpan(helidonTracer, openTelemetrySpan, isNoop);
+    }
+
+    /**
+     * Returns a Helidon {@link io.helidon.tracing.Scope} which wraps the provided OpenTelemetry
+     * {@link io.opentelemetry.context.Scope}.
+     *
+     * @param helidonTracer      Helidon {@link io.helidon.tracing.Tracer}
+     * @param helidonSpan        Helidon {@link io.helidon.tracing.Span} associated with the scope
+     * @param openTelemetryScope OpenTelemetry {@code Scope} to be wrapped
+     * @return Helidon {@link Scope} wrapping the OpenTelemetry {@code Scope}
+     */
+    public static Scope scope(Tracer helidonTracer, Span helidonSpan, io.opentelemetry.context.Scope openTelemetryScope) {
+        return new OpenTelemetryScope(helidonTracer.unwrap(OpenTelemetryTracer.class),
+                                      helidonSpan.unwrap(OpenTelemetrySpan.class),
+                                      openTelemetryScope);
+    }
+
     @Override
     public TracerBuilder<?> createBuilder() {
         return OpenTelemetryTracer.builder();
@@ -129,7 +169,6 @@ public class OpenTelemetryTracerProvider implements TracerProvider {
     public void global(Tracer tracer) {
         if (tracer instanceof OpenTelemetryTracer ott) {
             globalTracer(ott);
-            return;
         }
         throw new IllegalArgumentException("Tracer must be an instance of Helidon OpenTelemetry tracer. "
                                                    + "Please use HelidonOpenTelemetry to create such instance");

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Scope.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Scope.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Scope.java
@@ -27,4 +27,22 @@ public interface Scope extends AutoCloseable {
      * @return if this scope is closed
      */
     boolean isClosed();
+
+    /**
+     * Access the underlying scope by specific type.
+     * This is a dangerous operation that will succeed only if the scope is of expected type. This practically
+     * removes abstraction capabilities of this API.
+     *
+     * @param scopeClass type to access
+     * @param <T>        type of the scope
+     * @return instance of the scope
+     * @throws java.lang.IllegalArgumentException in case the scope cannot provide the expected type
+     */
+    default <T> T unwrap(Class<T> scopeClass) {
+        try {
+            return scopeClass.cast(this);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("This scope is not compatible with " + scopeClass.getName());
+        }
+    }
 }

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Wrapper.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Wrapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing;
+
+/**
+ * Behavior of a type that wraps a related type, typically through delegation.
+ */
+public interface Wrapper {
+
+    /**
+     * Unwraps the delegate as the specified type.
+     *
+     * @param c   {@link Class} to which to cast the delegate
+     * @param <R> type to cast to
+     * @return the delegate cast as the requested type
+     * @throws java.lang.ClassCastException if the delegate is not compatible with the requested type
+     */
+    <R> R unwrap(Class<? extends R> c);
+}

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Wrapper.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
Resolves #9079 

## Release Note
As part of Helidon's support for MP Telemetry developers have been able to inject the OpenTelemetry `Tracer` and `Span` types into their code. But these types do not support Helidon-specific span listeners (which are notified when spans start and end or scopes are activated and closed).

This PR allows users to assign the config setting `telemetry.injection-type` to `native` or `neutral`:
* `native` - the default and the prior behavior - Helidon injects native OTel `Tracer` and `Span` objects - span listeners are _not_ notified of state changes related to injected objects
* `neutral` - Helidon injects wrappers around the native OTel types which delegate to the underlying OTel object but also notify any registered `SpanListener` objects (which receive parameters that are the Helidon neutral types: `Tracer`, `Span.Builder`, `Span`, `Scope`).

Developers need to opt into the new behavior because pre-existing applications might use `instanceof` or similar type-sensitive constructs on injected values referring to OTel implementation types. If Helidon were to change now to _always_ inject wrapped objects in order to notify span listeners then those constructs would no longer work as before.

## Alternative not adopted: always inject the neutral wrapping objects
We could have just changed Helidon so it _always_ inject the neutral wrapping objects, avoiding the addition of the config setting and the parallel producers. 

Some people advocated for that, pointing out that developers should probably not be injecting objects (which could be proxies) and then query their types. 

But we know that some existing user code checks OTel `Span` objects to see if they are `ReadableSpan` and then casts them to use the `ReadableSpan` API. AFAIK these use cases do not currently do so with _injected_ spans but, if they do or if they tried to, such code would break if Helidon started injecting only the wrapping objects.

That's why this PR added the config setting, maintains the current behavior by default, and gives the user control (and responsibility).

## Highlights of the changes

The main point is offer a choice for whether Helidon should inject the native OTel `Span` and `Tracer` objects as before or to inject Helidon-written wrappers around those OTel types, wrappers which notify registered span listeners of state changes and also delegate to the native OTel objects.

1. Add the `io.helidon.tracing.Wrapper` interface which declares the `unwrap` method. The `neutral` injected objects implement `Wrapper` so developers, if needed, can cast injected objects to `Wrapper` and then unwrap them to get to the underlying OTel objects.
2. Add configuration for the `injection-type` setting. We do not have pre-existing telemetry-based configuration that is Helidon-specific. (There are `otel.*` settings which Helidon supports in compliance with the MP Telemetry spec but the new setting is Helidon-specific and not related to OTel so should not be under the `otel` section.)
3. Generalize the CDI producer for telemetry-related types so there are two implementations, one that returns native OTel objects and one that returns wrapped ones. Configuration determines which is used.
4. The wrapped implementations of the OTel interfaces contain a reference to the corresponding OTel native object and a reference to a Helidon `Tracer` or `Span` etc. wrapper around the native OTel object. Most methods in the wrapper classes simply delegate to the native OTel object. The exception: any method that causes changes of state (which the span listeners observe)--such as starting or ending a span or activating or closing a scope--invoke the Helidon wrapper which does the notification _and_ delegates to the OTel object.
5. Some new factory methods for the Helidon neutral types allow the new telemetry producer code to create Helidon neutral wrappers around existing OTel objects.
6. New tests exercise the config and injection of wrappers and check for proper notification of span listeners.
7. Updates to the telemetry page (under MP) describe the changes.

### Documentation
PR includes doc updates.