### PR TITLE
4.x: MicroProfile Testing AddConfigSource annotation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,11 +19,6 @@ Build just the javadocs:
 mvn package -Pjavadoc -Dhelidon.sitegen.skip=true
 ```
 
-Build docs and also update config reference docs:
-```bash
-mvn package -Pconfigdoc
-```
-
 ## Serve
 
 ```bash

--- a/docs/src/main/asciidoc/mp/testing/testing-common.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing-common.adoc
@@ -160,6 +160,9 @@ The "synthetic" configuration can be expressed using the following annotations:
 |link:{mp-testing-javadoc-url}/AddConfigBlock.html[`@AddConfigBlock`]
 |Formatted text block
 
+|link:{mp-testing-javadoc-url}/AddConfigSource.html[`@AddConfigSource`]
+|Programmatic config source
+
 |link:{mp-testing-javadoc-url}/Configuration.html[`@Configuration`]
 | Classpath resources using
 
@@ -184,9 +187,15 @@ include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_9, indent=0]
 ----
 
 [source,java]
-.Add classpath resources
+.Add config programmatically
 ----
 include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_10, indent=0]
+----
+
+[source,java]
+.Add classpath resources
+----
+include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_11, indent=0]
 ----
 
 ==== Configuration Ordering
@@ -200,7 +209,7 @@ of `1000`
 [source,java]
 .Add a properties text block with ordinal
 ----
-include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_11, indent=0]
+include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_12, indent=0]
 ----
 
 === Injectable Types
@@ -228,24 +237,16 @@ Here are all the built-in types that can be injected:
 
 NOTE: Types that reflect the current server require link:{mp-server-javadoc-url}/ServerCdiExtension.html[`ServerCdiExtension`]
 
-NOTE: All the injectable types are also available as method parameters.
-
 [source,java]
 .Inject a JAX-RS client for the default socket
 ----
-include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_12, indent=0]
+include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_13, indent=0]
 ----
 
 Use link:{mp-testing-javadoc-url}/Socket.html[`@Socket`] to specify the socket for the clients and URIs.
 
 [source,java]
 .Inject a JAX-RS client for the admin socket
-----
-include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_13, indent=0]
-----
-
-[source,java]
-.Using a method parameter
 ----
 include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_14, indent=0]
 ----
@@ -277,6 +278,9 @@ Here is a brief overview of the MicroProfile testing annotations:
 
 |link:{mp-testing-javadoc-url}/AddConfigBlock.html[`@AddConfigBlock`]
 |Define a formatted text block in the "synthetic" configuration
+
+|link:{mp-testing-javadoc-url}/AddConfigSource.html[`@AddConfigSource`]
+|Add a programmatic config source to the "synthetic" configuration
 
 |link:{mp-testing-javadoc-url}/Configuration.html[`@Configuration`]
 | Switch between "synthetic" and "existing" ; Add classpath resources to the "synthetic" configuration

--- a/docs/src/main/asciidoc/mp/testing/testing.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing.adoc
@@ -66,6 +66,14 @@ include::{rootdir}/includes/dependencies.adoc[]
 
 include::{rootdir}/mp/testing/testing-common.adoc[tag=usage]
 
+NOTE: All the injectable types are also available as method parameters.
+
+[source,java]
+.Using a method parameter
+----
+include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_1, indent=0]
+----
+
 === Test Instance Lifecyle
 
 The CDI scope used by the test instance follows the lifecyle defined by JUnit5. The default is `PER_CLASS` and is enforced
@@ -78,7 +86,7 @@ NOTE: The test instance is not re-used between CDI container, using a dedicated 
 [source,java]
 .Using per method lifecycle
 ----
-include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_1, indent=0]
+include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_2, indent=0]
 ----
 
 == API
@@ -101,7 +109,7 @@ instance.
 [source,java]
 .Mocking using CDI Alternative
 ----
