### PR TITLE
4.x: Update all module to be compilable and testable with Java 24.

### DIFF
--- a/common/types/src/main/java/io/helidon/common/types/TypeNameSupport.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeNameSupport.java
@@ -302,13 +302,9 @@ final class TypeNameSupport {
             className = className.substring(dot + 1);
         }
 
-        if (packageElements.isEmpty()) {
-            return builder.className(typeName)
-                    .build();
-        }
-
         String packageName = String.join(".", packageElements);
         String[] types = className.split("\\.");
+
         return builder.packageName(packageName)
                 .update(it -> {
                     for (int i = 0; i < (types.length - 1); i++) {

--- a/common/types/src/test/java/io/helidon/common/types/TypeNameTest.java
+++ b/common/types/src/test/java/io/helidon/common/types/TypeNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static io.helidon.common.types.TypeName.builder;
 import static io.helidon.common.types.TypeName.create;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -489,6 +490,16 @@ class TypeNameTest {
 
         assertThat(f.wildcard(), is(true));
         assertThat(s.wildcard(), is(true));
+    }
+
+    @Test
+    void testInnerClassNoPackageWildcard() {
+        TypeName t = TypeName.create("ServiceRegistryConfig.BuilderBase<?,?>");
+
+        assertThat(t.packageName(), is(""));
+        assertThat(t.className(), is("BuilderBase"));
+        assertThat(t.enclosingNames(), hasItems("ServiceRegistryConfig"));
+        assertThat(t.typeArguments(), hasItems(TypeNames.WILDCARD, TypeNames.WILDCARD));
     }
 
     private static Stream<EqualsData> equalsAndCompareSource() {

--- a/config/encryption/pom.xml
+++ b/config/encryption/pom.xml
@@ -94,7 +94,6 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <addClasspath>true</addClasspath>
                             <mainClass>io.helidon.config.encryption.Main</mainClass>
                         </manifest>
                     </archive>

--- a/integrations/micronaut/data/pom.xml
+++ b/integrations/micronaut/data/pom.xml
@@ -140,45 +140,6 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
-                        <configuration>
-                            <compilerArgument>-proc:none</compilerArgument>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                        <configuration>
-                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                            <annotationProcessorPaths>
-                                <path>
-                                    <groupId>io.micronaut</groupId>
-                                    <artifactId>micronaut-inject-java</artifactId>
-                                    <version>${version.lib.micronaut}</version>
-                                </path>
-                                <path>
-                                    <groupId>io.micronaut</groupId>
-                                    <artifactId>micronaut-core-processor</artifactId>
-                                    <version>${version.lib.micronaut}</version>
-                                </path>
-                                <path>
-                                    <groupId>io.micronaut.validation</groupId>
-                                    <artifactId>micronaut-validation-processor</artifactId>
-                                    <version>${version.lib.micronaut.validation}</version>
-                                </path>
-                                <path>
-                                    <groupId>io.micronaut.data</groupId>
-                                    <artifactId>micronaut-data-processor</artifactId>
-                                    <version>${version.lib.micronaut.data}</version>
-                                </path>
-                                <path>
-                                    <groupId>io.helidon.integrations.micronaut</groupId>
-                                    <artifactId>helidon-integrations-micronaut-cdi-processor</artifactId>
-                                    <version>${helidon.version}</version>
-                                </path>
-                            </annotationProcessorPaths>
-                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
@@ -193,4 +154,85 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- This fails on Java 24, until we resolve the problem, just limit to 21 -->
+            <id>java-21</id>
+            <activation>
+                <jdk>21</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                                <configuration>
+                                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                                    <annotationProcessorPaths>
+                                        <path>
+                                            <groupId>io.micronaut</groupId>
+                                            <artifactId>micronaut-inject-java</artifactId>
+                                            <version>${version.lib.micronaut}</version>
+                                        </path>
+                                        <path>
+                                            <groupId>io.micronaut</groupId>
+                                            <artifactId>micronaut-core-processor</artifactId>
+                                            <version>${version.lib.micronaut}</version>
+                                        </path>
+                                        <path>
+                                            <groupId>io.micronaut.validation</groupId>
+                                            <artifactId>micronaut-validation-processor</artifactId>
+                                            <version>${version.lib.micronaut.validation}</version>
+                                        </path>
+                                        <path>
+                                            <groupId>io.micronaut.data</groupId>
+                                            <artifactId>micronaut-data-processor</artifactId>
+                                            <version>${version.lib.micronaut.data}</version>
+                                        </path>
+                                        <path>
+                                            <groupId>io.helidon.integrations.micronaut</groupId>
+                                            <artifactId>helidon-integrations-micronaut-cdi-processor</artifactId>
+                                            <version>${helidon.version}</version>
+                                        </path>
+                                    </annotationProcessorPaths>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Disable tests on Java 24, until we resolve the problem -->
+            <id>not-java-21</id>
+            <activation>
+                <jdk>!21</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integrations/micronaut/data/src/main/java/io/helidon/integrations/micronaut/cdi/data/MicronautDataCdiExtension.java
+++ b/integrations/micronaut/data/src/main/java/io/helidon/integrations/micronaut/cdi/data/MicronautDataCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,12 @@ import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
  * Currently adds support for injecting {@link java.sql.Connection}.
  */
 public class MicronautDataCdiExtension implements Extension {
+    /**
+     * Default constructor required by {@link java.util.ServiceLoader}.
+     */
+    public MicronautDataCdiExtension() {
+    }
+
     void afterBeanDiscovery(@Priority(PLATFORM_BEFORE + 10) @Observes AfterBeanDiscovery event) {
         event.addBean()
                 .addType(Connection.class)

--- a/integrations/microstream/cache/pom.xml
+++ b/integrations/microstream/cache/pom.xml
@@ -63,4 +63,31 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <!--
+            Disable tests on Java 24, until we resolve the problem
+            io.helidon.integrations.microstream.core.ConfigurationTest.createFromConfigTest  Time elapsed: 0.455 s  <<< ERROR!
+            java.lang.NoSuchMethodError: 'void sun.misc.Unsafe.ensureClassInitialized(java.lang.Class)'
+            at one.microstream.memory.sun.JdkInternals.ensureClassInitialized(JdkInternals.java:988)
+
+            Intentionally not using Java 25 or newer, as our next Java update MUST support this
+            -->
+            <id>java-24</id>
+            <activation>
+                <jdk>24</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integrations/microstream/cdi/pom.xml
+++ b/integrations/microstream/cdi/pom.xml
@@ -93,4 +93,32 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!--
+            Disable tests on Java 24, until we resolve the problem
+            io.helidon.integrations.microstream.core.ConfigurationTest.createFromConfigTest  Time elapsed: 0.455 s  <<< ERROR!
+            java.lang.NoSuchMethodError: 'void sun.misc.Unsafe.ensureClassInitialized(java.lang.Class)'
+            at one.microstream.memory.sun.JdkInternals.ensureClassInitialized(JdkInternals.java:988)
+
+            Intentionally not using Java 25 or newer, as our next Java update MUST support this
+            -->
+            <id>java-24</id>
+            <activation>
+                <jdk>24</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integrations/microstream/core/pom.xml
+++ b/integrations/microstream/core/pom.xml
@@ -91,4 +91,32 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!--
+            Disable tests on Java 24, until we resolve the problem
+            io.helidon.integrations.microstream.core.ConfigurationTest.createFromConfigTest  Time elapsed: 0.455 s  <<< ERROR!
+            java.lang.NoSuchMethodError: 'void sun.misc.Unsafe.ensureClassInitialized(java.lang.Class)'
+            at one.microstream.memory.sun.JdkInternals.ensureClassInitialized(JdkInternals.java:988)
+
+            Intentionally not using Java 25 or newer, as our next Java update MUST support this
+            -->
+            <id>java-24</id>
+            <activation>
+                <jdk>24</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestPinnedThread.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestPinnedThread.java
@@ -28,6 +28,9 @@ import jakarta.ws.rs.client.WebTarget;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.platform.testkit.engine.EngineTestKit;
 import org.junit.platform.testkit.engine.Event;
 import org.junit.platform.testkit.engine.Events;
@@ -44,6 +47,7 @@ import static org.junit.platform.testkit.engine.TestExecutionResultConditions.me
 class TestPinnedThread {
 
     @Test
+    @EnabledOnJre(JRE.JAVA_21)
     void engineTest() {
         Events events = EngineTestKit.engine("junit-jupiter")
                 .configurationParameter("TestPinnedThread", "true")
@@ -64,6 +68,25 @@ class TestPinnedThread {
                         event(displayClass(PinningTestCase.class), failedWithPinningException("pinningInResourceMethod")),
                         event(displayClass(PinningExtraThreadTestCase.class), failedWithPinningException("lambda$pinningTest$0"))
                 );
+    }
+
+    @Test
+    // disable for Java 21, which pins on synchronized, current "tip" of Java is 24, which is not pinning
+    @DisabledOnJre(JRE.JAVA_21)
+    void engineTestNewJava() {
+        Events events = EngineTestKit.engine("junit-jupiter")
+                .configurationParameter("TestPinnedThread", "true")
+                .selectors(
+                        selectClass(PinningTestCase.class),
+                        selectClass(PinningExtraThreadTestCase.class),
+                        selectClass(NoPinningTestCase.class),
+                        selectClass(NoPinningExtraThreadTestCase.class)
+                )
+                .execute()
+                .containerEvents()
+                .assertStatistics(stats -> stats
+                        .failed(0)
+                        .succeeded(5));
     }
 
     private Condition<Event> failedWithPinningException(String expectedPinningMethodName) {

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestPinnedThread.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestPinnedThread.java
@@ -43,7 +43,7 @@ public class TestPinnedThread {
     void testPinnedThread() {
         String javaVersion = System.getProperty("java.version");
         // when building on Java "tip" (currently 24), synchronized no longer pins
-        boolean expectedToPin = javaVersion.equals("21");
+        boolean expectedToPin = javaVersion.startsWith("21");
 
         TestListenerAdapter tla = new TestNGRunner()
                 .name("TestPinnedThread")

--- a/tests/integration/tls-revocation-config/src/test/java/io/helidon/examples/webserver/mtls/RevocationConfigTest.java
+++ b/tests/integration/tls-revocation-config/src/test/java/io/helidon/examples/webserver/mtls/RevocationConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import io.helidon.webserver.WebServerConfig;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -83,7 +84,7 @@ public class RevocationConfigTest {
         //Exception happens on the server, this connection just fails with HandshakeException
         UncheckedIOException exception = assertThrows(UncheckedIOException.class, this::executeRequest);
         assertThat(exception.getCause(), instanceOf(SSLHandshakeException.class));
-        assertThat(exception.getCause().getMessage(), is("Received fatal alert: certificate_unknown"));
+        assertThat(exception.getCause().getMessage(), containsString("Received fatal alert: certificate_unknown"));
     }
 
     private void executeRequest() {

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,13 +49,13 @@ import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static io.helidon.http.Method.GET;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @ServerTest
 public class HeadersServerTest {
@@ -64,6 +64,13 @@ public class HeadersServerTest {
     private static final String DATA = "Helidon!!!".repeat(10);
     private static final Header TEST_TRAILER_HEADER = HeaderValues.create("test-trailer", "trailer-value");
     private final Http2Client client;
+
+    HeadersServerTest(WebServer server) {
+        client = Http2Client.builder()
+                .baseUri("http://localhost:" + server.port())
+                .protocolConfig(Http2ClientProtocolConfig.builder().priorKnowledge(true).build())
+                .build();
+    }
 
     @SetUpServer
     static void setUpServer(WebServerConfig.Builder serverBuilder) {
@@ -143,13 +150,6 @@ public class HeadersServerTest {
         ));
     }
 
-    HeadersServerTest(WebServer server) {
-        client = Http2Client.builder()
-                .baseUri("http://localhost:" + server.port())
-                .protocolConfig(Http2ClientProtocolConfig.builder().priorKnowledge(true).build())
-                .build();
-    }
-
     @Test
     void serverOutbound(WebServer server) throws IOException, InterruptedException {
         URI base = URI.create("http://localhost:" + server.port());
@@ -203,20 +203,32 @@ public class HeadersServerTest {
     @Test
     void serverInboundTooLarge(WebServer server) throws IOException, InterruptedException {
         URI base = URI.create("http://localhost:" + server.port());
-        HttpClient client = http2Client(base);
+        try (HttpClient client = http2Client(base)) {
 
-        HttpRequest.Builder req = HttpRequest.newBuilder()
-                .timeout(TIMEOUT)
-                .GET();
+            HttpRequest.Builder req = HttpRequest.newBuilder()
+                    .timeout(TIMEOUT)
+                    .GET();
 
-        for (int i = 0; i < 5200; i++) {
-            req.setHeader("test-header-" + i, DATA + i);
+            for (int i = 0; i < 5200; i++) {
+                req.setHeader("test-header-" + i, DATA + i);
+            }
+
+            // There is no way how to access GO_AWAY status code and additional data with JDK Http client
+            try {
+                HttpResponse<String> response = client.send(req.uri(base.resolve("/cont-in")).build(),
+                                                            HttpResponse.BodyHandlers.ofString());
+
+                int status = response.statusCode();
+                // since Java 24, we get a 400 back and not an exception
+                assertThat("IOException or status 400 was expected, but go status " + response.statusCode()
+                                   + ", headers: " + response.headers()
+                                   + ", and response: " + response.body(),
+                           status,
+                           is(400));
+            } catch (IOException e) {
+                // this is expected
+            }
         }
-
-        // There is no way how to access GO_AWAY status code and additional data with JDK Http client
-        Assertions.assertThrows(IOException.class,
-                () -> client.send(req.uri(base.resolve("/cont-in")).build(),
-                        HttpResponse.BodyHandlers.ofString()));
     }
 
     @Test

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -220,7 +220,7 @@ public class HeadersServerTest {
 
                 int status = response.statusCode();
                 // since Java 24, we get a 400 back and not an exception
-                assertThat("IOException or status 400 was expected, but go status " + response.statusCode()
+                assertThat("IOException or status 400 was expected, but got status " + response.statusCode()
                                    + ", headers: " + response.headers()
                                    + ", and response: " + response.body(),
                            status,

--- a/webserver/tests/webserver/src/test/resources/cipherSuiteConfig.yaml
+++ b/webserver/tests/webserver/src/test/resources/cipherSuiteConfig.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ server:
         resource:
           resource-path: "certificate.p12"
     cipher-suite:
-      - "TLS_RSA_WITH_AES_128_GCM_SHA256"
+      - "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"
   sockets:
     - name: "invalid"
       tls:


### PR DESCRIPTION
Resolves #9860 

Updates that allow us to build and test using Java 24

Some tests are disabled in Java 24 (where we need to handle external libraries), some are updated to have a different behavior on Java 21 and 24.

A few changes were done to allow work on both versions.