### PR TITLE
Metrics support for FT SE

### DIFF
--- a/docs/src/main/asciidoc/se/fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/se/fault-tolerance.adoc
@@ -262,19 +262,13 @@ in Helidon when a method is decorated with multiple annotations.
 == Metrics
 
 The Helidon Fault Tolerance module has support for some basic metrics to monitor
-certain conditions. Metrics are disabled by default, but can be enabled via config by
-setting the property `ft.metrics.enabled=true` and by including an actual metrics
-implementation in your classpath.
+certain application conditions. Metrics are disabled by default, but can be enabled
+via config by setting the property `ft.metrics.enabled=true` and by including an actual
+metrics implementation in your classpath. For more information about metrics implementations
+see xref:{rootdir}/se/metrics/metrics.adoc[Helidon Metrics].
 
-```
-<dependency>
-    <groupId>io.helidon.metrics</groupId>
-    <artifactId>helidon-metrics</artifactId>
-</dependency>
-```
-
-The following tables lists all the metrics created by the Fault Tolerance module.
-Note that these metrics are generated per instance, and that each instance _must_
+The following tables list all the metrics created by the Fault Tolerance module.
+Note that these metrics are generated per command instance, and that each instance _must_
 be identified by a unique name --assigned either programmatically by
 the application developer or automatically by the API.
 

--- a/docs/src/main/asciidoc/se/fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/se/fault-tolerance.adoc
@@ -277,7 +277,7 @@ the application developer or automatically by the API.
 |===
 ^|Name ^|Tags ^|Description
 |ft.bulkhead.calls.total | name="<bulkhead-name>" | Counter for all calls entering a bulkhead
-|ft.bulkhead.waitingDuration | name="<bulkhead-name>" | Histogram of waiting times to enter a bulkhead
+|ft.bulkhead.waitingDuration | name="<bulkhead-name>" | Distribution summary of waiting times to enter a bulkhead
 |ft.bulkhead.executionsRunning | name="<bulkhead-name>" | Gauge whose value is the number of executions running in a bulkhead
 |ft.bulkhead.executionsWaiting | name="<bulkhead-name>" | Gauge whose value is the number of executions waiting in a bulkhead
 |===
@@ -304,14 +304,14 @@ closed to open state
 |===
 ^|Name ^|Tags ^|Description
 |ft.timeout.calls.total | name="<timeout-name>" | Counter for all calls entering a timeout
-|ft.timeout.executionDuration | name="<timeout-name>" | Histogram of all execution durations in a timeout
+|ft.timeout.executionDuration | name="<timeout-name>" | Distribution summary of all execution durations in a timeout
 |===
 
 === Enabling Metrics Programmatically
 
 Metrics can be enabled programmatically either globally or, if disabled globally, individually for
 each command instance. To enable metrics globally, call `FaultTolerance.config(Config)` passing
-a Config instance that sets `ft.metrics.enabled=true`. This must be done on application startup,
+a Config instance that sets `ft.metrics.default-enabled=true`. This must be done on application startup,
 before any command instances are created.
 
 If metrics are not enabled globally, they can be enabled programmatically on each command instance
@@ -326,7 +326,6 @@ include::{sourcedir}/se/FaultToleranceSnippets.java[tag=snippet_8, indent=0]
 
 NOTE: The global config setting always takes precedence: that is, if metrics are enabled
 globally, they *cannot* be disabled individually by calling `enableMetrics(false)`.
-
 
 == Examples
 

--- a/docs/src/main/asciidoc/se/fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/se/fault-tolerance.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -258,6 +258,81 @@ and bulkhead is the last one (the first to be executed once a value is returned)
 
 NOTE: This is the ordering used by the MicroProfile Fault Tolerance implementation
 in Helidon when a method is decorated with multiple annotations.
+
+== Metrics
+
+The Helidon Fault Tolerance module has support for some basic metrics to monitor
+certain conditions. Metrics are disabled by default, but can be enabled via config by
+setting the property `ft.metrics.enabled=true` and by including an actual metrics
+implementation in your classpath.
+
+```
+<dependency>
+    <groupId>io.helidon.metrics</groupId>
+    <artifactId>helidon-metrics</artifactId>
+</dependency>
+```
+
+The following tables lists all the metrics created by the Fault Tolerance module.
+Note that these metrics are generated per instance, and that each instance _must_
+be identified by a unique name --assigned either programmatically by
+the application developer or automatically by the API.
+
+[cols="1,2,3"]
+.Bulkheads
+|===
+^|Name ^|Tags ^|Description
+|ft.bulkhead.calls.total | name="<bulkhead-name>" | Counter for all calls entering a bulkhead
+|ft.bulkhead.waitingDuration | name="<bulkhead-name>" | Histogram of waiting times to enter a bulkhead
+|ft.bulkhead.executionsRunning | name="<bulkhead-name>" | Gauge whose value is the number of executions running in a bulkhead
+|ft.bulkhead.executionsWaiting | name="<bulkhead-name>" | Gauge whose value is the number of executions waiting in a bulkhead
+|===
+
+[cols="1,2,3"]
+.Circuit Breakers
+|===
+^|Name ^|Tags ^|Description
+|ft.circuitbreaker.calls.total | name="<breaker-name>" | Counter for all calls entering a circuit breaker
+|ft.circuitbreaker.opened.total | name="<breaker-name>" | Counter for the number of times a circuit breaker has moved from
+closed to open state
+|===
+
+[cols="1,2,3"]
+.Retries
+|===
+^|Name ^|Tags ^|Description
+|ft.retry.calls.total | name="<retry-name>" | Counter for all calls entering a retry
+|ft.retry.retries.total | name="<retry-name>" | Counter for all retried calls, excluding the initial call
+|===
+
+[cols="1,2,3"]
+.Timeouts
+|===
+^|Name ^|Tags ^|Description
+|ft.timeout.calls.total | name="<timeout-name>" | Counter for all calls entering a timeout
+|ft.timeout.executionDuration | name="<timeout-name>" | Histogram of all execution durations in a timeout
+|===
+
+=== Enabling Metrics Programmatically
+
+Metrics can be enabled programmatically either globally or, if disabled globally, individually for
+each command instance. To enable metrics globally, call `FaultTolerance.config(Config)` passing
+a Config instance that sets `ft.metrics.enabled=true`. This must be done on application startup,
+before any command instances are created.
+
+If metrics are not enabled globally, they can be enabled programmatically on each command instance
+using the `enableMetrics(boolean)` method on its corresponding builder. For example, the
+following snippet shows how to create a `Retry` instance of name `my-retry` with metrics
+support enabled.
+
+[source,java]
+----
+include::{sourcedir}/se/FaultToleranceSnippets.java[tag=snippet_8, indent=0]
+----
+
+NOTE: The global config setting always takes precedence: that is, if metrics are enabled
+globally, they *cannot* be disabled individually by calling `enableMetrics(false)`.
+
 
 == Examples
 

