### PR TITLE
4.x: Upgrade snakeyaml to 2.4

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -158,7 +158,7 @@
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <version.lib.slf4j>2.0.16</version.lib.slf4j>
         <version.lib.smallrye-openapi>3.3.4</version.lib.smallrye-openapi>
-        <version.lib.snakeyaml>2.2</version.lib.snakeyaml>
+        <version.lib.snakeyaml>2.4</version.lib.snakeyaml>
         <version.lib.testcontainers>1.19.3</version.lib.testcontainers>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>
         <version.lib.tyrus>2.1.5</version.lib.tyrus>

--- a/microprofile/openapi/src/main/resources/META-INF/native-image/io.helidon.microprofile.openapi/helidon-microprofile-openapi/native-image.properties
+++ b/microprofile/openapi/src/main/resources/META-INF/native-image/io.helidon.microprofile.openapi/helidon-microprofile-openapi/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,5 @@
 #
 
 Args=--initialize-at-build-time=org.eclipse.microprofile.openapi \
-     --initialize-at-build-time=io.smallrye.openapi
+     --initialize-at-build-time=io.smallrye.openapi \
+     --initialize-at-build-time=java.beans


### PR DESCRIPTION
### Description

Upgrade snakeyaml to 2.4. 

In SnakeYaml 2.3 they made a change to make the `java.desktop` module optional. This resulted in a runtime check for the existence of `java.beans.Introspector` which caused a native image failure. That's why this PR modifies `native-image.properties`

See #9826



