### PR TITLE
4.x: Global Service Registry support in tests

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -444,6 +444,14 @@
             <artifactId>helidon-common-processor-class-model</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.testing</groupId>
             <artifactId>helidon-common-testing-junit5</artifactId>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -586,6 +586,16 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.helidon.testing</groupId>
+                <artifactId>helidon-testing</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.testing</groupId>
+                <artifactId>helidon-testing-junit5</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.helidon.common.testing</groupId>
                 <artifactId>helidon-common-testing-junit5</artifactId>
                 <version>${helidon.version}</version>

--- a/common/common/src/main/java/io/helidon/common/Functions.java
+++ b/common/common/src/main/java/io/helidon/common/Functions.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Functional interfaces required to complement the {@link java.lang.Runnable}, {@link java.util.concurrent.Callable},
+ * and {@link java.util.function.Supplier} to help with checked exceptions in lambdas.
+ */
+public final class Functions {
+    private Functions() {
+    }
+
+    /**
+     * Wrap a {@link CheckedSupplier} into a {@link java.util.function.Supplier}.
+     *
+     * @param supplier checked supplier
+     * @param <T>      supplier type
+     * @param <E>      checked exception type
+     * @return Supplier
+     */
+    public static <T, E extends Throwable> Supplier<T> unchecked(CheckedSupplier<T, E> supplier) {
+        return () -> {
+            try {
+                return supplier.get();
+            } catch (RuntimeException ex) {
+                throw ex;
+            } catch (Throwable ex) {
+                throw new UncheckedException(ex);
+            }
+        };
+    }
+
+    /**
+     * Wrap a {@link CheckedRunnable} into a {@link Runnable}.
+     *
+     * @param runnable checked runnable
+     * @param <E>      checked exception type
+     * @return Consumer
+     */
+    public static <E extends Throwable> Runnable unchecked(CheckedRunnable<E> runnable) {
+        return () -> {
+            try {
+                runnable.run();
+            } catch (RuntimeException | Error ex) {
+                throw ex;
+            } catch (Throwable ex) {
+                throw new UncheckedException(ex);
+            }
+        };
+    }
+
+    /**
+     * Wrap a {@link CheckedConsumer} into a {@link java.util.function.Consumer}.
+     *
+     * @param consumer checked consumer
+     * @param <T>      item type
+     * @param <E>      checked exception type
+     * @return Consumer
+     */
+    public static <T, E extends Throwable> Consumer<T> unchecked(CheckedConsumer<T, E> consumer) {
+        return t -> {
+            try {
+                consumer.accept(t);
+            } catch (RuntimeException | Error ex) {
+                throw ex;
+            } catch (Throwable ex) {
+                throw new UncheckedException(ex);
+            }
+        };
+    }
+
+    /**
+     * Wrap a {@link CheckedBiConsumer} into a {@link java.util.function.BiConsumer}.
+     *
+     * @param consumer checked consumer
+     * @param <T>      1st item type
+     * @param <U>      2nd item type
+     * @param <E>      checked exception type
+     * @return BiConsumer
+     */
+    public static <T, U, E extends Throwable> BiConsumer<T, U> unchecked(CheckedBiConsumer<T, U, E> consumer) {
+        return (t, u) -> {
+            try {
+                consumer.accept(t, u);
+            } catch (RuntimeException | Error ex) {
+                throw ex;
+            } catch (Throwable ex) {
+                throw new UncheckedException(ex);
+            }
+        };
+    }
+
+    /**
+     * Wrap a {@link CheckedBiConsumer} into a {@link BiConsumer}.
+     *
+     * @param function checked function
+     * @param <T>      1st item type
+     * @param <U>      2nd item type
+     * @param <E>      checked exception type
+     * @return Function
+     */
+    public static <T, U, E extends Throwable> Function<T, U> unchecked(CheckedFunction<T, U, E> function) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (RuntimeException | Error ex) {
+                throw ex;
+            } catch (Throwable ex) {
+                throw new UncheckedException(ex);
+            }
+        };
+    }
+
+    /**
+     * Wrap an exception wrapped with {@link UncheckedException} if checked.
+     *
+     * @param ex exception to wrap
+     * @return exception
+     */
+    public static RuntimeException wrap(Throwable ex) {
+        if (ex instanceof RuntimeException runtimeException) {
+            return runtimeException;
+        }
+        return new UncheckedException(ex);
+    }
+
+    /**
+     * Unwrap a checked exception wrapped with {@link UncheckedException}.
+     *
+     * @param ex exception to unwrap
+     * @return exception
+     */
+    public static Throwable unwrap(Throwable ex) {
+        if (ex instanceof UncheckedException) {
+            return ex.getCause();
+        }
+        return ex;
+    }
+
+    /**
+     * Checked consumer.
+     *
+     * @param <T> item type
+     * @param <E> checked exception type
+     */
+    @FunctionalInterface
+    public interface CheckedConsumer<T, E extends Throwable> {
+        /**
+         * Accept an item.
+         *
+         * @param item item
+         * @throws E if an error occurs
+         */
+        void accept(T item) throws E;
+    }
+
+    /**
+     * Checked bi-consumer.
+     *
+     * @param <T> 1st item type
+     * @param <U> 2nd item type
+     * @param <E> checked exception type
+     */
+    @FunctionalInterface
+    public interface CheckedBiConsumer<T, U, E extends Throwable> {
+
+        /**
+         * Accept an item.
+         *
+         * @param item1 1st item
+         * @param item2 2nd item
+         * @throws E if an error occurs
+         */
+        void accept(T item1, U item2) throws E;
+    }
+
+    /**
+     * Checked consumer.
+     *
+     * @param <T> input type
+     * @param <U> output type
+     * @param <E> checked exception type
+     */
+    @FunctionalInterface
+    public interface CheckedFunction<T, U, E extends Throwable> {
+
+        /**
+         * Accept an item.
+         *
+         * @param item input item
+         * @return U
+         * @throws E if an error occurs
+         */
+        U apply(T item) throws E;
+    }
+
+    /**
+     * Checked runnable.
+     *
+     * @param <E> checked exception type
+     */
+    @FunctionalInterface
+    public interface CheckedRunnable<E extends Throwable> {
+
+        /**
+         * Run.
+         *
+         * @throws E if an error occurs
+         */
+        void run() throws E;
+    }
+
+    /**
+     * Checked supplier.
+     *
+     * @param <T> supplier type
+     * @param <E> checked exception type
+     */
+    @FunctionalInterface
+    public interface CheckedSupplier<T, E extends Throwable> {
+
+        /**
+         * Get the value.
+         *
+         * @return T value
+         * @throws E if an error occurs
+         */
+        T get() throws E;
+    }
+
+    /**
+     * Unchecked exception.
+     *
+     * @see #unwrap(Throwable)
+     */
+    public static class UncheckedException extends RuntimeException {
+
+        /**
+         * Create a new unchecked exception.
+         *
+         * @param cause cause
+         */
+        public UncheckedException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/common/common/src/test/java/io/helidon/common/FunctionsTest.java
+++ b/common/common/src/test/java/io/helidon/common/FunctionsTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for classes and methods defined in {@link io.helidon.common.Functions}.
+ * <p>
+ * Tests for classes make sure we can use a lambda.
+ */
+public class FunctionsTest {
+    @Test
+    void testCheckedSupplier() {
+        try {
+            String result = supply(TestMethods::supplier);
+            assertThat(result, is("works"));
+        } catch (IOException e) {
+            // just making sure we can correctly catch the checked exception thrown by the runnable
+        }
+    }
+
+    @Test
+    void testUncheckedSupplier() {
+        String result = Functions.unchecked(TestMethods::supplier).get();
+        assertThat(result, is("works"));
+    }
+
+    @Test
+    void testCheckedRunnable() {
+        try {
+            run(TestMethods::runnable);
+        } catch (IOException e) {
+            // just making sure we can correctly catch the checked exception thrown by the runnable
+        }
+    }
+
+    @Test
+    void testUncheckedRunnable() {
+        Functions.unchecked(TestMethods::runnable)
+                .run();
+    }
+
+    @Test
+    void testCheckedConsumer() {
+        try {
+            consume(TestMethods::consumer, "hello");
+        } catch (IOException e) {
+            // just making sure we can correctly catch the checked exception thrown by the runnable
+        }
+    }
+
+    @Test
+    void testUncheckedConsumer() {
+        Functions.unchecked(TestMethods::consumer)
+                .accept("hello");
+    }
+
+    @Test
+    void testCheckedBiConsumer() {
+        try {
+            biConsume(TestMethods::biConsumer, "hello", 42);
+        } catch (IOException e) {
+            // just making sure we can correctly catch the checked exception thrown by the runnable
+        }
+    }
+
+    @Test
+    void testUncheckedBiConsumer() {
+        Functions.unchecked(TestMethods::biConsumer)
+                .accept("hello", 42);
+    }
+
+    @Test
+    void testCheckedFunction() {
+        try {
+            String result = function(TestMethods::function, "John");
+            assertThat(result, is("Hello John!"));
+        } catch (IOException e) {
+            // just making sure we can correctly catch the checked exception thrown by the runnable
+        }
+    }
+
+    @Test
+    void testUncheckedFunction() {
+        String result = Functions.unchecked(TestMethods::function)
+                .apply("jack");
+        assertThat(result, is("Hello jack!"));
+    }
+
+
+    private static <E extends Exception> void run(Functions.CheckedRunnable<E> runnable) throws E {
+        runnable.run();
+    }
+
+    private static <T, E extends Exception> T supply(Functions.CheckedSupplier<T, E> supplier) throws E {
+        return supplier.get();
+    }
+
+    private static <T, E extends Exception> void consume(Functions.CheckedConsumer<T, E> consumer, T value) throws E {
+        consumer.accept(value);
+    }
+
+    private static <T, U, E extends Exception> U function(Functions.CheckedFunction<T, U, E> function, T param) throws E {
+        return function.apply(param);
+    }
+
+
+    static <U, V, E extends Exception> void biConsume(Functions.CheckedBiConsumer<U, V, E> consumer, U value, V value2) throws E {
+        consumer.accept(value, value2);
+    }
+
+    private static class TestMethods {
+        static void runnable() throws IOException {
+        }
+
+        static String supplier() throws IOException {
+            return "works";
+        }
+
+        static void consumer(String param) throws IOException {
+        }
+
+        static void biConsumer(String param, int param2) throws IOException {
+        }
+
+        static String function(String param) throws IOException {
+            return "Hello " + param + "!";
+        }
+    }
+}

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Meter;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.microprofile.config.ConfigCdiExtension;
 import io.helidon.microprofile.server.JaxRsCdiExtension;
 import io.helidon.microprofile.server.ServerCdiExtension;
@@ -85,7 +86,6 @@ class OciMetricsCdiExtensionTest {
     private static CountDownLatch countDownLatch = new CountDownLatch(1);
     private static PostMetricDataDetails postMetricDataDetails;
     private static boolean activateOciMetricsSupportIsInvoked;
-    private static MeterRegistry registry = Metrics.globalRegistry();
 
     @AfterEach
     void resetState() {
@@ -112,6 +112,8 @@ class OciMetricsCdiExtensionTest {
     }
 
     private void validateOciMetricsSupport(boolean enabled) throws InterruptedException {
+        MeterRegistry registry = Metrics.globalRegistry();
+
         Counter c1 = registry.getOrCreate(Counter.builder(Meter.Scope.BASE + METRIC_NAME_SUFFIX)
                                      .scope(Meter.Scope.BASE));
         c1.increment();
@@ -150,6 +152,7 @@ class OciMetricsCdiExtensionTest {
         registry.remove(c1);
         registry.remove(c2);
         registry.remove(c3);
+        clear();
     }
 
     interface MetricDataDetailsOCIParams {
@@ -231,6 +234,27 @@ class OciMetricsCdiExtensionTest {
         protected void activateOciMetricsSupport(Config rootConfig, Config ociMetricsConfig, OciMetricsSupport.Builder builder) {
             activateOciMetricsSupportIsInvoked = true;
             super.activateOciMetricsSupport(rootConfig, ociMetricsConfig, builder);
+        }
+    }
+
+    static void clear() {
+        MetricsFactory.closeAll();
+
+        // And clear out Micrometer's global registry explicitly to be extra sure.
+        io.micrometer.core.instrument.MeterRegistry mmGlobal = io.micrometer.core.instrument.Metrics.globalRegistry;
+        mmGlobal.clear();
+
+        int delayMS = 250;
+        int maxSecondsToWait = 5;
+        int iterationsRemaining = (maxSecondsToWait * 1000) / delayMS;
+
+        while (iterationsRemaining > 0 && !mmGlobal.getMeters().isEmpty()) {
+            iterationsRemaining--;
+            try {
+                TimeUnit.MILLISECONDS.sleep(delayMS);
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Error awaiting clear-out of meter registries to finish", e);
+            }
         }
     }
 }

--- a/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
+++ b/integrations/oci/metrics/metrics/src/main/java/io/helidon/integrations/oci/metrics/OciMetricsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.config.metadata.Configured;
 import io.helidon.config.metadata.ConfiguredOption;
@@ -175,8 +177,12 @@ public class OciMetricsSupport implements HttpService {
     }
 
     private void startExecutor() {
+        Context ctx = Contexts.context().orElseGet(Contexts::globalContext);
         scheduledExecutorService = Executors.newScheduledThreadPool(1);
-        scheduledExecutorService.scheduleAtFixedRate(this::pushMetrics, initialDelay, delay, schedulingTimeUnit);
+        scheduledExecutorService.scheduleAtFixedRate(() -> Contexts.runInContext(ctx, this::pushMetrics),
+                                                     initialDelay,
+                                                     delay,
+                                                     schedulingTimeUnit);
     }
 
     private void pushMetrics() {

--- a/microprofile/testing/junit5/pom.xml
+++ b/microprofile/testing/junit5/pom.xml
@@ -48,6 +48,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
             <artifactId>jersey-weld2-se</artifactId>
             <optional>true</optional>

--- a/microprofile/testing/junit5/src/main/java/module-info.java
+++ b/microprofile/testing/junit5/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ module io.helidon.microprofile.testing.junit5 {
 
     requires io.helidon.config.mp;
     requires io.helidon.config.yaml.mp;
+    requires io.helidon.testing.junit5;
     requires io.helidon.microprofile.cdi;
     requires jakarta.inject;
     requires org.junit.jupiter.api;

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
         <module>codegen</module>
         <module>service</module>
         <module>metadata</module>
+        <module>testing</module>
     </modules>
 
     <build>

--- a/security/security/src/main/java/io/helidon/security/ClassToInstanceStore.java
+++ b/security/security/src/main/java/io/helidon/security/ClassToInstanceStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,11 @@ package io.helidon.security;
 
 import java.util.Collection;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Map of classes to their instances.
@@ -29,6 +32,7 @@ import java.util.Optional;
  */
 public final class ClassToInstanceStore<T> {
     private final Map<Class<? extends T>, T> backingMap = new IdentityHashMap<>();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     /**
      * Create a new instance based on explicit instances.
@@ -55,7 +59,12 @@ public final class ClassToInstanceStore<T> {
      * @return Instance of the class or null if no mapping exists
      */
     public <U extends T> Optional<U> getInstance(Class<U> clazz) {
-        return Optional.ofNullable(clazz.cast(backingMap.get(clazz)));
+        lock.readLock().lock();
+        try {
+            return Optional.ofNullable(clazz.cast(backingMap.get(clazz)));
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     /**
@@ -67,7 +76,12 @@ public final class ClassToInstanceStore<T> {
      * @return Instance of the class if a mapping previously existed or null for no existing mapping
      */
     public <U extends T> Optional<U> putInstance(Class<? extends U> clazz, U instance) {
-        return Optional.ofNullable(clazz.cast(backingMap.put(clazz, instance)));
+        lock.writeLock().lock();
+        try {
+            return Optional.ofNullable(clazz.cast(backingMap.put(clazz, instance)));
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**
@@ -78,7 +92,12 @@ public final class ClassToInstanceStore<T> {
      * @return instance that was removed (if there was one)
      */
     public <U extends T> Optional<U> removeInstance(Class<U> clazz) {
-        return Optional.ofNullable(clazz.cast(backingMap.remove(clazz)));
+        lock.writeLock().lock();
+        try {
+            return Optional.ofNullable(clazz.cast(backingMap.remove(clazz)));
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**
@@ -87,7 +106,12 @@ public final class ClassToInstanceStore<T> {
      * @param toCopy store to copy into this store
      */
     public void putAll(ClassToInstanceStore<? extends T> toCopy) {
-        this.backingMap.putAll(toCopy.backingMap);
+        lock.writeLock().lock();
+        try {
+            this.backingMap.putAll(toCopy.backingMap);
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**
@@ -97,7 +121,12 @@ public final class ClassToInstanceStore<T> {
      * @return true if there is a mapping for the class
      */
     public boolean containsKey(Class<? extends T> clazz) {
-        return backingMap.containsKey(clazz);
+        lock.readLock().lock();
+        try {
+            return backingMap.containsKey(clazz);
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     /**
@@ -106,7 +135,12 @@ public final class ClassToInstanceStore<T> {
      * @return true if there are no mappings in this store
      */
     public boolean isEmpty() {
-        return backingMap.isEmpty();
+        lock.readLock().lock();
+        try {
+            return backingMap.isEmpty();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     /**
@@ -120,7 +154,12 @@ public final class ClassToInstanceStore<T> {
      */
     @SuppressWarnings("unchecked")
     public <U extends T> Optional<U> putInstance(U instance) {
-        return putInstance((Class<? extends U>) instance.getClass(), instance);
+        lock.writeLock().lock();
+        try {
+            return putInstance((Class<? extends U>) instance.getClass(), instance);
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**
@@ -129,7 +168,12 @@ public final class ClassToInstanceStore<T> {
      * @return collection of values
      */
     public Collection<T> values() {
-        return backingMap.values();
+        lock.readLock().lock();
+        try {
+            return List.copyOf(backingMap.values());
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     /**
@@ -138,7 +182,12 @@ public final class ClassToInstanceStore<T> {
      * @return collection of classes used for mapping to instances
      */
     public Collection<Class<? extends T>> keys() {
-        return backingMap.keySet();
+        lock.readLock().lock();
+        try {
+            return Set.copyOf(backingMap.keySet());
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     /**
@@ -148,6 +197,11 @@ public final class ClassToInstanceStore<T> {
      */
     @Override
     public String toString() {
-        return backingMap.toString();
+        lock.readLock().lock();
+        try {
+            return backingMap.toString();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 }

--- a/service/registry/pom.xml
+++ b/service/registry/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2024 Oracle and/or its affiliates.
+    Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -46,6 +46,10 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-context</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/service/registry/src/main/java/io/helidon/service/registry/GlobalServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/GlobalServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,38 @@
 
 package io.helidon.service.registry;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+
 /**
- * A global singleton manager for a service registry.
+ * Represents an application wide service registry.
  * <p>
- * Note that when using this registry, testing is a bit more complicated, as the registry is shared
- * statically.
+ * The registry instance is shared through {@link io.helidon.common.context.Context}, using the current context
+ * to obtain a context with classifier {@link #STATIC_CONTEXT_CLASSIFIER}. If such a context is found, the
+ * registry instance is obtained/stored there. If the context does not exist, the
+ * {@link io.helidon.common.context.Contexts#globalContext()} is used to store the value.
+ * <p>
+ * The first option is designed for testing, to make sure the global registry is only "global" for a single test class.
+ * The second option is the default for application runtime, where we intend to share the registry as a proper, static
+ * singleton instance.
+ * <p>
+ * Helidon testing libraries support this approach and correctly configure appropriate context for each execution.
  */
 public final class GlobalServiceRegistry {
-    private static final AtomicReference<ServiceRegistry> INSTANCE = new AtomicReference<>();
+    /**
+     * Classifier used to register a context that is to serve as the context that holds the
+     * global registry instance.
+     * <p>
+     * This is to allow testing in parallel, where we need the global registry instance restricted to a single test.
+     * In normal application runtime, the fallback is to use {@link io.helidon.common.context.Contexts#globalContext()}.
+     */
+    public static final String STATIC_CONTEXT_CLASSIFIER = "helidon-registry-static-context";
+
     private static final ReadWriteLock RW_LOCK = new ReentrantReadWriteLock();
 
     private GlobalServiceRegistry() {
@@ -40,7 +59,7 @@ public final class GlobalServiceRegistry {
      * @return {@code true} if a registry instance was already created
      */
     public static boolean configured() {
-        return INSTANCE.get() != null;
+        return current().isPresent();
     }
 
     /**
@@ -49,20 +68,20 @@ public final class GlobalServiceRegistry {
      * @return global service registry
      */
     public static ServiceRegistry registry() {
-        try {
-            RW_LOCK.readLock().lock();
-            ServiceRegistry currentInstance = INSTANCE.get();
-            if (currentInstance != null) {
-                return currentInstance;
-            }
-        } finally {
-            RW_LOCK.readLock().unlock();
+        var current = current();
+        if (current.isPresent()) {
+            return current.get();
         }
+
+        RW_LOCK.writeLock().lock();
         try {
-            RW_LOCK.writeLock().lock();
+            current = current();
+            if (current.isPresent()) {
+                return current.get();
+            }
             ServiceRegistryConfig config = ServiceRegistryConfig.create();
             ServiceRegistry newInstance = ServiceRegistryManager.create(config).registry();
-            INSTANCE.set(newInstance);
+            registry(newInstance);
             return newInstance;
         } finally {
             RW_LOCK.writeLock().unlock();
@@ -77,19 +96,22 @@ public final class GlobalServiceRegistry {
      * @return global service registry
      */
     public static ServiceRegistry registry(Supplier<ServiceRegistry> registrySupplier) {
-        try {
-            RW_LOCK.readLock().lock();
-            ServiceRegistry currentInstance = INSTANCE.get();
-            if (currentInstance != null) {
-                return currentInstance;
-            }
-        } finally {
-            RW_LOCK.readLock().unlock();
+        var current = current();
+        if (current.isPresent()) {
+            return current.get();
         }
+
+        RW_LOCK.writeLock().lock();
         try {
-            RW_LOCK.writeLock().lock();
+            current = current();
+            if (current.isPresent()) {
+                return current.get();
+            }
             ServiceRegistry newInstance = registrySupplier.get();
-            INSTANCE.set(newInstance);
+            if (newInstance == null) {
+                throw new ServiceRegistryException("Global registry supplier cannot return null.");
+            }
+            registry(newInstance);
             return newInstance;
         } finally {
             RW_LOCK.writeLock().unlock();
@@ -105,8 +127,38 @@ public final class GlobalServiceRegistry {
      * @return the same instance
      */
     public static ServiceRegistry registry(ServiceRegistry newGlobalRegistry) {
-        INSTANCE.set(newGlobalRegistry);
+        RW_LOCK.writeLock().lock();
+        try {
+            context().register(ContextQualifier.INSTANCE, newGlobalRegistry);
+        } finally {
+            RW_LOCK.writeLock().unlock();
+        }
         return newGlobalRegistry;
     }
 
+    private static Context context() {
+        Context globalContext = Contexts.globalContext();
+
+        // this is the context we expect to get (and set global instances)
+        return Contexts.context()
+                .orElse(globalContext)
+                .get(STATIC_CONTEXT_CLASSIFIER, Context.class)
+                .orElse(globalContext);
+    }
+
+    private static Optional<ServiceRegistry> current() {
+        RW_LOCK.readLock().lock();
+        try {
+            return context().get(ContextQualifier.INSTANCE, ServiceRegistry.class);
+        } finally {
+            RW_LOCK.readLock().unlock();
+        }
+    }
+
+    private static final class ContextQualifier {
+        private static final ContextQualifier INSTANCE = new ContextQualifier();
+
+        private ContextQualifier() {
+        }
+    }
 }

--- a/service/registry/src/main/java/io/helidon/service/registry/GlobalServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/GlobalServiceRegistry.java
@@ -44,7 +44,8 @@ public final class GlobalServiceRegistry {
      * global registry instance.
      * <p>
      * This is to allow testing in parallel, where we need the global registry instance restricted to a single test.
-     * In normal application runtime, the fallback is to use {@link io.helidon.common.context.Contexts#globalContext()}.
+     * <p>
+     * In normal application runtime we use {@link io.helidon.common.context.Contexts#globalContext()}.
      */
     public static final String STATIC_CONTEXT_CLASSIFIER = "helidon-registry-static-context";
 

--- a/service/registry/src/main/java/module-info.java
+++ b/service/registry/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import io.helidon.common.features.api.Preview;
 module io.helidon.service.registry {
     requires static io.helidon.common.features.api;
 
+    requires io.helidon.common.context;
     requires io.helidon.service.metadata;
     requires io.helidon.metadata.hson;
     requires io.helidon;

--- a/testing/junit5/pom.xml
+++ b/testing/junit5/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.testing</groupId>
+        <artifactId>helidon-testing-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>helidon-testing-junit5</artifactId>
+    <name>Helidon Testing JUnit5</name>
+
+    <properties>
+        <!-- helidon-common-types is breaking the check, as it claims it is test only, but in fact it is required -->
+        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testing/junit5/src/main/java/io/helidon/testing/junit5/TestJunitExtension.java
+++ b/testing/junit5/src/main/java/io/helidon/testing/junit5/TestJunitExtension.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing.junit5;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import io.helidon.common.Functions;
+import io.helidon.common.GenericType;
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.testing.TestException;
+import io.helidon.testing.TestRegistry;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.DynamicTestInvocationContext;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+/**
+ * Helidon JUnit extension, added through {@link io.helidon.testing.junit5.Testing.Test}.
+ * <p>
+ * This extension has the following features:
+ * <ul>
+ *     <li>Run constructor and every test class method within a custom {@link io.helidon.common.context.Context}</li>
+ *     <li>Support configuration annotations to set up configuration before running the tests</li>
+ *     <li>Support for injection service registry (if on classpath) to discover configuration</li>
+ * </ul>
+ */
+public class TestJunitExtension implements Extension,
+                                           InvocationInterceptor,
+                                           BeforeAllCallback,
+                                           AfterAllCallback,
+                                           ParameterResolver {
+
+    static {
+        LogConfig.initClass();
+    }
+
+    /**
+     * Default constructor with no side effects.
+     */
+    protected TestJunitExtension() {
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        Class<?> testClass = context.getRequiredTestClass();
+        Context helidonContext = Context.builder()
+                .id("test-" + testClass.getName() + "-" + System.identityHashCode(testClass))
+                .build();
+        // self-register, so this context is used even if the current context is some child of it
+        helidonContext.register(GlobalServiceRegistry.STATIC_CONTEXT_CLASSIFIER, helidonContext);
+
+        ExtensionContext.Store store = extensionStore(context);
+        store.put(Context.class, helidonContext);
+
+        run(context, () -> {
+            LogConfig.configureRuntime();
+            createRegistry(store, testClass);
+        });
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        run(context, () -> afterShutdownMethods(context.getRequiredTestClass()));
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        Class<?> paramType = parameterContext.getParameter().getType();
+        if (!GenericType.create(parameterContext.getParameter().getParameterizedType())
+                .isClass()) {
+            return false;
+        }
+
+        return registrySupportedType(extensionContext, paramType);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        Class<?> paramType = parameterContext.getParameter().getType();
+
+        if (registrySupportedType(extensionContext, paramType)) {
+            // at this point in time the registry must be ready
+            return registry(extensionContext)
+                    .orElseThrow()
+                    .get(paramType);
+        }
+
+        throw new ParameterResolutionException("Failed to resolve parameter of type "
+                                                       + paramType.getName());
+    }
+
+    @Override
+    public <T> T interceptTestClassConstructor(Invocation<T> invocation,
+                                               ReflectiveInvocationContext<Constructor<T>> invocationContext,
+                                               ExtensionContext extensionContext) throws Throwable {
+        return invoke(extensionContext, invocation);
+    }
+
+    @Override
+    public void interceptBeforeAllMethod(Invocation<Void> invocation,
+                                         ReflectiveInvocationContext<Method> invocationContext,
+                                         ExtensionContext extensionContext) throws Throwable {
+        invoke(extensionContext, invocation);
+    }
+
+    @Override
+    public void interceptBeforeEachMethod(Invocation<Void> invocation,
+                                          ReflectiveInvocationContext<Method> invocationContext,
+                                          ExtensionContext extensionContext) throws Throwable {
+        invoke(extensionContext, invocation);
+    }
+
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation,
+                                    ReflectiveInvocationContext<Method> invocationContext,
+                                    ExtensionContext extensionContext) throws Throwable {
+        invoke(extensionContext, invocation);
+    }
+
+    @Override
+    public <T> T interceptTestFactoryMethod(Invocation<T> invocation,
+                                            ReflectiveInvocationContext<Method> invocationContext,
+                                            ExtensionContext extensionContext) throws Throwable {
+        return invoke(extensionContext, invocation);
+    }
+
+    @Override
+    public void interceptTestTemplateMethod(Invocation<Void> invocation,
+                                            ReflectiveInvocationContext<Method> invocationContext,
+                                            ExtensionContext extensionContext) throws Throwable {
+        invoke(extensionContext, invocation);
+    }
+
+    @Override
+    public void interceptDynamicTest(Invocation<Void> invocation,
+                                     DynamicTestInvocationContext invocationContext,
+                                     ExtensionContext extensionContext) throws Throwable {
+        invoke(extensionContext, invocation);
+    }
+
+    @Override
+    public void interceptAfterEachMethod(Invocation<Void> invocation,
+                                         ReflectiveInvocationContext<Method> invocationContext,
+                                         ExtensionContext extensionContext) throws Throwable {
+        invoke(extensionContext, invocation);
+    }
+
+    @Override
+    public void interceptAfterAllMethod(Invocation<Void> invocation,
+                                        ReflectiveInvocationContext<Method> invocationContext,
+                                        ExtensionContext extensionContext) throws Throwable {
+        invoke(extensionContext, invocation);
+    }
+
+    /**
+     * Service registry associated with the provided extension contexts
+     * (uses {@link #extensionStore(org.junit.jupiter.api.extension.ExtensionContext)}).
+     *
+     * @param extensionContext extension context
+     * @return service registry
+     */
+    protected Optional<ServiceRegistry> registry(ExtensionContext extensionContext) {
+        return Optional.ofNullable(extensionStore(extensionContext)
+                                           .get(ServiceRegistry.class, ServiceRegistry.class));
+    }
+
+    /**
+     * Extension store used by this extension to store context, service registry etc.
+     *
+     * @param ctx extension context
+     * @return extension store
+     */
+    protected ExtensionContext.Store extensionStore(ExtensionContext ctx) {
+        Class<?> testClass = ctx.getRequiredTestClass();
+        return ctx.getStore(ExtensionContext.Namespace.create(testClass));
+    }
+
+    /**
+     * Context to be used for all actions this extension invokes, and to store the global instances.
+     * This extension creates a unit test context by default for each test class.
+     *
+     * @param ctx     JUnit extension context
+     * @param context Helidon context to set
+     */
+    protected void context(ExtensionContext ctx, Context context) {
+        // self-register, so this context is used even if the current context is some child of it
+        context.register(GlobalServiceRegistry.STATIC_CONTEXT_CLASSIFIER, context);
+        extensionStore(ctx)
+                .put(Context.class, context);
+    }
+
+    /**
+     * The current context (if already available) that the test actions will be executed in.
+     *
+     * @param ctx JUnit extension context
+     * @return context used by this extension
+     */
+    protected Optional<Context> context(ExtensionContext ctx) {
+        return Optional.ofNullable(extensionStore(ctx).get(Context.class, Context.class));
+    }
+
+    /**
+     * Call a supplier within context.
+     *
+     * @param ctx      JUnit extension context
+     * @param supplier callable to invoke
+     * @param <T>      type of the result
+     * @return result of the callable
+     * @throws Throwable in case the call to callable threw an exception
+     */
+    protected <T> T supply(ExtensionContext ctx, Supplier<T> supplier) throws Throwable {
+        return Contexts.runInContext(context(ctx).orElseThrow(), supplier::get);
+    }
+
+    /**
+     * Call a supplier that can throw {@link java.lang.Throwable} within context.
+     *
+     * @param ctx      JUnit extension context
+     * @param supplier supplier to invoke
+     * @param <T>      type of the result
+     * @param <E>      type of checked exception that is expected
+     * @return result of the callable
+     * @throws E in case the call to callable threw an exception
+     */
+    @SuppressWarnings("unchecked")
+    protected <T, E extends Throwable> T supplyChecked(ExtensionContext ctx,
+                                                       Functions.CheckedSupplier<T, E> supplier) throws E {
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        T response = Contexts.runInContext(context(ctx).orElseThrow(), () -> {
+            try {
+                return supplier.get();
+            } catch (Throwable e) {
+                thrown.set(e);
+                return null;
+            }
+        });
+        if (thrown.get() == null) {
+            return response;
+        }
+        Throwable throwable = thrown.get();
+        if (throwable instanceof RuntimeException rte) {
+            throw rte;
+        }
+        if (throwable instanceof Error err) {
+            throw err;
+        }
+        throw (E) throwable;
+    }
+
+    /**
+     * Run a runnable within context.
+     *
+     * @param ctx      JUnit extension context
+     * @param runnable runnable to run
+     */
+    protected void run(ExtensionContext ctx, Runnable runnable) {
+        Contexts.runInContext(context(ctx).orElseThrow(), runnable);
+    }
+
+    /**
+     * Invoke a runnable that may throw a checked exception.
+     *
+     * @param ctx      JUnit extension context
+     * @param runnable runnable to run
+     * @param <E>      type of the exception that can be thrown
+     * @throws E in case the runnable threw an exception
+     */
+    @SuppressWarnings("unchecked")
+    protected <E extends Throwable> void runChecked(ExtensionContext ctx, Functions.CheckedRunnable<E> runnable) throws E {
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        Contexts.runInContext(context(ctx).orElseThrow(), () -> {
+            try {
+                runnable.run();
+            } catch (Throwable e) {
+                thrown.set(e);
+            }
+        });
+
+        if (thrown.get() == null) {
+            return;
+        }
+        Throwable throwable = thrown.get();
+        if (throwable instanceof RuntimeException rte) {
+            throw rte;
+        }
+        if (throwable instanceof Error err) {
+            throw err;
+        }
+        throw (E) throwable;
+    }
+
+    /**
+     * Invoke a JUnit invocation within context.
+     *
+     * @param ctx        JUnit extension context
+     * @param invocation invocation to invoke
+     * @param <T>        type of the returned value
+     * @return result of the invocation
+     * @throws Throwable in case the invocation threw an exception
+     */
+    protected <T> T invoke(ExtensionContext ctx, Invocation<T> invocation) throws Throwable {
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        T response = Contexts.runInContext(context(ctx).orElseThrow(), () -> {
+            try {
+                return invocation.proceed();
+            } catch (Throwable e) {
+                thrown.set(e);
+                return null;
+            }
+        });
+        if (thrown.get() != null) {
+            throw thrown.get();
+        }
+        return response;
+    }
+
+    private void afterShutdownMethods(Class<?> requiredTestClass) {
+        for (Method declaredMethod : requiredTestClass.getDeclaredMethods()) {
+            TestRegistry.AfterShutdown annotation = declaredMethod.getAnnotation(TestRegistry.AfterShutdown.class);
+            if (annotation != null) {
+                try {
+                    declaredMethod.setAccessible(true);
+                    declaredMethod.invoke(null);
+                } catch (Exception e) {
+                    throw new TestException("Failed to invoke @TestRegistry.AfterShutdown annotated method "
+                                                    + declaredMethod.getName(), e);
+
+                }
+            }
+        }
+    }
+
+    private void createRegistry(ExtensionContext.Store store, Class<?> testClass) {
+        var registryConfig = ServiceRegistryConfig.builder();
+        var manager = ServiceRegistryManager.create(registryConfig.build());
+        var registry = manager.registry();
+        GlobalServiceRegistry.registry(registry);
+        store.put(ServiceRegistry.class, registry);
+        store.put(ServiceRegistryManager.class, new ClosableRegistryManager(manager));
+    }
+
+    private boolean registrySupportedType(ExtensionContext ctx, Class<?> paramType) {
+        if (ServiceRegistry.class.isAssignableFrom(paramType)) {
+            return true;
+        }
+        // we do not want to get the instance here (yet)
+        return !registry(ctx)
+                .map(it -> it.allServices(paramType))
+                .map(List::isEmpty)
+                .orElse(true);
+    }
+
+    private record ClosableRegistryManager(ServiceRegistryManager manager)
+            implements ExtensionContext.Store.CloseableResource {
+
+        @Override
+        public void close() {
+            manager.shutdown();
+        }
+    }
+}

--- a/testing/junit5/src/main/java/io/helidon/testing/junit5/Testing.java
+++ b/testing/junit5/src/main/java/io/helidon/testing/junit5/Testing.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Helidon testing related annotations and APIs.
+ */
+public final class Testing {
+    private Testing() {
+    }
+
+    /**
+     * A test class annotation that ensures Helidon extension is loaded.
+     */
+    @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @ExtendWith(TestJunitExtension.class)
+    public @interface Test {
+    }
+}

--- a/testing/junit5/src/main/java/io/helidon/testing/junit5/package-info.java
+++ b/testing/junit5/src/main/java/io/helidon/testing/junit5/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JUnit5 extensions for Helidon supporting configuration, and optionally the Inject service registry.
+ */
+package io.helidon.testing.junit5;

--- a/testing/junit5/src/main/java/module-info.java
+++ b/testing/junit5/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * See {@link io.helidon.testing.junit5}.
+ */
+module io.helidon.testing.junit5 {
+    requires org.junit.jupiter.api;
+    requires io.helidon.service.registry;
+    requires io.helidon.logging.common;
+    requires transitive io.helidon.testing;
+    requires transitive io.helidon.common.context;
+
+    exports io.helidon.testing.junit5;
+}

--- a/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassA.java
+++ b/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassA.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing.junit5;
+
+import io.helidon.service.registry.Services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/*
+Tests that each test class has its own instance of global registry.
+All three classes are required:
+TestClassA - custom instance set using Services.set
+TestClassB - custom instance set using Services.set, to make sure we can set different static values from different test classes
+TestClassDefault - expecting default (injected) value
+ */
+@Testing.Test
+public class TestClassA {
+    @Test
+    public void testRegistry() {
+        Services.set(TestService.class, new TestService("testA"));
+
+        TestService testService = Services.get(TestService.class);
+
+        assertThat(testService.message(), is("testA"));
+    }
+}

--- a/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassB.java
+++ b/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassB.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing.junit5;
+
+import io.helidon.service.registry.Services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/*
+Tests that each test class has its own instance of global registry.
+All three classes are required:
+TestClassA - custom instance set using Services.set
+TestClassB - custom instance set using Services.set, to make sure we can set different static values from different test classes
+TestClassDefault - expecting default (injected) value
+ */
+@Testing.Test
+public class TestClassB {
+    @Test
+    public void testRegistry() {
+        Services.set(TestService.class, new TestService("testB"));
+
+        TestService testService = Services.get(TestService.class);
+
+        assertThat(testService.message(), is("testB"));
+    }
+}

--- a/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassDefault.java
+++ b/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassDefault.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing.junit5;
+
+import io.helidon.service.registry.Services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/*
+Tests that each test class has its own instance of global registry.
+All three classes are required:
+TestClassA - custom instance set using Services.set
+TestClassB - custom instance set using Services.set, to make sure we can set different static values from different test classes
+TestClassDefault - expecting default (injected) value
+ */
+@Testing.Test
+public class TestClassDefault {
+    @Test
+    public void testRegistry() {
+        TestService testService = Services.get(TestService.class);
+
+        assertThat(testService.message(), is("default"));
+    }
+}

--- a/testing/junit5/src/test/java/io/helidon/testing/junit5/TestService.java
+++ b/testing/junit5/src/test/java/io/helidon/testing/junit5/TestService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing.junit5;
+
+import io.helidon.service.registry.Service;
+
+/*
+Service registry service to test.
+ */
+@Service.Singleton
+class TestService {
+    private final String message;
+
+    @Service.Inject
+    TestService() {
+        this("default");
+    }
+
+    TestService(String message) {
+        this.message = message;
+    }
+
+    String message() {
+        return message;
+    }
+}

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon</groupId>
+        <artifactId>helidon-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+    <groupId>io.helidon.testing</groupId>
+    <artifactId>helidon-testing-project</artifactId>
+    <name>Helidon Testing Project</name>
+
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
+    <modules>
+        <module>testing</module>
+        <module>junit5</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-dependencies</id>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testing/testing/README.md
+++ b/testing/testing/README.md
@@ -1,0 +1,30 @@
+Helidon Testing
+-----
+
+This module provides features that are most commonly required to test a Helidon application.
+
+# TestConfigSource
+
+Testing may require setting configuration values after the config instance is created, but before the value
+is used. This can be achieved through `TestConfigSource` (when creating configuration instance by hand or via
+ServiceRegistry; note that when using registry, there is nothing required to be done by you).
+
+Simply create a new instance of `TestConfigSource` (may only be one for the whole test class, as config is created only once in the registry).
+
+# Configuration annotations
+
+Configuration can be further customized by using configuration annotations.
+
+The following annotations are supported, to provide customized configuration.
+
+The following table shows all configuration types and their weight used when constructing config (if relevant):
+
+| Source                | Weight    | Description                                                                                                                      |
+|-----------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------|
+| `TestConfigSource`    | 1_000_000 | Use `TestConfig` to set values, always the highest weight form this table                                                        |
+| `@TestConfig.Profile` | N/A       | Customization of the config profile to use. Defaults to `test`                                                                   |
+| `@TestConfig.Value`   | 954_000   | Used to set a single key/value pair. Weight can be customized. Repeatable.                                                       |
+| `@TestConfig.Values`  | 953_000   | Use to set multiple key/value pairs, with a format defined (such as yaml, properties). Weight can be customized.                 |   
+| `@TestConfig.File`    | 952_000   | Use to set a whole config file. Type is determined based on file suffix. Weight can be customized. Repeatable.                   |
+| `@TestConfig.Source`  | 951_000   | Use to set a single config source. Weight can be customized. This annotation belongs to static method producing a config source. |
+

--- a/testing/testing/pom.xml
+++ b/testing/testing/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.testing</groupId>
+        <artifactId>helidon-testing-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>helidon-testing</artifactId>
+    <name>Helidon Testing</name>
+</project>

--- a/testing/testing/src/main/java/io/helidon/testing/TestException.java
+++ b/testing/testing/src/main/java/io/helidon/testing/TestException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing;
+
+import java.util.Objects;
+
+/**
+ * Exception during Helidon test processing.
+ */
+public class TestException extends RuntimeException {
+    /**
+     * Create a new exception with a customized message.
+     *
+     * @param message message
+     */
+    public TestException(String message) {
+        super(Objects.requireNonNull(message));
+    }
+
+    /**
+     * Create a new exception with a customized message and a cause.
+     *
+     * @param message message
+     * @param cause cause of this exception
+     */
+    public TestException(String message, Throwable cause) {
+        super(Objects.requireNonNull(message), Objects.requireNonNull(cause));
+    }
+}

--- a/testing/testing/src/main/java/io/helidon/testing/TestRegistry.java
+++ b/testing/testing/src/main/java/io/helidon/testing/TestRegistry.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Container for registry testing annotations.
+ */
+public final class TestRegistry {
+    private TestRegistry() {
+    }
+
+    /**
+     * Mark a static method to be executed after the service registry has been shut-down.
+     * <p>
+     * This will only be executed after all pre-destroy methods have been called and the registry is no
+     * longer available (i.e. you cannot obtain the registry instance that was used during all of your test
+     * methods).
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface AfterShutdown {
+    }
+
+}

--- a/testing/testing/src/main/java/io/helidon/testing/package-info.java
+++ b/testing/testing/src/main/java/io/helidon/testing/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Testing annotations and types for Helidon applications.
+ */
+package io.helidon.testing;

--- a/testing/testing/src/main/java/module-info.java
+++ b/testing/testing/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Testing annotations and types for Helidon applications.
+ */
+module io.helidon.testing {
+    exports io.helidon.testing;
+}

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityConfigSupport.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityConfigSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,9 @@ class SecurityConfigSupport {
             if (security.isPresent()) {
                 return;
             }
-            security = Contexts.globalContext().get(Security.class);
+            security = Contexts.context()
+                    .orElseGet(Contexts::globalContext)
+                    .get(Security.class);
             if (security.isPresent()) {
                 target.security(security.get());
                 return;

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityBuilderGateDefaultsTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityBuilderGateDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package io.helidon.webserver.security;
 import java.util.Optional;
 import java.util.Set;
 
-import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
@@ -86,8 +85,9 @@ class WebSecurityBuilderGateDefaultsTest {
                 .addAuditProvider(myAuditProvider)
                 .build();
 
-        Context context = Context.create();
-        context.register(myAuditProvider);
+        Contexts.context()
+                .orElseGet(Contexts::globalContext)
+                .register(myAuditProvider);
 
         serverBuilder
                 .featuresDiscoverServices(false)
@@ -96,7 +96,6 @@ class WebSecurityBuilderGateDefaultsTest {
                                     .defaults(SecurityFeature.rolesAllowed("admin"))
                                     .build())
                 .addFeature(ContextFeature.create())
-                .serverContext(context)
                 .routing(builder -> builder
                         // will only accept admin (due to gate defaults)
                         .get("/noRoles", SecurityFeature.authenticate())

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityFromConfigTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityFromConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,15 +49,16 @@ public class WebSecurityFromConfigTest extends WebSecurityTests {
 
         Security security = Security.builder()
                 .config(config.get("security"))
-                .addAuditProvider(myAuditProvider).build();
+                .addAuditProvider(myAuditProvider)
+                .build();
         // needed for other features, such as integration with webserver
-        Contexts.globalContext().register(security);
+        Context context = Contexts.context()
+                .orElseGet(Contexts::globalContext);
 
-        Context context = Context.create();
+        context.register(security);
         context.register(myAuditProvider);
 
         serverBuilder
-                .serverContext(context)
                 .config(config.get("server"))
                 .routing(routing -> routing.get("/*", (req, res) -> {
                     Optional<SecurityContext> securityContext = Contexts.context()

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityProgrammaticTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityProgrammaticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package io.helidon.webserver.security;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
@@ -55,11 +54,11 @@ public class WebSecurityProgrammaticTest extends WebSecurityTests {
         Security security = Security.builder(config.get("security"))
                 .addAuditProvider(myAuditProvider).build();
 
-        Context context = Context.create();
-        context.register(myAuditProvider);
+        Contexts.context()
+                .orElseGet(Contexts::globalContext)
+                .register(myAuditProvider);
 
-        serverBuilder.serverContext(context)
-                .featuresDiscoverServices(false)
+        serverBuilder.featuresDiscoverServices(false)
                 .addFeature(ContextFeature.create())
                 .addFeature(SecurityFeature.builder()
                                     .security(security)

--- a/webserver/testing/junit5/junit5/pom.xml
+++ b/webserver/testing/junit5/junit5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -41,6 +41,10 @@
         <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.testing</groupId>

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/HelidonRoutingJunitExtension.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/HelidonRoutingJunitExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import java.util.ServiceLoader;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.config.GlobalConfig;
 import io.helidon.common.context.Contexts;
-import io.helidon.logging.common.LogConfig;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.spi.ServerFeature;
@@ -65,7 +64,7 @@ class HelidonRoutingJunitExtension extends JunitExtensionBase
 
     @Override
     public void beforeAll(ExtensionContext context) {
-        LogConfig.configureRuntime();
+        super.beforeAll(context);
 
         Class<?> testClass = context.getRequiredTestClass();
         super.testClass(testClass);
@@ -114,7 +113,8 @@ class HelidonRoutingJunitExtension extends JunitExtensionBase
         }
 
         Class<?> paramType = parameterContext.getParameter().getType();
-        return Contexts.globalContext()
+        return Contexts.context()
+                .orElseGet(Contexts::globalContext)
                 .get(paramType)
                 .isPresent();
     }
@@ -131,7 +131,8 @@ class HelidonRoutingJunitExtension extends JunitExtensionBase
             }
         }
 
-        return Contexts.globalContext()
+        return Contexts.context()
+                .orElseGet(Contexts::globalContext)
                 .get(paramType)
                 .orElseThrow(() -> new ParameterResolutionException("Failed to resolve parameter of type "
                                                                             + paramType.getName()));

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,15 +21,21 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.helidon.testing.junit5.TestJunitExtension;
+
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-abstract class JunitExtensionBase implements AfterAllCallback {
+abstract class JunitExtensionBase extends TestJunitExtension implements AfterAllCallback {
     private Class<?> testClass;
+
+    JunitExtensionBase() {
+    }
 
     @Override
     public void afterAll(ExtensionContext extensionContext) {
         callAfterStop();
+        super.afterAll(extensionContext);
     }
 
     void testClass(Class<?> testClass) {

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/spi/ServerJunitExtension.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/spi/ServerJunitExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public interface ServerJunitExtension extends HelidonJunitExtension {
     /**
      * Handler of server test parameters of methods annotated with {@link io.helidon.webserver.testing.junit5.SetUpRoute}.
      *
-     * @param <T>
+     * @param <T> type of the parameter this handler handles
      */
     interface ParamHandler<T> {
         /**

--- a/webserver/testing/junit5/junit5/src/main/java/module-info.java
+++ b/webserver/testing/junit5/junit5/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,9 @@ module io.helidon.webserver.testing.junit5 {
     requires transitive io.helidon.common.testing.http.junit5;
     requires transitive io.helidon.webclient;
     requires transitive io.helidon.webserver;
+    requires transitive io.helidon.testing.junit5;
     requires transitive org.junit.jupiter.api;
+    requires io.helidon.service.registry;
 
     exports io.helidon.webserver.testing.junit5;
     exports io.helidon.webserver.testing.junit5.spi;


### PR DESCRIPTION
Resolves #9186 

Testing support for Service registry.
This change ensures that all tests are run in a specific "common Context" that holds the current global `ServiceRegistry`. 
This way each test class has its own global `ServiceRegistry` instance that does not interfere with other test classes.
