### PR TITLE
4.x silence jersey warnings

### DIFF
--- a/archetypes/archetypes/src/main/archetype/mp/common/files/src/main/resources/logging.properties.mustache
+++ b/archetypes/archetypes/src/main/archetype/mp/common/files/src/main/resources/logging.properties.mustache
@@ -20,9 +20,6 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 # Quiet Weld
 org.jboss.level=WARNING
 
-# Quiet Jersey wadl support
-org.glassfish.jersey.server.wadl.level=SEVERE
-
 # Component specific log levels
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -98,10 +98,8 @@ class JaxRsService implements HttpService {
 
     static JaxRsService create(ResourceConfig resourceConfig, InjectionManager injectionManager) {
 
-        Config config = ConfigProvider.getConfig();
-
         // Silence warnings from Jersey. See 9019. Allow overriding to pass tck
-        Boolean suppressDatasourceProvider = config.getOptionalValue(SUPPRESS_DATASOURCE_PROVIDER, Boolean.class).orElse(true);
+        boolean suppressDatasourceProvider = Boolean.parseBoolean(System.getProperty(SUPPRESS_DATASOURCE_PROVIDER, "true"));
         if (!resourceConfig.hasProperty(CommonProperties.PROVIDER_DEFAULT_DISABLE) && suppressDatasourceProvider) {
             resourceConfig.addProperties(Map.of(CommonProperties.PROVIDER_DEFAULT_DISABLE, "DATASOURCE"));
         }
@@ -114,6 +112,7 @@ class JaxRsService implements HttpService {
                                                                new WebServerBinder(),
                                                                ij);
         Container container = new HelidonJerseyContainer(appHandler);
+        Config config = ConfigProvider.getConfig();
 
         // This configuration via system properties is for the Jersey Client API. Any
         // response in an exception will be mapped to an empty one to prevent data leaks

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -66,6 +66,7 @@ import org.glassfish.jersey.server.ContainerException;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.spi.Container;
 import org.glassfish.jersey.server.spi.ContainerResponseWriter;
 
@@ -95,6 +96,14 @@ class JaxRsService implements HttpService {
     }
 
     static JaxRsService create(ResourceConfig resourceConfig, InjectionManager injectionManager) {
+
+        // Silence warnings from Jersey. See 9019
+        if (!resourceConfig.hasProperty(CommonProperties.PROVIDER_DEFAULT_DISABLE)) {
+            resourceConfig.addProperties(Map.of(CommonProperties.PROVIDER_DEFAULT_DISABLE, "DATASOURCE"));
+        }
+        if (!resourceConfig.hasProperty(ServerProperties.WADL_FEATURE_DISABLE)) {
+            resourceConfig.addProperties(Map.of(ServerProperties.WADL_FEATURE_DISABLE, "true"));
+        }
 
         InjectionManager ij = injectionManager == null ? null : new InjectionManagerWrapper(injectionManager, resourceConfig);
         ApplicationHandler appHandler = new ApplicationHandler(resourceConfig,

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
@@ -125,6 +125,7 @@
                         <webServerHost>localhost</webServerHost>
                         <webServerPort>8080</webServerPort>
                         <jersey.config.client.ignoreExceptionResponse>false</jersey.config.client.ignoreExceptionResponse>
+                        <jersey.config.server.suppressDataSourceProvider>false</jersey.config.server.suppressDataSourceProvider>
                         <jersey.config.allowSystemPropertiesProvider>true</jersey.config.allowSystemPropertiesProvider>
                         <org.jboss.weld.bootstrap.concurrentDeployment>false</org.jboss.weld.bootstrap.concurrentDeployment>
                         <org.jboss.weld.construction.relaxed>false</org.jboss.weld.construction.relaxed>

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/pom.xml
@@ -125,7 +125,7 @@
                         <webServerHost>localhost</webServerHost>
                         <webServerPort>8080</webServerPort>
                         <jersey.config.client.ignoreExceptionResponse>false</jersey.config.client.ignoreExceptionResponse>
-                        <jersey.config.server.suppressDataSourceProvider>false</jersey.config.server.suppressDataSourceProvider>
+                        <jersey.config.server.disableDataSourceProvider>false</jersey.config.server.disableDataSourceProvider>
                         <jersey.config.allowSystemPropertiesProvider>true</jersey.config.allowSystemPropertiesProvider>
                         <org.jboss.weld.bootstrap.concurrentDeployment>false</org.jboss.weld.bootstrap.concurrentDeployment>
                         <org.jboss.weld.construction.relaxed>false</org.jboss.weld.construction.relaxed>

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/src/test/resources/META-INF/microprofile-config.properties
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/src/test/resources/META-INF/microprofile-config.properties
@@ -15,3 +15,4 @@
 #
 
 jersey.config.client.ignoreExceptionResponse=false
+jersey.config.server.suppressDataSourceProvider=false

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/src/test/resources/META-INF/microprofile-config.properties
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/src/test/resources/META-INF/microprofile-config.properties
@@ -15,5 +15,3 @@
 #
 
 jersey.config.client.ignoreExceptionResponse=false
-jersey.config.server.suppressDataSourceProvider=false
-

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/src/test/resources/META-INF/microprofile-config.properties
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/src/test/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,3 +16,4 @@
 
 jersey.config.client.ignoreExceptionResponse=false
 jersey.config.server.suppressDataSourceProvider=false
+

--- a/microprofile/tests/tck/tck-restful/tck-restful-test/src/test/resources/META-INF/microprofile-config.properties
+++ b/microprofile/tests/tck/tck-restful/tck-restful-test/src/test/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Fix #9019

This configures Jersey to:
- Disable the WADL feature. With this we can remove setting log level for org.glassfish.jersey.server.wadl.  
- Disable DATASOURCE default provider

This silences warnings we were getting from Jersey at startup.

To allow user's to use these features in Jersey we do the following:
1. If `CommonProperties.PROVIDER_DEFAULT_DISABLE` or `ServerProperties.WADL_FEATURE_DISABLE` is set in ResourceConfig then we don't configure that property (we let user's settings take precedence).
2. If `jersey.config.server.disableDataSourceProvider` (system property or config property) is set to false, then we don't disable DATASOURCE default provider. This also allows us to pass the TCK.
