### PR TITLE
4.x: Upgrade OCI SDK to 3.57.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -132,7 +132,7 @@
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.118.Final</version.lib.netty>
-        <version.lib.oci>3.57.0</version.lib.oci>
+        <version.lib.oci>3.57.1</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <!--
             UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.


### PR DESCRIPTION
### Description

Upgrade OCI SDK to 3.57.1

