### PR TITLE
4.x: Make MP test annotations ordering deterministic

### DIFF
--- a/docs/src/main/asciidoc/mp/testing/testing-common.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing-common.adoc
@@ -203,14 +203,31 @@ include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_11, indent=0]
 The ordering of the test configuration can be controlled using the mechanism defined by the
 link:{microprofile-config-spec-url}#_configsource_ordering[MicroProfile Config specification].
 
-NOTE: The configuration expressed with link:{mp-testing-javadoc-url}/AddConfig.html[`@AddConfig`] has a fixed ordinal value
-of `1000`
-
 [source,java]
 .Add a properties text block with ordinal
 ----
 include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_12, indent=0]
 ----
+
+The default ordering is the following
+
+[cols="1,3"]
+|===
+|Annotation |Ordinal
+
+|link:{mp-testing-javadoc-url}/AddConfig.html[`@AddConfig`]
+|1000
+
+|link:{mp-testing-javadoc-url}/AddConfigBlock.html[`@AddConfigBlock`]
+|900
+
+|link:{mp-testing-javadoc-url}/AddConfigSource.html[`@AddConfigSource`]
+|800
+
+|link:{mp-testing-javadoc-url}/Configuration.html[`@Configuration`]
+|700
+
+|===
 
 === Injectable Types
 

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestAddConfigBlockProperties.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestAddConfigBlockProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,24 @@
 
 package io.helidon.microprofile.tests.testing.junit5;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import jakarta.inject.Inject;
 
+import io.helidon.microprofile.testing.Configuration;
 import io.helidon.microprofile.testing.junit5.AddConfigBlock;
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 @HelidonTest
 @AddConfigBlock("""
     some.key1=some.value1
     some.key2=some.value2
-""")
+    """)
+@Configuration(configSources = "configBlock.properties")
 class TestAddConfigBlockProperties {
 
     @Inject

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestAddConfigBlockYaml.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestAddConfigBlockYaml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 package io.helidon.microprofile.tests.testing.junit5;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import jakarta.inject.Inject;
 
+import io.helidon.microprofile.testing.Configuration;
 import io.helidon.microprofile.testing.junit5.AddConfigBlock;
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @HelidonTest
 @AddConfigBlock(type = "yaml", value = """
@@ -33,7 +34,8 @@ import org.junit.jupiter.api.Test;
       key: "another1.value"
     another2:
       key: "another2.value"
-""")
+    """)
+@Configuration(configSources = "configBlock.yaml")
 class TestAddConfigBlockYaml {
 
     @Inject

--- a/microprofile/tests/testing/junit5/src/test/resources/configBlock.properties
+++ b/microprofile/tests/testing/junit5/src/test/resources/configBlock.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+some.key1=foo
+some.key2=bar

--- a/microprofile/tests/testing/junit5/src/test/resources/configBlock.yaml
+++ b/microprofile/tests/testing/junit5/src/test/resources/configBlock.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+another1:
+  key: "foo"
+another2:
+  key: "bar"

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestAddConfigBlockProperties.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestAddConfigBlockProperties.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import jakarta.inject.Inject;
 
+import io.helidon.microprofile.testing.Configuration;
 import io.helidon.microprofile.testing.testng.AddConfigBlock;
 import io.helidon.microprofile.testing.testng.HelidonTest;
 
@@ -31,7 +32,8 @@ import org.testng.annotations.Test;
 @AddConfigBlock("""
     some.key1=some.value1
     some.key2=some.value2
-""")
+    """)
+@Configuration(configSources = "configBlock.properties")
 public class TestAddConfigBlockProperties {
 
     @Inject

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestAddConfigBlockYaml.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestAddConfigBlockYaml.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import jakarta.inject.Inject;
 
+import io.helidon.microprofile.testing.Configuration;
 import io.helidon.microprofile.testing.testng.AddConfigBlock;
 import io.helidon.microprofile.testing.testng.HelidonTest;
 
@@ -33,7 +34,8 @@ import org.testng.annotations.Test;
       key: "another1.value"
     another2:
       key: "another2.value"
-""")
+    """)
+@Configuration(configSources = "configBlock.yaml")
 public class TestAddConfigBlockYaml {
 
     @Inject

--- a/microprofile/tests/testing/testng/src/test/resources/configBlock.properties
+++ b/microprofile/tests/testing/testng/src/test/resources/configBlock.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+some.key1=prod.value
+some.key2=prod.value

--- a/microprofile/tests/testing/testng/src/test/resources/configBlock.yaml
+++ b/microprofile/tests/testing/testng/src/test/resources/configBlock.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+another1:
+  key: "prod.value"
+another2:
+  key: "prod.value"


### PR DESCRIPTION
### Description

Fixes #9410

Hard code ordinal in MP testing annotations.

### Documentation

Included inside this PR.
