### PR TITLE
Restore setting of no-cache header in health HTTP responses; add test

### DIFF
--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthHandler.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.List;
 
 import io.helidon.health.HealthCheck;
 import io.helidon.health.HealthCheckResponse;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.HtmlEncoder;
 import io.helidon.http.Status;
 import io.helidon.http.media.EntityWriter;
@@ -84,6 +85,7 @@ class HealthHandler implements Handler {
         };
 
         res.status(responseStatus);
+        res.header(HeaderValues.CACHE_NO_CACHE);
 
         if (details) {
             entityWriter.write(JsonpSupport.JSON_OBJECT_TYPE,

--- a/webserver/observe/health/src/test/java/io/helidon/webserver/observe/health/TestNoCacheHeaders.java
+++ b/webserver/observe/health/src/test/java/io/helidon/webserver/observe/health/TestNoCacheHeaders.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.observe.health;
+
+import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
+import io.helidon.http.HeaderNames;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+
+@ServerTest
+class TestNoCacheHeaders {
+
+    private final Http1Client client;
+
+    TestNoCacheHeaders(Http1Client client) {
+        this.client = client;
+    }
+
+    @Test
+    void testNoCacheHeaders() {
+        try (Http1ClientResponse response = client
+                .get("/observe/health")
+                .request()) {
+
+            assertThat("No-cache headers",
+                       response.headers(),
+                       allOf(HttpHeaderMatcher.hasHeader(HeaderNames.CACHE_CONTROL,
+                                                         "no-cache",
+                                                         "no-store",
+                                                         "must-revalidate",
+                                                         "no-transform")));
+        }
+    }
+}


### PR DESCRIPTION
### Description
Resolves #9670 

Release note:
___
Formerly (in 3.x) HTTP responses from the health endpoint set the `Cache-Control` header to `no-cache, no-store, must-revalidate, no-transform` because the returned result could well be different for each request. But 4.x does not do so. This change restores those response header values.
___

This PR Restores the addition of the no-cache group of headers to the health response that was seemingly accidentally  dropped in the move to 4.x.

Adds test checking for the header values.

### Documentation
Bug fix. No doc impact.