### PR TITLE
4.x fix status from deadlock health check if invoking the MBean fails

### DIFF
--- a/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
@@ -106,8 +106,8 @@ public class DeadlockHealthCheck implements HealthCheck {
                 LOGGER.log(Level.TRACE, "Health check observed deadlocked threads: " + Arrays.toString(deadlockedThreads));
             }
         } catch (Throwable e) {
-            // ThreadBean does not work - probably in native image. Report UP, not ERROR, because we do not want that failure to
-            // contaminate the overall health result.
+            // ThreadBean does not work - probably in native image. Report ERROR, not DOWN, because we do not know that
+            // there are deadlocks which DOWN should imply; we simply cannot find out.
             LOGGER.log(Level.TRACE, "Error invoking ThreadMXBean to find deadlocks; cannot complete this healthcheck", e);
             builder.status(Status.ERROR);
         }

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.health.checks;
 import java.lang.System.Logger.Level;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
 
 import io.helidon.common.NativeImageHelper;
 import io.helidon.health.HealthCheck;
@@ -95,17 +96,22 @@ public class DeadlockHealthCheck implements HealthCheck {
                     .build();
         }
 
-        boolean noDeadLock = false;
+        HealthCheckResponse.Builder builder = HealthCheckResponse.builder();
+
         try {
             // Thanks to https://stackoverflow.com/questions/1102359/programmatic-deadlock-detection-in-java#1102410
-            noDeadLock = (threadBean.findDeadlockedThreads() == null);
+            long[] deadlockedThreads = threadBean.findDeadlockedThreads();
+            if (deadlockedThreads != null) {
+                builder.status(Status.DOWN);
+                LOGGER.log(Level.TRACE, "Health check observed deadlocked threads: " + Arrays.toString(deadlockedThreads));
+            }
         } catch (Throwable e) {
-            // ThreadBean does not work - probably in native image
-            LOGGER.log(Level.TRACE, "Failed to find deadlocks in ThreadMXBean, ignoring this healthcheck", e);
+            // ThreadBean does not work - probably in native image. Report UP, not ERROR, because we do not want that failure to
+            // contaminate the overall health result.
+            LOGGER.log(Level.TRACE, "Error invoking ThreadMXBean to find deadlocks; cannot complete this healthcheck", e);
+            builder.status(Status.ERROR);
         }
-        return HealthCheckResponse.builder()
-                .status(noDeadLock ? Status.UP : Status.DOWN)
-                .build();
+        return builder.build();
     }
 }
 

--- a/health/health-checks/src/test/java/io/helidon/health/checks/DeadlockHealthCheckTest.java
+++ b/health/health-checks/src/test/java/io/helidon/health/checks/DeadlockHealthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,5 +62,14 @@ class DeadlockHealthCheckTest {
         DeadlockHealthCheck check = new DeadlockHealthCheck(threadBean);
         HealthCheckResponse response = check.call();
         assertThat(response.status(), is(HealthCheckResponse.Status.UP));
+    }
+
+    @Test
+
+    void errorInvokingMBean() {
+        Mockito.when(threadBean.findDeadlockedThreads()).thenThrow(new RuntimeException("Simulated error invoking MBean"));
+        DeadlockHealthCheck check = new DeadlockHealthCheck(threadBean);
+        HealthCheckResponse response = check.call();
+        assertThat(response.status(), is(HealthCheckResponse.Status.ERROR));
     }
 }


### PR DESCRIPTION
### Description
Resolves #9691 

Release Note
____
Helidon's built-in deadlock health check now reports the state `ERROR` instead of `DOWN` if the invocation of the MBean method to retrieve deadlocked thread IDs throws an exception. (It used to report `DOWN`.) 

Reporting `ERROR` is more accurate, and in such cases Helidon returns the HTTP status 500 for the health response. This lets a deployment environment, such as Kubernetes, allow the pod to continue running. In such error cases Helidon (as it has for some time) logs a `TRACE`-level message reporting the exception it encountered.
____

The code for the deadlock health check used to report `DOWN` if it failed to invoke the threads MBean to retrieve the list of deadlocked thread IDs. (The method returns null if no deadlocks exist.)

This PR changes that code to report `ERROR` instead of `DOWN`. By reporting `DOWN` the previous code incorrectly implied that there was a deadlock and the server instance should be considered "unwell." In fact, in that case the health check code does not know whether there is or is not a deadlock because of the error invoking the MBean method and it should report that way.

The PR also adds a test.

### Documentation
No impact.