### PR TITLE
4.1.7 : Upgrade Netty to 4.1.118.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -126,7 +126,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
-        <version.lib.netty>4.1.115.Final</version.lib.netty>
+        <version.lib.netty>4.1.118.Final</version.lib.netty>
         <version.lib.oci>3.46.1</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.6.0.24.10</version.lib.ojdbc>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>11.1.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.0.2</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

Upgrade Netty to 4.1.118.Final

Upgrade dependency check plugin to 12.0.2
