### PR TITLE
4.x: Fix typo @Provided -> @Provider in jaxrs-applications.adoc

### DIFF
--- a/docs/src/main/asciidoc/mp/jaxrs/jaxrs-applications.adoc
+++ b/docs/src/main/asciidoc/mp/jaxrs/jaxrs-applications.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ If one or more `Application` subclasses are found, call the `getClasses` and `ge
 in each subclass using the collections in steps (2) and (3) only as defaults, i.e. if these methods
 both return empty sets.
 
-NOTE: Helidon treats `@Path` and `@Provided` as bean-defining annotations but, as stated above,
+NOTE: Helidon treats `@Path` and `@Provider` as bean-defining annotations but, as stated above,
 `Application` subclasses may require additional annotations depending on the discovery mode
 
 == Setting Application Path


### PR DESCRIPTION
### Description
I use changes from [this PR](https://github.com/helidon-io/helidon/pull/8920), because the contribution agreement should be signed.