### PR TITLE
Accepts colon ':' as a valid character in a URI as mandated by RFC 3986

### DIFF
--- a/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ public final class UriValidator {
         }
 
         // query = *( pchar / "/" / "?" )
-        // pchar = unreserved / pct-encoded / sub-delims / "@"
+        // pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
         // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
         // pct-encoded = "%" HEXDIG HEXDIG
         // sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
@@ -167,6 +167,9 @@ public final class UriValidator {
                 continue;
             }
             if (c == '@') {
+                continue;
+            }
+            if (c == ':') {
                 continue;
             }
             if (c == '/') {

--- a/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,15 @@ class UriValidatorTest {
                          "Query contains invalid char: a=@/?%6147?, index: 10, char: 0x7b");
         validateBadQuery("a=@/?%6147\t",
                          "Query contains invalid char: a=@/?%6147?, index: 10, char: 0x09");
+    }
+
+    @Test
+    void testAllCharsInQuery() {
+        UriQuery.create("aA9-._~", true);
+        UriQuery.create("%20%AB", true);
+        UriQuery.create("!$&'()*+,;=", true);
+        UriQuery.create(":@", true);
+        UriQuery.create("/?", true);
     }
 
     @Test


### PR DESCRIPTION
### Description

Accepts colon ':' as a valid character in a URI as mandated by RFC 3986. See #9862.

### Documentation

None.
