### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@
 
 # don't let GIT perform end of line mapping on these files
 enum-test*.txt -text
+Object*._java_ -text


### PR DESCRIPTION
Resolves #9780


### Description
Tell GIT not to mess with end of line characters (especially on Windows) for new test files.

### Documentation

No Doc. Impact
