### PR TITLE
 4.1.7: 4.x fix status from deadlock health check if invoking the MBean fails

### DIFF
--- a/health/health-checks/src/test/java/io/helidon/health/checks/DeadlockHealthCheckTest.java
+++ b/health/health-checks/src/test/java/io/helidon/health/checks/DeadlockHealthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,5 +62,14 @@ class DeadlockHealthCheckTest {
         DeadlockHealthCheck check = new DeadlockHealthCheck(threadBean);
         HealthCheckResponse response = check.call();
         assertThat(response.status(), is(HealthCheckResponse.Status.UP));
+    }
+
+    @Test
+
+    void errorInvokingMBean() {
+        Mockito.when(threadBean.findDeadlockedThreads()).thenThrow(new RuntimeException("Simulated error invoking MBean"));
+        DeadlockHealthCheck check = new DeadlockHealthCheck(threadBean);
+        HealthCheckResponse response = check.call();
+        assertThat(response.status(), is(HealthCheckResponse.Status.ERROR));
     }
 }


### PR DESCRIPTION

Backport #9694 to Helidon 4.1.7

### Description
Resolves #9691 

Release Note
____
Helidon's built-in deadlock health check now reports the state `ERROR` instead of `DOWN` if the invocation of the MBean method to retrieve deadlocked thread IDs throws an exception. (It used to report `DOWN`.) 

Reporting `ERROR` is more accurate, and in such cases Helidon returns the HTTP status 500 for the health response. This lets a deployment environment, such as Kubernetes, allow the pod to continue running. In such error cases Helidon (as it has for some time) logs a `TRACE`-level message reporting the exception it encountered.
____

The code for the deadlock health check used to report `DOWN` if it failed to invoke the threads MBean to retrieve the list of deadlocked thread IDs. (The method returns null if no deadlocks exist.)

This PR changes that code to report `ERROR` instead of `DOWN`. By reporting `DOWN` the previous code incorrectly implied that there was a deadlock and the server instance should be considered "unwell." In fact, in that case the health check code does not know whether there is or is not a deadlock because of the error invoking the MBean method and it should report that way.

The PR also adds a test.

### Documentation
No impact.