### PR TITLE
Use helidon.oci prefix for OCI Config and allow some oci auth types to accept federation-endpoint and tenancy-id

### DIFF
--- a/etc/copyright-exclude.txt
+++ b/etc/copyright-exclude.txt
@@ -30,6 +30,7 @@ jaxb.index
 /MANIFEST.MF
 /README
 /CONTRIBUTING.md
+.crt
 .pem
 .p8
 .pkcs8.pem

--- a/integrations/oci/authentication/README.md
+++ b/integrations/oci/authentication/README.md
@@ -11,7 +11,7 @@ Helidon supports the following Authentication Methods:
   - `config-file`: based on OCI config file
 - `instance-principal`: instance principal (Such as an OCI VM)
 - `resource-prinicpal`: resource principal (Such as server-less functions)
-- `workload`: workload running on a k8s cluster
+- `oke-workload-identity`: identity of workload running on a k8s cluster
 
 The first two types are always available through `helidon-integrations-oci` module.
 Instance, resource, and workload support can be added through modules in this project module.

--- a/integrations/oci/authentication/instance/pom.xml
+++ b/integrations/oci/authentication/instance/pom.xml
@@ -63,6 +63,16 @@
             <artifactId>slf4j-jdk14</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrations/oci/authentication/instance/src/main/java/io/helidon/integrations/oci/authentication/instance/AuthenticationMethodInstancePrincipal.java
