### PR TITLE
Config to prevent reflection of user input when reporting errors

### DIFF
--- a/microprofile/tests/server/src/test/java/io/helidon/microprofile/tests/server/BadHostHeaderTest.java
+++ b/microprofile/tests/server/src/test/java/io/helidon/microprofile/tests/server/BadHostHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.microprofile.tests.server;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
+import io.helidon.microprofile.testing.AddConfig;
 import io.helidon.microprofile.testing.junit5.AddBean;
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 import io.helidon.webclient.api.WebClient;
@@ -37,6 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @HelidonTest
 @AddBean(BadHostHeaderTest.TestResource.class)
+@AddConfig(key = "server.error-handling.include-entity", value = "true")
 public class BadHostHeaderTest {
     private static final Header BAD_HOST_HEADER = HeaderValues.create("Host", "localhost:808a");
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -312,23 +312,16 @@ class Http2ServerStream implements Runnable, Http2Stream {
             // gather error handling properties
             ErrorHandling errorHandling = ctx.listenerContext()
                     .config()
-                    .errorHandling()
-                    .orElse(null);
-            boolean includeEntity = false;
-            boolean logAllMessages = false;
-            if (errorHandling != null) {
-                includeEntity = errorHandling.includeEntity();
-                logAllMessages = errorHandling.logAllMessages();
-            }
+                    .errorHandling();
 
             // log message in DEBUG mode
-            if (LOGGER.isLoggable(DEBUG) && (e.safeMessage() || logAllMessages)) {
+            if (LOGGER.isLoggable(DEBUG) && (e.safeMessage() || errorHandling.logAllMessages())) {
                 LOGGER.log(DEBUG, e);
             }
 
             // create message to return based on settings
             String message = null;
-            if (includeEntity) {
+            if (errorHandling.includeEntity()) {
                 message = e.safeMessage() ? e.getMessage() : "Bad request, see server log for more information";
             }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,12 +61,14 @@ import io.helidon.http.http2.StreamFlowControl;
 import io.helidon.http.http2.WindowSize;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ErrorHandling;
 import io.helidon.webserver.Router;
 import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 import io.helidon.webserver.http2.spi.SubProtocolResult;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.TRACE;
 
 /**
@@ -307,6 +309,29 @@ class Http2ServerStream implements Runnable, Http2Stream {
             writer.write(rst.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
             // no sense in throwing an exception, as this is invoked from an executor service directly
         } catch (RequestException e) {
+            // gather error handling properties
+            ErrorHandling errorHandling = ctx.listenerContext()
+                    .config()
+                    .errorHandling()
+                    .orElse(null);
+            boolean includeEntity = false;
+            boolean logAllMessages = false;
+            if (errorHandling != null) {
+                includeEntity = errorHandling.includeEntity();
+                logAllMessages = errorHandling.logAllMessages();
+            }
+
+            // log message in DEBUG mode
+            if (LOGGER.isLoggable(DEBUG) && (e.safeMessage() || logAllMessages)) {
+                LOGGER.log(DEBUG, e);
+            }
+
+            // create message to return based on settings
+            String message = null;
+            if (includeEntity) {
+                message = e.safeMessage() ? e.getMessage() : "Bad request, see server log for more information";
+            }
+
             DirectHandler handler = ctx.listenerContext()
                     .directHandlers()
                     .handler(e.eventType());
@@ -314,21 +339,21 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                                                       e.eventType(),
                                                                       e.status(),
                                                                       e.responseHeaders(),
-                                                                      e);
+                                                                      message);
 
             ServerResponseHeaders headers = response.headers();
-            byte[] message = response.entity().orElse(BufferData.EMPTY_BYTES);
-            if (message.length != 0) {
-                headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(message.length)));
+            byte[] entity = response.entity().orElse(BufferData.EMPTY_BYTES);
+            if (entity.length != 0) {
+                headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, String.valueOf(entity.length)));
             }
             Http2Headers http2Headers = Http2Headers.create(headers);
-            if (message.length == 0) {
+            if (entity.length == 0) {
                 writer.writeHeaders(http2Headers,
                                     streamId,
                                     Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
                                     flowControl.outbound());
             } else {
-                Http2FrameHeader dataHeader = Http2FrameHeader.create(message.length,
+                Http2FrameHeader dataHeader = Http2FrameHeader.create(entity.length,
                                                                       Http2FrameTypes.DATA,
                                                                       Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
                                                                       streamId);

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadHostTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadHostTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,13 @@ import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.ErrorHandling;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http1.Http1Route;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +43,13 @@ class BadHostTest {
 
     BadHostTest(Http1Client client) {
         this.client = client;
+    }
+
+    @SetUpServer
+    static void setupServer(WebServerConfig.Builder builder) {
+        builder.errorHandling(ErrorHandling.builder()
+                                      .includeEntity(true)          // enable error message entities
+                                      .build());
     }
 
     @SetUpRoute

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadPrologueNoEntityTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadPrologueNoEntityTest.java
@@ -22,13 +22,10 @@ import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.webclient.http1.Http1Client;
-import io.helidon.webserver.ErrorHandling;
-import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http1.Http1Route;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
-import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,25 +35,18 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Verifies that 400 bad request is returned when a bad prologue is sent. Enables
- * entities in {@link io.helidon.webserver.ErrorHandling} to get details about
- * the errors in entities.
+ * Verifies that 400 bad request is returned when a bad prologue is sent. Response
+ * entities must be empty given that {@link io.helidon.webserver.ErrorHandling#includeEntity()}
+ * is {@code false} by default.
  */
 @ServerTest
-class BadPrologueTest {
+class BadPrologueNoEntityTest {
     private final Http1Client client;
     private final SocketHttpClient socketClient;
 
-    BadPrologueTest(Http1Client client, SocketHttpClient socketClient) {
+    BadPrologueNoEntityTest(Http1Client client, SocketHttpClient socketClient) {
         this.client = client;
         this.socketClient = socketClient;
-    }
-
-    @SetUpServer
-    static void setupServer(WebServerConfig.Builder builder) {
-        builder.errorHandling(ErrorHandling.builder()
-                                      .includeEntity(true)          // enable error message entities
-                                      .build());
     }
 
     @SetUpRoute
@@ -91,9 +81,9 @@ class BadPrologueTest {
 
         assertThat(response, containsString("400 Bad Request"));
         // beginning of message to the first double quote
-        assertThat(response, containsString("Query contains invalid char: "));
+        assertThat(response, not(containsString("Query contains invalid char: ")));
         // end of message from double quote, index of bad char, and bad char
-        assertThat(response, containsString(", index: 2, char: 0x3c"));
+        assertThat(response, not(containsString(", index: 2, char: 0x3c")));
         assertThat(response, not(containsString(">")));
     }
 
@@ -106,9 +96,9 @@ class BadPrologueTest {
 
         assertThat(response, containsString("400 Bad Request"));
         // beginning of message to the first double quote
-        assertThat(response, containsString("Query contains invalid char: "));
+        assertThat(response, not(containsString("Query contains invalid char: ")));
         // end of message from double quote, index of bad char, and bad char
-        assertThat(response, containsString(", index: 10, char: 0x7b"));
+        assertThat(response, not(containsString(", index: 10, char: 0x7b")));
     }
 
     @Test
@@ -120,7 +110,7 @@ class BadPrologueTest {
 
         assertThat(response, containsString("400 Bad Request"));
         // for path we are on the safe side, and never return it back (even HTML encoded)
-        assertThat(response, containsString("Bad request, see server log for more information"));
+        assertThat(response, not(containsString("Bad request, see server log for more information")));
     }
 
     @Test
@@ -132,9 +122,9 @@ class BadPrologueTest {
 
         assertThat(response, containsString("400 Bad Request"));
         // beginning of message to the first double quote
-        assertThat(response, containsString("Fragment contains invalid char: "));
+        assertThat(response, not(containsString("Fragment contains invalid char: ")));
         // end of message from double quote, index of bad char, and bad char
-        assertThat(response, containsString(", index: 16, char: 0x3e"));
+        assertThat(response, not(containsString(", index: 16, char: 0x3e")));
         assertThat(response, not(containsString(">")));
     }
 }

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingDisabledTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ContentEncodingDisabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.ErrorHandling;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http1.Http1Config;
 import io.helidon.webserver.http1.Http1ConnectionSelector;
@@ -50,6 +51,10 @@ class ContentEncodingDisabledTest extends ContentEncodingDisabledAbstract {
     }
 
     @SetUpServer
+    static void setupServer(WebServerConfig.Builder builder) {
+
+    }
+    @SetUpServer
     static void server(WebServerConfig.Builder server) {
         ServerConnectionSelector http1 = Http1ConnectionSelector.builder()
                 // Headers validation is enabled by default
@@ -58,6 +63,9 @@ class ContentEncodingDisabledTest extends ContentEncodingDisabledAbstract {
         server.addConnectionSelector(http1)
                 // Content encoding needs to be completely disabled
                 .contentEncoding(emptyEncodingContext());
+        server.errorHandling(ErrorHandling.builder()
+                                     .includeEntity(true)          // enable error message entities
+                                     .build());
     }
 
     @Test

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ExceptionMessageTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/ExceptionMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,10 @@ import java.util.Collections;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
+import io.helidon.webserver.ErrorHandling;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +44,13 @@ class ExceptionMessageTest {
 
     ExceptionMessageTest(SocketHttpClient socketClient) {
         this.socketClient = socketClient;
+    }
+
+    @SetUpServer
+    static void setupServer(WebServerConfig.Builder builder) {
+        builder.errorHandling(ErrorHandling.builder()
+                                      .includeEntity(true)          // enable error message entities
+                                      .build());
     }
 
     @Test

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ErrorHandlingBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ErrorHandlingBlueprint.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Configured
+@Prototype.Blueprint
+interface ErrorHandlingBlueprint {
+
+    /**
+     * Whether to include a response entity when mapping a {@link io.helidon.http.RequestException}
+     * using a {@link io.helidon.http.DirectHandler}. Response entities may include data that
+     * is reflected back from the original request, albeit escaped to prevent potential attacks.
+     *
+     * @return include entity flag
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean includeEntity();
+
+    /**
+     * Whether to log all messages in a {@link io.helidon.http.RequestException} or not.
+     * If set to {@code false}, only those that return {@code true} for
+     * {@link io.helidon.http.RequestException#safeMessage()} are logged.
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean logAllMessages();
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -405,5 +405,6 @@ interface ListenerConfigBlueprint {
      *
      * @return optional error handling
      */
+    @Option.Configured
     Optional<ErrorHandling> errorHandling();
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -400,4 +400,10 @@ interface ListenerConfigBlueprint {
         }
     }
 
+    /**
+     * Configuration for this listener's error handling.
+     *
+     * @return optional error handling
+     */
+    Optional<ErrorHandling> errorHandling();
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -403,8 +403,9 @@ interface ListenerConfigBlueprint {
     /**
      * Configuration for this listener's error handling.
      *
-     * @return optional error handling
+     * @return error handling
      */
     @Option.Configured
-    Optional<ErrorHandling> errorHandling();
+    @Option.DefaultMethod("create")
+    ErrorHandling errorHandling();
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -648,23 +648,16 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         // gather error handling properties
         ErrorHandling errorHandling = ctx.listenerContext()
                 .config()
-                .errorHandling()
-                .orElse(null);
-        boolean includeEntity = false;
-        boolean logAllMessages = false;
-        if (errorHandling != null) {
-            includeEntity = errorHandling.includeEntity();
-            logAllMessages = errorHandling.logAllMessages();
-        }
+                .errorHandling();
 
         // log message in DEBUG mode
-        if (LOGGER.isLoggable(DEBUG) && (e.safeMessage() || logAllMessages)) {
+        if (LOGGER.isLoggable(DEBUG) && (e.safeMessage() || errorHandling.logAllMessages())) {
             LOGGER.log(DEBUG, e);
         }
 
         // create message to return based on settings
         String message = null;
-        if (includeEntity) {
+        if (errorHandling.includeEntity()) {
             message = e.safeMessage() ? e.getMessage() : "Bad request, see server log for more information";
         }
 


### PR DESCRIPTION
### Description

New config section in listeners for error handling. Default settings prevent any entity from being returned to avoid reflecting any data from a request. Default settings can be modified to return safe messages and to log all messages. Issue #9698.

### Documentation

None