### PR TITLE
4.x: Update issue template to work with latest issues update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,17 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
-[//]: # "Please remove these comments"
-[//]: # "Provide a general summary of the issue in the Title above"
+---
 
 ## Environment Details
 * Helidon Version:
 * Helidon SE or Helidon MP
 * JDK version:
 * OS:
-* Docker version (if applicable):
 
 ----------
 
@@ -19,4 +23,5 @@
 ## Steps to reproduce
 [//]: # "Step by step instructions to reproduce the problem"
 [//]: # "Provide sample code/application if relevant"
+
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
### Description

Update our issue template. The latest GitHub update to issues broke our old template (not sure why, legacy templates are supposed to still work).

After some experimentation this PR plus fiddling with repo settings should restore our template.

Fixes #9696