### PR TITLE
4.x: Don't manage logback version. Use slf4j-bom.

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -98,7 +98,6 @@
         <version.lib.junit-platform-testkit>1.11.3</version.lib.junit-platform-testkit>
         <version.lib.kafka>3.8.1</version.lib.kafka>
         <version.lib.log4j>2.21.1</version.lib.log4j>
-        <version.lib.logback>1.4.14</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.micrometer>1.13.4</version.lib.micrometer>
@@ -327,6 +326,12 @@
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
                 <version>${version.lib.jaxb-runtime}</version>
+            </dependency>
+            <dependency>
+                <!-- contains the API as well -->
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.el</artifactId>
+                <version>${version.lib.el-impl}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.ws.rs</groupId>
@@ -751,21 +756,6 @@
                 <version>${version.lib.jandex}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${version.lib.slf4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk-platform-logging</artifactId>
-                <version>${version.lib.slf4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-                <version>${version.lib.slf4j}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-core</artifactId>
                 <version>${version.lib.smallrye-openapi}</version>
@@ -1106,27 +1096,6 @@
 
             <!-- Section 2: third party dependencies used by examples -->
             <dependency>
-                <!-- contains the API as well -->
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>${version.lib.el-impl}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${version.lib.slf4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${version.lib.logback}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>${version.lib.logback}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
                 <version>${version.lib.activemq}</version>
@@ -1448,6 +1417,13 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
                 <version>${version.lib.log4j}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-bom</artifactId>
+                <version>${version.lib.slf4j}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
### Description

1. Don't manage the version of logback. Fixes #9644. 
2. Use `slf4j-bom` instead of managing individual artifacts.
3. Move `org.glassfish:jakarta-el` out of "examples" section of dependency management since it is used by Helidon code (microprofile/bean-validation)

Note that removing logback version management has the risk of breaking customer's builds if they rely on Helidon to version manage logback (which they shouldn't, but they might). This is not a Java API change and is easily remedied, and we've made these types of changes in minor releases before. This is why I am considering it for a minor release (4.2.0). If we deem this unacceptable then we'll have to make this change in Helidon 5.

### Documentation

No change
