### PR TITLE
4.x: Upgrade yasson to 3.0.4

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -164,7 +164,7 @@
         <version.lib.tyrus>2.1.5</version.lib.tyrus>
         <version.lib.weld-api>5.0.SP3</version.lib.weld-api>
         <version.lib.weld>5.1.1.SP2</version.lib.weld>
-        <version.lib.yasson>3.0.3</version.lib.yasson>
+        <version.lib.yasson>3.0.4</version.lib.yasson>
         <version.lib.zipkin.sender-urlconnection>2.16.4</version.lib.zipkin.sender-urlconnection>
         <version.lib.zipkin>2.12.5</version.lib.zipkin>
         <version.lib.zookeeper>3.5.7</version.lib.zookeeper>


### PR DESCRIPTION
### Description

Upgrade yasson to 3.0.4