--- a/docs/src/main/java/io/helidon/docs/se/FaultToleranceSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/FaultToleranceSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,5 +126,14 @@ class FaultToleranceSnippets {
 
         T result = builder.build().invoke(this::mayTakeVeryLong);
         // end::snippet_7[]
+    }
+
+    <T> void snippet_8() {
+        // tag::snippet_8[]
+        Retry retry = Retry.builder()
+                .name("my-retry")
+                .enableMetrics(true)
+                .build();
+        // end::snippet_8[]
     }
 }

--- a/fault-tolerance/fault-tolerance/pom.xml
+++ b/fault-tolerance/fault-tolerance/pom.xml
@@ -154,6 +154,14 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/fault-tolerance/fault-tolerance/pom.xml
+++ b/fault-tolerance/fault-tolerance/pom.xml
@@ -76,8 +76,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <groupId>io.helidon.metrics.providers</groupId>
+            <artifactId>helidon-metrics-providers-micrometer</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/fault-tolerance/fault-tolerance/pom.xml
+++ b/fault-tolerance/fault-tolerance/pom.xml
@@ -49,6 +49,14 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <!--
             Used to declare Features in module-info.java
             -->
@@ -69,6 +77,16 @@
         <dependency>
             <groupId>io.helidon.common.testing</groupId>
             <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/fault-tolerance/fault-tolerance/pom.xml
+++ b/fault-tolerance/fault-tolerance/pom.xml
@@ -53,10 +53,6 @@
             <artifactId>helidon-metrics-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.service</groupId>
