### PR TITLE
2.x: Upgrade snakeyaml to 2.4

### DIFF
--- a/config/yaml/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-yaml/native-image.properties
+++ b/config/yaml/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-yaml/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
-Args=--initialize-at-build-time=io.helidon.config.yaml
+Args=--initialize-at-build-time=io.helidon.config.yaml \
+     --initialize-at-build-time=java.beans

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -141,7 +141,7 @@
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>2.0.9</version.lib.slf4j>
         <version.lib.smallrye-openapi>2.0.26</version.lib.smallrye-openapi>
-        <version.lib.snakeyaml>2.0</version.lib.snakeyaml>
+        <version.lib.snakeyaml>2.4</version.lib.snakeyaml>
         <version.lib.transaction-api>1.3.3</version.lib.transaction-api>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>
         <version.lib.tyrus>1.17</version.lib.tyrus>


### PR DESCRIPTION
### Description

Upgrade snakeyaml to 2.4.

In SnakeYaml 2.3 they made a change to make the `java.desktop` module optional. This resulted in a runtime check for the existence of java.beans.Introspector which caused a native image failure. That's why this PR modifies `native-image.properties`

See #9826
