### PR TITLE
Upgrades version.lib.ojdbc to 23.7.0.25.01

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -138,7 +138,7 @@
             UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.
             Until this bug is fixed do not upgrade past version 21.9.0.0.
         -->
-        <version.lib.ojdbc>${version.lib.ojdbc.family}.6.0.24.10</version.lib.ojdbc>
+        <version.lib.ojdbc>${version.lib.ojdbc.family}.7.0.25.01</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
         <version.lib.okio>3.4.0</version.lib.okio>


### PR DESCRIPTION
This PR updates the `version.lib.ojdbc` property to, effectively, 23.7.0.25.01 to pick up a GraalVM native image-related fix.