### PR TITLE
4.x: Make sure service registry manager start works with empty binding

### DIFF
--- a/service/registry/src/main/java/io/helidon/service/registry/EmptyBinding.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/EmptyBinding.java
@@ -17,10 +17,13 @@
 package io.helidon.service.registry;
 
 /**
- * An empty binding that re-enables service discovery and configures nothing.
+ * An empty binding that configures nothing.
  * <p>
  * This is used as a base class for bindings generated during annotation processing, to be later replaced by
  * the {@code helidon-service-maven-plugin}.
+ * <p>
+ * Do not extend this class for custom binding implementations, as it will be ignored by some components,
+ * as any instance that is an instance of this class will have special handling.
  */
 public class EmptyBinding implements Binding {
     private static final System.Logger LOGGER = System.getLogger(EmptyBinding.class.getName());

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistryManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistryManager.java
@@ -156,6 +156,11 @@ public final class ServiceRegistryManager {
                 .update(binding::configure)
                 .build();
 
+        if (binding instanceof EmptyBinding) {
+            // we must make sure we start everything correctly when using empty binding
+            return start(config);
+        }
+
         ServiceRegistryManager manager = create(config);
         return boundManager(binding, config, manager);
     }
@@ -579,18 +584,9 @@ public final class ServiceRegistryManager {
         }
     }
 
-    private static class NoOpBinding implements Binding {
-        @Override
-        public String name() {
-            return "no-op";
-        }
-
-        @Override
-        public void binding(DependencyPlanBinder binder) {
-        }
-
-        @Override
-        public void configure(ServiceRegistryConfig.Builder builder) {
+    private static class NoOpBinding extends EmptyBinding {
+        protected NoOpBinding() {
+            super("no-op");
         }
     }
 }


### PR DESCRIPTION
Fix to make sure registry is correctly started even when using ServiceRegistryManager.start() with an empty binding as a parameter.

This does not require a change in examples, though you can now run the inject quickstart example from IDE.
Before this change the maven plugin has to run before the application can be started.