### PR TITLE
Improved clarity in the error log

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -661,7 +661,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                 throw new IOException("Stream already closed");
             }
             if (isNoEntityStatus && buffer.available() > 0) {
-                throw new IllegalStateException("Attempting to write data on a response with status " + status);
+                throw new IllegalStateException("Attempting to write data on a response with status " + status.get());
             }
 
             if (!isChunked) {


### PR DESCRIPTION
### Description

In certain scenarios, when an entity is included in a response that does not permit it, the logged error message lacks clarity.

**Current logs**

```
2025-01-29T13:49:03,362+00:00 | ERROR | ebServer socket | server.ServerRuntime$Responder | Error while closing the output stream in order to commit response.
java.lang.IllegalStateException: Attempting to write data on a response with status io.helidon.webserver.http1.Http1ServerResponse$$Lambda/0x00007f251874e920@46d6943f
        at io.helidon.webserver.http1.Http1ServerResponse$BlockingOutputStream.write(Http1ServerResponse.java:664) ~[helidon-webserver-4.1.6.jar:4.1.6]
        at io.helidon.webserver.http1.Http1ServerResponse$BlockingOutputStream.write(Http1ServerResponse.java:554) ~[helidon-webserver-4.1.6.jar:4.1.6]
        at java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:125) ~[?:?]
        at java.base/java.io.BufferedOutputStream.implFlush(BufferedOutputStream.java:252) ~[?:?]
        at java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:240) ~[?:?]
        at java.base/java.io.FilterOutputStream.close(FilterOutputStream.java:184) ~[?:?]
        at io.helidon.webserver.http1.Http1ServerResponse$ClosingBufferedOutputStream.close(Http1ServerResponse.java:853) ~[helidon-webserver-4.1.6.jar:4.1.6]
        at io.helidon.microprofile.server.JaxRsService$ReleaseLatchStream.close(JaxRsService.java:431) ~[helidon-microprofile-server-4.1.6.jar:4.1.6]
        at org.glassfish.jersey.message.internal.CommittingOutputStream.close(CommittingOutputStream.java:251) ~[jersey-common-3.1.8.jar:?]
``` 

### Documentation

None
