### PR TITLE
Improves handling of cookies in server responses

### DIFF
--- a/http/http/src/main/java/io/helidon/http/ServerResponseHeaders.java
+++ b/http/http/src/main/java/io/helidon/http/ServerResponseHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,11 +106,23 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
 
     /**
      * Clears a cookie by adding a {@code Set-Cookie} header with an expiration date in the past.
+     * It is recommended to use {@link #clearCookie(SetCookie)} instead for better handling
+     * of Path and Domain.
      *
      * @param name name of the cookie.
      * @return this instance
      */
     ServerResponseHeaders clearCookie(String name);
+
+    /**
+     * Clears a cookie by adding a {@code Set-Cookie} header with an expiration date in the past.
+     *
+     * @param setCookie the cookie.
+     * @return this instance
+     */
+    default ServerResponseHeaders clearCookie(SetCookie setCookie) {
+        return clearCookie(setCookie.name());
+    }
 
     /**
      * Sets the value of {@link HeaderNames#LAST_MODIFIED} header.

--- a/http/http/src/main/java/io/helidon/http/ServerResponseHeadersImpl.java
+++ b/http/http/src/main/java/io/helidon/http/ServerResponseHeadersImpl.java
@@ -68,7 +68,7 @@ class ServerResponseHeadersImpl extends HeadersImpl<ServerResponseHeaders> imple
                     String currentValue = currentValues.get(i);
                     SetCookie currentCookie = SetCookie.parse(currentValue);
                     if (predicate.test(currentCookie)) {
-                        newValues[i] = expiredCookie.text();            // replace with expired
+                        newValues[i] = expiredCookie.text();            // replaces with expired cookie
                         found = true;
                     } else {
                         newValues[i] = currentValue;
@@ -77,7 +77,7 @@ class ServerResponseHeadersImpl extends HeadersImpl<ServerResponseHeaders> imple
                 if (!found) {
                     String[] values = new String[newValues.length + 1];
                     System.arraycopy(newValues, 0, values, 0, newValues.length);
-                    values[values.length - 1] = expiredCookie.text();   // replace with expired
+                    values[values.length - 1] = expiredCookie.text();   // adds expired cookie
                     newValues = values;
                 }
                 set(HeaderValues.create(HeaderNames.SET_COOKIE, newValues));

--- a/http/http/src/main/java/io/helidon/http/SetCookie.java
+++ b/http/http/src/main/java/io/helidon/http/SetCookie.java
@@ -84,11 +84,15 @@ public class SetCookie {
      * @return new instance
      */
     public static SetCookie parse(String setCookie) {
+        Objects.requireNonNull(setCookie);
         String[] cookieParts = setCookie.split(PARAM_SEPARATOR);
         String nameAndValue = cookieParts[0];
         int equalsIndex = nameAndValue.indexOf('=');
-        String name = nameAndValue.substring(0, equalsIndex);
-        String value = nameAndValue.substring(equalsIndex + 1);
+        String name = (equalsIndex == -1) ? nameAndValue : nameAndValue.substring(0, equalsIndex);
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("Cookie name cannot be empty");
+        }
+        String value = (equalsIndex == -1) ? "" : nameAndValue.substring(equalsIndex + 1);
         Builder builder = builder(name, value);
 
         for (int i = 1; i < cookieParts.length; i++) {

--- a/http/http/src/main/java/io/helidon/http/SetCookie.java
+++ b/http/http/src/main/java/io/helidon/http/SetCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,16 @@ public class SetCookie {
     }
 
     /**
+     * Creates a new fluent API builder using another cookie.
+     *
+     * @param setCookie the other cookie
+     * @return a new fluent API builder
+     */
+    public static Builder builder(SetCookie setCookie) {
+        return new Builder(setCookie);
+    }
+
+    /**
      * Parses new instance of {@link SetCookie} from the String representation.
      *
      * @param setCookie string representation
@@ -78,7 +88,7 @@ public class SetCookie {
         String nameAndValue = cookieParts[0];
         int equalsIndex = nameAndValue.indexOf('=');
         String name = nameAndValue.substring(0, equalsIndex);
-        String value = nameAndValue.length() == equalsIndex ? null : nameAndValue.substring(equalsIndex + 1);
+        String value = nameAndValue.substring(equalsIndex + 1);
         Builder builder = builder(name, value);
 
         for (int i = 1; i < cookieParts.length; i++) {
@@ -88,7 +98,7 @@ public class SetCookie {
             String partValue;
             if (equalsIndex > -1) {
                 partName = cookiePart.substring(0, equalsIndex);
-                partValue = cookiePart.length() == equalsIndex ? null : cookiePart.substring(equalsIndex + 1);
+                partValue = cookiePart.substring(equalsIndex + 1);
             } else {
                 partName = cookiePart;
                 partValue = null;
@@ -277,6 +287,24 @@ public class SetCookie {
         return result.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SetCookie setCookie)) {
+            return false;
+        }
+        return Objects.equals(name, setCookie.name)
+                && Objects.equals(domain, setCookie.domain)
+                && Objects.equals(path, setCookie.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, domain, path);
+    }
+
     private static void hasNoValue(String partName, String partValue) {
         if (partValue != null) {
             throw new IllegalArgumentException("Set-Cookie parameter " + partName + " has to have no value!");
@@ -347,6 +375,19 @@ public class SetCookie {
             //todo validate accepted characters
             this.name = name;
             this.value = value;
+        }
+
+        private Builder(SetCookie other) {
+            Objects.requireNonNull(other);
+            this.name = other.name;
+            this.value = other.value;
+            this.expires = other.expires;
+            this.maxAge = other.maxAge;
+            this.domain = other.domain;
+            this.path = other.path;
+            this.secure = other.secure;
+            this.httpOnly = other.httpOnly;
+            this.sameSite = other.sameSite;
         }
 
         @Override

--- a/http/http/src/test/java/io/helidon/http/SetCookieTest.java
+++ b/http/http/src/test/java/io/helidon/http/SetCookieTest.java
@@ -40,7 +40,7 @@ public class SetCookieTest {
             + "SameSite=Lax";
 
     @Test
-    public void testSetCookiesFromString() {
+    void testSetCookiesFromString() {
         SetCookie setCookie = SetCookie.parse(TEMPLATE);
 
         assertThat(setCookie.name(), is("some-cookie"));
@@ -57,7 +57,7 @@ public class SetCookieTest {
     }
 
     @Test
-    public void testSetCookiesInvalidValue() {
+    void testSetCookiesInvalidValue() {
         String template = "some-cookie=some-cookie-value; "
                 + "Invalid=value";
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
@@ -66,13 +66,7 @@ public class SetCookieTest {
     }
 
     @Test
-    public void testEmptyValue() {
-        SetCookie setCookie = SetCookie.parse("some-cookie=");
-        assertThat(setCookie.value(), is(""));
-    }
-
-    @Test
-    public void testEquals() {
+    void testEquals() {
         SetCookie setCookie1 = SetCookie.parse(TEMPLATE);
         SetCookie setCookie2 = SetCookie.builder("some-cookie", "").build();
         SetCookie setCookie3 = SetCookie.builder("some-cookie", "")
@@ -90,7 +84,7 @@ public class SetCookieTest {
     }
 
     @Test
-    public void testCookieBuilder() {
+    void testCookieBuilder() {
         SetCookie setCookie1 = SetCookie.parse(TEMPLATE);
         SetCookie setCookie2 = SetCookie.builder(setCookie1).build();       // from setCookie1
 
@@ -105,5 +99,18 @@ public class SetCookieTest {
         assertThat(setCookie2.secure(), is(true));
         assertThat(setCookie2.httpOnly(), is(true));
         assertThat(setCookie2.sameSite(), optionalValue(is(SetCookie.SameSite.LAX)));
+    }
+
+    @Test
+    void testParse() {
+        assertThrows(NullPointerException.class,() -> SetCookie.parse(null));
+        assertThrows(IllegalArgumentException.class,() -> SetCookie.parse(""));
+        SetCookie setCookie1 = SetCookie.parse("some-cookie");
+        assertThat(setCookie1.name(), is("some-cookie"));
+        assertThat(setCookie1.value(), is(""));
+        SetCookie setCookie2 = SetCookie.parse("some-cookie=");
+        assertThat(setCookie2.name(), is("some-cookie"));
+        assertThat(setCookie2.value(), is(""));
+        assertThat(setCookie1.equals(setCookie2), is(true));
     }
 }

--- a/http/tests/cookie/pom.xml
+++ b/http/tests/cookie/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.http.tests</groupId>
+        <artifactId>helidon-http-tests-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-http-tests-cookie</artifactId>
+    <name>Helidon HTTP Tests Cookie</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/http/tests/cookie/src/test/java/io/helidon/http/tests/cookie/CookieTest.java
+++ b/http/tests/cookie/src/test/java/io/helidon/http/tests/cookie/CookieTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.http.tests.cookie;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.http.DateTime;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.SetCookie;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isIn;
+
+/**
+ * Validates that a cookie can be properly cleared in a handler method. An HTTP
+ * cookie is identified by its name, domain and path. In this test, two cookies
+ * with the same name but different domains are used.
+ */
+@ServerTest
+class CookieTest {
+    private static final String START_OF_YEAR_1970 =
+            ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT+0"))
+                    .format(DateTime.RFC_1123_DATE_TIME);
+
+    private final Http1Client client;
+
+    CookieTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void route(HttpRouting.Builder router) {
+        router.addFilter((chain, req, res) -> {
+                    // adds two cookies same name different domains
+                    res.headers().addCookie(newCookie("my-cookie", "my-domain1", "/"));
+                    res.headers().addCookie(newCookie("my-cookie", "my-domain2", "/"));
+                    chain.proceed();
+                })
+                .get("/cookie", (req, res) -> {
+                    // clears cookie in my-domain2
+                    res.headers().clearCookie(newCookie("my-cookie", "my-domain2", "/"));
+                    res.status(200).send();
+                });
+    }
+
+    @Test
+    void clearCookieTest() {
+        try (Http1ClientResponse res = client.get("/cookie").request()) {
+            assertThat(res.headers().contains(HeaderNames.SET_COOKIE), is(true));
+            List<String> values = res.headers().get(HeaderNames.SET_COOKIE).allValues();
+            assertThat(values.size(), is(2));
+            SetCookie first = SetCookie.parse(values.getFirst());
+            validateCookie(first);
+            SetCookie last = SetCookie.parse(values.getLast());
+            validateCookie(last);
+        }
+    }
+
+    static void validateCookie(SetCookie cookie) {
+        assertThat(cookie.name(), is("my-cookie"));
+        assertThat(cookie.path(), is(Optional.of("/")));
+        assertThat(cookie.domain().isPresent(), is(true));
+        assertThat(cookie.domain().get(), isIn(new String[] {"my-domain1", "my-domain2"}));
+        if (cookie.domain().get().equals("my-domain1")) {
+            assertThat(cookie.expires().isEmpty(), is(true));
+        } else if (cookie.domain().get().equals("my-domain2")) {
+            assertThat(cookie.expires().isPresent(), is(true));
+            assertThat(cookie.expires().get().format(DateTime.RFC_1123_DATE_TIME), is(START_OF_YEAR_1970));      // cleared
+        }
+    }
+
+    static SetCookie newCookie(String name, String domain, String path) {
+        return SetCookie.builder(name, name + "-value")
+                .domain(domain)
+                .path(path)
+                .build();
+    }
+}

--- a/http/tests/pom.xml
+++ b/http/tests/pom.xml
@@ -36,6 +36,7 @@
     <modules>
         <module>encoding</module>
         <module>media</module>
+        <module>cookie</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### Description

Improves handling of cookies in server responses:

- A cookie's identity is now defined by its name, domain and path, not just its name as before
- A new method in `ServerResponseHeaders` enables clearing a cookie by passing all three values (a complete cookie)
- The equals and hashCode methods in `SetCookie` have been overridden as well
- Backward compatiblity with old clear cookie behavior is preserved, but Javadoc suggests using new method
- New unit tests added
- Issue #9592

### Documentation

None