### PR TITLE
4.x: Use runtime dependencies in Service Maven Plugin

### DIFF
--- a/docs/src/main/asciidoc/se/injection.adoc
+++ b/docs/src/main/asciidoc/se/injection.adoc
@@ -835,6 +835,10 @@ annotation (i.e. `start(ApplicationBinding.create())`)
 - `start(Binding, ServiceRegistryConfig)` - same as above, allows for customization of configuration,
 if used, remember to set discovery to `false` to prevent automated discovery from the classpath
 
+Application binding contains reference to all services that can be used by the application at runtime. As a result,
+when using the generated binding and JPMS (`module-info.java`), all modules that contain services (or Java ServiceLoader providers used by the registry) must be configured as `required` in the module info, otherwise
+the binding cannot be compiled.
+
 All options to start a Helidon application that uses service registry:
 // Can be commented out once the PR https://github.com/helidon-io/helidon/pull/9840 is merged
 // - A custom Main method using `ServiceRegistryManager.start(...)` methods, or `ServiceRegistryManager.create(...)` methods

--- a/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/CreateApplicationAbstractMojo.java
+++ b/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/CreateApplicationAbstractMojo.java
@@ -379,11 +379,12 @@ abstract class CreateApplicationAbstractMojo extends CodegenAbstractMojo {
     }
 
     LinkedHashSet<Path> getSourceClasspathElements() {
+        // the application biding must use runtime classpath
         MavenProject project = mavenProject();
-        LinkedHashSet<Path> result = new LinkedHashSet<>(project.getCompileArtifacts().size());
+        LinkedHashSet<Path> result = new LinkedHashSet<>();
         result.add(Paths.get(project.getBuild().getOutputDirectory()));
-        for (Object a : project.getCompileArtifacts()) {
-            result.add(((Artifact) a).getFile().toPath());
+        for (Object dependency : project.getRuntimeArtifacts()) {
+            result.add(((Artifact) dependency).getFile().toPath());
         }
         return result;
     }

--- a/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/CreateApplicationMojo.java
+++ b/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/CreateApplicationMojo.java
@@ -34,7 +34,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(name = "create-application",
       defaultPhase = LifecyclePhase.COMPILE,
       threadSafe = true,
-      requiresDependencyResolution = ResolutionScope.COMPILE)
+      requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class CreateApplicationMojo extends CreateApplicationAbstractMojo {
 
     /**

--- a/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/CreateTestApplicationMojo.java
+++ b/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/CreateTestApplicationMojo.java
@@ -35,7 +35,9 @@ import org.apache.maven.project.MavenProject;
  * A mojo wrapper to {@link BindingGenerator} for test specific types.
  * For test scope, we only generate binding, as main class would not be useful.
  */
-@Mojo(name = "test-application-create", defaultPhase = LifecyclePhase.TEST_COMPILE, threadSafe = true,
+@Mojo(name = "test-application-create",
+      defaultPhase = LifecyclePhase.TEST_COMPILE,
+      threadSafe = true,
       requiresDependencyResolution = ResolutionScope.TEST)
 @SuppressWarnings("unused")
 public class CreateTestApplicationMojo extends CreateApplicationAbstractMojo {


### PR DESCRIPTION
Resolves #9866 

The Service registry Maven plugin must use runtime dependencies when generating the ApplicationBinding, as otherwise the services from them are not "seen" by the runtime.

Example: helidon-config-yaml in runtime scope will not be used at all when using generated binding.

Updated documentation as well.