-            <artifactId>helidon-service-registry</artifactId>
-        </dependency>
-        <dependency>
             <!--
             Used to declare Features in module-info.java
             -->

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
@@ -54,6 +54,11 @@ public interface Bulkhead extends FtHandler, RuntimeType.Api<BulkheadConfig> {
     String FT_BULKHEAD_EXECUTIONSWAITING = "ft.bulkhead.executionsWaiting";
 
     /**
+     * Gauge of number of executions rejected by the bulkhead.
+     */
+    String FT_BULKHEAD_EXECUTIONSREJECTED = "ft.bulkhead.executionsRejected";
+
+    /**
      * Create {@link Bulkhead} from its configuration.
      *
      * @param config configuration of a bulkhead to create

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,27 @@ import io.helidon.builder.api.RuntimeType;
  */
 @RuntimeType.PrototypedBy(BulkheadConfig.class)
 public interface Bulkhead extends FtHandler, RuntimeType.Api<BulkheadConfig> {
+
+    /**
+     * Counter for all the calls in a bulkhead.
+     */
+    String FT_BULKHEAD_CALLS_TOTAL = "ft.bulkhead.calls.total";
+
+    /**
+     * Histogram of waiting time to enter a bulkhead.
+     */
+    String FT_BULKHEAD_WAITINGDURATION = "ft.bulkhead.waitingDuration";
+
+    /**
+     * Gauge of number of executions running at a certain time.
+     */
+    String FT_BULKHEAD_EXECUTIONSRUNNING = "ft.bulkhead.executionsRunning";
+
+    /**
+     * Gauge of number of executions waiting at a certain time.
+     */
+    String FT_BULKHEAD_EXECUTIONSWAITING = "ft.bulkhead.executionsWaiting";
+
     /**
      * Create {@link Bulkhead} from its configuration.
      *

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,19 @@ interface BulkheadConfigBlueprint extends Prototype.Factory<Bulkhead> {
      * @return name of this bulkhead
      */
     Optional<String> name();
+
+    /**
+     * Flag to enable metrics for this instance. The value of this flag is
+     * combined with the global config entry
+     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_ENABLED}.
+     * If either of these flags is {@code true}, then metrics will be enabled
+     * for the instance.
+     *
+     * @return metrics enabled flag
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean enableMetrics();
 
     class BuilderDecorator implements Prototype.BuilderDecorator<BulkheadConfig.BuilderBase<?, ?>> {
         @Override

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadConfigBlueprint.java
@@ -81,7 +81,7 @@ interface BulkheadConfigBlueprint extends Prototype.Factory<Bulkhead> {
     /**
      * Flag to enable metrics for this instance. The value of this flag is
      * combined with the global config entry
-     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_ENABLED}.
+     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_DEFAULT_ENABLED}.
      * If either of these flags is {@code true}, then metrics will be enabled
      * for the instance.
      *

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
@@ -66,7 +66,7 @@ class BulkheadImpl implements Bulkhead {
         this.inProgressLock = new ReentrantLock(true);
         this.config = config;
 
-        this.metricsEnabled = config.enableMetrics() || MetricsUtils.enableMetrics();
+        this.metricsEnabled = config.enableMetrics() || MetricsUtils.defaultEnabled();
         if (metricsEnabled) {
             Tag nameTag = Tag.create("name", name);
             callsCounterMetric = MetricsUtils.counterBuilder(FT_BULKHEAD_CALLS_TOTAL, nameTag);

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreaker.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,18 @@ import io.helidon.builder.api.RuntimeType;
  */
 @RuntimeType.PrototypedBy(CircuitBreakerConfig.class)
 public interface CircuitBreaker extends FtHandler, RuntimeType.Api<CircuitBreakerConfig> {
+
+    /**
+     * Counter for all the calls in a timeout.
+     */
+    String FT_CIRCUITBREAKER_CALLS_TOTAL = "ft.circuitbreaker.calls.total";
+
+    /**
+     * Counter for the number of times a circuit breaks has moved from
+     * {@link State#CLOSED} to {@link State#OPEN}.
+     */
+    String FT_CIRCUITBREAKER_OPENED_TOTAL = "ft.circuitbreaker.opened.total";
+
     /**
      * Create a new circuit builder based on its configuration.
      *

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,19 @@ interface CircuitBreakerConfigBlueprint extends Prototype.Factory<CircuitBreaker
      */
     @Option.Singular
     Set<Class<? extends Throwable>> applyOn();
+
+    /**
+     * Flag to enable metrics for this instance. The value of this flag is
+     * combined with the global config entry
+     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_ENABLED}.
+     * If either of these flags is {@code true}, then metrics will be enabled
+     * for the instance.
+     *
+     * @return metrics enabled flag
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean enableMetrics();
 
     class BuilderDecorator implements Prototype.BuilderDecorator<CircuitBreakerConfig.BuilderBase<?, ?>> {
         @Override

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerConfigBlueprint.java
@@ -105,7 +105,7 @@ interface CircuitBreakerConfigBlueprint extends Prototype.Factory<CircuitBreaker
     /**
      * Flag to enable metrics for this instance. The value of this flag is
      * combined with the global config entry
-     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_ENABLED}.
+     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_DEFAULT_ENABLED}.
      * If either of these flags is {@code true}, then metrics will be enabled
      * for the instance.
      *

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
@@ -63,7 +63,7 @@ class CircuitBreakerImpl implements CircuitBreaker {
         this.name = config.name().orElseGet(() -> "circuit-breaker-" + System.identityHashCode(config));
         this.config = config;
 
-        this.metricsEnabled = config.enableMetrics() || MetricsUtils.enableMetrics();
+        this.metricsEnabled = config.enableMetrics() || MetricsUtils.defaultEnabled();
         if (metricsEnabled) {
             Tag nameTag = Tag.create("name", name);
             callsCounterMetric = MetricsUtils.counterBuilder(FT_CIRCUITBREAKER_CALLS_TOTAL, nameTag);

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Tag;
 
 class CircuitBreakerImpl implements CircuitBreaker {
     /*
@@ -47,6 +50,9 @@ class CircuitBreakerImpl implements CircuitBreaker {
     private final String name;
     private final CircuitBreakerConfig config;
 
+    private Counter callsCounterMetric;
+    private Counter openedCounterMetric;
+
     CircuitBreakerImpl(CircuitBreakerConfig config) {
         this.delayMillis = config.delay().toMillis();
         this.successThreshold = config.successThreshold();
@@ -55,6 +61,12 @@ class CircuitBreakerImpl implements CircuitBreaker {
         this.errorChecker = ErrorChecker.create(config.skipOn(), config.applyOn());
         this.name = config.name().orElseGet(() -> "circuit-breaker-" + System.identityHashCode(config));
         this.config = config;
+
+        if (MetricsUtils.metricsEnabled()) {
+            Tag nameTag = Tag.create("name", name);
+            callsCounterMetric = MetricsUtils.counterBuilder(FT_CIRCUITBREAKER_CALLS_TOTAL, nameTag);
+            openedCounterMetric = MetricsUtils.counterBuilder(FT_CIRCUITBREAKER_OPENED_TOTAL, nameTag);
+        }
     }
 
     @Override
@@ -69,6 +81,9 @@ class CircuitBreakerImpl implements CircuitBreaker {
 
     @Override
     public <T> T invoke(Supplier<? extends T> supplier) {
+        if (MetricsUtils.metricsEnabled()) {
+            callsCounterMetric.increment();
+        }
         return switch (state.get()) {
             case CLOSED -> executeTask(supplier);
             case HALF_OPEN -> halfOpenTask(supplier);
@@ -131,6 +146,10 @@ class CircuitBreakerImpl implements CircuitBreaker {
                 results.reset();
                 // if we successfully switch to open, we need to schedule switch to half-open
                 scheduleHalf();
+                // update metrics for this transition
+                if (MetricsUtils.metricsEnabled()) {
+                    openedCounterMetric.increment();
+                }
             }
         }
     }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -51,10 +51,10 @@ public final class FaultTolerance {
 
     /**
      * Config key to enable metrics in Fault Tolerance. This flag can be overridden by
-     * each FT operation. See for example {@link BulkheadConfigBlueprint#enableMetrics()}.
+     * each FT command builder. See for example {@link BulkheadConfigBlueprint#enableMetrics()}.
      * All metrics are disabled by default.
      */
-    public static final String FT_METRICS_ENABLED = "ft.metrics.enabled";
+    public static final String FT_METRICS_DEFAULT_ENABLED = "ft.metrics.default-enabled";
 
     private static final System.Logger LOGGER = System.getLogger(FaultTolerance.class.getName());
 

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,14 @@ import static java.lang.System.Logger.Level.ERROR;
  * @see #builder()
  */
 public final class FaultTolerance {
+
+    /**
+     * Config key to enable metrics in Fault Tolerance. This flag can be overridden by
+     * each FT operation. See for example {@link BulkheadConfigBlueprint#enableMetrics()}.
+     * All metrics are disabled by default.
+     */
+    public static final String FT_METRICS_ENABLED = "ft.metrics.enabled";
+
     private static final System.Logger LOGGER = System.getLogger(FaultTolerance.class.getName());
 
     private static final AtomicReference<LazyValue<ExecutorService>> EXECUTOR = new AtomicReference<>();

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.faulttolerance;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.helidon.common.config.Config;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Gauge;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.Timer;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import static io.helidon.metrics.api.Meter.Scope.VENDOR;
+
+@SuppressWarnings("unchecked")
+class MetricsUtils {
+
+    private static final String FT_METRICS_ENABLED = "ft.metrics.enabled";
+    private static final MetricsFactory METRICS_FACTORY = MetricsFactory.getInstance();
+    private static final MeterRegistry METRICS_REGISTRY = Metrics.globalRegistry();
+
+    private static volatile Boolean metricsEnabled;
+
+    private MetricsUtils() {
+    }
+
+    /**
+     * Looks for the metrics enabled flag in config and caches result. FT metrics
+     * are disabled by default.
+     *
+     * @return value of metrics flag
+     */
+    static boolean metricsEnabled() {
+        if (metricsEnabled == null) {
+            ServiceRegistry registry = ServiceRegistryManager.create().registry();
+            Config config = registry.get(Config.class);
+            metricsEnabled = config.get(FT_METRICS_ENABLED).asBoolean().orElse(false);
+        }
+        return metricsEnabled;
+    }
+
+    static <T extends Number> Gauge<T> gaugeBuilder(String name, Supplier<T> supplier, Tag... tags) {
+        Gauge.Builder<T> builder = METRICS_FACTORY.gaugeBuilder(name, supplier).scope(VENDOR);
+        List<Tag> tagList = List.of(tags);
+        builder.tags(tagList);
+        METRICS_REGISTRY.getOrCreate(builder);
+        return METRICS_REGISTRY.gauge(name, tagList).orElseThrow();
+    }
+
+    static Counter counterBuilder(String name, Tag... tags) {
+        Counter.Builder builder = METRICS_FACTORY.counterBuilder(name).scope(VENDOR);
+        List<Tag> tagList = List.of(tags);
+        builder.tags(tagList);
+        METRICS_REGISTRY.getOrCreate(builder);
+        return METRICS_REGISTRY.counter(name, tagList).orElseThrow();
+    }
+
+    static Timer timerBuilder(String name, Tag... tags) {
+        Timer.Builder builder = METRICS_FACTORY.timerBuilder(name).scope(VENDOR);
+        List<Tag> tagList = List.of(tags);
+        builder.tags(tagList);
+        METRICS_REGISTRY.getOrCreate(builder);
+        return METRICS_REGISTRY.timer(name, tagList).orElseThrow();
+    }
+
+    static <T extends Number> Gauge<T> gauge(String name, Tag... tags) {
+        return METRICS_REGISTRY.gauge(name, List.of(tags)).orElseThrow();
+    }
+
+    static Counter counter(String name, Tag... tags) {
+        return METRICS_REGISTRY.counter(name, List.of(tags)).orElseThrow();
+    }
+
+    static Timer timer(String name, Tag... tags) {
+        return METRICS_REGISTRY.timer(name, List.of(tags)).orElseThrow();
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -18,6 +18,7 @@ package io.helidon.faulttolerance;
 import java.util.List;
 import java.util.function.Supplier;
 
+import io.helidon.common.LazyValue;
 import io.helidon.common.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Gauge;
@@ -33,8 +34,8 @@ import static io.helidon.metrics.api.Meter.Scope.VENDOR;
 @SuppressWarnings("unchecked")
 class MetricsUtils {
 
-    private static final MetricsFactory METRICS_FACTORY = MetricsFactory.getInstance();
-    private static final MeterRegistry METRICS_REGISTRY = Metrics.globalRegistry();
+    private static final LazyValue<MetricsFactory> METRICS_FACTORY = LazyValue.create(MetricsFactory::getInstance);
+    private static final LazyValue<MeterRegistry> METRICS_REGISTRY = LazyValue.create(Metrics::globalRegistry);
 
     private static volatile Boolean enableMetrics;
 
@@ -55,39 +56,39 @@ class MetricsUtils {
         return enableMetrics;
     }
 
-    static <T extends Number> Gauge<T> gaugeBuilder(String name, Supplier<T> supplier, Tag... tags) {
-        Gauge.Builder<T> builder = METRICS_FACTORY.gaugeBuilder(name, supplier).scope(VENDOR);
+    static <T extends Number> void gaugeBuilder(String name, Supplier<T> supplier, Tag... tags) {
+        Gauge.Builder<T> builder = METRICS_FACTORY.get().gaugeBuilder(name, supplier).scope(VENDOR);
         List<Tag> tagList = List.of(tags);
         builder.tags(tagList);
-        METRICS_REGISTRY.getOrCreate(builder);
-        return METRICS_REGISTRY.gauge(name, tagList).orElseThrow();
+        METRICS_REGISTRY.get().getOrCreate(builder);
+        METRICS_REGISTRY.get().gauge(name, tagList).orElseThrow();
     }
 
     static Counter counterBuilder(String name, Tag... tags) {
-        Counter.Builder builder = METRICS_FACTORY.counterBuilder(name).scope(VENDOR);
+        Counter.Builder builder = METRICS_FACTORY.get().counterBuilder(name).scope(VENDOR);
         List<Tag> tagList = List.of(tags);
         builder.tags(tagList);
-        METRICS_REGISTRY.getOrCreate(builder);
-        return METRICS_REGISTRY.counter(name, tagList).orElseThrow();
+        METRICS_REGISTRY.get().getOrCreate(builder);
+        return METRICS_REGISTRY.get().counter(name, tagList).orElseThrow();
     }
 
     static Timer timerBuilder(String name, Tag... tags) {
-        Timer.Builder builder = METRICS_FACTORY.timerBuilder(name).scope(VENDOR);
+        Timer.Builder builder = METRICS_FACTORY.get().timerBuilder(name).scope(VENDOR);
         List<Tag> tagList = List.of(tags);
         builder.tags(tagList);
-        METRICS_REGISTRY.getOrCreate(builder);
-        return METRICS_REGISTRY.timer(name, tagList).orElseThrow();
+        METRICS_REGISTRY.get().getOrCreate(builder);
+        return METRICS_REGISTRY.get().timer(name, tagList).orElseThrow();
     }
 
     static <T extends Number> Gauge<T> gauge(String name, Tag... tags) {
-        return METRICS_REGISTRY.gauge(name, List.of(tags)).orElseThrow();
+        return METRICS_REGISTRY.get().gauge(name, List.of(tags)).orElseThrow();
     }
 
     static Counter counter(String name, Tag... tags) {
-        return METRICS_REGISTRY.counter(name, List.of(tags)).orElseThrow();
+        return METRICS_REGISTRY.get().counter(name, List.of(tags)).orElseThrow();
     }
 
     static Timer timer(String name, Tag... tags) {
-        return METRICS_REGISTRY.timer(name, List.of(tags)).orElseThrow();
+        return METRICS_REGISTRY.get().timer(name, List.of(tags)).orElseThrow();
     }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -28,7 +28,7 @@ import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 
-import static io.helidon.faulttolerance.FaultTolerance.FT_METRICS_ENABLED;
+import static io.helidon.faulttolerance.FaultTolerance.FT_METRICS_DEFAULT_ENABLED;
 import static io.helidon.metrics.api.Meter.Scope.VENDOR;
 
 @SuppressWarnings("unchecked")
@@ -37,7 +37,7 @@ class MetricsUtils {
     private static final LazyValue<MetricsFactory> METRICS_FACTORY = LazyValue.create(MetricsFactory::getInstance);
     private static final LazyValue<MeterRegistry> METRICS_REGISTRY = LazyValue.create(Metrics::globalRegistry);
 
-    private static volatile Boolean enableMetrics;
+    private static volatile Boolean defaultEnabled;
 
     private MetricsUtils() {
     }
@@ -48,12 +48,12 @@ class MetricsUtils {
      *
      * @return value of metrics flag
      */
-    static boolean enableMetrics() {
-        if (enableMetrics == null) {
+    static boolean defaultEnabled() {
+        if (defaultEnabled == null) {
             Config config = FaultTolerance.config();
-            enableMetrics = config.get(FT_METRICS_ENABLED).asBoolean().orElse(false);
+            defaultEnabled = config.get(FT_METRICS_DEFAULT_ENABLED).asBoolean().orElse(false);
         }
-        return enableMetrics;
+        return defaultEnabled;
     }
 
     static <T extends Number> void gaugeBuilder(String name, Supplier<T> supplier, Tag... tags) {

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -26,19 +26,17 @@ import io.helidon.metrics.api.Metrics;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
-import io.helidon.service.registry.ServiceRegistry;
-import io.helidon.service.registry.ServiceRegistryManager;
 
+import static io.helidon.faulttolerance.FaultTolerance.FT_METRICS_ENABLED;
 import static io.helidon.metrics.api.Meter.Scope.VENDOR;
 
 @SuppressWarnings("unchecked")
 class MetricsUtils {
 
-    private static final String FT_METRICS_ENABLED = "ft.metrics.enabled";
     private static final MetricsFactory METRICS_FACTORY = MetricsFactory.getInstance();
     private static final MeterRegistry METRICS_REGISTRY = Metrics.globalRegistry();
 
-    private static volatile Boolean metricsEnabled;
+    private static volatile Boolean enableMetrics;
 
     private MetricsUtils() {
     }
@@ -49,13 +47,12 @@ class MetricsUtils {
      *
      * @return value of metrics flag
      */
-    static boolean metricsEnabled() {
-        if (metricsEnabled == null) {
-            ServiceRegistry registry = ServiceRegistryManager.create().registry();
-            Config config = registry.get(Config.class);
-            metricsEnabled = config.get(FT_METRICS_ENABLED).asBoolean().orElse(false);
+    static boolean enableMetrics() {
+        if (enableMetrics == null) {
+            Config config = FaultTolerance.config();
+            enableMetrics = config.get(FT_METRICS_ENABLED).asBoolean().orElse(false);
         }
-        return metricsEnabled;
+        return enableMetrics;
     }
 
     static <T extends Number> Gauge<T> gaugeBuilder(String name, Supplier<T> supplier, Tag... tags) {

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,18 @@ import io.helidon.builder.api.RuntimeType;
  */
 @RuntimeType.PrototypedBy(RetryConfig.class)
 public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
+
+    /**
+     * Counter for all the calls in a retry. Will always be greater than
+     * {@link #FT_RETRY_RETRIES_TOTAL} that only counts actual retries.
+     */
+    String FT_RETRY_CALLS_TOTAL = "ft.retry.calls.total";
+
+    /**
+     * Counter for all retry calls, excluding the initial call.
+     */
+    String FT_RETRY_RETRIES_TOTAL = "ft.retry.retries.total";
+
     /**
      * Create a new retry from its configuration.
      *

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
@@ -132,7 +132,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     /**
      * Flag to enable metrics for this instance. The value of this flag is
      * combined with the global config entry
-     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_ENABLED}.
+     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_DEFAULT_ENABLED}.
      * If either of these flags is {@code true}, then metrics will be enabled
      * for the instance.
      *

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,6 +128,19 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      * @return retry policy
      */
     Optional<Retry.RetryPolicy> retryPolicy();
+
+    /**
+     * Flag to enable metrics for this instance. The value of this flag is
+     * combined with the global config entry
+     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_ENABLED}.
+     * If either of these flags is {@code true}, then metrics will be enabled
+     * for the instance.
+     *
+     * @return metrics enabled flag
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean enableMetrics();
 
     class BuilderDecorator implements Prototype.BuilderDecorator<RetryConfig.BuilderBase<?, ?>> {
         @Override

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -49,7 +49,7 @@ class RetryImpl implements Retry {
         this.retryPolicy = config.retryPolicy().orElseThrow();
         this.retryConfig = config;
 
-        this.metricsEnabled = config.enableMetrics() || MetricsUtils.enableMetrics();
+        this.metricsEnabled = config.enableMetrics() || MetricsUtils.defaultEnabled();
         if (metricsEnabled) {
             Tag nameTag = Tag.create("name", name);
             callsCounterMetric = MetricsUtils.counterBuilder(FT_RETRY_CALLS_TOTAL, nameTag);

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Timeout.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,17 @@ import io.helidon.builder.api.RuntimeType;
  */
 @RuntimeType.PrototypedBy(TimeoutConfig.class)
 public interface Timeout extends FtHandler, RuntimeType.Api<TimeoutConfig> {
+
+    /**
+     * Counter for all the calls in a timeout.
+     */
+    String FT_TIMEOUT_CALLS_TOTAL = "ft.timeout.calls.total";
+
+    /**
+     * Histogram of execution durations.
+     */
+    String FT_TIMEOUT_EXECUTIONDURATION = "ft.timeout.executionDuration";
+
     /**
      * Create a timeout based on configuration.
      *

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,19 @@ interface TimeoutConfigBlueprint extends Prototype.Factory<Timeout> {
      * @return executor service to use
      */
     Optional<ExecutorService> executor();
+
+    /**
+     * Flag to enable metrics for this instance. The value of this flag is
+     * combined with the global config entry
+     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_ENABLED}.
+     * If either of these flags is {@code true}, then metrics will be enabled
+     * for the instance.
+     *
+     * @return metrics enabled flag
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean enableMetrics();
 
     class BuilderDecorator implements Prototype.BuilderDecorator<TimeoutConfig.BuilderBase<?, ?>> {
         @Override

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutConfigBlueprint.java
@@ -66,7 +66,7 @@ interface TimeoutConfigBlueprint extends Prototype.Factory<Timeout> {
     /**
      * Flag to enable metrics for this instance. The value of this flag is
      * combined with the global config entry
-     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_ENABLED}.
+     * {@link io.helidon.faulttolerance.FaultTolerance#FT_METRICS_DEFAULT_ENABLED}.
      * If either of these flags is {@code true}, then metrics will be enabled
      * for the instance.
      *

--- a/fault-tolerance/fault-tolerance/src/main/java/module-info.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/module-info.java
@@ -32,7 +32,6 @@ module io.helidon.faulttolerance {
     requires io.helidon.config;
     requires io.helidon.builder.api;
     requires io.helidon.metrics.api;
-    requires io.helidon.service.registry;
 
     requires static io.helidon.common.features.api;
 

--- a/fault-tolerance/fault-tolerance/src/main/java/module-info.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@ module io.helidon.faulttolerance {
     requires io.helidon.common.configurable;
     requires io.helidon.config;
     requires io.helidon.builder.api;
+    requires io.helidon.metrics.api;
+    requires io.helidon.service.registry;
 
     requires static io.helidon.common.features.api;
 

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/BulkheadBaseTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/BulkheadBaseTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static java.lang.System.Logger.Level.TRACE;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class BulkheadBaseTest {
+
+    protected static final long WAIT_TIMEOUT_MILLIS = 5000;
+    protected static final System.Logger LOGGER = System.getLogger(BulkheadBaseTest.class.getName());
+
+    /**
+     * A task to submit to a bulkhead. Can be checked for startup and manually
+     * unblocked for completion.
+     */
+    protected static class Task {
+        private final CountDownLatch started = new CountDownLatch(1);
+        private final CountDownLatch blocked = new CountDownLatch(1);
+
+        private final int index;
+        private CompletableFuture<?> future;
+
+        Task(int index) {
+            this.index = index;
+        }
+
+        int run() {
+            LOGGER.log(TRACE, "Task " + index + " running on thread " + Thread.currentThread().getName());
+
+            started.countDown();
+            try {
+                blocked.await();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return index;
+        }
+
+        boolean isStarted() {
+            return started.getCount() == 0;
+        }
+
+        boolean waitUntilStarted(long millis) throws InterruptedException {
+            return started.await(millis, TimeUnit.MILLISECONDS);
+        }
+
+        boolean isBlocked() {
+            return blocked.getCount() == 1;
+        }
+
+        void unblock() {
+            blocked.countDown();
+        }
+
+        void future(CompletableFuture<?> future) {
+            this.future = future;
+        }
+
+        CompletableFuture<?> future() {
+            return future;
+        }
+    }
+
+    protected static void assertEventually(Supplier<Boolean> predicate, long millis) throws InterruptedException {
+        long start = System.currentTimeMillis();
+        do {
+            if (predicate.get()) {
+                return;
+            }
+            Thread.sleep(100);
+        } while (System.currentTimeMillis() - start <= millis);
+        fail("Predicate failed after " + millis + " milliseconds");
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerBaseTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerBaseTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.faulttolerance;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CircuitBreakerBaseTest {
+
+    protected void breakerOpen(CircuitBreaker breaker) {
+        Request good = new Request();
+        assertThrows(CircuitBreakerOpenException.class, () -> breaker.invoke(good::invoke));
+    }
+
+    protected void bad(CircuitBreaker breaker) {
+        Failing failing = new Failing(new IllegalStateException("Fail"));
+        assertThrows(IllegalStateException.class, () -> breaker.invoke(failing::invoke));
+    }
+
+    protected void good(CircuitBreaker breaker) {
+        Request good = new Request();
+        breaker.invoke(good::invoke);
+    }
+
+    protected static class Failing {
+        private final RuntimeException exception;
+
+        Failing(RuntimeException exception) {
+            this.exception = exception;
+        }
+
+        Integer invoke() {
+            throw exception;
+        }
+    }
+
+    protected static class Request {
+        Request() {
+        }
+
+        Integer invoke() {
+            return 1;
+        }
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerMetricsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Tag;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.faulttolerance.CircuitBreaker.FT_CIRCUITBREAKER_CALLS_TOTAL;
+import static io.helidon.faulttolerance.CircuitBreaker.FT_CIRCUITBREAKER_OPENED_TOTAL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class CircuitBreakerMetricsTest extends CircuitBreakerBaseTest {
+
+    @Test
+    void testCircuitBreaker() {
+        CircuitBreaker breaker = CircuitBreaker.builder()
+                .volume(10)
+                .errorRatio(20)
+                .delay(Duration.ofMillis(200))
+                .successThreshold(2)
+                .build();
+
+        good(breaker);
+        good(breaker);
+        bad(breaker);
+        good(breaker);
+        good(breaker);
+        good(breaker);
+        good(breaker);
+        good(breaker);
+        bad(breaker);
+        bad(breaker);       // should open - window complete
+
+        Counter callsCounter = MetricsUtils.counter(FT_CIRCUITBREAKER_CALLS_TOTAL, Tag.create("name", breaker.name()));
+        assertThat(callsCounter.count(), is(10L));
+        Counter openedCounter = MetricsUtils.counter(FT_CIRCUITBREAKER_OPENED_TOTAL, Tag.create("name", breaker.name()));
+        assertThat(openedCounter.count(), is(1L));
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerMetricsTest.java
@@ -18,9 +18,11 @@ package io.helidon.faulttolerance;
 
 import java.time.Duration;
 
+import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Tag;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.faulttolerance.CircuitBreaker.FT_CIRCUITBREAKER_CALLS_TOTAL;
@@ -29,6 +31,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 class CircuitBreakerMetricsTest extends CircuitBreakerBaseTest {
+
+    @BeforeAll
+    static void setupTest() {
+        FaultTolerance.config(Config.create());
+    }
 
     @Test
     void testCircuitBreaker() {

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/CircuitBreakerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class CircuitBreakerTest {
+class CircuitBreakerTest extends CircuitBreakerBaseTest {
 
     private static final long WAIT_TIMEOUT_MILLIS = 2000;
 
@@ -96,41 +95,5 @@ class CircuitBreakerTest {
         good(breaker);
 
         assertThat(breaker.state(), is(CircuitBreaker.State.OPEN));
-    }
-
-    private void breakerOpen(CircuitBreaker breaker) {
-        Request good = new Request();
-        assertThrows(CircuitBreakerOpenException.class, () -> breaker.invoke(good::invoke));
-    }
-
-    private void bad(CircuitBreaker breaker) {
-        Failing failing = new Failing(new IllegalStateException("Fail"));
-        assertThrows(IllegalStateException.class, () -> breaker.invoke(failing::invoke));
-    }
-
-    private void good(CircuitBreaker breaker) {
-        Request good = new Request();
-        breaker.invoke(good::invoke);
-    }
-
-    private static class Failing {
-        private final RuntimeException exception;
-
-        Failing(RuntimeException exception) {
-            this.exception = exception;
-        }
-
-        Integer invoke() {
-            throw exception;
-        }
-    }
-
-    private static class Request {
-        Request() {
-        }
-
-        Integer invoke() {
-            return 1;
-        }
     }
 }

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsEnableTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsEnableTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+import java.util.NoSuchElementException;
+
+import io.helidon.config.Config;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Tag;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.faulttolerance.Bulkhead.FT_BULKHEAD_CALLS_TOTAL;
+import static io.helidon.faulttolerance.CircuitBreaker.FT_CIRCUITBREAKER_CALLS_TOTAL;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class MetricsEnableTest extends CircuitBreakerBaseTest {
+
+    private static final long WAIT_TIMEOUT_MILLIS = 5000;
+
+    @BeforeAll
+    static void setupTest() {
+        FaultTolerance.config(Config.empty());      // empty config
+    }
+
+    @Test
+    void testEnableBulkhead() throws InterruptedException {
+        Bulkhead bulkhead = BulkheadConfig.builder()
+                .enableMetrics(true)    // metrics enabled
+                .build();
+
+        BulkheadBaseTest.Task inProgress = new BulkheadBaseTest.Task(0);
+        Async.invokeStatic(() -> bulkhead.invoke(inProgress::run));
+        if (!inProgress.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task inProgress not started");
+        }
+
+        Tag nameTag = Tag.create("name", bulkhead.name());
+        Counter callsTotal = MetricsUtils.counter(FT_BULKHEAD_CALLS_TOTAL, nameTag);
+        assertThat(callsTotal.count(), is(1L));
+    }
+
+    @Test
+    void testDisableBulkhead() throws InterruptedException {
+        Bulkhead bulkhead = BulkheadConfig.builder()
+                .enableMetrics(false)       // metrics disabled
+                .build();
+
+        BulkheadBaseTest.Task inProgress = new BulkheadBaseTest.Task(0);
+        Async.invokeStatic(() -> bulkhead.invoke(inProgress::run));
+        if (!inProgress.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task inProgress not started");
+        }
+
+        Tag nameTag = Tag.create("name", bulkhead.name());
+        assertThrows(NoSuchElementException.class,
+                     () -> MetricsUtils.counter(FT_BULKHEAD_CALLS_TOTAL, nameTag));
+    }
+
+    @Test
+    void testEnableCircuitBreaker() {
+        CircuitBreaker breaker = CircuitBreaker.builder()
+                .enableMetrics(true)        // metrics enabled
+                .delay(Duration.ofMillis(200))
+                .build();
+
+        good(breaker);
+        good(breaker);
+
+        Counter callsCounter = MetricsUtils.counter(FT_CIRCUITBREAKER_CALLS_TOTAL, Tag.create("name", breaker.name()));
+        assertThat(callsCounter.count(), Matchers.is(2L));
+    }
+
+    @Test
+    void testDisableCircuitBreaker() {
+        CircuitBreaker breaker = CircuitBreaker.builder()
+                .enableMetrics(false)        // metrics disabled
+                .delay(Duration.ofMillis(200))
+                .build();
+
+        good(breaker);
+        good(breaker);
+
+        assertThrows(NoSuchElementException.class,
+                     () -> MetricsUtils.counter(FT_CIRCUITBREAKER_CALLS_TOTAL, Tag.create("name", breaker.name())));
+    }
+
+    @Test
+    void testEnableRetry() {
+        Retry retry = Retry.builder()
+                .enableMetrics(true)        // metrics enabled
+                .build();
+
+        retry.invoke(() -> 0);
+
+        Tag nameTag = Tag.create("name", retry.name());
+        Counter callsCounter = MetricsUtils.counter(Retry.FT_RETRY_CALLS_TOTAL, nameTag);
+        assertThat(callsCounter.count(), is(1L));
+    }
+
+    @Test
+    void testDisableRetry() {
+        Retry retry = Retry.builder()
+                .enableMetrics(false)        // metrics disabled
+                .build();
+
+        retry.invoke(() -> 0);
+
+        Tag nameTag = Tag.create("name", retry.name());
+        assertThrows(NoSuchElementException.class,
+                     () -> MetricsUtils.counter(Retry.FT_RETRY_CALLS_TOTAL, nameTag));
+    }
+
+    @Test
+    void testEnableTimeout() {
+        Timeout timeout = Timeout.builder()
+                .enableMetrics(true)        // metrics enabled
+                .build();
+
+        timeout.invoke(() -> 0);
+
+        Tag nameTag = Tag.create("name", timeout.name());
+        Counter callsCounter = MetricsUtils.counter(Timeout.FT_TIMEOUT_CALLS_TOTAL, nameTag);
+        assertThat(callsCounter.count(), is(1L));
+    }
+
+    @Test
+    void testDisableTimeout() {
+        Timeout timeout = Timeout.builder()
+                .enableMetrics(false)        // metrics disabled
+                .build();
+
+        timeout.invoke(() -> 0);
+
+        Tag nameTag = Tag.create("name", timeout.name());
+        assertThrows(NoSuchElementException.class,
+                     () -> MetricsUtils.counter(Timeout.FT_TIMEOUT_CALLS_TOTAL, nameTag));
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryMetricsTest.java
@@ -20,15 +20,23 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import io.helidon.config.Config;
+import io.helidon.logging.common.LogConfig;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Tag;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class RetryMetricsTest {
+
+    @BeforeAll
+    static void setupTest() {
+        FaultTolerance.config(Config.create());
+    }
 
     @Test
     void testRetry() {

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryMetricsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Tag;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RetryMetricsTest {
+
+    @Test
+    void testRetry() {
+        Retry retry;
+        Counter retryCounter;
+        Counter callsCounter;
+
+        retry = Retry.builder()
+                     .calls(3)
+                     .overallTimeout(Duration.ofSeconds(5))
+                     .delay(Duration.ofMillis(0))
+                     .name("flaky")     // same name
+                     .build();
+        retry.invoke(new FlakySupplier(2));
+        callsCounter = MetricsUtils.counter(Retry.FT_RETRY_CALLS_TOTAL, Tag.create("name", "flaky"));
+        assertThat(callsCounter.count(), is(3L));
+        retryCounter = MetricsUtils.counter(Retry.FT_RETRY_RETRIES_TOTAL, Tag.create("name", "flaky"));
+        assertThat(retryCounter.count(), is(2L));
+
+        retry = Retry.builder()
+                     .calls(4)
+                     .overallTimeout(Duration.ofSeconds(5))
+                     .delay(Duration.ofMillis(0))
+                     .name("flaky")     // same name
+                     .build();
+        retry.invoke(new FlakySupplier(3));
+        assertThat(callsCounter.count(), is(7L));
+        assertThat(retryCounter.count(), is(5L));
+    }
+
+    @Test
+    void testRetryGeneratedName() {
+        Retry retry;
+        Counter retryCounter;
+        Counter callsCounter;
+
+        retry = Retry.builder()
+                .calls(2)
+                .overallTimeout(Duration.ofSeconds(5))
+                .delay(Duration.ofMillis(0))
+                .build();
+        retry.invoke(new FlakySupplier(1));
+        callsCounter = MetricsUtils.counter(Retry.FT_RETRY_CALLS_TOTAL, Tag.create("name", retry.name()));
+        assertThat(callsCounter.count(), is(2L));
+        retryCounter = MetricsUtils.counter(Retry.FT_RETRY_RETRIES_TOTAL, Tag.create("name", retry.name()));
+        assertThat(retryCounter.count(), is(1L));
+    }
+
+    private static class FlakySupplier implements Supplier<Long> {
+
+        private final AtomicInteger failures;
+
+        FlakySupplier(int failures) {
+            this.failures = new AtomicInteger(Integer.max(0, failures));
+        }
+
+        @Override
+        public Long get() {
+            if (failures.getAndDecrement() == 0) {
+                return 0L;      // success
+            }
+            throw new RuntimeException("failed");
+        }
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutMetricsTest.java
@@ -18,16 +18,23 @@ package io.helidon.faulttolerance;
 
 import java.time.Duration;
 
+import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class TimeoutMetricsTest {
+
+    @BeforeAll
+    static void setupTest() {
+        FaultTolerance.config(Config.create());
+    }
 
     @Test
     void testTimeout() {

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/TimeoutMetricsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.Timer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TimeoutMetricsTest {
+
+    @Test
+    void testTimeout() {
+        Timeout timeout;
+        Counter callsCounter;
+
+        timeout = Timeout.builder()
+                .timeout(Duration.ofSeconds(1))
+                .name("quick")      // same name
+                .build();
+        timeout.invoke(() -> null);
+        callsCounter = MetricsUtils.counter(Timeout.FT_TIMEOUT_CALLS_TOTAL, Tag.create("name", "quick"));
+        assertThat(callsCounter.count(), is(1L));
+
+        timeout = Timeout.builder()
+                .timeout(Duration.ofSeconds(1))
+                .name("quick")      // same name
+                .build();
+        timeout.invoke(() -> null);
+        assertThat(callsCounter.count(), is(2L));
+    }
+
+    @Test
+    void testTimeoutTimer() {
+        Timer timer;
+        Timeout timeout;
+
+        timeout = Timeout.builder()
+                .timeout(Duration.ofSeconds(1))
+                .name("very_quick")      // same name
+                .build();
+        timeout.invoke(() -> null);
+        timer = MetricsUtils.timer(Timeout.FT_TIMEOUT_EXECUTIONDURATION, Tag.create("name", "very_quick"));
+        assertThat(timer.count(), is(1L));
+
+        timeout = Timeout.builder()
+                .timeout(Duration.ofSeconds(1))
+                .name("very_quick")      // same name
+                .build();
+        timeout.invoke(() -> null);
+        assertThat(timer.count(), is(2L));
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/resources/application.yaml
+++ b/fault-tolerance/fault-tolerance/src/test/resources/application.yaml
@@ -16,4 +16,4 @@
 
 ft:
   metrics:
-    enabled: true
+    default-enabled: true

--- a/fault-tolerance/fault-tolerance/src/test/resources/application.yaml
+++ b/fault-tolerance/fault-tolerance/src/test/resources/application.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ft:
+  metrics:
+    enabled: true


### PR DESCRIPTION
### Description

Basic support for metrics in FT SE. The following metrics are supported:

- ft.bulkhead.calls.total
- ft.bulkhead.waitingDuration
- ft.bulkhead.executionsRunning
- ft.bulkhead.executionsWaiting
- ft.circuitbreaker.calls.total 
- ft.circuitbreaker.opened.total
- ft.retry.calls.total
- ft.retry.retries.total
- ft.timeout.calls.total
- ft.timeout.executionDuration 

Metrics are disabled by default but can be enabled using `ft.metrics.enabled=true` or individually using `enableMetrics(boolean)` on the corresponding metric builder. For more information about these new metrics see `fault-tolerance.adoc` updates included in this PR.

### Documentation

Included as part of this PR.

