### PR TITLE
4.x: Remove unnecessary check in BiConsumerChain

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/BiConsumerChain.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/BiConsumerChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,11 +50,7 @@ class BiConsumerChain<T, S>
             return ((BiConsumerChain<T, S>) current).combineWith(another);
         }
         BiConsumerChain<T, S> newChain = new BiConsumerChain<>();
-        if (current instanceof BiConsumerChain) {
-            newChain.addAll((BiConsumerChain<T, S>) current);
-        } else {
-            newChain.add(current);
-        }
+        newChain.add(current);
 
         if (another instanceof BiConsumerChain) {
             newChain.addAll((BiConsumerChain<T, S>) another);


### PR DESCRIPTION
### Description
There is duplicate check in `BiConsumerChain`. It was added [in this PR](https://github.com/helidon-io/helidon/pull/3232/files#diff-6084cd75144d370760d33a084cbc9ad084b77a526b3018a0d28f9f905372566bR53).

This check is always `false`, because of the early return above. Or there should be  the different check?
<img width="1401" alt="Screenshot 2025-02-14 at 18 42 17" src="https://github.com/user-attachments/assets/44655896-3460-4638-8f22-a91040c86745" />

