### PR TITLE
4.x: CDI bridge for service registry + config factory improvements

### DIFF
--- a/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
+++ b/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ public final class GlobalConfig {
      * @param config configuration to use
      * @param overwrite whether to overwrite an existing configured value
      * @return current global config
-     * @deprecated use {@link io.helidon.service.registry.Services#get(Class)} instead
+     * @deprecated use {@link io.helidon.service.registry.Services#set(Class, Object[])} instead
      */
     @Deprecated(forRemoval = true, since = "4.2.0")
     public static Config config(Supplier<Config> config, boolean overwrite) {

--- a/config/config/src/main/java/io/helidon/config/ConfigProvider.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigProvider.java
@@ -272,6 +272,16 @@ class ConfigProvider implements Supplier<Config> {
         public io.helidon.common.config.Config get(io.helidon.common.config.Config.Key key) {
             return delegate.get(key);
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            return delegate.equals(obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
     }
 
     private static class CommonKeyWrapper implements Config.Key {
@@ -302,115 +312,18 @@ class ConfigProvider implements Supplier<Config> {
         }
 
         @Override
-        public int compareTo(io.helidon.common.config.Config.Key o) {
-            return delegate.compareTo(o);
-        }
-    }
-
-    static class SeConfigValue<T> implements ConfigValue<T> {
-        private final Config.Key key;
-        private final Supplier<T> valueSupplier;
-        private final Config owningConfig;
-
-        SeConfigValue(Config config, Config.Key key, Supplier<T> valueSupplier) {
-            this.owningConfig = config;
-            this.key = key;
-            this.valueSupplier = valueSupplier;
-        }
-
-        @Override
-        public Config.Key key() {
-            return key;
-        }
-
-        @Override
-        public Optional<T> asOptional() throws ConfigMappingException {
-            try {
-                return Optional.of(valueSupplier.get());
-            } catch (MissingValueException e) {
-                return Optional.empty();
-            }
-        }
-
-        @Override
-        public <N> ConfigValue<N> as(Function<? super T, ? extends N> mapper) {
-            return new SeConfigValue<>(owningConfig, key, () -> mapper.apply(valueSupplier.get()));
-        }
-
-        @Override
-        public <N> ConfigValue<N> as(Class<N> type) {
-            return owningConfig.as(type);
-        }
-
-        @Override
-        public <N> ConfigValue<N> as(GenericType<N> type) {
-            return owningConfig.as(type);
-        }
-
-        @Override
-        public Supplier<T> supplier() {
-            return valueSupplier;
-        }
-
-        @Override
-        public Supplier<T> supplier(T defaultValue) {
-            return () -> {
-                try {
-                    return valueSupplier.get();
-                } catch (MissingValueException e) {
-                    return defaultValue;
-                }
-            };
-        }
-
-        @Override
-        public Supplier<Optional<T>> optionalSupplier() {
-            return this::asOptional;
+        public boolean equals(Object obj) {
+            return delegate.equals(obj);
         }
 
         @Override
         public int hashCode() {
-            try {
-                return Objects.hash(key, asOptional());
-            } catch (ConfigMappingException e) {
-                return Objects.hash(key);
-            }
+            return delegate.hashCode();
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            SeConfigValue<?> that = (SeConfigValue<?>) o;
-            if (!key.equals(that.key)) {
-                return false;
-            }
-
-            Optional<?> myOptional;
-            try {
-                myOptional = asOptional();
-            } catch (ConfigMappingException e) {
-                try {
-                    that.asOptional();
-                    // same key, one failed -> different value
-                    return false;
-                } catch (ConfigMappingException configMappingException) {
-                    // same key, both failed -> same value
-                    return true;
-                }
-            }
-            try {
-                Optional<?> thatOptional = that.asOptional();
-                return myOptional.equals(thatOptional);
-            } catch (ConfigMappingException e) {
-                // same key, one failed -> different value
-                return false;
-            }
+        public int compareTo(io.helidon.common.config.Config.Key o) {
+            return delegate.compareTo(o);
         }
     }
-
 }

--- a/config/config/src/main/java/io/helidon/config/ConfigProvider.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,32 @@
 
 package io.helidon.config;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import io.helidon.common.config.Config;
+import io.helidon.common.GenericType;
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
 import io.helidon.config.spi.ConfigFilter;
+import io.helidon.config.spi.ConfigMapper;
 import io.helidon.config.spi.ConfigMapperProvider;
 import io.helidon.config.spi.ConfigParser;
 import io.helidon.config.spi.ConfigSource;
 import io.helidon.service.registry.Service;
 
 @Service.Singleton
+@Weight(Weighted.DEFAULT_WEIGHT - 10) // less than default, so it can be easily overridden
 class ConfigProvider implements Supplier<Config> {
     private final Config config;
 
@@ -42,11 +53,11 @@ class ConfigProvider implements Supplier<Config> {
                    Supplier<List<ConfigFilter>> configFilters,
                    Supplier<List<ConfigMapperProvider>> configMappers) {
         if (io.helidon.common.config.GlobalConfig.configured()) {
-            config = io.helidon.common.config.GlobalConfig.config();
+            config = wrapCommon(io.helidon.common.config.GlobalConfig.config());
         } else {
-            config = io.helidon.config.Config.builder()
+            config = Config.builder()
                     .update(it -> metaConfig.get().ifPresent(metaConfigInstance ->
-                                                               it.config(metaConfigInstance.metaConfiguration())))
+                                                                     it.config(metaConfigInstance.metaConfiguration())))
                     .update(it -> configSources.get()
                             .forEach(it::addSource))
                     .update(it -> defaultConfigSources(it, configParsers))
@@ -71,6 +82,13 @@ class ConfigProvider implements Supplier<Config> {
         return config;
     }
 
+    private Config wrapCommon(io.helidon.common.config.Config config) {
+        if (config instanceof Config cfg) {
+            return cfg;
+        }
+        return new CommonConfigWrapper(Config.empty(), config);
+    }
+
     private void defaultConfigSources(io.helidon.config.Config.Builder configBuilder,
                                       Supplier<List<ConfigParser>> configParsers) {
 
@@ -87,6 +105,312 @@ class ConfigProvider implements Supplier<Config> {
         // default config source(s)
         MetaConfigFinder.configSources(new ArrayList<>(supportedSuffixes))
                 .forEach(configBuilder::addSource);
-
     }
+
+    private static class CommonConfigWrapper implements Config {
+        private final Config emptyConfig;
+        private final Instant timestamp;
+        private final io.helidon.common.config.Config delegate;
+
+        private CommonConfigWrapper(Config realConfig, io.helidon.common.config.Config delegate) {
+            this(realConfig, Instant.now(), delegate);
+        }
+
+        private CommonConfigWrapper(Config realConfig,
+                                    Instant timestamp,
+                                    io.helidon.common.config.Config delegate) {
+            this.emptyConfig = realConfig;
+            this.delegate = delegate;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return timestamp;
+        }
+
+        @Override
+        public Key key() {
+            return new CommonKeyWrapper(delegate.key());
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public Config get(String key) {
+            return new CommonConfigWrapper(emptyConfig, timestamp, delegate.get(key));
+        }
+
+        @Override
+        public Config root() {
+            return new CommonConfigWrapper(emptyConfig, timestamp, delegate.root());
+        }
+
+        @Override
+        public Config get(Key key) {
+            return new CommonConfigWrapper(emptyConfig, timestamp, delegate.get(key));
+        }
+
+        @Override
+        public Config detach() {
+            return new CommonConfigWrapper(emptyConfig, timestamp, delegate.detach());
+        }
+
+        @Override
+        public Type type() {
+            if (delegate.isList()) {
+                return Type.LIST;
+            }
+            if (delegate.isObject()) {
+                return Type.OBJECT;
+            }
+            if (delegate.exists()) {
+                return Type.VALUE;
+            }
+            return Type.MISSING;
+        }
+
+        @Override
+        public boolean exists() {
+            return delegate.exists();
+        }
+
+        @Override
+        public boolean isLeaf() {
+            return delegate.isLeaf();
+        }
+
+        @Override
+        public boolean isObject() {
+            return delegate.isObject();
+        }
+
+        @Override
+        public boolean isList() {
+            return delegate.isList();
+        }
+
+        @Override
+        public boolean hasValue() {
+            return delegate.hasValue();
+        }
+
+        @Override
+        public void ifExists(Consumer<Config> action) {
+            if (delegate.exists()) {
+                action.accept(this);
+            }
+        }
+
+        @Override
+        public Stream<Config> traverse() {
+            return delegate.asList(io.helidon.common.config.Config.class)
+                    .stream()
+                    .flatMap(List::stream)
+                    .map(it -> new CommonConfigWrapper(emptyConfig, timestamp, it));
+        }
+
+        @Override
+        public Stream<Config> traverse(Predicate<Config> predicate) {
+            return traverse()
+                    .filter(predicate);
+        }
+
+        @Override
+        public <T> T convert(Class<T> type, String value) throws ConfigMappingException {
+            return emptyConfig.convert(type, value);
+        }
+
+        @Override
+        public ConfigMapper mapper() {
+            return emptyConfig.mapper();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> ConfigValue<T> as(GenericType<T> genericType) {
+            if (genericType.isClass()) {
+                return (ConfigValue<T>) as(genericType.rawType());
+            }
+            return ConfigValues.create(this, genericType, mapper());
+        }
+
+        @Override
+        public <T> ConfigValue<T> as(Class<T> type) {
+            return ConfigValues.create(this, type, mapper());
+        }
+
+        @Override
+        public <T> ConfigValue<T> as(Function<Config, T> mapper) {
+            return ConfigValues.create(this, mapper);
+        }
+
+        @Override
+        public <T> ConfigValue<List<T>> asList(Class<T> type) throws ConfigMappingException {
+            return ConfigValues.createList(this, cfg -> cfg.as(type), cfg -> cfg.asList(type));
+        }
+
+        @Override
+        public <T> ConfigValue<List<T>> asList(Function<Config, T> mapper) throws ConfigMappingException {
+            return ConfigValues.createList(this, cfg -> cfg.as(mapper), cfg -> cfg.asList(mapper));
+        }
+
+        @Override
+        public ConfigValue<List<Config>> asNodeList() throws ConfigMappingException {
+            return asList(Config.class);
+        }
+
+        @Override
+        public ConfigValue<Map<String, String>> asMap() throws MissingValueException {
+            return ConfigValues.createMap(this, mapper());
+        }
+
+        @Override
+        public io.helidon.common.config.Config get(io.helidon.common.config.Config.Key key) {
+            return delegate.get(key);
+        }
+    }
+
+    private static class CommonKeyWrapper implements Config.Key {
+        private final io.helidon.common.config.Config.Key delegate;
+
+        private CommonKeyWrapper(io.helidon.common.config.Config.Key key) {
+            this.delegate = key;
+        }
+
+        @Override
+        public Config.Key parent() {
+            return new CommonKeyWrapper(delegate.parent());
+        }
+
+        @Override
+        public Config.Key child(io.helidon.common.config.Config.Key key) {
+            return new CommonKeyWrapper(delegate.child(key));
+        }
+
+        @Override
+        public boolean isRoot() {
+            return delegate.isRoot();
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public int compareTo(io.helidon.common.config.Config.Key o) {
+            return delegate.compareTo(o);
+        }
+    }
+
+    static class SeConfigValue<T> implements ConfigValue<T> {
+        private final Config.Key key;
+        private final Supplier<T> valueSupplier;
+        private final Config owningConfig;
+
+        SeConfigValue(Config config, Config.Key key, Supplier<T> valueSupplier) {
+            this.owningConfig = config;
+            this.key = key;
+            this.valueSupplier = valueSupplier;
+        }
+
+        @Override
+        public Config.Key key() {
+            return key;
+        }
+
+        @Override
+        public Optional<T> asOptional() throws ConfigMappingException {
+            try {
+                return Optional.of(valueSupplier.get());
+            } catch (MissingValueException e) {
+                return Optional.empty();
+            }
+        }
+
+        @Override
+        public <N> ConfigValue<N> as(Function<? super T, ? extends N> mapper) {
+            return new SeConfigValue<>(owningConfig, key, () -> mapper.apply(valueSupplier.get()));
+        }
+
+        @Override
+        public <N> ConfigValue<N> as(Class<N> type) {
+            return owningConfig.as(type);
+        }
+
+        @Override
+        public <N> ConfigValue<N> as(GenericType<N> type) {
+            return owningConfig.as(type);
+        }
+
+        @Override
+        public Supplier<T> supplier() {
+            return valueSupplier;
+        }
+
+        @Override
+        public Supplier<T> supplier(T defaultValue) {
+            return () -> {
+                try {
+                    return valueSupplier.get();
+                } catch (MissingValueException e) {
+                    return defaultValue;
+                }
+            };
+        }
+
+        @Override
+        public Supplier<Optional<T>> optionalSupplier() {
+            return this::asOptional;
+        }
+
+        @Override
+        public int hashCode() {
+            try {
+                return Objects.hash(key, asOptional());
+            } catch (ConfigMappingException e) {
+                return Objects.hash(key);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SeConfigValue<?> that = (SeConfigValue<?>) o;
+            if (!key.equals(that.key)) {
+                return false;
+            }
+
+            Optional<?> myOptional;
+            try {
+                myOptional = asOptional();
+            } catch (ConfigMappingException e) {
+                try {
+                    that.asOptional();
+                    // same key, one failed -> different value
+                    return false;
+                } catch (ConfigMappingException configMappingException) {
+                    // same key, both failed -> same value
+                    return true;
+                }
+            }
+            try {
+                Optional<?> thatOptional = that.asOptional();
+                return myOptional.equals(thatOptional);
+            } catch (ConfigMappingException e) {
+                // same key, one failed -> different value
+                return false;
+            }
+        }
+    }
+
 }

--- a/config/config/src/main/java/io/helidon/config/ConfigProvider.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigProvider.java
@@ -20,7 +20,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;

--- a/config/config/src/main/java/io/helidon/config/ConfigValues.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.helidon.common.GenericType;
+import io.helidon.config.spi.ConfigMapper;
 
 /**
  * Factory for config values.
@@ -146,7 +147,7 @@ public final class ConfigValues {
 
     static <T> ConfigValue<T> create(Config config,
                                      Class<T> type,
-                                     ConfigMapperManager mapperManager) {
+                                     ConfigMapper mapperManager) {
 
         return new GenericConfigValueImpl<>(config,
                                             () -> Optional.ofNullable(mapperManager.map(config, type)),
@@ -155,7 +156,7 @@ public final class ConfigValues {
 
     static <T> ConfigValue<T> create(Config config,
                                      GenericType<T> genericType,
-                                     ConfigMapperManager mapperManager) {
+                                     ConfigMapper mapperManager) {
         return new GenericConfigValueImpl<>(config,
                                             () -> Optional.ofNullable(mapperManager.map(config, genericType)),
                                             aConfig -> aConfig.as(genericType));
@@ -190,7 +191,7 @@ public final class ConfigValues {
     }
 
     static ConfigValue<Map<String, String>> createMap(Config config,
-                                                             ConfigMapperManager mapperManager) {
+                                                      ConfigMapper mapperManager) {
 
         Supplier<Optional<Map<String, String>>> valueSupplier = () -> {
             Map<?, ?> map = mapperManager.map(config, Map.class);

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigProducerTest.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/ConfigProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ package io.helidon.config.tests.service.registry;
 import java.util.Optional;
 
 import io.helidon.common.config.Config;
-import io.helidon.common.config.GlobalConfig;
+import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -47,22 +48,41 @@ class ConfigProducerTest {
         // this must be first, as once we set global config, this method will always fail
     void testConfig() {
         registryManager = ServiceRegistryManager.create();
+        GlobalServiceRegistry.registry(registryManager.registry());
 
         // value should be overridden using our custom config source
-        Config config = registryManager
-                .registry()
-                .get(Config.class);
+        Config config = Services.get(Config.class);
 
         assertThat(config.get("app.value").asString().asOptional(), is(Optional.of("source")));
+
+        // make sure we can get the config from registry as io.helidon.config.Config as well
+        io.helidon.config.Config helidonConfig = Services.get(io.helidon.config.Config.class);
+        assertThat(helidonConfig.get("app.value").asString().asOptional(), is(Optional.of("source")));
     }
 
     @Test
     @Order(1)
-    void testExplicitConfig() {
-        // value should use the config as we provided it
-        GlobalConfig.config(io.helidon.config.Config::create, true);
-
+    void testEmptyGlobalConfig() {
         registryManager = ServiceRegistryManager.create();
+        GlobalServiceRegistry.registry(registryManager.registry());
+
+        // we want to use an instance of common config, that will be wrapped in the ConfigProvider
+        Services.set(Config.class, Config.empty());
+
+        Config config = registryManager
+                .registry()
+                .get(Config.class);
+
+        assertThat(config.get("app.value").asString().asOptional(), is(Optional.empty()));
+    }
+
+    @Test
+    @Order(2)
+    void testExplicitConfig() {
+        registryManager = ServiceRegistryManager.create();
+        GlobalServiceRegistry.registry(registryManager.registry());
+        // value should use the config as we provided it
+        Services.set(Config.class, io.helidon.config.Config.create());
 
         Config config = registryManager
                 .registry()

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/TestConfigSource.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/TestConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import io.helidon.config.spi.ConfigNode;
 import io.helidon.config.spi.NodeConfigSource;
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.Singleton
 @Weight(200)
 class TestConfigSource implements NodeConfigSource {
 

--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
@@ -48,7 +48,6 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
-import jakarta.enterprise.inject.spi.Extension;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.weld.AbstractCDI;
@@ -174,8 +173,11 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
 
         setProperties(new HashMap<>(properties));
 
-        // this is required for correct startup
-        addExtension(new Extension() {});
+        // at least one extension must be added for correct startup, if the two extensions are removed
+        // uncomment the next line
+        // addExtension(new Extension() {});
+        addExtension(new ExecuteOnExtension());
+        addExtension(new ServiceRegistryExtension());
 
         Deployment deployment = createDeployment(resourceLoader, bootstrap);
         // we need to configure custom proxy services to

--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/ServiceRegistryExtension.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/ServiceRegistryExtension.java
@@ -18,7 +18,6 @@ package io.helidon.microprofile.cdi;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -90,31 +89,24 @@ import static io.helidon.service.registry.Service.Named.WILDCARD_NAME;
 /**
  * {@link java.util.ServiceLoader} provider implementation of CDI extension to add service registry types as CDI beans.
  */
-/*
-How does this work:
-- we add all Helidon Service Registry qualifiers as CDI qualifiers (registerTypes)
-- we collect all synthetic and managed beans of CDI (processManagedBean, processSyntheticBean)
-- we collect all producers of CDI (processProducers)
-- we add ServiceRegistry itself as a bean (afterBeanDiscovery)
-- we add CDI beans to service registry and registry beans to CDI in crossRegisterBeans
- */
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class ServiceRegistryExtension implements Extension {
+class ServiceRegistryExtension implements Extension {
+    /*
+    - we add all Helidon Service Registry qualifiers as CDI qualifiers (registerTypes)
+    - we add ServiceRegistry itself as a bean (afterBeanDiscovery)
+    - we add CDI beans to service registry (from managed beans, producers, and synthetic beans)
+    - we add registry services to CDI
+     */
+
     private static final TypeName CDI_NAMED_TYPE = TypeName.create(Named.class);
     private static final System.Logger LOGGER = System.getLogger(ServiceRegistryExtension.class.getName());
     // higher than default - CDI beans are "more important" as we run in CDI
     private static final double WEIGHT = Weighted.DEFAULT_WEIGHT + 10;
 
-    // set of beans that are already in CDI and that should not be added by service registry
-    private final Set<UniqueBean> beansAlreadyInCdi = new HashSet<>();
     private final Set<CdiServiceId> processedBeans = new HashSet<>();
-    private final List<CdiBean> collectedCdiBeans = new ArrayList<>();
-    private final List<CdiProducer> collectedCdiProducers = new ArrayList<>();
-    // registry was not yet created, we can collect all the beans
-    private boolean registryPending = true;
 
     @SuppressWarnings("unchecked")
-    void registerTypes(@Observes BeforeBeanDiscovery bbd) {
+    void registerTypes(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER) BeforeBeanDiscovery bbd) {
         var registry = GlobalServiceRegistry.registry();
         List<ServiceInfo> allServices = registry.lookupServices(Lookup.EMPTY);
 
@@ -128,33 +120,25 @@ public class ServiceRegistryExtension implements Extension {
                     bbd.addQualifier((Class<? extends Annotation>) TypeFactory.toClass(typeName));
                 }
             }
-
-            // and service types
-            // the service types cannot be added as annotated type this way, as our tests
-            // start failing - in some cases, a CDI bean is created for a Helidon registry service and
-            // fed back to us, which ends in expected disaster; this behavior must be investigated, and then
-            // the following code can (maybe) be used
-            //   var providedType = service.providedType();
-            //   if (addedAnnotatedTypes.add(providedType)) {
-            //     var annotatedType = bm.createAnnotatedType(TypeFactory.toClass(service.serviceType()));
-            //     bbd.addAnnotatedType(annotatedType, providedType.fqName());
-            //   }
         }
     }
 
-    /*
-    We must be one of the last ones, as what we get here, we insert to registry
-     */
-    void processManagedBean(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER) ProcessManagedBean<?> pb) {
-        this.doProcessBean(pb);
+    void processManagedBean(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER) ProcessManagedBean<?> pb,
+                            BeanManager bm) {
+        this.doProcessBean(bm, pb);
     }
 
-    void processSyntheticBean(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER) ProcessSyntheticBean<?> pb) {
-        this.doProcessBean(pb);
+    void processSyntheticBean(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER) ProcessSyntheticBean<?> pb,
+                              BeanManager bm) {
+        if (pb.getSource() == this) {
+            return;
+        }
+        this.doProcessBean(bm, pb);
     }
 
-    void processProducer(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER) ProcessProducer pb) {
-        // make sure we also add produced stuff (now we only add beans themself)
+    void processProducer(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER) ProcessProducer pb,
+                         BeanManager bm) {
+        // make sure we also add produced stuff
         var member = pb.getAnnotatedMember();
         Set<Type> typeClosure = member.getTypeClosure();
         Set<Annotation> annotations = member.getAnnotations();
@@ -163,32 +147,15 @@ public class ServiceRegistryExtension implements Extension {
         TypeName beanType = TypeName.create(member.getDeclaringType().getJavaClass());
 
         for (Type type : typeClosure) {
-            this.collectedCdiProducers.add(new CdiProducer(beanType, type, annotations, qualifiers));
-
-            beansAlreadyInCdi.add(new UniqueBean(ResolvedType.create(type), qualifiers));
+            addCdiProducer(bm, new CdiProducer(beanType, type, annotations, qualifiers));
         }
     }
 
-    /*
-    We must handle all synthetic beans created as part of other extensions in after bean discovery,
-    so we must do this late
-     */
-    void crossRegisterBeans(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER + 2000) AfterBeanDiscovery abd, BeanManager bm) {
-        registryPending = false;
-
+    void registryToCdi(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER + 2000) AfterBeanDiscovery abd,
+                       BeanManager bm) {
         var registry = GlobalServiceRegistry.registry();
         List<ServiceInfo> allServices = registry.lookupServices(Lookup.EMPTY);
         Set<UniqueBean> processedTypes = new HashSet<>();
-
-        // now we can add CDI beans to service registry
-        for (CdiBean cdiBean : collectedCdiBeans) {
-            addCdiBean(bm, cdiBean);
-        }
-
-        // and all CDI producers
-        for (CdiProducer cdiProducer : collectedCdiProducers) {
-            addCdiProducer(bm, cdiProducer);
-        }
 
         for (ServiceInfo service : allServices) {
             if (service instanceof CdiBeanDescriptor || service instanceof CdiProducerDescriptor) {
@@ -253,6 +220,9 @@ public class ServiceRegistryExtension implements Extension {
                               Class<? extends Annotation> cdiScope,
                               String name,
                               Supplier<Object> instanceSupplier) {
+        if (typeClosure.isEmpty()) {
+            return;
+        }
         var configurator = addBean(abd, serviceType, beanClass, typeClosure, cdiScope, "-" + name);
         beanCreateWith(bm, annotatedType, beanClass, configurator, instanceSupplier);
         configurator.addQualifier(new NamedLiteral(name));
@@ -463,21 +433,14 @@ public class ServiceRegistryExtension implements Extension {
         return Optional.empty();
     }
 
-    private void doProcessBean(ProcessBean<?> pb) {
-        if (registryPending) {
-            Bean<?> bean = pb.getBean();
+    private void doProcessBean(BeanManager bm, ProcessBean<?> pb) {
 
-            // we need to be sure we register each bean only once
-            CdiServiceId id = new CdiServiceId(bean.getBeanClass(), bean.hashCode());
-            if (processedBeans.add(id)) {
-                Set<Qualifier> registryQualifiers = findRegistryQualifiers(bean.getQualifiers());
-                Set<Type> types = bean.getTypes();
-                for (Type type : types) {
-                    beansAlreadyInCdi.add(new UniqueBean(ResolvedType.create(type), registryQualifiers));
-                }
+        Bean<?> bean = pb.getBean();
 
-                collectedCdiBeans.add(new CdiBean(id, bean, pb.getAnnotated()));
-            }
+        // we need to be sure we register each bean only once
+        CdiServiceId id = new CdiServiceId(bean.getBeanClass(), bean.hashCode());
+        if (processedBeans.add(id)) {
+            addCdiBean(bm, new CdiBean(id, bean, pb.getAnnotated()));
         }
     }
 
@@ -578,10 +541,6 @@ public class ServiceRegistryExtension implements Extension {
                 // this contract is already advertised by a higher weighted service; CDI only supports one bean
                 continue;
             }
-            if (beansAlreadyInCdi.contains(uniqueBean)) {
-                // this is already in CDI, we cannot add it again
-                continue;
-            }
 
             if (invalidContract(contract)) {
                 // this is not a contract we can support
@@ -592,13 +551,18 @@ public class ServiceRegistryExtension implements Extension {
         }
 
         TypeName serviceProvidedType = service.providedType();
-        // we also advertise the service provided type (factories are NOT advertised)
-        usedContracts.add(ResolvedType.create(serviceProvidedType));
-            /*
-            bean class: provided type (MyService, MyContract - never MyFactory)
-            id: provided type fq name with our prefix
-            scope: "guessed" from registry scope
-             */
+        ResolvedType serviceProvidedResolved = ResolvedType.create(serviceProvidedType);
+        if (processedTypes.add(new UniqueBean(serviceProvidedResolved, service.qualifiers()))
+                && !invalidContract(serviceProvidedResolved)) {
+            // we also advertise the service provided type (factories are NOT advertised)
+            usedContracts.add(serviceProvidedResolved);
+        }
+
+        /*
+        bean class: provided type (MyService, MyContract - never MyFactory)
+        id: provided type fq name with our prefix
+        scope: "guessed" from registry scope
+         */
         Class<?> beanClass = TypeFactory.toClass(serviceProvidedType);
         // annotated type of our provided type, to support interception
         var annotatedType = abd.getAnnotatedType(beanClass, serviceProvidedType.fqName());
@@ -615,18 +579,20 @@ public class ServiceRegistryExtension implements Extension {
         var cdiScope = toCdiScope(service);
 
         if (named.isEmpty()) {
-            // unnamed
-            addBean(
-                    abd,
-                    serviceType,
-                    beanClass,
-                    typeClosure,
-                    cdiScope,
-                    "")
-                    .createWith(ctx -> {
-                        Object instance = registry.get(serviceProvidedType);
-                        return interceptInstance(bm, beanClass, annotatedType, ctx, instance);
-                    });
+            if (!typeClosure.isEmpty()) {
+                // unnamed
+                addBean(
+                        abd,
+                        serviceType,
+                        beanClass,
+                        typeClosure,
+                        cdiScope,
+                        "")
+                        .createWith(ctx -> {
+                            Object instance = registry.get(serviceProvidedType);
+                            return interceptInstance(bm, beanClass, annotatedType, ctx, instance);
+                        });
+            }
         } else {
             if (WILDCARD_NAME.equals(named.get().value().orElse(WILDCARD_NAME))) {
                 // services factory (or other factory type)

--- a/microprofile/cdi/src/main/java/module-info.java
+++ b/microprofile/cdi/src/main/java/module-info.java
@@ -71,10 +71,6 @@ module io.helidon.microprofile.cdi {
     provides org.jboss.weld.bootstrap.api.Service
             with io.helidon.microprofile.cdi.ExecutorServices;
 
-    provides jakarta.enterprise.inject.spi.Extension
-            with io.helidon.microprofile.cdi.ExecuteOnExtension,
-                    io.helidon.microprofile.cdi.ServiceRegistryExtension;
-
     opens io.helidon.microprofile.cdi to weld.core.impl;
 
 }

--- a/microprofile/config/pom.xml
+++ b/microprofile/config/pom.xml
@@ -114,8 +114,45 @@
                             <artifactId>helidon-common-features-processor</artifactId>
                             <version>${helidon.version}</version>
                         </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.common.features</groupId>
+                        <artifactId>helidon-common-features-processor</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -43,6 +43,7 @@ import io.helidon.common.NativeImageHelper;
 import io.helidon.config.ConfigException;
 import io.helidon.config.mp.MpConfig;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -64,6 +65,7 @@ import jakarta.enterprise.inject.spi.ProcessBean;
 import jakarta.enterprise.inject.spi.ProcessObserverMethod;
 import jakarta.enterprise.inject.spi.WithAnnotations;
 import jakarta.inject.Provider;
+import jakarta.interceptor.Interceptor;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.ConfigValue;
@@ -165,7 +167,7 @@ public class ConfigCdiExtension implements Extension {
      *
      * @param abd event from CDI container
      */
-    private void registerConfigProducer(@Observes AfterBeanDiscovery abd) {
+    private void registerConfigProducer(@Observes @Priority(Interceptor.Priority.PLATFORM_BEFORE) AfterBeanDiscovery abd) {
         // we also must support injection of Config itself
         abd.addBean()
                 .addTransitiveTypeClosure(org.eclipse.microprofile.config.Config.class)

--- a/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
 
 import io.helidon.common.NativeImageHelper;
 import io.helidon.config.ConfigException;
-import io.helidon.config.mp.MpConfig;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -174,19 +173,6 @@ public class ConfigCdiExtension implements Extension {
                 .beanClass(org.eclipse.microprofile.config.Config.class)
                 .scope(ApplicationScoped.class)
                 .createWith(creationalContext -> new SerializableConfig());
-
-        abd.addBean()
-                .addTransitiveTypeClosure(io.helidon.config.Config.class)
-                .beanClass(io.helidon.config.Config.class)
-                .scope(ApplicationScoped.class)
-                .createWith(creationalContext -> {
-                    Config config = ConfigProvider.getConfig();
-                    if (config instanceof io.helidon.config.Config) {
-                        return config;
-                    } else {
-                        return MpConfig.toHelidonConfig(config);
-                    }
-                });
 
         Set<Type> types = ips.stream()
                 .map(InjectionPoint::getType)

--- a/microprofile/config/src/main/java/io/helidon/microprofile/config/MpConfigFactory.java
+++ b/microprofile/config/src/main/java/io/helidon/microprofile/config/MpConfigFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.config;
+
+import java.util.function.Supplier;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.config.Config;
+import io.helidon.config.mp.MpConfig;
+import io.helidon.service.registry.Service;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+// per lookup, to make sure we provide a config wrapping the current MP config
+@Service.PerLookup
+// Higher than default, as we are in MicroProfile and we should use MP config
+@Weight(Weighted.DEFAULT_WEIGHT + 1)
+class MpConfigFactory implements Supplier<Config> {
+    MpConfigFactory() {
+    }
+
+    @Override
+    public Config get() {
+        // creates an instance that is automatically provided to CDI through the registry/CDI bridge
+        return MpConfig.toHelidonConfig(ConfigProvider.getConfig());
+    }
+}

--- a/microprofile/config/src/main/java/module-info.java
+++ b/microprofile/config/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ module io.helidon.microprofile.config {
     requires io.helidon.common;
     requires io.helidon.config.mp;
     requires io.helidon.config;
+    requires io.helidon.service.registry;
     requires jakarta.annotation;
     requires jakarta.cdi;
     requires jakarta.inject;
@@ -40,6 +41,7 @@ module io.helidon.microprofile.config {
     requires static io.helidon.common.features.api;
 
     requires transitive microprofile.config.api;
+
 
     exports io.helidon.microprofile.config;
 


### PR DESCRIPTION
Resolves #9849 

### Description

Add support for injection of io.helidon.config.Config
Reduce weight of the config factory, so it can be easily overridden 
Fix error in javadoc of GlobalConfig
Update test to validate the change
