### PR TITLE
4.1.7: Upgrade OCI SDK to 3.57.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -127,7 +127,7 @@
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.12.0</version.lib.neo4j>
         <version.lib.netty>4.1.118.Final</version.lib.netty>
-        <version.lib.oci>3.46.1</version.lib.oci>
+        <version.lib.oci>3.57.1</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.6.0.24.10</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>


### PR DESCRIPTION
### Description

Upgrade OCI SDK to 3.57.1