### PR TITLE
3.x: Upgrade Netty to 4.1.118.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -128,7 +128,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
-        <version.lib.netty>4.1.115.Final</version.lib.netty>
+        <version.lib.netty>4.1.118.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
         <version.lib.oci>3.46.1</version.lib.oci>
         <version.lib.ojdbc8>21.15.0.0</version.lib.ojdbc8>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.plugin.source>3.3.0</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>11.1.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.0.2</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

Upgrade Netty to 4.1.118.Final

Upgrade dependency check plugin to 12.0.2

