### PR TITLE
4.x: Registry services factory fix

### DIFF
--- a/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/LookupBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,13 +172,21 @@ interface LookupBlueprint {
                     || this.contracts().contains(ResolvedType.create(serviceInfo.serviceType()))
                     || serviceInfo.factoryContracts().containsAll(this.contracts());
         }
-        return matches
+        matches = matches
                 && matchesProviderTypes(factoryTypes(), serviceInfo.factoryType())
                 && matchesAbstract(includeAbstract(), serviceInfo.isAbstract())
                 && (this.scopes().isEmpty() || this.scopes().contains(serviceInfo.scope()))
-                && Qualifiers.matchesQualifiers(serviceInfo.qualifiers(), this.qualifiers())
                 && matchesWeight(serviceInfo, this)
                 && matchesOptionals(serviceInfo.runLevel(), this.runLevel());
+
+        if (serviceInfo.factoryType() == FactoryType.SERVICES) {
+            // if the service info is a services factory, it may have qualifiers defined at runtime,
+            // resolve based on instances (i.e. later)
+            return matches;
+        }
+
+        return matches
+                && Qualifiers.matchesQualifiers(serviceInfo.qualifiers(), this.qualifiers());
     }
 
     /**

--- a/service/registry/src/main/java/io/helidon/service/registry/LookupSupport.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/LookupSupport.java
@@ -112,6 +112,29 @@ final class LookupSupport {
             builder.serviceType(TypeName.create(contract));
         }
 
+        /**
+         * Only lookup services with the provided named qualifier.
+         *
+         * @param builder  builder instance
+         * @param name the name qualifier (use {@link io.helidon.service.registry.Service.Named#WILDCARD_NAME} to find all
+         */
+        @Prototype.BuilderMethod
+        static void named(Lookup.BuilderBase<?, ?> builder, String name) {
+            builder.addQualifier(Qualifier.createNamed(name));
+        }
+
+        /**
+         * Only lookup services with the provided named qualifier, where name is the fully qualified name of the class.
+         *
+         * @param builder  builder instance
+         * @param clazz fully qualified name of the class is the name qualifier to use
+         * @see #named(String)
+         */
+        @Prototype.BuilderMethod
+        static void named(Lookup.BuilderBase<?, ?> builder, Class<?> clazz) {
+            builder.addQualifier(Qualifier.createNamed(clazz));
+        }
+
         private static Lookup createEmpty() {
             return Lookup.builder().build();
         }
