### PR TITLE
Adds afterStart(WebServer) implementations to various delegating ServerLifecycle implementations that were missing it

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerFeatureContextImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerFeatureContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -322,6 +322,11 @@ class ServerFeatureContextImpl implements ServerFeature.ServerFeatureContext {
         @Override
         public void beforeStart() {
             delegate.get().beforeStart();
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            delegate.get().afterStart(webServer);
         }
 
         @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/Filters.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/Filters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.helidon.http.RoutedPath;
 import io.helidon.http.Status;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ServerLifecycle;
+import io.helidon.webserver.WebServer;
 
 /**
  * Handler of HTTP filters.
@@ -56,6 +57,11 @@ public final class Filters implements ServerLifecycle {
     @Override
     public void beforeStart() {
         filters.forEach(Filter::beforeStart);
+    }
+
+    @Override
+    public void afterStart(WebServer webServer) {
+        filters.forEach(f -> f.afterStart(webServer));
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouteImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouteImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
+import io.helidon.webserver.WebServer;
 
 class HttpRouteImpl extends HttpRouteBase implements HttpRoute {
     private final Handler handler;
@@ -51,6 +52,11 @@ class HttpRouteImpl extends HttpRouteBase implements HttpRoute {
     @Override
     public void beforeStart() {
         handler.beforeStart();
+    }
+
+    @Override
+    public void afterStart(WebServer webServer) {
+        handler.afterStart(webServer);
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouteWrap.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouteWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.webserver.http;
 
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.PathMatchers;
+import io.helidon.webserver.WebServer;
 
 class HttpRouteWrap extends HttpRouteBase {
     private final HttpRoute route;
@@ -29,6 +30,11 @@ class HttpRouteWrap extends HttpRouteBase {
     @Override
     public void beforeStart() {
         route.beforeStart();
+    }
+
+    @Override
+    public void afterStart(WebServer webServer) {
+        route.afterStart(webServer);
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import io.helidon.http.RequestException;
 import io.helidon.http.Status;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ServerLifecycle;
+import io.helidon.webserver.WebServer;
 
 final class HttpRoutingImpl implements HttpRouting {
     private static final System.Logger LOGGER = System.getLogger(HttpRoutingImpl.class.getName());
@@ -78,6 +79,13 @@ final class HttpRoutingImpl implements HttpRouting {
         filters.beforeStart();
         rootRoute.beforeStart();
         features.forEach(ServerLifecycle::beforeStart);
+    }
+
+    @Override
+    public void afterStart(WebServer webServer) {
+        filters.afterStart(webServer);
+        rootRoute.afterStart(webServer);
+        features.forEach(f -> f.afterStart(webServer));
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceRoute.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import io.helidon.http.Method;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.WebServer;
 
 class ServiceRoute extends HttpRouteBase implements HttpRoute {
     private final HttpService theService;
@@ -45,6 +46,12 @@ class ServiceRoute extends HttpRouteBase implements HttpRoute {
     public void beforeStart() {
         theService.beforeStart();
         this.routes.forEach(HttpRouteBase::beforeStart);
+    }
+
+    @Override
+    public void afterStart(WebServer webServer) {
+        theService.afterStart(webServer);
+        this.routes.forEach(r -> r.afterStart(webServer));
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Route.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Route.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.Handler;
 import io.helidon.webserver.http.HttpRoute;
 
@@ -74,6 +75,11 @@ public class Http1Route implements HttpRoute {
     @Override
     public void beforeStart() {
         handler.beforeStart();
+    }
+
+    @Override
+    public void afterStart(WebServer webServer) {
+        handler.afterStart(webServer);
     }
 
     @Override


### PR DESCRIPTION
PR #9655 added an `afterStart(WebServer)` method to `ServerLifecycle`. It was approved on February 4. There were more `ServerLifecycle` implementations than showed up at first glance. This PR attempts to ensure that all of the known `ServerLifecycle` implementations in the code base do the right thing with their `afterStart(WebServer)` implementations, so that they don't simply (incorrectly) inherit the (necessary) `default` "no-op" implementation.

This PR gates #9704 and #9789.