### PR TITLE
4.1.7: Segregate tests that use special global tracer 

### DIFF
--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -151,6 +151,8 @@
                             </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/AgentDetectorTest.java</exclude>
+                                <exclude>**/TestSpanListenersWithInjection.java</exclude>
+                                <exclude>**/TestGlobalTracerAssignment.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -166,6 +168,31 @@
                         <configuration>
                             <includes>
                                 <include>**/AgentDetectorTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>callback-enabled-injection-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestSpanListenersWithInjection.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!--
+                        This test sets the global tracer to a no-op tracer which would interfere with other tests.
+                        -->
+                        <id>test-global-tracer-assignment</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestGlobalTracerAssignment.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/tracing/providers/opentelemetry/pom.xml
+++ b/tracing/providers/opentelemetry/pom.xml
@@ -107,6 +107,27 @@
                         </configurationParameters>
                     </properties>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/TestGlobalTracerAssignment.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-global-tracer-assignment</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestGlobalTracerAssignment.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
### Description
Resolves #9778 

One test sets a special global tracer which pollutes the environment for tests which happen to run later in the same VM.

The PR separates that test from the others.

### Documentation
No impact.
