### PR TITLE
 4.1.7: Allow colon in Prometheus meter name; add test

### DIFF
--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
         }
 
         // Replace non-identifier characters.
-        result = result.replaceAll("[^A-Za-z0-9_]", "_");
+        result = result.replaceAll("[^A-Za-z0-9_:]", "_");
 
         return result;
     }


### PR DESCRIPTION

Backport #9689  to Helidon 4.1.7


### Description
Resolves #9686 

Release note:
____
Helidon now correctly includes in the Prometheus/OpenMetrics output data for meters with colons in their names. They were previously excluded from Prometheus/OpenMetrics output although they were included in the JSON output and were correctly registered in the meter registry.
____

A colon is, in fact, a legal character in Prometheus meter names. The Helidon logic that queries the Micrometer Prometheus meter registry prepares a list of names to scrape to get the output. That logic was incorrectly replacing a ":" in meter names with an "_", treating it as an _illegal_ character in meter names. 

This PR corrects that replacement.

For example, a "?" is truly illegal and the Micrometer Prometheus meter register converts them to "_" before storing the names in that registry. So the Helidon code that prepares the names for scraping continues to replace "?" with "_". It just no longer replaces ":" as it used to.

The PR also contains a test to make sure that names with colons (valid name character) and 
