### PR TITLE
3.x: Refactoring and enabling tests io.helidon.microprofile.messaging.connector.ConnectorTest

### DIFF
--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/connector/ConnectorTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/connector/ConnectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,77 +16,64 @@
 
 package io.helidon.microprofile.messaging.connector;
 
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.helidon.microprofile.messaging.AbstractCDITest;
+import io.helidon.microprofile.messaging.MessagingCdiExtension;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.DisableDiscovery;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
 
-import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.util.AnnotationLiteral;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled
-public class ConnectorTest extends AbstractCDITest {
-
-    @Override
-    public void setUp() {
-        //starting container manually
-    }
+@HelidonTest(resetPerTest = true)
+@DisableDiscovery
+@AddExtension(MessagingCdiExtension.class)
+public class ConnectorTest {
 
     @Test
+    @AddConfig(key = "mp.messaging.incoming.iterable-channel-in.connector", value = "iterable-connector")
+    @AddBean(IterableConnector.class)
+    @AddBean(ConnectedBean.class)
     void connectorTest() throws InterruptedException {
-        cdiContainer = startCdiContainer(
-                Map.of("mp.messaging.incoming.iterable-channel-in.connector", "iterable-connector"),
-                IterableConnector.class,
-                ConnectedBean.class);
         assertThat("Not connected in time.", ConnectedBean.LATCH.await(2, TimeUnit.SECONDS));
     }
 
     @Test
+    @AddConfig(key = "mp.messaging.outgoing.to-connector-1.connector", value= "iterable-connector")
+    @AddConfig(key = "mp.messaging.outgoing.to-connector-2.connector", value = "iterable-connector")
+    @AddConfig(key = "mp.messaging.outgoing.to-connector-3.connector", value = "iterable-connector")
+    @AddConfig(key = "mp.messaging.outgoing.to-connector-4.connector", value = "iterable-connector")
+    @AddBean(IterableConnector.class)
+    @AddBean(LeakingPayloadBean.class)
     void payloadLeakTest() throws InterruptedException {
-        cdiContainer = startCdiContainer(
-                Map.of(
-                        "mp.messaging.outgoing.to-connector-1.connector", "iterable-connector",
-                        "mp.messaging.outgoing.to-connector-2.connector", "iterable-connector",
-                        "mp.messaging.outgoing.to-connector-3.connector", "iterable-connector",
-                        "mp.messaging.outgoing.to-connector-4.connector", "iterable-connector"
-                        ),
-                IterableConnector.class,
-                LeakingPayloadBean.class);
-        IterableConnector connector = (IterableConnector) cdiContainer.select(ConnectorLiteral.INSTANCE).get();
+        IterableConnector connector = (IterableConnector) CDI.current().select(ConnectorLiteral.INSTANCE).get();
         assertThat("Not connected in time.", connector.await());
     }
 
     @Test
+    @AddConfig(key = "mp.messaging.incoming.iterable-channel-in.connector", value = "iterable-connector")
+    @AddBean(IterableConnector.class)
+    @AddBean(ConnectedProcessorBean.class)
     void connectorWithProcessorTest() throws InterruptedException {
-        cdiContainer = startCdiContainer(
-                Map.of("mp.messaging.incoming.iterable-channel-in.connector", "iterable-connector"),
-                IterableConnector.class,
-                ConnectedProcessorBean.class);
         assertThat("Not connected in time.", ConnectedProcessorBean.LATCH.await(2, TimeUnit.SECONDS));
     }
 
-    @Test
-    void connectorWithProcessorOnlyTest() throws InterruptedException {
-        Map<String, String> p = Map.of(
-                "mp.messaging.incoming.iterable-channel-in.connector", "iterable-connector",
-                "mp.messaging.outgoing.iterable-channel-out.connector", "iterable-connector");
-        cdiContainer = startCdiContainer(p, IterableConnector.class, ConnectedOnlyProcessorBean.class);
-        IterableConnector connector = (IterableConnector) cdiContainer.select(ConnectorLiteral.INSTANCE).get();
-        assertThat("Not connected in time.", connector.await());
-    }
 
     @Test
-    void missingConnectorTest() {
-        assertThrows(DeploymentException.class, () ->
-                cdiContainer = startCdiContainer(
-                        Map.of("mp.messaging.incoming.iterable-channel-in.connector", "iterable-connector"),
-                        ConnectedBean.class));
+    @AddConfig(key = "mp.messaging.incoming.iterable-channel-in.connector", value = "iterable-connector")
+    @AddConfig(key = "mp.messaging.outgoing.iterable-channel-out.connector", value = "iterable-connector")
+    @AddBean(IterableConnector.class)
+    @AddBean(ConnectedOnlyProcessorBean.class)
+    void connectorWithProcessorOnlyTest() throws InterruptedException {
+        IterableConnector connector = (IterableConnector) CDI.current().select(ConnectorLiteral.INSTANCE).get();
+        assertThat("Not connected in time.", connector.await());
     }
 
     public static final class ConnectorLiteral extends AnnotationLiteral<Connector> implements Connector {


### PR DESCRIPTION
### Description
I've found test class `io.helidon.microprofile.messaging.connector.ConnectorTest`. Tests were disabled in [this PR](https://github.com/helidon-io/helidon/pull/3635) (PR is big and GitHub can't load it, that's why I can't provide direct link to file).

I think, these tests can be enabled. It was done [here for 4.x](https://github.com/helidon-io/helidon/pull/9750/files#diff-10152972f2b48e2dfc98fb30b45ff4e78b1e2d789592777d809adc310831e917). I used it like "template" for my changes.

Tests are green:
`
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.06 s - in io.helidon.microprofile.messaging.connector.ConnectorTest
` 

For 3.x there is no `@AddConfigBlock`, that's why I use `@AddConfig` many times.