+++ b/integrations/oci/authentication/instance/src/main/java/io/helidon/integrations/oci/authentication/instance/AuthenticationMethodInstancePrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.integrations.oci.authentication.instance;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.Weight;
@@ -42,7 +43,7 @@ class AuthenticationMethodInstancePrincipal implements OciAuthenticationMethod {
     private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
     AuthenticationMethodInstancePrincipal(OciConfig config,
-                                          InstancePrincipalsAuthenticationDetailsProviderBuilder builder) {
+                                          Supplier<Optional<InstancePrincipalsAuthenticationDetailsProviderBuilder>> builder) {
         provider = createProvider(config, builder);
     }
 
@@ -58,10 +59,11 @@ class AuthenticationMethodInstancePrincipal implements OciAuthenticationMethod {
 
     private static LazyValue<Optional<BasicAuthenticationDetailsProvider>>
     createProvider(OciConfig config,
-                   InstancePrincipalsAuthenticationDetailsProviderBuilder builder) {
+                   Supplier<Optional<InstancePrincipalsAuthenticationDetailsProviderBuilder>> builder) {
         return LazyValue.create(() -> {
             if (HelidonOci.imdsAvailable(config)) {
-                return Optional.of(builder.build());
+                return builder.get()
+                        .map(InstancePrincipalsAuthenticationDetailsProviderBuilder::build);
             }
             if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
                 LOGGER.log(System.Logger.Level.TRACE, "OCI Metadata service is not available, "

--- a/integrations/oci/authentication/instance/src/main/java/io/helidon/integrations/oci/authentication/instance/InstancePrincipalBuilderProvider.java
+++ b/integrations/oci/authentication/instance/src/main/java/io/helidon/integrations/oci/authentication/instance/InstancePrincipalBuilderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,8 @@ class InstancePrincipalBuilderProvider implements Supplier<InstancePrincipalsAut
 
     @Override
     public InstancePrincipalsAuthenticationDetailsProviderBuilder get() {
-        var builder = InstancePrincipalsAuthenticationDetailsProvider.builder()
-                .timeoutForEachRetry((int) config.authenticationTimeout().toMillis());
+        var builder = getBuilder();
+        builder.timeoutForEachRetry((int) config.authenticationTimeout().toMillis());
 
         config.imdsDetectRetries()
                 .ifPresent(builder::detectEndpointRetries);
@@ -50,8 +50,14 @@ class InstancePrincipalBuilderProvider implements Supplier<InstancePrincipalsAut
         config.imdsBaseUri()
                 .map(URI::toString)
                 .ifPresent(builder::metadataBaseUrl);
+        config.tenantId()
+                .ifPresent(builder::tenancyId);
 
         return builder;
+    }
+
+    InstancePrincipalsAuthenticationDetailsProviderBuilder getBuilder() {
+        return InstancePrincipalsAuthenticationDetailsProvider.builder();
     }
 
 }

--- a/integrations/oci/authentication/instance/src/test/java/io/helidon/integrations/oci/authentication/instance/AuthenticationMethodInstancePrincipalTest.java
+++ b/integrations/oci/authentication/instance/src/test/java/io/helidon/integrations/oci/authentication/instance/AuthenticationMethodInstancePrincipalTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.authentication.instance;
+
+import java.util.Properties;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ServerTest
+public class AuthenticationMethodInstancePrincipalTest {
+    private static ServiceRegistryManager registryManager;
+    private static ServiceRegistry registry;
+    private static String imdsBaseUri;
+
+    AuthenticationMethodInstancePrincipalTest(WebServer server) {
+        imdsBaseUri = "http://localhost:%d/opc/v2/".formatted(server.port());
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.get("/opc/v2/instance", ImdsEmulator::emulateImdsInstance);
+    }
+
+    void setUp(Properties p) {
+        p.put("helidon.oci.authentication-method", "instance-principal");
+        p.put("helidon.oci.imds-timeout", "PT1S");
+        p.put("helidon.oci.imds-detect-retries", "0");
+        p.put("helidon.oci.imds-base-uri", imdsBaseUri);
+        System.setProperties(p);
+
+        registryManager = ServiceRegistryManager.create();
+        registry = registryManager.registry();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        registry = null;
+        if (registryManager != null) {
+            registryManager.shutdown();
+        }
+    }
+
+    @Test
+    public void testInstancePrincipalConfigurationAndInstantiation() {
+        final String FEDERATION_ENDPOINT = "https://auth.us-myregion-1.oraclecloud.com";
+        final String TENANT_ID = "ocid1.tenancy.oc1..mytenancyid";
+
+        Properties p = System.getProperties();
+        p.put("helidon.oci.federation-endpoint", FEDERATION_ENDPOINT);
+        p.put("helidon.oci.tenant-id", TENANT_ID);
+        setUp(p);
+
+        // This error indicates that the instance principal provider has been instantiated
+        var thrown = assertThrows(IllegalArgumentException.class,
+                                  () -> registry.get(BasicAuthenticationDetailsProvider.class));
+        assertThat(thrown.getMessage(),
+                   containsString(MockedInstancePrincipalBuilderProvider.INSTANCE_PRINCIPAL_INSTANTIATION_MESSAGE));
+
+        // The following validation indicates that the instance principal provider has been configured properly
+        assertThat(MockedAuthenticationMethodInstancePrincipal.getBuilder().getMetadataBaseUrl(), is(imdsBaseUri));
+        assertThat(MockedAuthenticationMethodInstancePrincipal.getBuilder().getFederationEndpoint(), is(FEDERATION_ENDPOINT));
+        assertThat(MockedAuthenticationMethodInstancePrincipal.getBuilder().getTenancyId(), is(TENANT_ID));
+    }
+
+    public static class ImdsEmulator {
+        // This will allow HelidonOci.imdsAvailable() to be tested by making the server that simulates IMDS to return a JSON value
+        // when instance property is queried
+        private static final String IMDS_INSTANCE_RESPONSE = """
+                {
+                 "displayName": "helidon-server"
+                }
+                """;
+
+        private static void emulateImdsInstance(ServerRequest req, ServerResponse res) {
+            res.send(IMDS_INSTANCE_RESPONSE);
+        }
+    }
+}

--- a/integrations/oci/authentication/instance/src/test/java/io/helidon/integrations/oci/authentication/instance/MockedAuthenticationMethodInstancePrincipal.java
+++ b/integrations/oci/authentication/instance/src/test/java/io/helidon/integrations/oci/authentication/instance/MockedAuthenticationMethodInstancePrincipal.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.authentication.instance;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.integrations.oci.OciConfig;
+import io.helidon.service.registry.Service;
+
+import com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider.InstancePrincipalsAuthenticationDetailsProviderBuilder;
+
+@Weight(Weighted.DEFAULT_WEIGHT)
+@Service.Provider
+class MockedAuthenticationMethodInstancePrincipal extends AuthenticationMethodInstancePrincipal {
+
+    private static InstancePrincipalsAuthenticationDetailsProviderBuilder providerBuilder;
+
+    MockedAuthenticationMethodInstancePrincipal(OciConfig config,
+                                                Supplier<Optional<InstancePrincipalsAuthenticationDetailsProviderBuilder>>
+                                                       builder) {
+        super(config, builder);
+        providerBuilder = builder.get().get();
+    }
+
+    static InstancePrincipalsAuthenticationDetailsProviderBuilder getBuilder() {
+        return providerBuilder;
+    }
+}

--- a/integrations/oci/authentication/instance/src/test/java/io/helidon/integrations/oci/authentication/instance/MockedInstancePrincipalBuilderProvider.java
+++ b/integrations/oci/authentication/instance/src/test/java/io/helidon/integrations/oci/authentication/instance/MockedInstancePrincipalBuilderProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.authentication.instance;
+
+import java.util.function.Supplier;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.integrations.oci.OciConfig;
+import io.helidon.service.registry.Service;
+
+import com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider.InstancePrincipalsAuthenticationDetailsProviderBuilder;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+@Weight(Weighted.DEFAULT_WEIGHT + 10)
+@Service.Provider
+class MockedInstancePrincipalBuilderProvider extends InstancePrincipalBuilderProvider
+        implements Supplier<InstancePrincipalsAuthenticationDetailsProviderBuilder> {
+    static final String INSTANCE_PRINCIPAL_INSTANTIATION_MESSAGE = "Instance Principal has been instantiated";
+    private String metadataBaseUrl = null;
+    private String tenancyID = null;
+    private String federationEndpoint = null;
+
+    MockedInstancePrincipalBuilderProvider(OciConfig config) {
+        super(config);
+    }
+
+    @Override
+    InstancePrincipalsAuthenticationDetailsProviderBuilder getBuilder() {
+        // Mock the InstancePrincipalsAuthenticationDetailsProviderBuilder
+        final InstancePrincipalsAuthenticationDetailsProviderBuilder builder =
+                mock(InstancePrincipalsAuthenticationDetailsProviderBuilder.class);
+
+        doAnswer(invocation -> {
+            throw new IllegalArgumentException(INSTANCE_PRINCIPAL_INSTANTIATION_MESSAGE);
+        }).when(builder).build();
+
+        // Process metadataBaseUrl
+        doAnswer(invocation -> {
+            metadataBaseUrl = invocation.getArgument(0);
+            return null;
+        }).when(builder).metadataBaseUrl(any());
+        doAnswer(invocation -> {
+            return metadataBaseUrl;
+        }).when(builder).getMetadataBaseUrl();
+
+        // Process federationEndpoint
+        doAnswer(invocation -> {
+            federationEndpoint = invocation.getArgument(0);
+            return null;
+        }).when(builder).federationEndpoint(any());
+        doAnswer(invocation -> {
+            return federationEndpoint;
+        }).when(builder).getFederationEndpoint();
+
+        // Process tenancyId
+        doAnswer(invocation -> {
+            tenancyID = invocation.getArgument(0);
+            return null;
+        }).when(builder).tenancyId(any());
+        doAnswer(invocation -> {
+            return tenancyID;
+        }).when(builder).getTenancyId();
+
+        return builder;
+    }
+}

--- a/integrations/oci/authentication/oke-workload/pom.xml
+++ b/integrations/oci/authentication/oke-workload/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>slf4j-jdk14</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common-httpclient-jersey3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -110,6 +115,18 @@
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                        This will allow AuthenticationMethodOkeWorkload.available() to work during testing
+                    -->
+                    <environmentVariables>
+                        <OCI_KUBERNETES_SERVICE_ACCOUNT_CERT_PATH>${project.build.testResources[0].directory}/dummy-ca.crt</OCI_KUBERNETES_SERVICE_ACCOUNT_CERT_PATH>
+                    </environmentVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrations/oci/authentication/oke-workload/src/main/java/io/helidon/integrations/oci/authentication/okeworkload/OkeWorkloadBuilderProvider.java
+++ b/integrations/oci/authentication/oke-workload/src/main/java/io/helidon/integrations/oci/authentication/okeworkload/OkeWorkloadBuilderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.oracle.bmc.auth.okeworkloadidentity.OkeWorkloadIdentityAuthentication
 import com.oracle.bmc.auth.okeworkloadidentity.OkeWorkloadIdentityAuthenticationDetailsProvider.OkeWorkloadIdentityAuthenticationDetailsProviderBuilder;
 
 /**
- * OKE Workload  builder provider, uses the
+ * OKE Workload Identity builder provider, uses the
  * {@link OkeWorkloadIdentityAuthenticationDetailsProviderBuilder}.
  */
 @Service.Provider
@@ -50,6 +50,8 @@ class OkeWorkloadBuilderProvider implements Supplier<OkeWorkloadIdentityAuthenti
         config.imdsBaseUri()
                 .map(URI::toString)
                 .ifPresent(builder::metadataBaseUrl);
+        config.tenantId()
+                .ifPresent(builder::tenancyId);
 
         return builder;
     }

--- a/integrations/oci/authentication/oke-workload/src/test/java/io/helidon/integrations/oci/authentication/okeworkload/AuthenticationMethodOkeWorkloadTest.java
+++ b/integrations/oci/authentication/oke-workload/src/test/java/io/helidon/integrations/oci/authentication/okeworkload/AuthenticationMethodOkeWorkloadTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.authentication.okeworkload;
+
+import java.util.Properties;
+
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AuthenticationMethodOkeWorkloadTest {
+    private static ServiceRegistryManager registryManager;
+    private static ServiceRegistry registry;
+
+    void setUp(Properties p) {
+        p.put("helidon.oci.authentication-method", "oke-workload-identity");
+        System.setProperties(p);
+
+        registryManager = ServiceRegistryManager.create();
+        registry = registryManager.registry();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        registry = null;
+        if (registryManager != null) {
+            registryManager.shutdown();
+        }
+    }
+
+    @Test
+    public void testOkeWorkloadIdentityConfigurationAndInstantiation() {
+        final String FEDERATION_ENDPOINT = "https://auth.us-myregion-1.oraclecloud.com";
+        final String TENANT_ID = "ocid1.tenancy.oc1..mytenancyid";
+
+        Properties p = System.getProperties();
+        p.put("helidon.oci.federation-endpoint", FEDERATION_ENDPOINT);
+        p.put("helidon.oci.tenant-id", TENANT_ID);
+        setUp(p);
+
+        // This error indicates that the oke-workload-identity provider has been instantiated
+        var thrown = assertThrows(IllegalArgumentException.class,
+                                                          () -> registry.get(BasicAuthenticationDetailsProvider.class));
+        assertThat(thrown.getMessage(), containsString("Invalid Kubernetes ca certification"));
+        // The following validation indicates that the oke-workload-identity provider has been configured properly
+        assertThat(MockedAuthenticationMethodOkeWorkload.getBuilder().getFederationEndpoint(), is(FEDERATION_ENDPOINT));
+        assertThat(MockedAuthenticationMethodOkeWorkload.getBuilder().getTenancyId(), is(TENANT_ID));
+    }
+}

--- a/integrations/oci/authentication/oke-workload/src/test/java/io/helidon/integrations/oci/authentication/okeworkload/MockedAuthenticationMethodOkeWorkload.java
+++ b/integrations/oci/authentication/oke-workload/src/test/java/io/helidon/integrations/oci/authentication/okeworkload/MockedAuthenticationMethodOkeWorkload.java
@@ -26,7 +26,6 @@ import io.helidon.service.registry.Service;
 import com.oracle.bmc.auth.okeworkloadidentity
         .OkeWorkloadIdentityAuthenticationDetailsProvider.OkeWorkloadIdentityAuthenticationDetailsProviderBuilder;
 
-@Weight(Weighted.DEFAULT_WEIGHT)
 @Service.Provider
 class MockedAuthenticationMethodOkeWorkload extends AuthenticationMethodOkeWorkload {
 

--- a/integrations/oci/authentication/oke-workload/src/test/java/io/helidon/integrations/oci/authentication/okeworkload/MockedAuthenticationMethodOkeWorkload.java
+++ b/integrations/oci/authentication/oke-workload/src/test/java/io/helidon/integrations/oci/authentication/okeworkload/MockedAuthenticationMethodOkeWorkload.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.authentication.okeworkload;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.service.registry.Service;
+
+import com.oracle.bmc.auth.okeworkloadidentity
+        .OkeWorkloadIdentityAuthenticationDetailsProvider.OkeWorkloadIdentityAuthenticationDetailsProviderBuilder;
+
+@Weight(Weighted.DEFAULT_WEIGHT)
+@Service.Provider
+class MockedAuthenticationMethodOkeWorkload extends AuthenticationMethodOkeWorkload {
+
+    private static OkeWorkloadIdentityAuthenticationDetailsProviderBuilder providerBuilder;
+
+    MockedAuthenticationMethodOkeWorkload(Supplier<Optional<OkeWorkloadIdentityAuthenticationDetailsProviderBuilder>> builder) {
+        super(builder);
+        providerBuilder = builder.get().get();
+    }
+
+    static OkeWorkloadIdentityAuthenticationDetailsProviderBuilder getBuilder() {
+        return providerBuilder;
+    }
+}

--- a/integrations/oci/authentication/oke-workload/src/test/resources/dummy-ca.crt
+++ b/integrations/oci/authentication/oke-workload/src/test/resources/dummy-ca.crt
@@ -1,0 +1,4 @@
+NOTICE:
+=======
+This file represents a dummy ca.crt that will be used by the AuthenticationMethodOkeWorkload to validate if it can proceed with
+authentication processing.

--- a/integrations/oci/authentication/resource/pom.xml
+++ b/integrations/oci/authentication/resource/pom.xml
@@ -107,6 +107,18 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                        This will allow test to reach Resource Principal provider build
+                    -->
+                    <environmentVariables>
+                        <OCI_RESOURCE_PRINCIPAL_VERSION>2.2</OCI_RESOURCE_PRINCIPAL_VERSION>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/integrations/oci/authentication/resource/src/main/java/io/helidon/integrations/oci/authentication/resource/AuthenticationMethodResourcePrincipal.java
+++ b/integrations/oci/authentication/resource/src/main/java/io/helidon/integrations/oci/authentication/resource/AuthenticationMethodResourcePrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.integrations.oci.authentication.resource;
 
 import java.lang.System.Logger.Level;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.Weight;
@@ -42,7 +43,7 @@ class AuthenticationMethodResourcePrincipal implements OciAuthenticationMethod {
 
     private final LazyValue<Optional<BasicAuthenticationDetailsProvider>> provider;
 
-    AuthenticationMethodResourcePrincipal(ResourcePrincipalAuthenticationDetailsProviderBuilder builder) {
+    AuthenticationMethodResourcePrincipal(Supplier<Optional<ResourcePrincipalAuthenticationDetailsProviderBuilder>> builder) {
         provider = createProvider(builder);
     }
 
@@ -57,7 +58,7 @@ class AuthenticationMethodResourcePrincipal implements OciAuthenticationMethod {
     }
 
     private static LazyValue<Optional<BasicAuthenticationDetailsProvider>>
-    createProvider(ResourcePrincipalAuthenticationDetailsProviderBuilder builder) {
+    createProvider(Supplier<Optional<ResourcePrincipalAuthenticationDetailsProviderBuilder>> builder) {
 
         return LazyValue.create(() -> {
             // https://github.com/oracle/oci-java-sdk/blob/v2.19.0/bmc-common/src/main/java/com/oracle/bmc/auth/ResourcePrincipalAuthenticationDetailsProvider.java#L246-L251
@@ -68,7 +69,8 @@ class AuthenticationMethodResourcePrincipal implements OciAuthenticationMethod {
                 }
                 return Optional.empty();
             }
-            return Optional.of(builder.build());
+            return builder.get()
+                    .map(ResourcePrincipalAuthenticationDetailsProviderBuilder::build);
         });
     }
 }

--- a/integrations/oci/authentication/resource/src/main/java/io/helidon/integrations/oci/authentication/resource/ResourcePrincipalBuilderProvider.java
+++ b/integrations/oci/authentication/resource/src/main/java/io/helidon/integrations/oci/authentication/resource/ResourcePrincipalBuilderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ class ResourcePrincipalBuilderProvider implements Supplier<ResourcePrincipalAuth
         config.imdsBaseUri()
                 .map(URI::toString)
                 .ifPresent(builder::metadataBaseUrl);
+        config.tenantId()
+                .ifPresent(builder::tenancyId);
 
         return builder;
     }

--- a/integrations/oci/authentication/resource/src/test/java/io/helidon/integrations/oci/authentication/resource/AuthenticationMethodResourcePrincipalTest.java
+++ b/integrations/oci/authentication/resource/src/test/java/io/helidon/integrations/oci/authentication/resource/AuthenticationMethodResourcePrincipalTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.authentication.resource;
+
+import java.util.Properties;
+
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AuthenticationMethodResourcePrincipalTest {
+    private static ServiceRegistryManager registryManager;
+    private static ServiceRegistry registry;
+
+    void setUp(Properties p) {
+        p.put("helidon.oci.authentication-method", "resource-principal");
+        System.setProperties(p);
+
+        registryManager = ServiceRegistryManager.create();
+        registry = registryManager.registry();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        registry = null;
+        if (registryManager != null) {
+            registryManager.shutdown();
+        }
+    }
+
+    @Test
+    public void testResourcePrincipalConfigurationAndInstantiation() {
+        final String FEDERATION_ENDPOINT = "https://auth.us-myregion-1.oraclecloud.com";
+        final String TENANT_ID = "ocid1.tenancy.oc1..mytenancyid";
+
+        Properties p = System.getProperties();
+        p.put("helidon.oci.federation-endpoint", FEDERATION_ENDPOINT);
+        p.put("helidon.oci.tenant-id", TENANT_ID);
+        setUp(p);
+
+        // This error indicates that the resource principal provider has been instantiated
+        var thrown = assertThrows(IllegalArgumentException.class,
+                                  () -> registry.get(BasicAuthenticationDetailsProvider.class));
+        assertThat(thrown.getMessage(),
+                   containsString("Resource principals authentication can only be used in certain OCI services"));
+        // The following validation indicates that the resource principal provider has been configured properly
+        assertThat(MockedAuthenticationMethodResourcePrincipal.getBuilder().getFederationEndpoint(), is(FEDERATION_ENDPOINT));
+        assertThat(MockedAuthenticationMethodResourcePrincipal.getBuilder().getTenancyId(), is(TENANT_ID));
+    }
+}

--- a/integrations/oci/authentication/resource/src/test/java/io/helidon/integrations/oci/authentication/resource/MockedAuthenticationMethodResourcePrincipal.java
+++ b/integrations/oci/authentication/resource/src/test/java/io/helidon/integrations/oci/authentication/resource/MockedAuthenticationMethodResourcePrincipal.java
@@ -25,7 +25,6 @@ import io.helidon.service.registry.Service;
 
 import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider.ResourcePrincipalAuthenticationDetailsProviderBuilder;
 
-@Weight(Weighted.DEFAULT_WEIGHT)
 @Service.Provider
 class MockedAuthenticationMethodResourcePrincipal extends AuthenticationMethodResourcePrincipal {
 

--- a/integrations/oci/authentication/resource/src/test/java/io/helidon/integrations/oci/authentication/resource/MockedAuthenticationMethodResourcePrincipal.java
+++ b/integrations/oci/authentication/resource/src/test/java/io/helidon/integrations/oci/authentication/resource/MockedAuthenticationMethodResourcePrincipal.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.authentication.resource;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.service.registry.Service;
+
+import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider.ResourcePrincipalAuthenticationDetailsProviderBuilder;
+
+@Weight(Weighted.DEFAULT_WEIGHT)
+@Service.Provider
+class MockedAuthenticationMethodResourcePrincipal extends AuthenticationMethodResourcePrincipal {
+
+    private static ResourcePrincipalAuthenticationDetailsProviderBuilder providerBuilder;
+
+    MockedAuthenticationMethodResourcePrincipal(Supplier<Optional<ResourcePrincipalAuthenticationDetailsProviderBuilder>> builder) {
+        super(builder);
+        providerBuilder = builder.get().get();
+    }
+
+    static ResourcePrincipalAuthenticationDetailsProviderBuilder getBuilder() {
+        return providerBuilder;
+    }
+}

--- a/integrations/oci/oci/README.md
+++ b/integrations/oci/oci/README.md
@@ -38,13 +38,14 @@ The provider is looked up by using instances of `io.helidon.integrations.oci.spi
 
 The following out-of-the-box implementations exist:
 
-| Provider           | Weight | Description                                                   |
-|--------------------|--------|---------------------------------------------------------------|
-| Config             | 90     | Uses `OciConfig`                                              |
-| Session Token      | 85     | Uses `OciConfig` or config file, if it contains session token |
-| Config File        | 80     | Uses `~/.oci/config` file                                     |
-| Resource Principal | 70     | Resource principal (such as functions)                        |
-| Instance Principal | 60     | Principal of the compute instance                             | 
+| Provider              | Weight | Description                                                   |
+|-----------------------|--------|---------------------------------------------------------------|
+| Config                | 90     | Uses `OciConfig`                                              |
+| Session Token         | 85     | Uses `OciConfig` or config file, if it contains session token |
+| Config File           | 80     | Uses `~/.oci/config` file                                     |
+| Resource Principal    | 70     | Resource principal (such as functions)                        |
+| Instance Principal    | 60     | Principal of the compute instance                             |
+| OKE Workload Identity | 50     | Identity of the OKE Workload                                  |
 
 To create a custom instance of authentication details provider, just create a new service for service registry
 with default or higher weight that provides an instance of the `BasicAuthenticationDetailsProvider` 

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigBlueprint.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,8 +72,9 @@ interface OciConfigBlueprint {
      *     <li>{@code instance-principal} - use identity of the OCI instance the service is running on, uses
      *     {@link com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider}, and is available in a
      *     separate module {@code helidon-integrations-oci-authentication-resource}</li>
-     *     <li>{@code workload} - use workload identity of the OCI Kubernetes workload, available in a
-     *     separate module {@code helidon-integrations-oci-authentication-workload}</li>
+     *     <li>{@code oke-workload-identity} - use identity of the OCI Kubernetes workload, uses
+     *     {@code com.oracle.bmc.auth.okeworkloadidentity.OkeWorkloadIdentityAuthenticationDetailsProvider}, and is available in a
+     *     separate module {@code helidon-integrations-oci-authentication-oke-workload}</li>
      * </ul>
      *
      * @return the authentication method to apply
@@ -161,7 +162,16 @@ interface OciConfigBlueprint {
      *
      * @return custom federation endpoint URI
      */
+    @Option.Configured
     Optional<URI> federationEndpoint();
+
+    /**
+     * OCI tenant id for Instance Principal, Resource Principal or OKE Workload.
+     *
+     * @return the OCI tenant id
+     */
+    @Option.Configured
+    Optional<String> tenantId();
 
     /**
      * Get the config used to update the builder.

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigProvider.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigProvider.java
@@ -77,8 +77,8 @@ class OciConfigProvider implements Supplier<io.helidon.integrations.oci.OciConfi
             ociConfig = OciConfig.create(config.get(CONFIG_PREFIX));
         } else {
             ociConfig = OciConfig.create(config);
-            if (LOGGER.isLoggable(System.Logger.Level.WARNING)) {
-                LOGGER.log(System.Logger.Level.WARNING,
+            if (LOGGER.isLoggable(System.Logger.Level.TRACE)) {
+                LOGGER.log(System.Logger.Level.TRACE,
                            String.format("OCI Configuration needs to be prefixed with \"%s\"", CONFIG_PREFIX));
             }
         }

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigProvider.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@ import io.helidon.service.registry.Service;
 @Weight(Weighted.DEFAULT_WEIGHT - 10)
 class OciConfigProvider implements Supplier<io.helidon.integrations.oci.OciConfig> {
     private static final ReentrantReadWriteLock LOCK = new ReentrantReadWriteLock();
+    private static final String CONFIG_PREFIX = "helidon.oci";
+    private static final System.Logger LOGGER = System.getLogger(AuthenticationMethodConfig.class.getName());
     private static volatile OciConfig ociConfig;
 
     OciConfigProvider() {
@@ -71,7 +73,14 @@ class OciConfigProvider implements Supplier<io.helidon.integrations.oci.OciConfi
                 ConfigSources.systemProperties(),
                 ConfigSources.file("oci-config.yaml").optional(true),
                 ConfigSources.classpath("oci-config.yaml").optional(true));
-
-        ociConfig = OciConfig.create(config);
+        if (config.get(CONFIG_PREFIX).exists()) {
+            ociConfig = OciConfig.create(config.get(CONFIG_PREFIX));
+        } else {
+            ociConfig = OciConfig.create(config);
+            if (LOGGER.isLoggable(System.Logger.Level.WARNING)) {
+                LOGGER.log(System.Logger.Level.WARNING,
+                           String.format("OCI Configuration needs to be prefixed with \"%s\"", CONFIG_PREFIX));
+            }
+        }
     }
 }

--- a/integrations/oci/oci/src/test/java/io/helidon/integrations/oci/OciConfigProviderTest.java
+++ b/integrations/oci/oci/src/test/java/io/helidon/integrations/oci/OciConfigProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class OciConfigProviderTest {
+    @Test
+    void testConfig() {
+        final String FEDERATION_ENDPOINT = "https://auth.us-myregion-1.oraclecloud.com";
+        final String TENANT_ID = "ocid1.tenancy.oc1..mytenancyid";
+        final String REGION = "us-phoenix-1";
+        final String CONFIG_FILE_PATH = "/path1/path2/.oci/config";
+
+        Properties p = System.getProperties();
+        p.put("helidon.oci.authentication-method", AuthenticationMethodConfigFile.METHOD);
+        p.put("helidon.oci.federation-endpoint", FEDERATION_ENDPOINT);
+        p.put("helidon.oci.tenant-id", TENANT_ID);
+        p.put("HELIDON_OCI_REGION", REGION);
+        p.put("helidon.oci.authentication.config-file.path", CONFIG_FILE_PATH);
+        System.setProperties(p);
+
+        // clean up ociConfig from OciConfigProvider
+        OciConfigProvider.config(null);
+        var ociConfig = new OciConfigProvider().get();
+        assertThat(ociConfig.authenticationMethod(), is(AuthenticationMethodConfigFile.METHOD));
+        assertThat(ociConfig.federationEndpoint().get().toString(), is(FEDERATION_ENDPOINT));
+        assertThat(ociConfig.tenantId().get().toString(), is(TENANT_ID));
+        assertThat(ociConfig.region().get().getRegionId(), is(REGION));
+        assertThat(ociConfig.configFileMethodConfig().get().path().get(), is(CONFIG_FILE_PATH));
+    }
+}


### PR DESCRIPTION
### Description
The PR fixes Issues [9681](https://github.com/helidon-io/helidon/issues/9681) and [9734](https://github.com/helidon-io/helidon/issues/9734) which includes the following:
1. Allow instance-principal, resource-principal and oke-workload-identity to accept federation-endpoint and tenancy-id as config parameters. This is originally targeted just for oke-workload-identity where Instance Metadata Service (IMDS) does not work on an OKE environment. Because of these, it is unable to assemble the target endpoint as it needs the IMDS to retrieve the region. To resolve the issue, the federation-endpoint configuration is now allowed to be explicitly specified to avoid generation of endpoint using the region from IMDS. In some examples of the use of oke-workload-identity, the tenancy id is required, so this configuration parameter is also added as an option. Furthermore, because instance-principal and resource-principal providers extends AbstractRequestingAuthenticationDetailsProvider similar to oke-workload-instance, hence they are included in the change to allow those optional parameters.
2. Fix a bug where the oci configuration does not work when prefixed with "helidon.oci".
3. Add comprehensive testing coverage for above changes.

### Documentation
Related readme files were already updated as part of this change

If no doc impact: None
