### PR TITLE
Adds an afterStart pseudo-event to LoomServer observable by Router implementations

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/Router.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Router.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,14 @@ public interface Router {
      * This is called before server opens ports.
      */
     void beforeStart();
+
+    /**
+     * This is called after the server's listeners have successfully started.
+     *
+     * @param webServer the {@link WebServer} that has successfully started
+     */
+    default void afterStart(WebServer webServer) {
+    }
 
     /**
      * List of all conifgured routings.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RouterImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RouterImpl.java
@@ -63,6 +63,13 @@ class RouterImpl implements Router {
     }
 
     @Override
+    public void afterStart(WebServer webServer) {
+        for (Routing value : routings.values()) {
+            value.afterStart(webServer);
+        }
+    }
+
+    @Override
     public List<? extends Routing> routings() {
         return List.copyOf(routings.values());
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerLifecycle.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,14 @@ public interface ServerLifecycle {
      * Before server start.
      */
     default void beforeStart() {
+    }
+
+    /**
+     * After server start.
+     *
+     * @param webServer the {@link WebServer} that was started
+     */
+    default void afterStart(WebServer webServer) {
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -210,6 +210,10 @@ class ServerListener implements ListenerContext {
 
     int port() {
         return connectedPort;
+    }
+
+    Router router() {
+        return router;
     }
 
     InetSocketAddress configuredAddress() {


### PR DESCRIPTION
This PR adds an `afterStart` "event" in the same spirit as the existing `beforeStart` and `afterStop` "events" that are found in `ServerLifecycle` implementations (but dispatchable only via `Router` implementations).

I am not sure that I have written it correctly and expect it to be discussed thoroughly. My goal with this first pass has been to simply preserve the spirit and style of the preexisting "event" notifications in `LoomServer`, together with preserving design decisions made internally by members of the Helidon team.

`LoomServer` (package private) has a collection of (package private) `ServerListener` instances, indexed by name, that have access to `Router` implementations internally. I found that to preserve the spirit of the existing code I had to provide access to these `Router`s, since they are currently the only recipients of `beforeStart` and `afterStop` "events", and so, it seemed to me, should be the recipients of (the new) `afterStart` "event".

Internal discussions said that the notification mechanism should be serial, i.e. not in parallel, so I did not use the `parallel` method to dispatch the `afterStart` "event".

Currently if an `afterStart` "observer" throws an exception undefined behavior occurs. I believe that there will be many good opinions on what should happen instead.

Internal discussions also said that the new "event" payload should be the `WebServer` itself so there is now a bidirectional dependency between, e.g., `Router` and `WebServer`. I'm not sure if this was intended to be the case.

I also noticed that `Router` is effectively implementing the `ServerLifecycle` contract, but does not officially implement it, so I didn't add that.

I expect that there will be many changes requested, possibly even a completely different architecture for this originally-intended-to-be-small change.