### PR TITLE
Use actions/cache v4.2.0

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -84,7 +84,7 @@ runs:
         java-version: ${{ env.JAVA_VERSION }}
     - name: Cache local Maven repository (read-write)
       if: ${{ inputs.maven-cache == 'read-write' }}
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.0
       with:
         # See https://github.com/actions/toolkit/issues/713
         # Include must not match top level directories
@@ -98,7 +98,7 @@ runs:
           local-maven-
     - name: Cache local Maven repository (read-only)
       if: ${{ inputs.maven-cache == 'read-only' }}
-      uses: actions/cache/restore@v4.0.2
+      uses: actions/cache/restore@v4.2.0
       with:
         path: |
           .m2/repository/**/*.*
@@ -109,7 +109,7 @@ runs:
           local-maven-
     - name: Build cache (read-write)
       if: ${{ inputs.build-cache == 'read-write' }}
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.0
       with:
         path: |
           ./**/target/**
@@ -121,7 +121,7 @@ runs:
           build-cache-${{ github.run_id }}-
     - name: Build cache (read-only)
       if: ${{ inputs.build-cache == 'read-only' }}
-      uses: actions/cache/restore@v4.0.2
+      uses: actions/cache/restore@v4.2.0
       with:
         path: |
           ./**/target/**

--- a/common/common/src/main/java/io/helidon/common/Functions.java
+++ b/common/common/src/main/java/io/helidon/common/Functions.java
@@ -246,21 +246,4 @@ public final class Functions {
          */
         T get() throws E;
     }
-
-    /**
-     * Unchecked exception.
-     *
-     * @see #unwrap(Throwable)
-     */
-    public static class UncheckedException extends RuntimeException {
-
-        /**
-         * Create a new unchecked exception.
-         *
-         * @param cause cause
-         */
-        public UncheckedException(Throwable cause) {
-            super(cause);
-        }
-    }
 }

--- a/common/common/src/main/java/io/helidon/common/UncheckedException.java
+++ b/common/common/src/main/java/io/helidon/common/UncheckedException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common;
+
+/**
+ * Unchecked exception.
+ */
+public class UncheckedException extends RuntimeException {
+
+    /**
+     * Create a new unchecked exception.
+     *
+     * @param cause cause
+     */
+    public UncheckedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/ReflectionHelper.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/ReflectionHelper.java
@@ -30,6 +30,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.helidon.common.UncheckedException;
+
 /**
  * Reflection helper.
  */
@@ -285,14 +287,8 @@ class ReflectionHelper {
             method.setAccessible(true);
             Object value = method.invoke(instance, args);
             return type.cast(value);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        } catch (InvocationTargetException e) {
-            Throwable target = e.getTargetException();
-            if (e.getTargetException() instanceof RuntimeException re) {
-                throw re;
-            }
-            throw new RuntimeException(target);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new UncheckedException(e);
         }
     }
 }

--- a/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListener.java
+++ b/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListener.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 
-import io.helidon.common.Functions.UncheckedException;
+import io.helidon.common.UncheckedException;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.microprofile.testing.HelidonTestContainer;
@@ -268,13 +268,13 @@ public class HelidonTestNgListener extends HelidonTestNgListenerBase implements 
                     method.setAccessible(true);
                     return method.invoke(instance, args);
                 } catch (InvocationTargetException e) {
-                    if (e.getTargetException() instanceof RuntimeException) {
-                        throw (RuntimeException) e.getTargetException();
-                    }
-                    throw new UncheckedException(e.getTargetException());
+                    throw new UncheckedException(e);
                 }
             });
         } catch (UncheckedException e) {
+            if (e.getCause() instanceof InvocationTargetException te) {
+                throw te.getCause();
+            }
             throw e.getCause();
         }
     }


### PR DESCRIPTION
### Description

actions/cache v4.0.2 is removed and pipelines are failing.
Upgrade to v4.2.0.

Fix TestSpanListenersWithInjection to register listeners on CDI container startup.

Fixes #9730
Fixes #9728

### Documentation

None.
