### PR TITLE
Add support for span lifecycle callbacks for selected OTel objects

### DIFF
--- a/docs/src/main/asciidoc/includes/tracing/common-callbacks.adoc
+++ b/docs/src/main/asciidoc/includes/tracing/common-callbacks.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2024 Oracle and/or its affiliates.
+    Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ Applications and libraries can register listeners to be notified at several mome
 * After a scope is closed
 
 // end::intro[]
-
+// tag::detailed-after-intro[]
 The next sections explain how you can write and add a listener and what it can do. See the link:{tracing-api-javadoc}/{listener-type}.html[`{listener-type}`] Javadoc for more information.
 
 === Understanding What Listeners Do
@@ -152,7 +152,7 @@ Helidon invokes each listener's methods in the following order:
 |====
 
 
-
+// end::detailed-after-intro[]
 // end::detailed[]
 
 // tag::brief[]

--- a/docs/src/main/asciidoc/mp/telemetry.adoc
+++ b/docs/src/main/asciidoc/mp/telemetry.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -202,7 +202,23 @@ include::{sourcedir}/mp/TelemetrySnippets.java[tag=snippet_6, indent=0]
 <2> Use the injected baggage.
 <3> Use `Baggage.current()` to access the current baggage.
 
-include::{rootdir}/includes/tracing/common-callbacks.adoc[tags=defs;detailed,leveloffset=+1]
+include::{rootdir}/includes/tracing/common-callbacks.adoc[tags=defs;intro,leveloffset=+1]
+
+As an implementation of MicroProfile Telemetry, Helidon allows your code to inject the OpenTelemetry `Tracer` and the current `Span` (if any). The following table summarizes how Helidon delivers lifecycle notifications for OpenTelemetry tracing objects.
+
+.Helidon Span Lifecycle Events for OpenTelemetry Objects
+|===
+| OpenTelemetry Object | OpenTelemetry Operation | link:{tracing-api-javadoc}/{listener-type}.html[`{listener-type}`] Callback
+
+.2+| `SpanBuilder` from the injected `Tracer` .2+| `startSpan` | `starting`
+|  `started`
+.2+| Injected `Span` or a `Span` built from a `SpanBuilder` obtained from the injected `Tracer` | `end` | `ended`
+| `makeCurrent` | `activated`
+| `Scope` returned from `makeCurrent` invoked on one of the above `Span` objects | `close` | `closed`
+|===
+Callback support works _only_ for the specific objects in the table. Helidon cannot provide callback support for arbitrary  OpenTelemetry objects your code gets directly from the OpenTelemetry APIs.
+
+include::{rootdir}/includes/tracing/common-callbacks.adoc[tag=detailed-after-intro,leveloffset=+1]
 
 === Controlling Automatic Span Creation
 By default, Helidon MP Telemetry creates a new child span for each incoming REST request and for each outgoing REST client request. You can selectively control if Helidon creates these automatic spans on a request-by-request basis by adding a very small amount of code to your project.

--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -156,6 +156,7 @@
                             </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/AgentDetectorTest.java</exclude>
+                                <exclude>**/TestSpanListenersWithInjection.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -171,6 +172,21 @@
                         <configuration>
                             <includes>
                                 <include>**/AgentDetectorTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-listeners-with-injection</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <otel.bsp.schedule.delay>${otel.bsp.schedule.delay}</otel.bsp.schedule.delay>
