### PR TITLE
Remove GlobalServiceRegistry context qualifier constants

### DIFF
--- a/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListener.java
+++ b/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListener.java
@@ -40,7 +40,6 @@ import io.helidon.microprofile.testing.HelidonTestInfo.ClassInfo;
 import io.helidon.microprofile.testing.HelidonTestInfo.MethodInfo;
 import io.helidon.microprofile.testing.HelidonTestScope;
 import io.helidon.microprofile.testing.Proxies;
-import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
 
@@ -302,10 +301,10 @@ public class HelidonTestNgListener extends HelidonTestNgListenerBase implements 
                 .build();
 
         // self-register, so this context is used even if the current context is some child of it
-        context.register(GlobalServiceRegistry.STATIC_CONTEXT_CLASSIFIER, context);
+        context.register("helidon-registry-static-context", context);
 
         // supply registry
-        context.supply(GlobalServiceRegistry.CONTEXT_QUALIFIER, ServiceRegistry.class,
+        context.supply("helidon-registry", ServiceRegistry.class,
                 () -> ServiceRegistryManager.create().registry());
 
         return context;

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestGlobalServiceRegistry.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestGlobalServiceRegistry.java
@@ -69,7 +69,7 @@ class TestGlobalServiceRegistry {
         assertThat(INSTANCES.size(), is(1));
         assertThat(INSTANCES.iterator().next(),
                 is(not(System.identityHashCode(Contexts.globalContext()
-                        .get(GlobalServiceRegistry.CONTEXT_QUALIFIER, ServiceRegistry.class)
+                        .get("helidon-registry", ServiceRegistry.class)
                         .orElse(null)))));
     }
 

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestGlobalServiceRegistry.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestGlobalServiceRegistry.java
@@ -69,7 +69,7 @@ public class TestGlobalServiceRegistry {
         assertThat(INSTANCES.size(), is(1));
         assertThat(INSTANCES.iterator().next(),
                 is(not(System.identityHashCode(Contexts.globalContext()
-                        .get(GlobalServiceRegistry.CONTEXT_QUALIFIER, ServiceRegistry.class)
+                        .get("helidon-registry", ServiceRegistry.class)
                         .orElse(null)))));
     }
 

--- a/testing/junit5/src/main/java/io/helidon/testing/junit5/TestJunitExtension.java
+++ b/testing/junit5/src/main/java/io/helidon/testing/junit5/TestJunitExtension.java
@@ -204,10 +204,10 @@ public class TestJunitExtension implements Extension,
                     .build();
 
             // self-register, so this context is used even if the current context is some child of it
-            context.register(GlobalServiceRegistry.STATIC_CONTEXT_CLASSIFIER, context);
+            context.register("helidon-registry-static-context", context);
 
             // supply registry
-            context.supply(GlobalServiceRegistry.CONTEXT_QUALIFIER, ServiceRegistry.class, () -> {
+            context.supply("helidon-registry", ServiceRegistry.class, () -> {
                 var manager = ServiceRegistryManager.create();
                 var registry = manager.registry();
                 store.put(ServiceRegistryManager.class, (CloseableResource) manager::shutdown);


### PR DESCRIPTION
### Description

Remove the following (unreleased) constants to minimize temporary API surface of 4.2.0
- GlobalServiceRegistry.STATIC_CONTEXT_CLASSIFIER
- GlobalServiceRegistry.CONTEXT_CLASSIFIER

### Documentation

None.
