### PR TITLE
Use Helidon gRPC client in Config Etcd module

### DIFF
--- a/config/etcd/pom.xml
+++ b/config/etcd/pom.xml
@@ -49,7 +49,10 @@
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-media-type</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-grpc</artifactId>
+        </dependency>
         <!-- etcd v2 -->
         <dependency>
             <groupId>org.mousio</groupId>
@@ -59,11 +62,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -135,21 +133,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <property>
-                            <!-- on big machines (e.g. 52 cores hyperthreaded)
-                             this failed with too many open files
-                             -->
-                            <name>io.netty.eventLoopThreads</name>
-                            <value>2</value>
-                        </property>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2Client.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class EtcdV2Client implements EtcdClient {
      *
      * @deprecated
      */
-    EtcdV2Client(URI... uris) {
+    public EtcdV2Client(URI... uris) {
         etcd = new mousio.etcd4j.EtcdClient(uris);
         etcd.setRetryHandler(new RetryWithTimeout(100, 2000));
     }

--- a/config/etcd/src/main/java/module-info.java
+++ b/config/etcd/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ module io.helidon.config.etcd {
     requires io.grpc.stub;
     requires io.helidon.common.media.type;
     requires io.helidon.common;
+    requires io.helidon.webclient.grpc;
 
     requires static java.annotation;
 


### PR DESCRIPTION
### Description

Use Helidon gRPC client in config etcd module. Updates old IT tests to run with etcd V3 only. IT tests manually executed and shown to pass with all the latest changes and V3 etcd server. Issue #9650.

### Documentation. 

None