@@ -133,7 +156,8 @@ final class LookupSupport {
                     // clear if contained only IP stuff
                     boolean shouldClear = builder.qualifiers().equals(existing.qualifiers());
 
-                    if (!(builder.contracts().contains(ResolvedType.create(existing.contract()))
+                    if (!(
+                            builder.contracts().contains(ResolvedType.create(existing.contract()))
                                     && builder.contracts().size() == 1)) {
                         shouldClear = false;
                     }

--- a/service/tests/inject/src/main/java/io/helidon/service/tests/inject/NamedServicesFactoryTypes.java
+++ b/service/tests/inject/src/main/java/io/helidon/service/tests/inject/NamedServicesFactoryTypes.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.inject;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceInstance;
+
+final class NamedServicesFactoryTypes {
+    private NamedServicesFactoryTypes() {
+    }
+
+    interface NamedConfig {
+        String name();
+    }
+
+    interface TargetType {
+        NamedConfig config();
+    }
+
+    @Service.Singleton
+    static class ConfigFactory implements Service.ServicesFactory<NamedConfig> {
+        private final List<NamedConfig> configs;
+
+        @Service.Inject
+        ConfigFactory() {
+            configs = List.of(new NamedConfigImpl("first"),
+                              new NamedConfigImpl("second"),
+                              new NamedConfigImpl("third"));
+        }
+
+        ConfigFactory(List<NamedConfig> configs) {
+            this.configs = configs;
+        }
+
+        @Override
+        public List<Service.QualifiedInstance<NamedConfig>> services() {
+            return configs.stream()
+                    .map(it -> Service.QualifiedInstance.create(it, Qualifier.createNamed(it.name())))
+                    .collect(Collectors.toUnmodifiableList());
+        }
+    }
+
+    @Service.Singleton
+    @Service.PerInstance(NamedConfig.class)
+    static class TargetTypeProvider implements TargetType {
+        private final NamedConfig config;
+
+        @Service.Inject
+        TargetTypeProvider(@Service.InstanceName String name,
+                           NamedConfig config,
+                           List<ServiceInstance<CharSequence>> emptyList) {
+            this.config = config;
+            if (!name.equals(config.name())) {
+                throw new IllegalStateException("Got name: " + name + " but config is named: " + config.name());
+            }
+        }
+
+        @Override
+        public NamedConfig config() {
+            return config;
+        }
+    }
+
+    @Service.Singleton
+    static class NamedReceiver {
+        private final NamedConfig config;
+        private final List<NamedConfig> all;
+
+        @Service.Inject
+        NamedReceiver(@Service.Named("second") NamedConfig config,
+                      @Service.Named(Service.Named.WILDCARD_NAME) List<NamedConfig> all) {
+            this.config = config;
+            this.all = all;
+        }
+
+        String name() {
+            return config.name();
+        }
+
+        List<String> allNames() {
+            return all.stream()
+                    .map(NamedConfig::name)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    static class NamedConfigImpl implements NamedConfig {
+        private final String name;
+
+        NamedConfigImpl(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+    }
+}

--- a/service/tests/inject/src/test/java/io/helidon/service/tests/inject/NamedServicesFactoryTest.java
+++ b/service/tests/inject/src/test/java/io/helidon/service/tests/inject/NamedServicesFactoryTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.inject;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.helidon.service.registry.Lookup;
+import io.helidon.service.registry.Qualifier;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+public class NamedServicesFactoryTest {
+    private static ServiceRegistryManager registryManager;
+    private static ServiceRegistry registry;
+
+    @BeforeAll
+    public static void initRegistry() {
+        var injectConfig = ServiceRegistryConfig.builder()
+                .addServiceDescriptor(NamedServicesFactoryTypes_TargetTypeProvider__ServiceDescriptor.INSTANCE)
+                .addServiceDescriptor(NamedServicesFactoryTypes_ConfigFactory__ServiceDescriptor.INSTANCE)
+                .addServiceDescriptor(NamedServicesFactoryTypes_NamedReceiver__ServiceDescriptor.INSTANCE)
+                .discoverServices(false)
+                .discoverServicesFromServiceLoader(false)
+                .build();
+        registryManager = ServiceRegistryManager.create(injectConfig);
+        registry = registryManager.registry();
+    }
+
+    @AfterAll
+    public static void tearDownRegistry() {
+        if (registryManager != null) {
+            registryManager.shutdown();
+        }
+    }
+
+    @Test
+    void testInjected() {
+        var injected = registry.get(NamedServicesFactoryTypes.NamedReceiver.class);
+
+        assertThat(injected.name(), is("second"));
+        assertThat(injected.allNames(), hasItems("first", "second", "third"));
+    }
+
+    @Test
+    void testServicesFactoryConfig() {
+        List<NamedServicesFactoryTypes.NamedConfig> targetTypes =
+                registry.all(Lookup.builder()
+                                     .addQualifier(Qualifier.WILDCARD_NAMED)
+                                     .addContract(NamedServicesFactoryTypes.NamedConfig.class)
+                                     .build());
+
+        assertThat(targetTypes, hasSize(3));
+        var names = targetTypes.stream()
+                .map(NamedServicesFactoryTypes.NamedConfig::name)
+                .collect(Collectors.toUnmodifiableSet());
+
+        assertThat(names, hasItems("first", "second", "third"));
+    }
+
+    @Test
+    void testServicesFactoryConfigFirst() {
+        NamedServicesFactoryTypes.NamedConfig instance =
+                registry.get(Lookup.builder()
+                                     .named("first")
+                                     .addContract(NamedServicesFactoryTypes.NamedConfig.class)
+                                     .build());
+
+        assertThat(instance.name(), is("first"));
+    }
+
+    @Test
+    void testServicesFactoryConfigSecond() {
+        NamedServicesFactoryTypes.NamedConfig instance =
+                registry.get(Lookup.builder()
+                                     .named("second")
+                                     .addContract(NamedServicesFactoryTypes.NamedConfig.class)
+                                     .build());
+
+        assertThat(instance.name(), is("second"));
+    }
+
+    @Test
+    void testServicesFactoryConfigThird() {
+        NamedServicesFactoryTypes.NamedConfig instance =
+                registry.get(Lookup.builder()
+                                     .named("third")
+                                     .addContract(NamedServicesFactoryTypes.NamedConfig.class)
+                                     .build());
+
+        assertThat(instance.name(), is("third"));
+    }
+
+    @Test
+    void testServicesFactory() {
+        List<NamedServicesFactoryTypes.TargetType> targetTypes =
+                registry.all(Lookup.builder()
+                                     .addQualifier(Qualifier.WILDCARD_NAMED)
+                                     .addContract(NamedServicesFactoryTypes.TargetType.class)
+                                     .build());
+
+        assertThat(targetTypes, hasSize(3));
+        var names = targetTypes.stream()
+                .map(NamedServicesFactoryTypes.TargetType::config)
+                .map(NamedServicesFactoryTypes.NamedConfig::name)
+                .collect(Collectors.toUnmodifiableSet());
+
+        assertThat(names, hasItems("first", "second", "third"));
+    }
+
+    @Test
+    void testServicesFactoryFirst() {
+        NamedServicesFactoryTypes.TargetType instance =
+                registry.get(Lookup.builder()
+                                     .named("first")
+                                     .addContract(NamedServicesFactoryTypes.TargetType.class)
+                                     .build());
+
+        assertThat(instance.config().name(), is("first"));
+    }
+
+    @Test
+    void testServicesFactorySecond() {
+        NamedServicesFactoryTypes.TargetType instance =
+                registry.get(Lookup.builder()
+                                     .named("second")
+                                     .addContract(NamedServicesFactoryTypes.TargetType.class)
+                                     .build());
+
+        assertThat(instance.config().name(), is("second"));
+    }
+
+    @Test
+    void testServicesFactoryThird() {
+        NamedServicesFactoryTypes.TargetType instance =
+                registry.get(Lookup.builder()
+                                     .named("third")
+                                     .addContract(NamedServicesFactoryTypes.TargetType.class)
+                                     .build());
+
+        assertThat(instance.config().name(), is("third"));
+    }
+}

--- a/service/tests/inject/src/test/java/io/helidon/service/tests/inject/ServicesFactoryProvidedInstancesTest.java
+++ b/service/tests/inject/src/test/java/io/helidon/service/tests/inject/ServicesFactoryProvidedInstancesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +40,10 @@ public class ServicesFactoryProvidedInstancesTest {
     @BeforeAll
     public static void initRegistry() {
         var injectConfig = ServiceRegistryConfig.builder()
-                .addServiceDescriptor(ServicesFactoryTypes_TargetTypeProvider__ServiceDescriptor.INSTANCE)
-                .addServiceDescriptor(ServicesFactoryTypes_ConfigFactory__ServiceDescriptor.INSTANCE)
-                .putServiceInstance(ServicesFactoryTypes_ConfigFactory__ServiceDescriptor.INSTANCE,
-                                    new ServicesFactoryTypes.ConfigFactory(List.of(new ServicesFactoryTypes.NamedConfigImpl(
+                .addServiceDescriptor(NamedServicesFactoryTypes_TargetTypeProvider__ServiceDescriptor.INSTANCE)
+                .addServiceDescriptor(NamedServicesFactoryTypes_ConfigFactory__ServiceDescriptor.INSTANCE)
+                .putServiceInstance(NamedServicesFactoryTypes_ConfigFactory__ServiceDescriptor.INSTANCE,
+                                    new NamedServicesFactoryTypes.ConfigFactory(List.of(new NamedServicesFactoryTypes.NamedConfigImpl(
                                             "custom"))))
                 .discoverServices(false)
                 .discoverServicesFromServiceLoader(false)
@@ -61,16 +61,16 @@ public class ServicesFactoryProvidedInstancesTest {
 
     @Test
     void testServicesFactory() {
-        List<ServicesFactoryTypes.TargetType> targetTypes =
+        List<NamedServicesFactoryTypes.TargetType> targetTypes =
                 registry.all(Lookup.builder()
                                      .addQualifier(Qualifier.WILDCARD_NAMED)
-                                     .addContract(ServicesFactoryTypes.TargetType.class)
+                                     .addContract(NamedServicesFactoryTypes.TargetType.class)
                                      .build());
 
         assertThat(targetTypes, hasSize(1));
         var names = targetTypes.stream()
-                .map(ServicesFactoryTypes.TargetType::config)
-                .map(ServicesFactoryTypes.NamedConfig::name)
+                .map(NamedServicesFactoryTypes.TargetType::config)
+                .map(NamedServicesFactoryTypes.NamedConfig::name)
                 .collect(Collectors.toUnmodifiableSet());
 
         assertThat(names, hasItems("custom"));


### PR DESCRIPTION
A fix to make sure `ServicesFactory` can create instances with various qualifiers, not just named.
Also the `@Named("*")` is no longer needed.