### PR TITLE
Apply config setting for built-in meter name case to extended KPI meter names

### DIFF
--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,8 @@ class MetricsFeature {
                 KeyPerformanceIndicatorMetricsImpls.get(meterRegistry,
                                                         KPI_METER_NAME_PREFIX_WITH_DOT,
                                                         metricsConfig
-                                                                .keyPerformanceIndicatorMetricsConfig());
+                                                                .keyPerformanceIndicatorMetricsConfig(),
+                                                        metricsConfig.builtInMeterNameFormat());
 
         rules.addFilter((chain, req, res) -> {
             KeyPerformanceIndicatorSupport.Context kpiContext = kpiContext(req);

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestKpiMeterNameCase.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestKpiMeterNameCase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.observe.metrics;
+
+import io.helidon.metrics.api.BuiltInMeterNameFormat;
+import io.helidon.metrics.api.KeyPerformanceIndicatorMetricsConfig;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+class TestKpiMeterNameCase {
+
+    @BeforeEach
+    void clear() {
+        KeyPerformanceIndicatorMetricsImpls.close();
+    }
+
+    @Test
+    void testExtendedWithNoCaseSetting() {
+        MetricsConfig metricsConfig = MetricsConfig.builder()
+                .keyPerformanceIndicatorMetricsConfig(() -> KeyPerformanceIndicatorMetricsConfig.builder()
+                        .extended(true)
+                        .build())
+                .build();
+        MeterRegistry meterRegistry = Metrics.createMeterRegistry(metricsConfig);
+
+        // As a side-effect, the following line registers the KPI metrics in the meter registry.
+        KeyPerformanceIndicatorMetricsImpls.get(meterRegistry,
+                                                "requests.",
+                                                KeyPerformanceIndicatorMetricsConfig.builder().extended(true).build(),
+                                                BuiltInMeterNameFormat.CAMEL);
+
+        assertThat("In-flight KPI",
+                   meterRegistry.meters().stream()
+                           .map(m -> m.id().name())
+                           .toList(),
+                   hasItem("requests.inFlight"));
+    }
+
+    @Test
+    void testExtendedWithSnakeCaseSetting() {
+        MetricsConfig metricsConfig = MetricsConfig.builder()
+                .keyPerformanceIndicatorMetricsConfig(() -> KeyPerformanceIndicatorMetricsConfig.builder()
+                        .extended(true)
+                        .build())
+                .builtInMeterNameFormat(BuiltInMeterNameFormat.SNAKE)
+                .build();
+        MeterRegistry meterRegistry = Metrics.createMeterRegistry(metricsConfig);
+
+        // As a side-effect, the following line registers the KPI metrics in the meter registry.
+        KeyPerformanceIndicatorMetricsImpls.get(meterRegistry,
+                                                "requests.",
+                                                KeyPerformanceIndicatorMetricsConfig.builder().extended(true).build(),
+                                                BuiltInMeterNameFormat.SNAKE);
+
+        assertThat("In-flight KPI",
+                   meterRegistry.meters().stream()
+                           .map(m -> m.id().name())
+                           .toList(),
+                   hasItem("requests.in_flight"));
+    }
+}


### PR DESCRIPTION
### Description
Resolves #9791 

#### Release Note
____
Users can set `metrics.built-in-meter-name-format` to `CAMEL` (the default) or `SNAKE` to control the case of built-in meter names. 

Previously, Helidon did not apply this setting to the key performance indicator meters `inFlight` and `longRunning`. Now it does.
____

#### PR Overview
The configured case setting is now passed as a parameter when `KeyPerformanceIndicatorMetricsImpls` is instantiated so that class (which registers the relevant KPI metrics) can use the selected case.

The PR includes a new test to make sure the config setting has this effect.

### Documentation
Bug fix. No doc impact.