### PR TITLE
4.x: Disable only the slowest test in FileSystemWatcherTest

### DIFF
--- a/config/config/src/test/java/io/helidon/config/FileSystemWatcherTest.java
+++ b/config/config/src/test/java/io/helidon/config/FileSystemWatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Tests {@link io.helidon.config.FileSystemWatcher}.
  */
-@Disabled //TODO tests are still TOO slow to be unit tests -> refactor it to run much quicker
 public class FileSystemWatcherTest {
     private static final String WATCHED_FILE = "watched-file.yaml";
 
@@ -104,6 +103,7 @@ public class FileSystemWatcherTest {
         assertThat(watchedFileLatch.await(40, TimeUnit.SECONDS), is(true));
     }
 
+    @Disabled //TODO test is still TOO slow to be unit test -> refactor it to run much quicker
     @Test
     public void testPollingSymLink() throws InterruptedException, IOException {
         CountDownLatch firstEventLatch = new CountDownLatch(1);


### PR DESCRIPTION
### Description
Now all tests in `FileSystemWatcherTest` are disabled, because they are too slow. But only one test is too slow  `testPollingSymLink`. Is it better to disable only the specific test? I'm not sure, but 4 seconds look like not so much time.

<img width="611" alt="slow" src="https://github.com/user-attachments/assets/d6c89a0a-dec3-4f2d-bc9d-fc0173478afb" />
<img width="595" alt="fast" src="https://github.com/user-attachments/assets/b6c0745d-3aa5-4dc7-b619-5d36ae9d0595" />
