### PR TITLE
4.x: Docs: Do not use --short with kubectl version

### DIFF
--- a/docs/src/main/asciidoc/about/kubernetes.adoc
+++ b/docs/src/main/asciidoc/about/kubernetes.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/about/kubernetes.adoc
+++ b/docs/src/main/asciidoc/about/kubernetes.adoc
@@ -57,6 +57,6 @@ set correctly to use docker-for-desktop.
 kubectl config get-contexts
 kubectl config use-context docker-for-desktop
 kubectl cluster-info
-kubectl version --short
+kubectl version
 kubectl get nodes
 ----

--- a/docs/src/main/asciidoc/about/prerequisites.adoc
+++ b/docs/src/main/asciidoc/about/prerequisites.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/asciidoc/about/prerequisites.adoc
+++ b/docs/src/main/asciidoc/about/prerequisites.adoc
@@ -35,7 +35,7 @@ include::{rootdir}/about/introduction.adoc[tag=prereqs]
 java -version
 mvn --version
 docker --version
-kubectl version --short
+kubectl version
 ----
 
 == Setting `JAVA_HOME`

--- a/docs/src/main/asciidoc/includes/prerequisites.adoc
+++ b/docs/src/main/asciidoc/includes/prerequisites.adoc
@@ -46,7 +46,7 @@ ifndef::h1-prefix[:h1-prefix: SE]
 java -version
 mvn --version
 docker --version
-kubectl version --short
+kubectl version
 ----
 
 [source,bash]


### PR DESCRIPTION
### Description

Docs: Do not use --short with kubectl version since it has been removed from kubectl

Fixes #9199