### PR TITLE
 4.1.7: Avoid cross-test config contamination in `microprofile/telemetry` tests

### DIFF
--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -147,7 +147,26 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <otel.bsp.schedule.delay>${otel.bsp.schedule.delay}</otel.bsp.schedule.delay>
+                                <otel.sdk.disabled>false</otel.sdk.disabled>
                             </systemPropertyVariables>
+                            <excludes>
+                                <exclude>**/AgentDetectorTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!--
+                        This test does not need an active OTel SDK so run it separately to prevent it from running first
+                        and leaving other tests with a no-op Otel which will cause them to fail.
+                         -->
+                        <id>agent-detector-tests</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/AgentDetectorTest.java</include>
+                            </includes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Backport #9685 to Helidon 4.1.7

### Description
Resolves #9513 

Intermittent test failures in `micrometer/telemetry` seem to be due to tests which need a full-featured OTel instance inheriting a default no-op one from other tests which run earlier which do not need a full OTel and in fact establish a no-op default one.

This PR segregates the test that does not enforce an active OTel from the others.

### Documentation
No impact.
