### PR TITLE
4.x: Add more javadoc for AddConfigBlock annotations (#9697)

### DIFF
--- a/microprofile/testing/junit5/src/main/java/io/helidon/microprofile/testing/junit5/AddConfigBlock.java
+++ b/microprofile/testing/junit5/src/main/java/io/helidon/microprofile/testing/junit5/AddConfigBlock.java
@@ -25,6 +25,20 @@ import java.lang.annotation.Target;
 /**
  * Add a configuration fragment to the {@link Configuration#useExisting() synthetic test configuration}.
  * <p>
+ * Example:
+ * <pre>
+ *  &#64;AddConfigBlock(type = "yaml", value = """
+ *      foo1:
+ *        bar: "value1"
+ *  """)
+ *  &#64;AddConfigBlock(type = "properties", value = """
+ *       foo2=value2
+ *       foo3=value3
+ *  """)
+ *  class MyTest {
+ *  }
+ * </pre>
+ * <p>
  * This annotation can be repeated.
  * <p>
  * If used on a method, the container will be reset regardless of the test lifecycle.
@@ -40,7 +54,7 @@ import java.lang.annotation.Target;
 @Deprecated(since = "4.2.0")
 public @interface AddConfigBlock {
     /**
-     * Specifies the configuration format.
+     * Specifies the configuration format. Possible values are: 'yaml' and `properties`.
      * <p>
      * The default format is 'properties'
      *

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/AddConfigBlock.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/AddConfigBlock.java
@@ -26,6 +26,20 @@ import java.lang.annotation.Target;
 /**
  * Add a configuration fragment to the {@link Configuration#useExisting() synthetic test configuration}.
  * <p>
+ * Example:
+ * <pre>
+ *  &#64;AddConfigBlock(type = "yaml", value = """
+ *      foo1:
+ *        bar: "value1"
+ *  """)
+ *  &#64;AddConfigBlock(type = "properties", value = """
+ *       foo2=value2
+ *       foo3=value3
+ *  """)
+ *  class MyTest {
+ *  }
+ * </pre>
+ * <p>
  * This annotation can be repeated.
  * <p>
  * If used on a method, the container will be reset regardless of the test lifecycle.
@@ -40,7 +54,7 @@ import java.lang.annotation.Target;
 @Repeatable(AddConfigBlocks.class)
 public @interface AddConfigBlock {
     /**
-     * Specifies the configuration format.
+     * Specifies the configuration format. Possible values are: 'yaml' and `properties`.
      * <p>
      * The default format is 'properties'
      *

--- a/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/AddConfigBlock.java
+++ b/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/AddConfigBlock.java
@@ -25,6 +25,20 @@ import java.lang.annotation.Target;
 /**
  * Add a configuration fragment to the {@link Configuration#useExisting() synthetic test configuration}.
  * <p>
+ * Example:
+ * <pre>
+ *  &#64;AddConfigBlock(type = "yaml", value = """
+ *      foo1:
+ *        bar: "value1"
+ *  """)
+ *  &#64;AddConfigBlock(type = "properties", value = """
+ *       foo2=value2
+ *       foo3=value3
+ *  """)
+ *  class MyTest {
+ *  }
+ * </pre>
+ * <p>
  * This annotation can be repeated.
  * <p>
  * If used on a method, the container will be reset regardless of the test lifecycle.
@@ -40,7 +54,7 @@ import java.lang.annotation.Target;
 @Deprecated(since = "4.2.0")
 public @interface AddConfigBlock {
     /**
-     * Specifies the configuration format.
+     * Specifies the configuration format. Possible values are: 'yaml' and `properties`.
      * <p>
      * The default format is 'properties'
      *


### PR DESCRIPTION
### Description
Fixes #9697 

Some docs were added in [this PR](https://github.com/helidon-io/helidon/pull/9695/files#diff-ad5ca5d1746e5ff6c17a18e54c66700915371dbc9e4f1883fbf0bebee9ffd4b9R175). I think, it's better to add some explanations and examples in javadoc.

### Documentation
Added javadoc for `AddConfigBlock` annotations (deprecated versions too).

It looks:
<img width="548" alt="Screenshot 2025-02-10 at 10 45 56" src="https://github.com/user-attachments/assets/a84f03d9-37de-47e6-9647-75d6ab6b3bdf" />
