### PR TITLE
Gracefully reject HTTP 1.0 connections 

### DIFF
--- a/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.common.buffers.DataReader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ConnectionHandlerTest {
+
+    @Test
+    void testHttp10Prologue() {
+        DataReader reader = new DataReader(() -> "GET / HTTP/1.0\r\n".getBytes(StandardCharsets.US_ASCII));
+        assertThat(ConnectionHandler.isHttp10Connection(reader), is(true));
+    }
+}


### PR DESCRIPTION
### Description

- Gracefully reject HTTP 1.0 connections with a 505 error code (and log entry) that are routed directly to our 1.1 provider
- If multiple providers are available, we cannot easily return 505 but we now detect HTTP 1.0 and log an informative message

### Documentation

None