### PR TITLE
Have JaxRsService save response headers and, if Jersey does not handle the request, restore the saved headers

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsService.java
@@ -41,6 +41,7 @@ import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.InternalServerException;
+import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.Status;
 import io.helidon.microprofile.server.HelidonHK2InjectionManagerFactory.InjectionManagerWrapper;
 import io.helidon.webserver.KeyPerformanceIndicatorSupport;
@@ -201,6 +202,7 @@ class JaxRsService implements HttpService {
     }
 
     private void doHandle(Context ctx, ServerRequest req, ServerResponse res) {
+        ServerResponseHeaders savedResponseHeaders = ServerResponseHeaders.create(res.headers());
         BaseUriRequestUri uris = BaseUriRequestUri.resolve(req);
         ContainerRequest requestContext = new ContainerRequest(uris.baseUri,
                                                                uris.requestUri,
@@ -250,6 +252,7 @@ class JaxRsService implements HttpService {
                 if (res instanceof RoutingResponse routing) {
                     if (routing.reset()) {
                         res.status(Status.OK_200);
+                        savedResponseHeaders.forEach(res::header);
                         routing.next();
                     }
                 }

--- a/tests/integration/mp-jaxrs-preserve-headers/pom.xml
+++ b/tests/integration/mp-jaxrs-preserve-headers/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../../../applications/mp/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.tests.integration</groupId>
+    <artifactId>helidon-tests-integration-jaxrs-preserve-headers</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Helidon Tests Integration JaxRsService Preserve Headers from SE filter</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.health</groupId>
+            <artifactId>helidon-microprofile-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/mp-jaxrs-preserve-headers/src/main/java/io/helidon/tests/integration/mp/jaxrs/preserve/headers/GreetResource.java
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/main/java/io/helidon/tests/integration/mp/jaxrs/preserve/headers/GreetResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.jaxrs.preserve.headers;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/greet")
+public class GreetResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String greet() {
+        return "Hello World!";
+    }
+}

--- a/tests/integration/mp-jaxrs-preserve-headers/src/main/java/io/helidon/tests/integration/mp/jaxrs/preserve/headers/HeaderAdjustmentFeatureProvider.java
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/main/java/io/helidon/tests/integration/mp/jaxrs/preserve/headers/HeaderAdjustmentFeatureProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.jaxrs.preserve.headers;
+
+import io.helidon.common.Weight;
+import io.helidon.config.Config;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderValues;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.observe.health.HealthObserverConfig;
+import io.helidon.webserver.spi.ServerFeature;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+/**
+ * Server feature to insert headers for the health responses using an SE filter. The header so added
+ * is removed by JaxRsService#doHandle without the fix to save headers and, if Jersey does not handle the
+ * request, restoring the saved headers before handing the request off to SE to see if it can deal with it.
+ */
+@Weight(HeaderAdjustmentFeatureProvider.WEIGHT)
+public class HeaderAdjustmentFeatureProvider
+        implements ServerFeatureProvider<HeaderAdjustmentFeatureProvider.HeaderAdjustmentFeature> {
+
+    static final Header ADDED_HEADER = HeaderValues.create("X-Helidon-Test", "example");
+
+    static final double WEIGHT = 90D;
+
+    @Override
+    public String configKey() {
+        return "header-adjustment";
+    }
+
+    @Override
+    public HeaderAdjustmentFeature create(io.helidon.common.config.Config config, String name) {
+        return new HeaderAdjustmentFeature();
+    }
+
+    @Weight(WEIGHT)
+    public static class HeaderAdjustmentFeature implements ServerFeature {
+
+        public HeaderAdjustmentFeature() {
+        }
+
+        @Override
+        public void setup(ServerFeatureContext serverFeatureContext) {
+            serverFeatureContext.socket(WebServer.DEFAULT_SOCKET_NAME)
+                    .httpRouting()
+                    .addFeature(new HeaderAdjustmentHttpFeature(Config.global()));
+        }
+
+        @Override
+        public String name() {
+            return "header-adjustment";
+        }
+
+        @Override
+        public String type() {
+            return "header-adjustment";
+        }
+
+        @Weight(WEIGHT)
+        private static class HeaderAdjustmentHttpFeature implements HttpFeature {
+
+            private final io.helidon.common.config.Config config;
+
+            private HeaderAdjustmentHttpFeature(io.helidon.common.config.Config config) {
+                this.config = config;
+            }
+
+            @Override
+            public void setup(HttpRouting.Builder builder) {
+
+                HealthObserverConfig healthObserverConfig =
+                        HealthObserverConfig.create(config.root().get("server.features.observe.observers.health"));
+                builder.addFilter((chain, req, resp) -> {
+                    if (req.path().path().endsWith(healthObserverConfig.endpoint())) {
+                        resp.header(ADDED_HEADER);
+                    }
+                    chain.proceed();
+                });
+            }
+        }
+    }
+}

--- a/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Microprofile server properties
+server.port=8080
+server.host=0.0.0.0

--- a/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/META-INF/services/io.helidon.webserver.spi.ServerFeatureProvider
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/META-INF/services/io.helidon.webserver.spi.ServerFeatureProvider
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.tests.integration.mp.jaxrs.preserve.headers.HeaderAdjustmentFeatureProvider

--- a/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/application.yaml
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+server:
+  features:
+    header-adjustment:

--- a/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/application.yaml
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/main/resources/application.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 server:
   features:
     header-adjustment:

--- a/tests/integration/mp-jaxrs-preserve-headers/src/test/java/io/helidon/tests/integration/mp/jaxrs/preserve/headers/TestHeaderPreservation.java
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/test/java/io/helidon/tests/integration/mp/jaxrs/preserve/headers/TestHeaderPreservation.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.jaxrs.preserve.headers;
+
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+
+@HelidonTest
+class TestHeaderPreservation {
+
+    private final WebTarget webTarget;
+
+    @Inject
+    TestHeaderPreservation(WebTarget webTarget) {
+        this.webTarget = webTarget;
+    }
+
+    @Test
+    void testHeaderPreservation() {
+        Response response = webTarget.path("health").request(MediaType.APPLICATION_JSON_TYPE).get();
+
+        assertThat("Health response status", response.getStatus(), equalTo(200));
+        // Without the fix to JaxRsService, the added header will have been removed.
+        assertThat("Health response headers",
+                   response.getHeaders(),
+                   hasKey(HeaderAdjustmentFeatureProvider.ADDED_HEADER.name()));
+    }
+}

--- a/tests/integration/mp-jaxrs-preserve-headers/src/test/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/mp-jaxrs-preserve-headers/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Override configuration to use a random port for the unit tests
+config_ordinal=1000
+# Microprofile server properties
+server.port=-1
+server.host=0.0.0.0

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -68,6 +68,7 @@
         <module>tls-revocation-config</module>
         <module>h2spec</module>
         <module>mp-telemetry</module>
+        <module>mp-jaxrs-preserve-headers</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description
Resolves #9675 

If `JaxRsService#doHandle` finds that Jersey does not handle a request, it resets the routing and lets the SE request handling have a chance.

Resetting the routing also clears any response headers (for example, set by an upstream SE filter). 

With this PR, `#doHandle` saves the current response headers and, if Jersey did not handle the request, resets the routing _and restores the saved headers` before handing the request off to SE.

The PR also adds an integration test.

### Documentation
No impact.