### PR TITLE
4.x: Update instructions for generation docs in README.md (#9759)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ $ mvn verify  -Pspotbugs
 **Documentation**
 
 ```bash
-# At the root of the project
-$ mvn site
+# in the docs directory
+$ mvn package -Pjavadoc
 ```
 
 **Build Scripts**


### PR DESCRIPTION
### Description
Fixes #9759 

I use info from [docs/README.md](https://github.com/helidon-io/helidon/blob/95af89efb622b90fe578cd2443c835ef2aa7afad/docs/README.md?plain=1#L9)

Maybe it's better to add `-DskipTests=true`, but I'm not sure.