+                                <otel.sdk.disabled>false</otel.sdk.disabled>
+                            </systemPropertyVariables>
+                            <includes>
+                                <include>**/TestSpanListenersWithInjection.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/OtelProxy.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/OtelProxy.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.Errors;
+import io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+/**
+ * Provides proxies for OpenTelemetry types.
+ * <p>
+ * The proxies allow users to inject {@link io.opentelemetry.api.trace.Tracer} and {@link io.opentelemetry.api.trace.Span} and
+ * invoke state-changing operations on them and on related types ({@link io.opentelemetry.context.Scope}) in a way that notifies
+ * developer-provided {@link io.helidon.tracing.SpanListener} objects that have been registered with the Helidon tracer.
+ */
+class OtelProxy {
+
+    static OpenTelemetry openTelemetry(OpenTelemetry openTelemetry) {
+        return (OpenTelemetry) Proxy.newProxyInstance(OtelProxy.class.getClassLoader(),
+                                                      openTelemetry.getClass().getInterfaces(),
+                                                      new OpenTelemetryHandler(openTelemetry));
+    }
+
+    static Tracer tracer(OpenTelemetry openTelemetry, Tracer otelTracer) {
+        Class<?>[] allInterfaces = Arrays.copyOf(otelTracer.getClass().getInterfaces(),
+                                                 otelTracer.getClass().getInterfaces().length + 1);
+        allInterfaces[allInterfaces.length - 1] = ProxiedTracer.class;
+        return (Tracer) Proxy.newProxyInstance(OtelProxy.class.getClassLoader(),
+                                               allInterfaces,
+                                               new TracerHandler(otelTracer, HelidonOpenTelemetry.create(openTelemetry,
+                                                                                                         otelTracer,
+                                                                                                         Map.of())));
+    }
+
+    static Span span(io.helidon.tracing.Span.Extended<Scope> helidonSpan) {
+        Span delegate = helidonSpan.unwrap(Span.class);
+        return (Span) Proxy.newProxyInstance(OtelProxy.class.getClassLoader(),
+                                             delegate.getClass().getInterfaces(),
+                                             new SpanHandler(delegate, helidonSpan));
+    }
+
+    interface ProxiedTracer {
+        io.helidon.tracing.Tracer helidonTracer();
+    }
+
+    private static SpanBuilder spanBuilder(io.helidon.tracing.Span.Builder<?> helidonSpanBuilder) {
+        SpanBuilder delegate = helidonSpanBuilder.unwrap(SpanBuilder.class);
+        return (SpanBuilder) Proxy.newProxyInstance(OtelProxy.class.getClassLoader(),
+                                                    delegate.getClass().getInterfaces(),
+                                                    new SpanBuilderHandler(delegate, helidonSpanBuilder));
+    }
+
+    private static Scope scope(io.helidon.tracing.Scope helidonScope,
+                               Scope delegate) {
+        return (Scope) Proxy.newProxyInstance(OtelProxy.class.getClassLoader(),
+                                              delegate.getClass().getInterfaces(),
+                                              new ScopeHandler(delegate, helidonScope));
+    }
+
+    private OtelProxy() {
+    }
+
+    private record OpenTelemetryHandler(OpenTelemetry openTelemetry) implements InvocationHandler {
+
+            private static final Method TRACER_WITH_NAME;
+            private static final Method TRACER_WITH_NAME_AND_VERSION;
+
+            static {
+                try (MethodHelper methodHelper = new MethodHelper(OpenTelemetry.class)) {
+                    TRACER_WITH_NAME = methodHelper.method("getTracer", String.class);
+                    TRACER_WITH_NAME_AND_VERSION = methodHelper.method("getTracer", String.class, String.class);
+                }
+            }
+
+        @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                if (TRACER_WITH_NAME.equals(method) || TRACER_WITH_NAME_AND_VERSION.equals(method)) {
+                    return OtelProxy.tracer(openTelemetry, (Tracer) method.invoke(openTelemetry, args));
+                } else {
+                    return method.invoke(openTelemetry, args);
+                }
+            }
+        }
+
+    private record TracerHandler(Tracer otelTracer, io.helidon.tracing.Tracer helidonTracer) implements InvocationHandler {
+
+            // Preparing the methods of interest as constants allows fail-fast if the API changes.
+            private static final Method SPAN_BUILDER;
+            private static final Method HELIDON_TRACER;
+
+            static {
+                try (MethodHelper methodHelper = new MethodHelper(Tracer.class)) {
+                    SPAN_BUILDER = methodHelper.method("spanBuilder", String.class);
+                }
+                try (MethodHelper methodHelper = new MethodHelper(ProxiedTracer.class)) {
+                    HELIDON_TRACER = methodHelper.method("helidonTracer");
+                }
+            }
+
+        @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                if (method.equals(SPAN_BUILDER)) {
+                    io.helidon.tracing.Span.Builder<?> helidonSpanBuilder = helidonTracer.spanBuilder((String) args[0]);
+                    return OtelProxy.spanBuilder(helidonSpanBuilder);
+                } else if (method.equals(HELIDON_TRACER)) {
+                    return helidonTracer;
+                } else {
+                    return method.invoke(otelTracer, args);
+                }
+            }
+        }
+
+    private static class SpanBuilderHandler implements InvocationHandler {
+
+        private static final Method SET_START_TIME_INSTANT;
+        private static final Method SET_START_TIME_TIME_UNIT;
+        private static final Method START_SPAN;
+
+        static {
+            try (MethodHelper methodHelper = new MethodHelper(SpanBuilder.class)) {
+                SET_START_TIME_INSTANT = methodHelper.method("setStartTimestamp", Instant.class);
+                SET_START_TIME_TIME_UNIT = methodHelper.method("setStartTimestamp", long.class, TimeUnit.class);
+                START_SPAN = methodHelper.method("startSpan");
+            }
+        }
+
+        private final SpanBuilder otelSpanBuilder;
+        private final io.helidon.tracing.Span.Builder<?> helidonSpanBuilder;
+        private Instant startInstant;
+
+        private SpanBuilderHandler(SpanBuilder otelSpanBuilder, io.helidon.tracing.Span.Builder<?> helidonSpanBuilder) {
+            this.otelSpanBuilder = otelSpanBuilder;
+            this.helidonSpanBuilder = helidonSpanBuilder;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (SET_START_TIME_INSTANT.equals(method)) {
+                startInstant = (Instant) args[0];
+            } else if (SET_START_TIME_TIME_UNIT.equals(method)) {
+                startInstant = Instant.ofEpochMilli(((TimeUnit) args[1]).toMillis((Long) args[0]));
+            } else if (START_SPAN.equals(method)) {
+                if (startInstant == null) {
+                    startInstant = Instant.now();
+                }
+                // The Helidon span builder will notify listeners and also delegate to the OTel span builder.
+                io.helidon.tracing.Span helidonSpan = helidonSpanBuilder.start(startInstant);
+                return OtelProxy.span((io.helidon.tracing.Span.Extended<Scope>) helidonSpan);
+            }
+            return method.invoke(otelSpanBuilder, args);
+        }
+    }
+
+    private record SpanHandler(Span otelSpan, io.helidon.tracing.Span.Extended<Scope> helidonSpan) implements InvocationHandler {
+
+            private static final Method END;
+            private static final Method END_INSTANT;
+            private static final Method END_UNIT;
+            private static final Method MAKE_CURRENT;
+
+            static {
+                try (MethodHelper methodHelper = new MethodHelper(Span.class)) {
+                    END = methodHelper.method("end");
+                    END_INSTANT = methodHelper.method("end", Instant.class);
+                    END_UNIT = methodHelper.method("end", long.class, TimeUnit.class);
+                    MAKE_CURRENT = methodHelper.method("makeCurrent");
+                }
+            }
+
+        @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                if (END.equals(method) || END_INSTANT.equals(method) || END_UNIT.equals(method)) {
+                    // The Helidon span notifies listeners and invokes its delegate's end method.
+                    helidonSpan.end();
+                    return null;
+                } else if (MAKE_CURRENT.equals(method)) {
+                    // Activating the Helidon span using helidonSpan.activate() would make the native OTel span stored inside the
+                    // Helidon span the current span for OTel. Normally that would be reasonable, but instead we need the current
+                    // OTel span to be our proxy so our proxy will be injected as the current span. That way, if user code
+                    // operates on an injected current OTel span it will actually operate on our proxy which will notify the
+                    // registered listeners.
+                    Scope otelScope = Context.current().with((Span) proxy).makeCurrent();
+                    io.helidon.tracing.Scope helidonScope = helidonSpan.activate(otelScope);
+                    return OtelProxy.scope(helidonScope, otelScope);
+                }
+                return method.invoke(otelSpan, args);
+            }
+        }
+
+    private record ScopeHandler(Scope otelScope, io.helidon.tracing.Scope helidonScope) implements InvocationHandler {
+
+            private static final Method CLOSE;
+
+            static {
+                try (MethodHelper methodHelper = new MethodHelper(Scope.class)) {
+                    CLOSE = methodHelper.method("close");
+                }
+            }
+
+        @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                if (CLOSE.equals(method)) {
+                    helidonScope.close();
+                    return null;
+                } else {
+                    return method.invoke(otelScope, args);
+                }
+            }
+        }
+
+    private static class MethodHelper implements AutoCloseable {
+
+        private final Class<?> declaringClass;
+        private final Errors.Collector collector = Errors.collector();
+
+        private MethodHelper(Class<?> declaringClass) {
+            this.declaringClass = declaringClass;
+        }
+
+        private Method method(String name, Class<?>... args) {
+            Method result = null;
+            try {
+                result = declaringClass.getMethod(name, args);
+            } catch (NoSuchMethodException e) {
+                collector.fatal(name + List.of(args));
+            }
+            return result;
+        }
+
+        @Override
+        public void close() {
+            collector.collect().checkValid();
+        }
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanListenersWithInjection.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestSpanListenersWithInjection.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.telemetry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+import io.helidon.tracing.SpanListener;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+@HelidonTest
+@AddBean(TestSpanListenersWithInjection.MyBean.class)
+class TestSpanListenersWithInjection {
+
+    private static MyListener listener;
+
+    @Inject
+    private MyBean myBean;
+
+    @BeforeAll
+    static void setup() {
+        listener = new MyListener();
+        io.helidon.tracing.Tracer.global().register(listener);
+    }
+
+    @BeforeEach
+    void clearListener() {
+        listener.clear();
+
+    }
+
+    @Test
+    void testSpanFromInjectedTracer() {
+        Tracer injectedTracer = myBean.injectedTracer();
+        checkListenerCounts("Init", 0, 0, 0, 0, 0);
+
+        // Make sure building a span from the injected tracer and making it current triggers notifications.
+        SpanBuilder spanBuilderFromInjectedTracer = injectedTracer.spanBuilder("span-from-tracer-from-injected-opentelemetry");
+        Span spanFromInjectedTracer = spanBuilderFromInjectedTracer.startSpan();
+        checkListenerCounts("After span start", 1, 1, 0, 0, 0);
+
+        Scope scope = spanFromInjectedTracer.makeCurrent();
+        checkListenerCounts("After make current", 1, 1, 0, 1, 0);
+
+        scope.close();
+        checkListenerCounts("After close", 1, 1, 0, 1, 1);
+
+        spanFromInjectedTracer.end();
+        checkListenerCounts("After span end", 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    void testInjectedSpan() {
+
+        checkListenerCounts("Init", 0, 0, 0, 0, 0);
+
+        // First, before accessing the injected current span, create a new span and make it current explicitly.
+        Span span = myBean.injectedTracer().spanBuilder("span-from-injected-tracer-for-currency-check").startSpan();
+        checkListenerCounts("After span start", 1, 1, 0, 0, 0);
+
+        Scope scope = span.makeCurrent();
+        checkListenerCounts("After make current", 1, 1, 0, 1, 0);
+
+        // Now retrieve the "currently current" span from the bean. It should be the "same" one we just made current, but
+        // we cannot use sameInstance because our span provider method must inject its own wrapper around the current span.
+        Span currentSpan = myBean.currentSpanFromInjection();
+        assertThat("Current span vs. activated span", currentSpan.getSpanContext(), equalTo(span.getSpanContext()));
+
+        scope.close();
+        checkListenerCounts("After close", 1, 1, 0, 1, 1);
+
+        span.end();
+        checkListenerCounts("After span end", 1, 1, 1, 1, 1);
+    }
+
+    private void checkListenerCounts(String message,
+                                     int expectedStarting,
+                                     int expectedStarted,
+                                     int expectedEnded,
+                                     int expectedActivated,
+                                     int expectedClosed) {
+        assertThat(message + ": Starting spans", listener.starting(), hasSize(expectedStarting));
+        assertThat(message + ": Started spans", listener.started(), hasSize(expectedStarted));
+        assertThat(message + ": Ended spans", listener.ended(), hasSize(expectedEnded));
+        assertThat(message + ": Activated scopes", listener.activated().keySet(), hasSize(expectedActivated));
+        assertThat(message + ": Closed scopes", listener.closed().keySet(), hasSize(expectedClosed));
+    }
+
+    static class MyBean {
+
+        @Inject
+        private OpenTelemetry openTelemetry;
+
+        @Inject
+        private Tracer otelTracer;
+
+        @Inject
+        private Span otelSpan;
+
+        Tracer injectedTracer() {
+            return otelTracer;
+        }
+
+        Span currentSpanFromInjection() {
+            return otelSpan;
+        }
+    }
+
+    /**
+     * A span lifecycle listener that just saves the span builder, span, and/or scope associated with each reported event.
+     */
+    static class MyListener implements SpanListener {
+
+        private final List<io.helidon.tracing.Span.Builder<?>> starting = new ArrayList<>();
+        private final List<io.helidon.tracing.Span> started = new ArrayList<>();
+        private final List<io.helidon.tracing.Span> ended = new ArrayList<>();
+        private final Map<io.helidon.tracing.Span, io.helidon.tracing.Scope> activated = new HashMap<>();
+        private final Map<io.helidon.tracing.Span, io.helidon.tracing.Scope> closed = new HashMap<>();
+
+        @Override
+        public void starting(io.helidon.tracing.Span.Builder<?> spanBuilder) {
+            starting.add(spanBuilder);
+        }
+
+        @Override
+        public void started(io.helidon.tracing.Span span) {
+            started.add(span);
+        }
+
+        @Override
+        public void ended(io.helidon.tracing.Span span) {
+            ended.add(span);
+        }
+
+        @Override
+        public void ended(io.helidon.tracing.Span span, Throwable t) {
+            ended.add(span);
+        }
+
+        @Override
+        public void activated(io.helidon.tracing.Span span, io.helidon.tracing.Scope scope) {
+            activated.put(span, scope);
+        }
+
+        @Override
+        public void closed(io.helidon.tracing.Span span, io.helidon.tracing.Scope scope) {
+            closed.put(span, scope);
+        }
+
+        void clear() {
+            starting.clear();
+            started.clear();
+            ended.clear();
+            activated.clear();
+            closed.clear();
+        }
+
+        List<io.helidon.tracing.Span.Builder<?>> starting() {
+            return starting;
+        }
+
+        List<io.helidon.tracing.Span> started() {
+            return started;
+        }
+
+        List<io.helidon.tracing.Span> ended() {
+            return ended;
+        }
+
+        Map<io.helidon.tracing.Span, io.helidon.tracing.Scope> activated() {
+            return activated;
+        }
+
+        Map<io.helidon.tracing.Span, io.helidon.tracing.Scope> closed() {
+            return closed;
+        }
+    }
+}

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryScope.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,14 @@ class OpenTelemetryScope implements Scope {
     @Override
     public boolean isClosed() {
         return closed.get();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> scopeClass) {
+        if (io.opentelemetry.context.Scope.class.isAssignableFrom(scopeClass)) {
+            return scopeClass.cast(delegate);
+        }
+        return Scope.super.unwrap(scopeClass);
     }
 
     Limited limited() {

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Scope.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,4 +27,22 @@ public interface Scope extends AutoCloseable {
      * @return if this scope is closed
      */
     boolean isClosed();
+
+    /**
+     * Access the underlying scope by specific type.
+     * This is a dangerous operation that will succeed only if the scope is of expected type. This practically
+     * removes abstraction capabilities of this API.
+     *
+     * @param scopeClass type to access
+     * @param <T>        type of the scope
+     * @return instance of the scope
+     * @throws java.lang.IllegalArgumentException in case the scope cannot provide the expected type
+     */
+    default <T> T unwrap(Class<T> scopeClass) {
+        try {
+            return scopeClass.cast(this);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("This scope is not compatible with " + scopeClass.getName());
+        }
+    }
 }

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Span.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,5 +315,24 @@ public interface Span {
             throw new IllegalArgumentException("This instance cannot be unwrapped to " + type.getName()
                                                        + ", this builder: " + getClass().getName());
         }
+    }
+
+    /**
+     * Span with extended behavior for special cases; most code should use {@link io.helidon.tracing.Span} instead.
+     *
+     * @param <T> type of the native scope
+     *
+     * @see io.helidon.tracing.Span
+     */
+    interface Extended<T> extends Span {
+
+        /**
+         * Activates the span using the provided native scope.
+         *
+         * @param nativeScope native scope to activate
+         *
+         * @return {@link io.helidon.tracing.Scope} resulting from activating the native scope
+         */
+        Scope activate(T nativeScope);
     }
 }

--- a/tracing/tracing/src/main/java/io/helidon/tracing/Wrapper.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/Wrapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing;
+
+/**
+ * Behavior of a type that wraps a related type, typically through delegation.
+ */
+public interface Wrapper {
+
+    /**
+     * Unwraps the delegate as the specified type.
+     *
+     * @param c   {@link Class} to which to cast the delegate
+     * @param <R> type to cast to
+     * @return the delegate cast as the requested type
+     * @throws java.lang.ClassCastException if the delegate is not compatible with the requested type
+     */
+    <R> R unwrap(Class<? extends R> c);
+}


### PR DESCRIPTION
### Description
Resolves #9079 

### Release note
____
For several releases, Helidon's neutral tracing API (used primarily in Helidon SE applications) has invoked callbacks in your own `SpanListener` when a Helidon neutral `Span` or `Scope` changes state. See https://helidon.io/docs/latest/se/tracing#Tracing-callbacks. 

Separately, Helidon's support for MicroProfile Telemetry already lets your code inject an OpenTelemetry `Tracer` and the current OpenTelemetry `Span`. 

Starting with this release of Helidon, `SpanListener`s you register now receive lifecycle events for _selected_ OpenTelemetry objects:
* `Span` objects: 
   * the injected current `Span`
   * a `Span` created by a `SpanBuilder` that is obtained from the injected `Tracer`
* `Scope` objects returned from invoking `makeCurrent()` on the specific `Span` objects described above.

See the updated documentation under MP -> Telemetry for more information.
____

### PR Overview
We know of user applications which obtain an OpenTelemetry `Span` and type-check and cast it to `ReadableSpan` (another OpenTelemetry interface). To add the callback functionality while supporting that type-checking and casting usage on injected objects--inadvisable though such checking and casting of _injected_ instances might be--the changes in the PR wrap the injected OTel instances in Java proxies. This preserves type-checking and casting compatibility while adding the callback behavior.

The CDI producer methods now return proxies rather than the native OTel objects.

Each proxy invocation handler holds references to the OTel delegate and a corresponding Helidon wrapper object.

Basically, the proxies do additional work for only a few methods:
* methods which cause a state change in a span or scope
* methods which return another OTel type that exposes methods that cause a state change

For other methods the proxies just invoke the method on the delegate.

For operations which induce state changes, the proxy code invokes the corresponding method on the _Helidon wrapper_. Those methods do the correct notification (as they always have) and invoke the corresponding method on the OTel delegate (as they always have). Using the Helidon wrappers this way avoids replicating the wrappers' notification logic in the proxies.

There is one change to the public API to allow all this to work. The existing Helidon `Span` interface now has a new sub-interface `Span.Extended` which adds one additional method. Only our OpenTelemetry-based implementation of `Span` really needs this new method (so proxy invocation handler code can invoke it), but our OTel-based `Span` implementation `OpenTelemetrySpan` is in the `tracing/providers/opentelemetry` module and is package-private, so the `microprofile/telemetry` module cannot know about it. Adding the new public sub-interface and having `OpenTelemetrySpan` implement it minimizes the public changes while letting the proxy invoke the new method.

### Documentation
Update included in the PR.