-include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_2, indent=0]
+include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_3, indent=0]
 ----
 <1> Create the mock instance in the test class
 <2> Create a CDI producer method annotated with `@Alternative`

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
@@ -41,9 +41,12 @@ class TestingJunit5Snippets {
     class Snippet1 {
 
         // tag::snippet_1[]
-        @TestInstance(TestInstance.Lifecycle.PER_METHOD)
         @HelidonTest
         class MyTest {
+
+            @Test
+            void testOne(WebTarget target) {
+            }
         }
         // end::snippet_1[]
     }
@@ -51,6 +54,16 @@ class TestingJunit5Snippets {
     class Snippet2 {
 
         // tag::snippet_2[]
+        @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+        @HelidonTest
+        class MyTest {
+        }
+        // end::snippet_2[]
+    }
+
+    class Snippet3 {
+
+        // tag::snippet_3[]
         @HelidonTest
         @Priority(1) // <3>
         class MyTest {
@@ -98,6 +111,6 @@ class TestingJunit5Snippets {
                 return "Not Mocked";
             }
         }
-        // end::snippet_2[]
+        // end::snippet_3[]
     }
 }

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingSnippets.java
@@ -15,8 +15,12 @@
  */
 package io.helidon.docs.mp.testing;
 
+import java.util.Map;
+
+import io.helidon.config.mp.MpConfigSources;
 import io.helidon.microprofile.config.ConfigCdiExtension;
 import io.helidon.microprofile.testing.AddConfigBlock;
+import io.helidon.microprofile.testing.AddConfigSource;
 import io.helidon.microprofile.testing.Configuration;
 import io.helidon.microprofile.testing.Socket;
 import io.helidon.microprofile.testing.AddBean;
@@ -34,6 +38,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.mockito.Answers;
 import org.mockito.Mockito;
 
@@ -90,6 +95,18 @@ class TestingSnippets {
     class Snippet3 {
 
         // tag::snippet_3[]
+        @DisableDiscovery
+        @AddJaxRs // <1>
+        @AddBean(MyResource.class) // <2>
+        @HelidonTest
+        class MyTest {
+        }
+        // end::snippet_3[]
+    }
+
+    class Snippet4 {
+
+        // tag::snippet_4[]
         @HelidonTest(resetPerTest = true)
         class MyTest {
 
@@ -101,12 +118,12 @@ class TestingSnippets {
             void testTwo() { // <2>
             }
         }
-        // end::snippet_3[]
+        // end::snippet_4[]
     }
 
-    class Snippet4 {
+    class Snippet5 {
 
-        // tag::snippet_4[]
+        // tag::snippet_5[]
         @HelidonTest
         class MyTest {
 
@@ -119,18 +136,6 @@ class TestingSnippets {
             @AddBean(MyBean.class)
             void testTwo() { // <2>
             }
-        }
-        // end::snippet_4[]
-    }
-
-    class Snippet5 {
-
-        // tag::snippet_5[]
-        @DisableDiscovery
-        @AddJaxRs // <1>
-        @AddBean(MyResource.class) // <2>
-        @HelidonTest
-        class MyTest {
         }
         // end::snippet_5[]
     }
@@ -185,12 +190,15 @@ class TestingSnippets {
     class Snippet10 {
 
         // tag::snippet_10[]
-        @Configuration(configSources = {
-                "my-test1.yaml",
-                "my-test2.yaml"
-        })
         @HelidonTest
         class MyTest {
+
+            @AddConfigSource
+            static ConfigSource config() {
+                return MpConfigSources.create(Map.of(
+                        "foo", "bar",
+                        "bob", "alice"));
+            }
         }
         // end::snippet_10[]
     }
@@ -198,10 +206,10 @@ class TestingSnippets {
     class Snippet11 {
 
         // tag::snippet_11[]
-        @AddConfigBlock(value = """
-                config_ordinal=120
-                foo=bar
-                """)
+        @Configuration(configSources = {
+                "my-test1.yaml",
+                "my-test2.yaml"
+        })
         @HelidonTest
         class MyTest {
         }
@@ -211,12 +219,12 @@ class TestingSnippets {
     class Snippet12 {
 
         // tag::snippet_12[]
+        @AddConfigBlock(value = """
+                config_ordinal=120
+                foo=bar
+                """)
         @HelidonTest
         class MyTest {
-
-            @Inject
-            @Socket("admin")
-            WebTarget target;
         }
         // end::snippet_12[]
     }
@@ -239,9 +247,9 @@ class TestingSnippets {
         @HelidonTest
         class MyTest {
 
-            @Test
-            void testOne(WebTarget target) {
-            }
+            @Inject
+            @Socket("admin")
+            WebTarget target;
         }
         // end::snippet_14[]
     }

--- a/microprofile/testing/junit5/src/main/java/io/helidon/microprofile/testing/junit5/HelidonJunitExtension.java
+++ b/microprofile/testing/junit5/src/main/java/io/helidon/microprofile/testing/junit5/HelidonJunitExtension.java
@@ -67,6 +67,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
  *     <li>{@link io.helidon.microprofile.testing.Configuration} global setting for MicroProfile configuration</li>
  *     <li>{@link io.helidon.microprofile.testing.AddConfig} declarative key/value pair configuration</li>
  *     <li>{@link io.helidon.microprofile.testing.AddConfigBlock} declarative fragment configuration</li>
+ *     <li>{@link io.helidon.microprofile.testing.AddConfigSource} programmatic configuration</li>
  * </ul>
  * <p>
  * See also {@link io.helidon.microprofile.testing.Socket}, a CDI qualifier to inject JAX-RS client or URI.

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/AddConfigSource.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/AddConfigSource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Mark a static method that provides a {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSource}
+ * to add to the {@link Configuration#useExisting() synthetic test configuration}.
+ * <p>
+ * E.g.
+ * <pre>
+ * &#064;AddConfigSource
+ * static ConfigSource config() {
+ *     return MpConfigSources.create(Map.of("foo", "bar"));
+ * }</pre>
+ *
+ * @see io.helidon.config.mp.MpConfigSources
+ * @see AddConfig
+ * @see AddConfigs
+ * @see AddConfigBlock
+ * @see Configuration
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface AddConfigSource {
+}

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestConfigSynthetic.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestConfigSynthetic.java
@@ -66,6 +66,7 @@ class HelidonTestConfigSynthetic extends HelidonTestConfigDelegate {
         map.put("mp.config.profile", "test");
         testInfo.addConfigs().forEach(this::update);
         testInfo.addConfigBlocks().forEach(this::update);
+        testInfo.addConfigSources().forEach(this::update);
         testInfo.configuration().ifPresent(this::update);
     }
 

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestDescriptor.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestDescriptor.java
@@ -17,6 +17,7 @@ package io.helidon.microprofile.testing;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -116,6 +117,13 @@ public interface HelidonTestDescriptor<T extends AnnotatedElement> {
      * @return annotations
      */
     List<AddConfigBlock> addConfigBlocks();
+
+    /**
+     * Get the discovered {@link AddConfigSource} methods.
+     *
+     * @return annotations
+     */
+    List<Method> addConfigSources();
 
     /**
      * Test if the given extension is configured.

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestDescriptorBase.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestDescriptorBase.java
@@ -28,6 +28,7 @@ import io.helidon.microprofile.testing.ReflectionHelper.Annotated;
 
 import static io.helidon.common.testing.virtualthreads.PinningRecorder.DEFAULT_THRESHOLD;
 import static io.helidon.microprofile.testing.ReflectionHelper.annotated;
+import static io.helidon.microprofile.testing.ReflectionHelper.filterAnnotated;
 import static io.helidon.microprofile.testing.ReflectionHelper.filterAnnotations;
 
 /**
@@ -48,6 +49,7 @@ public abstract class HelidonTestDescriptorBase<T extends AnnotatedElement> impl
     private final LazyValue<Boolean> disableDiscovery = LazyValue.create(this::lookupDisableDiscovery);
     private final LazyValue<List<AddConfig>> addConfigs = LazyValue.create(this::lookupAddConfigs);
     private final LazyValue<List<AddConfigBlock>> addConfigBlocks = LazyValue.create(this::lookupAddConfigBlocks);
+    private final LazyValue<List<Method>> addConfigSources = LazyValue.create(this::lookupAddConfigSources);
     private final LazyValue<Optional<Configuration>> configuration = LazyValue.create(this::lookupConfiguration);
 
     /**
@@ -117,6 +119,15 @@ public abstract class HelidonTestDescriptorBase<T extends AnnotatedElement> impl
     @Override
     public List<AddConfigBlock> addConfigBlocks() {
         return addConfigBlocks.get();
+    }
+
+    /**
+     * Get the discovered {@link AddConfigSource} methods.
+     *
+     * @return annotations
+     */
+    public List<Method> addConfigSources() {
+        return addConfigSources.get();
     }
 
     /**
@@ -229,5 +240,12 @@ public abstract class HelidonTestDescriptorBase<T extends AnnotatedElement> impl
     @Override
     public <A extends Annotation> Stream<A> annotations(Class<A> aType) {
         return filterAnnotations(annotated, aType);
+    }
+
+    private List<Method> lookupAddConfigSources() {
+        return filterAnnotated(annotated, AddConfigSource.class)
+                .map(Annotated::element)
+                .map(Method.class::cast)
+                .toList();
     }
 }

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestDescriptorDelegate.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestDescriptorDelegate.java
@@ -17,6 +17,7 @@ package io.helidon.microprofile.testing;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -88,6 +89,11 @@ class HelidonTestDescriptorDelegate<T extends AnnotatedElement> implements Helid
     @Override
     public List<AddConfigBlock> addConfigBlocks() {
         return delegate.addConfigBlocks();
+    }
+
+    @Override
+    public List<Method> addConfigSources() {
+        return delegate.addConfigSources();
     }
 
     @Override

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestExtension.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestExtension.java
@@ -89,6 +89,7 @@ public abstract class HelidonTestExtension implements Extension {
             AddConfig.class,
             AddConfigs.class,
             AddConfigBlock.class,
+            AddConfigSource.class,
             AfterStop.class,
             Configuration.class);
 
@@ -193,7 +194,9 @@ public abstract class HelidonTestExtension implements Extension {
      * @param method     method
      */
     protected void processStaticMethodAnnotation(Annotation annotation, Method method) {
-        if (annotation instanceof AfterStop) {
+        if (annotation instanceof AddConfigSource) {
+            processAddConfigSource(method);
+        } else if (annotation instanceof AfterStop) {
             processAfterStop(method);
         } else {
             throw new IllegalStateException(String.format(
@@ -246,6 +249,15 @@ public abstract class HelidonTestExtension implements Extension {
      */
     protected final void processAddConfigBlock(AddConfigBlock... annotations) {
         testConfig.synthetic().update(annotations);
+    }
+
+    /**
+     * Process a {@link AddConfigSource} method.
+     *
+     * @param method method
+     */
+    protected final void processAddConfigSource(Method method) {
+        testConfig.synthetic().update(method);
     }
 
     /**

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestInfo.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestInfo.java
@@ -307,6 +307,11 @@ public sealed interface HelidonTestInfo<T extends AnnotatedElement> extends Heli
         }
 
         @Override
+        public List<Method> addConfigSources() {
+            return classInfo.addConfigSources();
+        }
+
+        @Override
         public <A extends Annotation, C extends Annotation> Stream<A> annotations(Class<A> aType,
                                                                                   Class<C> cType,
                                                                                   Function<C, A[]> function) {

--- a/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListener.java
+++ b/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListener.java
@@ -86,6 +86,7 @@ import static java.util.stream.Collectors.joining;
  *     <li>{@link io.helidon.microprofile.testing.Configuration} global setting for MicroProfile configuration</li>
  *     <li>{@link io.helidon.microprofile.testing.AddConfig} declarative key/value pair configuration</li>
  *     <li>{@link io.helidon.microprofile.testing.AddConfigBlock} declarative fragment configuration</li>
+ *     <li>{@link io.helidon.microprofile.testing.AddConfigSource} programmatic configuration</li>
  * </ul>
  * <p>
  * See also {@link io.helidon.microprofile.testing.Socket}, a CDI qualifier to inject JAX-RS client or URI.

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestAddConfigSource.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestAddConfigSource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testing.junit5;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import io.helidon.config.mp.MpConfigSources;
+import io.helidon.microprofile.testing.AddConfigSource;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+class TestAddConfigSource {
+
+    @AddConfigSource
+    static ConfigSource config() {
+        return MpConfigSources.create(Map.of(
+                "some.key", "some.value",
+                "another.key", "another.value"));
+    }
+
+    @Inject
+    @ConfigProperty(name = "some.key")
+    private String someKey;
+
+    @Inject
+    @ConfigProperty(name = "another.key")
+    private String anotherKey;
+
+    @Test
+    void testValue() {
+        assertThat(someKey, is("some.value"));
+        assertThat(anotherKey, is("another.value"));
+    }
+}

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestAddConfigSource.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestAddConfigSource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testing.testng;
+
+import java.util.Map;
+
+import io.helidon.config.mp.MpConfigSources;
+import io.helidon.microprofile.testing.AddConfigSource;
+import io.helidon.microprofile.testing.testng.HelidonTest;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+public class TestAddConfigSource {
+
+    @AddConfigSource
+    static ConfigSource config() {
+        return MpConfigSources.create(Map.of(
+                "some.key", "some.value",
+                "another.key", "another.value"));
+    }
+
+    @Inject
+    @ConfigProperty(name = "some.key")
+    private String someKey;
+
+    @Inject
+    @ConfigProperty(name = "another.key")
+    private String anotherKey;
+
+    @Test
+    void testValue() {
+        assertThat(someKey, is("some.value"));
+        assertThat(anotherKey, is("another.value"));
+    }
+}


### PR DESCRIPTION
### Description

Add support for a new annotation `@AddConfigSource` to add programmatic config sources.

```java
@HelidonTest
class MyTest {

    @AddConfigSource
    static ConfigSource config() {
        return MpConfigSources.create(Map.of(
                "foo", "bar",
                "bob", "alice"));
    }
}
```

This annotation simplifies the usage of TestContainers with Helidon MP.

E.g.

```java
@HelidonTest
@Testcontainers(disabledWithoutDocker = true)
class MyTest {

   static final DockerImageName IMAGE = DockerImageName.parse(
                    "container-registry.oracle.com/mysql/community-server")
            .asCompatibleSubstituteFor("mysql");

    @Container
    static final MySQLContainer<?> CONTAINER = new MySQLContainer<>(IMAGE)
            .withUsername("test")
            .withPassword("mysql123")
            .withDatabaseName("test");

    @AddConfigSource
    static ConfigSource config() {
        return MpConfigSources.create(Map.of("javax.sql.DataSource.test.dataSource.url", CONTAINER.getJdbcUrl()));
    }
}
```

### Documentation

- Added documentation for the new annotation
- Fix snippet mismatches
- Moved snippet and note about method parameter injection to JUnit only (not supported in TestNG).

