### PR TITLE
4.x: Upgrade neo4j driver to 5.28.3

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -130,7 +130,7 @@
         <version.lib.mssql-jdbc>8.4.1.jre8</version.lib.mssql-jdbc>
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
-        <version.lib.neo4j>5.12.0</version.lib.neo4j>
+        <version.lib.neo4j>5.28.3</version.lib.neo4j>
         <version.lib.netty>4.1.118.Final</version.lib.netty>
         <version.lib.oci>3.57.2</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>


### PR DESCRIPTION
### Description

4.x: Upgrade neo4j driver to 5.28.3

