### PR TITLE
4.x metrics app name tag fix

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
@@ -24,6 +24,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
+import io.helidon.common.Weighted;
 import io.helidon.common.config.Config;
 import io.helidon.common.config.GlobalConfig;
 import io.helidon.metrics.spi.MetersProvider;
@@ -66,13 +67,17 @@ class MetricsFactoryManager {
     /**
      * Config overrides that can change the {@link io.helidon.metrics.api.MetricsConfig} that is read from config sources
      * if there are specific requirements in a given runtime (e.g., MP) for certain settings. For example, the tag name used
-     * for recording scope, the app name, etc.
+     * for recording scope, the app name, etc. We apply all overriding config implementations, so reverse the list after the
+     * Helidon service loader computes it so we apply lower-weight implementations first so higher-weight ones can override.
      */
     private static final LazyValue<Collection<MetricsProgrammaticConfig>> METRICS_CONFIG_OVERRIDES =
             io.helidon.common.LazyValue.create(() ->
-                                                       HelidonServiceLoader
-                                                               .create(ServiceLoader.load(MetricsProgrammaticConfig.class))
-                                                               .asList());
+                       HelidonServiceLoader.builder(ServiceLoader.load(MetricsProgrammaticConfig.class))
+                               .addService(new SeMetricsProgrammaticConfig(),
+                                           Weighted.DEFAULT_WEIGHT - 50)
+                               .build()
+                               .asList()
+                               .reversed());
     private static final ReentrantLock LOCK = new ReentrantLock();
     /**
      * Providers of meter builders (such as the built-in "base" meters for system performance information). All providers are

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SeMetricsProgrammaticConfig.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SeMetricsProgrammaticConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.api;
+
+import java.util.Optional;
+
+import io.helidon.metrics.spi.MetricsProgrammaticConfig;
+
+/**
+ * Provides SE defaults for config values defaulted in a flavor-dependent way.
+ */
+public class SeMetricsProgrammaticConfig implements MetricsProgrammaticConfig {
+
+    @Override
+    public Optional<String> appTagName() {
+        return Optional.of("app");
+    }
+}

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SeMetricsProgrammaticConfig.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SeMetricsProgrammaticConfig.java
@@ -24,8 +24,24 @@ import io.helidon.metrics.spi.MetricsProgrammaticConfig;
  */
 public class SeMetricsProgrammaticConfig implements MetricsProgrammaticConfig {
 
+    /**
+     * For service loading.
+     */
+    public SeMetricsProgrammaticConfig() {
+    }
+
+    @Override
+    public Optional<String> scopeTagName() {
+        return Optional.of("scope");
+    }
+
     @Override
     public Optional<String> appTagName() {
         return Optional.of("app");
+    }
+
+    @Override
+    public Optional<String> scopeDefaultValue() {
+        return Optional.of(Meter.Scope.DEFAULT);
     }
 }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManager.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.metrics.api;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -118,6 +119,18 @@ public interface SystemTagsManager {
      * @return system tags
      */
     Iterable<Tag> displayTags();
+
+    /**
+     * Returns name/value pairs of system tags, avoiding constructing the provider's {@link io.helidon.metrics.api.Tag}
+     * implementations for each.
+     *
+     * @return system tag name/value pairs
+     */
+    default Map<String, String> displayTagPairs() {
+        Map<String, String> result = new TreeMap<>();
+        displayTags().forEach(tag -> result.put(tag.key(), tag.value()));
+        return result;
+    }
 
     /**
      * Scans the provided tag names and throws an exception if any is a reserved tag name.

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManagerImpl.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
 
+import io.helidon.common.LazyValue;
 import io.helidon.metrics.spi.MetricsProgrammaticConfig;
 
 /**
@@ -47,19 +48,29 @@ class SystemTagsManagerImpl implements SystemTagsManager {
 
     private static final Collection<Consumer<SystemTagsManager>> ON_CHANGE_SUBSCRIBERS = new ArrayList<>();
 
-    private final List<Tag> systemTags; // global tags plus the app tag, if any specified
+    private final Map<String, String> systemTagPairs = new TreeMap<>();
     private final Set<String> systemTagNames = new HashSet<>(); // tag names for global tags and app
     private final Set<String> systemAndScopeTagNames = new HashSet<>(); // tag names for globa tags, app, and scope
+
+    /*
+    Defer invoking Tag.create because that could create a infinite recursive loop; Tag.create invokes
+    MetricsFactory.getInstance().tagCreate and MetricsFactory.getInstance could trigger another attempt to instantiate this
+    SystemTagsManagerImpl.
+     */
+    private final LazyValue<List<Tag>> systemTags = LazyValue.create(() ->
+             systemTagPairs.entrySet().stream()
+                     .map(entry -> Tag.create(entry.getKey(), entry.getValue()))
+                     .toList()); // global tags plus the app
+    // tag, if any specified
     private String scopeTagName;
     private String defaultScopeValue;
 
     private SystemTagsManagerImpl(MetricsConfig metricsConfig) {
 
-        metricsConfig.tags().forEach(tag -> systemTagNames.add(tag.key()));
-        systemAndScopeTagNames.addAll(systemTagNames);
-        metricsConfig.scoping().tagName().ifPresent(systemAndScopeTagNames::add);
-
-        List<Tag> result = new ArrayList<>(metricsConfig.tags());
+        metricsConfig.tags().forEach(tag -> {
+            systemTagNames.add(tag.key());
+            systemTagPairs.put(tag.key(), tag.value());
+        });
 
         // Add a tag for the app name if there is an appName setting in config AND we have a setting
         // from somewhere for the tag name to use for recording the app name.
@@ -68,14 +79,17 @@ class SystemTagsManagerImpl implements SystemTagsManager {
                 .filter(Predicate.not(String::isBlank))
                 .ifPresent(tagNameToUse ->
                                    metricsConfig.appName()
-                                           .ifPresent(appNameToUse -> result.add(Tag.create(tagNameToUse, appNameToUse)))
+                                           .ifPresent(appNameToUse -> {
+                                               systemTagPairs.put(tagNameToUse, appNameToUse);
+                                               systemTagNames.add(tagNameToUse);
+                                           })
                 );
 
-        systemTags = List.copyOf(result);
-
-        // Set the scope tag, if appropriate.
-        metricsConfig.scoping().tagName()
-                .ifPresent(tagNameToUse -> scopeTagName = tagNameToUse);
+        systemAndScopeTagNames.addAll(systemTagNames);
+        metricsConfig.scoping().tagName().ifPresent(scopeTagNameToUse -> {
+            systemAndScopeTagNames.add(scopeTagNameToUse);
+            scopeTagName = scopeTagNameToUse;
+        });
         defaultScopeValue = metricsConfig.scoping().defaultValue().orElse(null);
     }
 
@@ -85,7 +99,6 @@ class SystemTagsManagerImpl implements SystemTagsManager {
 
     // for testing
     private SystemTagsManagerImpl() {
-        systemTags = List.of();
         scopeTagName = "scope";
     }
 
@@ -105,7 +118,7 @@ class SystemTagsManagerImpl implements SystemTagsManager {
 
     static SystemTagsManagerImpl instance(MetricsConfig metricsConfig) {
         instance = createWithoutSaving(metricsConfig);
-        ON_CHANGE_SUBSCRIBERS.forEach(sub -> sub.accept(instance()));
+        ON_CHANGE_SUBSCRIBERS.forEach(sub -> sub.accept(instance));
         return instance;
     }
 
@@ -180,7 +193,12 @@ class SystemTagsManagerImpl implements SystemTagsManager {
 
     @Override
     public Iterable<Tag> displayTags() {
-        return List.copyOf(systemTags);
+        return List.copyOf(systemTags.get());
+    }
+
+    @Override
+    public Map<String, String> displayTagPairs() {
+        return Map.copyOf(systemTagPairs);
     }
 
     @Override

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManagerImpl.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManagerImpl.java
@@ -49,7 +49,6 @@ class SystemTagsManagerImpl implements SystemTagsManager {
     private static final Collection<Consumer<SystemTagsManager>> ON_CHANGE_SUBSCRIBERS = new ArrayList<>();
 
     private final Map<String, String> systemTagPairs = new TreeMap<>();
-    private final Set<String> systemTagNames = new HashSet<>(); // tag names for global tags and app
     private final Set<String> systemAndScopeTagNames = new HashSet<>(); // tag names for globa tags, app, and scope
 
     /*
@@ -67,10 +66,8 @@ class SystemTagsManagerImpl implements SystemTagsManager {
 
     private SystemTagsManagerImpl(MetricsConfig metricsConfig) {
 
-        metricsConfig.tags().forEach(tag -> {
-            systemTagNames.add(tag.key());
-            systemTagPairs.put(tag.key(), tag.value());
-        });
+        metricsConfig.tags().forEach(tag ->
+                                             systemTagPairs.put(tag.key(), tag.value()));
 
         // Add a tag for the app name if there is an appName setting in config AND we have a setting
         // from somewhere for the tag name to use for recording the app name.
@@ -79,13 +76,11 @@ class SystemTagsManagerImpl implements SystemTagsManager {
                 .filter(Predicate.not(String::isBlank))
                 .ifPresent(tagNameToUse ->
                                    metricsConfig.appName()
-                                           .ifPresent(appNameToUse -> {
-                                               systemTagPairs.put(tagNameToUse, appNameToUse);
-                                               systemTagNames.add(tagNameToUse);
-                                           })
+                                           .ifPresent(appNameToUse ->
+                                                              systemTagPairs.put(tagNameToUse, appNameToUse))
                 );
 
-        systemAndScopeTagNames.addAll(systemTagNames);
+        systemAndScopeTagNames.addAll(systemTagPairs.keySet());
         metricsConfig.scoping().tagName().ifPresent(scopeTagNameToUse -> {
             systemAndScopeTagNames.add(scopeTagNameToUse);
             scopeTagName = scopeTagNameToUse;
@@ -137,7 +132,7 @@ class SystemTagsManagerImpl implements SystemTagsManager {
 
     @Override
     public Iterable<Tag> withoutSystemTags(Iterable<Tag> tags) {
-        return without(tags, systemTagNames);
+        return without(tags, systemTagPairs.keySet());
     }
 
     @Override

--- a/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManagerImpl.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/SystemTagsManagerImpl.java
@@ -17,6 +17,7 @@ package io.helidon.metrics.api;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -188,12 +189,12 @@ class SystemTagsManagerImpl implements SystemTagsManager {
 
     @Override
     public Iterable<Tag> displayTags() {
-        return List.copyOf(systemTags.get());
+        return Collections.unmodifiableCollection(systemTags.get());
     }
 
     @Override
     public Map<String, String> displayTagPairs() {
-        return Map.copyOf(systemTagPairs);
+        return Collections.unmodifiableMap(systemTagPairs);
     }
 
     @Override

--- a/metrics/api/src/main/java/io/helidon/metrics/spi/MetricsProgrammaticConfig.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/spi/MetricsProgrammaticConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,10 @@ import java.util.stream.Stream;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
+import io.helidon.common.Weighted;
 import io.helidon.metrics.api.MetricsConfig;
 import io.helidon.metrics.api.ScopingConfig;
+import io.helidon.metrics.api.SeMetricsProgrammaticConfig;
 
 /**
  * Programmatic (rather than user-configurable) settings that govern certain metrics behavior.
@@ -128,8 +130,8 @@ public interface MetricsProgrammaticConfig {
                                          HelidonServiceLoader.builder(
                                                          ServiceLoader.load(
                                                                  MetricsProgrammaticConfig.class))
-                                                 .addService(new MetricsProgrammaticConfig() {},
-                                                             Double.MIN_VALUE)
+                                                 .addService(new SeMetricsProgrammaticConfig(),
+                                                             Weighted.DEFAULT_WEIGHT - 50)
                                                  .build()
                                                  .asList()
                                                  .get(0));

--- a/metrics/api/src/main/java/module-info.java
+++ b/metrics/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,4 +46,6 @@ import io.helidon.common.features.api.HelidonFlavor;
     uses io.helidon.metrics.spi.MetersProvider;
 
     uses io.helidon.metrics.spi.MeterRegistryLifeCycleListener;
+
+    provides io.helidon.metrics.spi.MetricsProgrammaticConfig with io.helidon.metrics.api.SeMetricsProgrammaticConfig;
 }

--- a/metrics/api/src/test/java/io/helidon/metrics/api/TestSystemTagsManager.java
+++ b/metrics/api/src/test/java/io/helidon/metrics/api/TestSystemTagsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,8 +94,10 @@ class TestSystemTagsManager {
     @Test
     void checkForAppTag() {
         Config mConfig = Config.just(ConfigSources.create(APP_ONLY_TAGS_SETTINGS)).get("metrics");
-        MetricsConfig metricsConfig = MetricsConfig.create(mConfig);
-        SystemTagsManager mgr = SystemTagsManager.create(metricsConfig);
+        // Set up the metrics factory which applies the SE-specific programmatic defaults for the system tags manager.
+        MetricsFactory metricsFactory = MetricsFactory.getInstance(mConfig);
+        MetricsConfig metricsConfig = metricsFactory.metricsConfig();
+        SystemTagsManager mgr = SystemTagsManager.instance(metricsConfig);
 
         Meter.Id meterId = MeterId.create("my-metric", io.helidon.metrics.api.Tag.create(METRIC_TAG_NAME,
                                                                                          METRIC_TAG_VALUE));
@@ -105,7 +107,8 @@ class TestSystemTagsManager {
         assertThat("Global tags derived from tagless metric ID",
                    fullTags, allOf(not(hasEntry(GLOBAL_TAG_1, GLOBAL_VALUE_1)),
                                    not(hasEntry(GLOBAL_TAG_2, GLOBAL_VALUE_2))));
-        if (MetricsProgrammaticConfig.instance().appTagName().isPresent()) {
+        // By default, specifying just the app name in config should trigger the default or explicit app tag name and value.
+        if (metricsConfig.appName().isPresent()) {
             assertThat("App tag", fullTags, hasKey(MetricsProgrammaticConfig.instance().appTagName().get()));
         }
     }
@@ -113,8 +116,10 @@ class TestSystemTagsManager {
     @Test
     void checkForGlobalAndAppTags() {
         Config mConfig = Config.just(ConfigSources.create(GLOBAL_AND_APP_TAG_SETTINGS)).get("metrics");
-        MetricsConfig metricsConfig = MetricsConfig.create(mConfig);
-        SystemTagsManager mgr = SystemTagsManager.create(metricsConfig);
+        // Set up the metrics factory which applies the SE-specific programmatic defaults for the system tags manager.
+        MetricsFactory metricsFactory = MetricsFactory.getInstance(mConfig);
+        MetricsConfig metricsConfig = metricsFactory.metricsConfig();
+        SystemTagsManager mgr = SystemTagsManager.instance();
 
         Meter.Id meterId = MeterId.create("my-metric", io.helidon.metrics.api.Tag.create(METRIC_TAG_NAME,
                                                                                          METRIC_TAG_VALUE));
@@ -124,7 +129,8 @@ class TestSystemTagsManager {
         assertThat("Global tags derived from tagless metric ID",
                    fullTags, allOf(hasEntry(GLOBAL_TAG_1, GLOBAL_VALUE_1),
                                    hasEntry(GLOBAL_TAG_2, GLOBAL_VALUE_2)));
-        if (MetricsProgrammaticConfig.instance().appTagName().isPresent()) {
+        // By default, specifying just the app name in config should trigger the default or explicit app tag name and value.
+        if (metricsConfig.appName().isPresent()) {
             assertThat("App tag", fullTags, hasKey(MetricsProgrammaticConfig.instance().appTagName()));
         }
     }
@@ -144,8 +150,10 @@ class TestSystemTagsManager {
     @Test
     void checkForGlobalButNoMetricTags() {
         Config mConfig = Config.just(ConfigSources.create(GLOBAL_AND_APP_TAG_SETTINGS)).get("metrics");
-        MetricsConfig metricsConfig = MetricsConfig.create(mConfig);
-        SystemTagsManager mgr = SystemTagsManager.create(metricsConfig);
+        // Set up the metrics factory which applies the SE-specific programmatic defaults for the system tags manager.
+        MetricsFactory metricsFactory = MetricsFactory.getInstance(mConfig);
+        MetricsConfig metricsConfig = metricsFactory.metricsConfig();
+        SystemTagsManager mgr = SystemTagsManager.instance();
 
         Meter.Id meterId = MeterId.create("no-tags-metric", Set.of());
         Map<String, String> fullTags = new HashMap<>();
@@ -154,7 +162,8 @@ class TestSystemTagsManager {
         assertThat("Global tags derived from tagless metric ID",
                    fullTags, allOf(hasEntry(GLOBAL_TAG_1, GLOBAL_VALUE_1),
                                    hasEntry(GLOBAL_TAG_2, GLOBAL_VALUE_2)));
-        if (MetricsProgrammaticConfig.instance().appTagName().isPresent()) {
+        // By default, specifying just the app name in config should trigger the default or explicit app tag name and value.
+        if (metricsConfig.appName().isPresent()) {
             assertThat("App tag", fullTags, hasKey(MetricsProgrammaticConfig.instance().appTagName()));
         }
     }

--- a/metrics/provider-tests/src/main/java/io/helidon/metrics/provider/tests/TestGlobalTags.java
+++ b/metrics/provider-tests/src/main/java/io/helidon/metrics/provider/tests/TestGlobalTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,5 +88,13 @@ class TestGlobalTags {
                    counter1.id().tags(),
                    hasItem(Tag.create("local1", "a")));
 
+    }
+
+    @Test
+    void testAppName() {
+        String appNameTag = "se-app";
+        String appNameValue = "test-app";
+        Config metricsConfig = Config.just(ConfigSources.create(Map.of("app-tag-name", appNameTag, "app-name", appNameValue)));
+        MetricsFactory.getInstance(metricsConfig);
     }
 }

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/SystemTagsMeterFilterManager.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/SystemTagsMeterFilterManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,9 +71,8 @@ class SystemTagsMeterFilterManager implements Consumer<SystemTagsManager> {
 
         try {
             micrometerSystemTags.clear();
-            systemTagsManager.displayTags()
-                    .forEach(tag -> micrometerSystemTags.add(Tag.of(tag.key(),
-                                                                    tag.value())));
+            systemTagsManager.displayTagPairs()
+                    .forEach((name, value) -> micrometerSystemTags.add(Tag.of(name, value)));
             return this;
         } finally {
             lock.unlock();


### PR DESCRIPTION
### Description
Resolves #9664 

The fix for the main bug exposed another problem (see below) which this PR also fixes.

## The main fix
Synopsis: Helidon failed to correctly provide in SE the tag to be used for conveying the app name if the user specified an app name in the config (but not explicitly the tag name to use).

Details:
Metrics has a `MetricsProgrammaticConfig` interface which is primarily a way for SE and MP to dictate config settings in the `MetricsConfig` type. (Even if the user sets them, the implementations of this interface override those settings.) Among other things, this type allows control over reserved tag names, the tag name used to convey the meter's scope, etc.

The pre-existing MP implementation is fine. There was no SE implementation, relying on (incomplete) default behavior defined in the interface itself. 

This PR introduces, for clarity as well as the bug fix, an explicit SE-specific implementation. It is always consulted, but if the MP one is also present the code runs it last, overriding anything the SE implementation might have assigned.

These implementations are invoked when the `MetricsFactoryManager` is invoked with a `MetricsConfig` instance to prepare a `MetricsFactory` (which, ultimately, instantiates a `MeterRegistry` which is where some of the settings go into effect.) There is a slight change in that class where it collects the `MetricsProgrammaticConfig` instances to apply them so that the MP implementation supersedes the SE one.

## The other problem: recursive infinite loop exposed
Synopsis: `SystemTagsManagerImpl` is initialized by `MetricsFactory`, and during its initialization it would invoke `MetricsFactory` which would attempt to re-initialize `SystemTagsManagerImpl`, and around we go.

In metrics, the `MetricsFactory` is a gateway to many operations whose implementations depend on the underlying metrics provider (Micrometer is the only one so far). In obtaining an instance of this type, the system also prepares an instance of `SystemTagsManager`. One responsibility of that type is to provide a collection of Helidon `Tag`s containing whatever tags should be applied to all meters created. 

Before this PR, that code would prepare the `Tag` collection during initialization. The latent bug (hidden by the main bug) was that this initialization code would invoke `Tag.create` (on the Helidon-neutral `Tag` interface) which has to ensure that the tag names from the caller (usually the app developer) do not conflict with the reserved tags, which in turn would need to access the `MetricsFactory` which was currently being initialized so the `LazyValue` holding it was still empty...triggering a recursive construction.

The fix to this bug is to store a `Map<String, String>` for the universal tag names and values during initialization and only manufacture `Tag` instances upon first real need...after initialization has completed. This new map removes the need for the separate `systemTagNames` set (because it can be derived from the key set of the new `Map<String, String>`. 

There was one other bit of code that referred to the `instance()` method instead of the `instance` parameter which caused a separate recursive infinite loop, also fixed.

### Documentation
No doc impact.
