### PR TITLE
4.x: Clarify docs about built-in healthchecks and Graal VM (#9021)

### DIFF
--- a/docs/src/main/asciidoc/se/health.adoc
+++ b/docs/src/main/asciidoc/se/health.adoc
@@ -272,18 +272,17 @@ common health check statuses:
 // Had to move the anchor to the heading above because the rendered page did not define the ID
 // correctly on the table so the link did not work. The link itself looks OK; just no ID generated on the page.
 //[[built-in-health-checks-table]]
-[cols="1,1,3,15,3,3"]
+[cols="1,1,3,15,3"]
 |=======
-|Built-in health check |Health check name |JavaDoc |Config properties (within `server.features.observe.observers.health`) |Default config value |Graal VM Support
+|Built-in health check |Health check name |JavaDoc |Config properties (within `server.features.observe.observers.health`) |Default config value
 
-|deadlock detection
+|deadlock detection &dagger;
 |`deadlock`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/DeadlockHealthCheck.html[`DeadlockHealthCheck`]
 | n/a
 | n/a
-| No
 
-|available disk space
+|available disk space &dagger;
 |`diskSpace`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/DiskSpaceHealthCheck.html[`DiskSpaceHealthCheck`]
 |`helidon.health.diskSpace.thresholdPercent` +
@@ -292,14 +291,13 @@ common health check statuses:
 | `99.999` +
 +
 `/`
-| No
 |available heap memory
 | `heapMemory`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/HeapMemoryHealthCheck.html[`HeapMemoryHealthCheck`]
 |`helidon.health.heapMemory.thresholdPercent`
 |`98`
-| Yes
 |=======
+&dagger; Helidon cannot support the indicated health checks in the GraalVM native image environment, so with native image those health checks do not appear in the health output.
 
 Simply adding the built-in health check dependency is sufficient to register all the built-in health checks automatically.
 If you want to use only some of the built-in checks in your application, you can disable automatic discovery of the built-in health checks and register only the ones you want.

--- a/docs/src/main/asciidoc/se/health.adoc
+++ b/docs/src/main/asciidoc/se/health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -272,15 +272,16 @@ common health check statuses:
 // Had to move the anchor to the heading above because the rendered page did not define the ID
 // correctly on the table so the link did not work. The link itself looks OK; just no ID generated on the page.
 //[[built-in-health-checks-table]]
-[cols="1,1,3,15,3"]
+[cols="1,1,3,15,3,3"]
 |=======
-|Built-in health check |Health check name |JavaDoc |Config properties (within `server.features.observe.observers.health`) |Default config value
+|Built-in health check |Health check name |JavaDoc |Config properties (within `server.features.observe.observers.health`) |Default config value |Graal VM Support
 
 |deadlock detection
 |`deadlock`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/DeadlockHealthCheck.html[`DeadlockHealthCheck`]
 | n/a
 | n/a
+| No
 
 |available disk space
 |`diskSpace`
@@ -291,11 +292,13 @@ common health check statuses:
 | `99.999` +
 +
 `/`
+| No
 |available heap memory
 | `heapMemory`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/HeapMemoryHealthCheck.html[`HeapMemoryHealthCheck`]
 |`helidon.health.heapMemory.thresholdPercent`
 |`98`
+| Yes
 |=======
 
 Simply adding the built-in health check dependency is sufficient to register all the built-in health checks automatically.


### PR DESCRIPTION
### Description
Fixes #9021 

I've changed docs according to the code:
<img width="1146" alt="Screenshot 2025-02-16 at 22 29 08" src="https://github.com/user-attachments/assets/030b2d84-3aa7-45b2-974e-b5f4a9510a07" />

It looks now (in IDE preview):
<img width="1042" alt="Screenshot 2025-02-16 at 22 30 59" src="https://github.com/user-attachments/assets/cc164070-9ab4-49b0-bdf2-5871ab88c93b" />


If it's wrong don't hesitate to close this PR :) . It's only my guess, how it can be done.