### PR TITLE
1.x: examples: Use correct version of com.google.protobuf:protoc in protobuf maven plugin

### DIFF
--- a/examples/grpc/common/pom.xml
+++ b/examples/grpc/common/pom.xml
@@ -76,6 +76,16 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
+                <version>${version.plugin.protobuf}</version>
+                <configuration>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <protocArtifact>com.google.protobuf:protoc:${version.lib.google-protobuf}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <pluginArtifact>
+                        io.grpc:protoc-gen-grpc-java:${version.lib.grpc}:exe:${os.detected.classifier}
+                    </pluginArtifact>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION

### Description

1.x: examples: Use correct version of com.google.protobuf:protoc in protobuf maven plugin
