### PR TITLE
4.1.7: Connection cache 100 continue

### DIFF
--- a/common/socket/src/main/java/io/helidon/common/socket/IdleInputStream.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/IdleInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package io.helidon.common.socket;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -36,13 +38,24 @@ import io.helidon.common.LazyValue;
  */
 class IdleInputStream extends InputStream {
 
+    /**
+     * This needs to cooperate with 100-continue timeout.
+     * Some low number is needed here for a quick iterations.
+     * Using these small iterations allows us to cancel the idle check much faster,
+     * without the need to wait for a full socket read timeout.
+     */
+    private static final int ITERATION_TIME_MILLIS = 101;
+
+    private final Socket socket;
     private final InputStream upstream;
     private final LazyValue<ExecutorService> executor;
     private volatile int next = -1;
     private volatile boolean closed = false;
+    private volatile boolean cancelled = false;
     private Future<?> idlingThread;
 
-    IdleInputStream(InputStream upstream, String childSocketId, String socketId) {
+    IdleInputStream(Socket socket, InputStream upstream, String childSocketId, String socketId) {
+        this.socket = socket;
         this.upstream = upstream;
         executor = LazyValue.create(() -> Executors.newThreadPerTaskExecutor(
                 Thread.ofVirtual()
@@ -107,10 +120,34 @@ class IdleInputStream extends InputStream {
 
     private void handle() {
         try {
-            next = upstream.read();
-            if (next <= 0) {
-                closed = true;
+            //Currently configured socket read timeout. This is intended to be restored after this method finishes.
+            int toRestore = socket.getSoTimeout();
+            int idleTimeoutIterations = Math.ceilDiv(Math.max(1, toRestore), ITERATION_TIME_MILLIS);
+            for (int i = 0; !cancelled; i++) {
+                try {
+                    //We need to check the current socket timeout before each iteration.
+                    //This time out could have changed,
+                    //and now it would represent the new timeout we should restore after this method ends.
+                    int currentSoTimeout = socket.getSoTimeout();
+                    if (currentSoTimeout != ITERATION_TIME_MILLIS) {
+                        toRestore = currentSoTimeout;
+                    }
+                    //Set iteration read timeout
+                    socket.setSoTimeout(ITERATION_TIME_MILLIS);
+                    next = upstream.read();
+                    if (next <= 0) {
+                        closed = true;
+                        return;
+                    }
+                    break;
+                } catch (SocketTimeoutException e) {
+                    if (i + 1 >= idleTimeoutIterations) {
+                        throw e;
+                    }
+                }
             }
+            //Idle checking thread was canceled or detected as not idle. Restore socket timeout it should have.
+            socket.setSoTimeout(toRestore);
         } catch (IOException e) {
             closed = true;
             throw new UncheckedIOException(e);
@@ -119,8 +156,10 @@ class IdleInputStream extends InputStream {
 
     private void endIdle() {
         try {
+            cancelled = true;
             idlingThread.get();
             idlingThread = null;
+            cancelled = false;
         } catch (InterruptedException | ExecutionException e) {
             closed = true;
             throw new RuntimeException("Exception in socket monitor thread.", e);

--- a/common/socket/src/main/java/io/helidon/common/socket/PlainSocket.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/PlainSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public sealed class PlainSocket implements HelidonSocket permits TlsSocket {
         this.childSocketId = childSocketId;
         this.socketId = socketId;
         try {
-            this.inputStream = new IdleInputStream(delegate.getInputStream(), childSocketId, socketId);
+            this.inputStream = new IdleInputStream(delegate, delegate.getInputStream(), childSocketId, socketId);
             this.outputStream = delegate.getOutputStream();
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,4 +61,21 @@ public interface ClientConnection extends ReleasableResource {
      * @param readTimeout connection read timeout
      */
     void readTimeout(Duration readTimeout);
+
+    /**
+     * Check whether this connection is allowed to send 100-Continue.
+     *
+     * @return whether 100-Continue is allowed
+     */
+    default boolean allowExpectContinue() {
+        return true;
+    }
+
+    /**
+     * Set whether this connection allows 100-Continue to be sent.
+     *
+     * @param allowExpectContinue whether to allow 100-Continue
+     */
+    default void allowExpectContinue(boolean allowExpectContinue) {
+    }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/TcpClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ public class TcpClientConnection implements ClientConnection {
     private DataReader reader;
     private DataWriter writer;
     private boolean closed;
+    private boolean allowExpectContinue = true;
 
     private TcpClientConnection(WebClient webClient,
                                 ConnectionKey connectionKey,
@@ -233,6 +234,16 @@ public class TcpClientConnection implements ClientConnection {
 
     public boolean isConnected() {
         return socket != null && socket.isConnected() && helidonSocket().isConnected();
+    }
+
+    @Override
+    public boolean allowExpectContinue() {
+        return allowExpectContinue;
+    }
+
+    @Override
+    public void allowExpectContinue(boolean allowExpectContinue) {
+        this.allowExpectContinue = allowExpectContinue;
     }
 
     Socket socket() {

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/FollowRedirectTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/FollowRedirectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -261,6 +261,7 @@ class FollowRedirectTest {
         // the webclient just starts sending entity (that is the reason for the timeout, for servers that may not send continue)
         ClientResponseTyped<String> http1ClientResponse = webClient.put()
                 .path("/wait")
+                .keepAlive(false)
                 .readContinueTimeout(Duration.ofMillis(200))
                 .header(REDIRECT_TO_OTHER_NAME, redirectToOtherPort)
                 .outputStream(it -> {


### PR DESCRIPTION

Backport #9795 to Helidon 4.1.7

### Description

Fixes #9736
Fixes #9731

This issue introduces a new way of idle connection handling. It splits the desired idle timeout and uses small 500 ms timeouts until the overall desired timeout is reached. This helps to interrupt the idle timeout mechanism.

FYI: I will add some more comments to the code

### Documentation

None