### PR TITLE
3.x: Clarify docs about built-in healthchecks and Graal VM (#9906)

### DIFF
--- a/docs/se/health.adoc
+++ b/docs/se/health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -208,13 +208,13 @@ common health check statuses:
 |=======
 |Built-in health check |Health check name |JavaDoc |Config properties |Default config value
 
-|deadlock detection
+|deadlock detection &dagger;
 |`deadlock`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/DeadlockHealthCheck.html[`DeadlockHealthCheck`]
 | n/a
 | n/a
 
-|available disk space
+|available disk space &dagger;
 |`diskSpace`
 | link:{health-javadoc-base-url}/io/helidon/health/checks/DiskSpaceHealthCheck.html[`DiskSpaceHealthCheck`]
 |`{built-in-health-check-config-prefix}.diskSpace.thresholdPercent` +
@@ -227,6 +227,7 @@ common health check statuses:
 |`{built-in-health-check-config-prefix}.heapMemory.thresholdPercent`
 |`98`
 |=======
+&dagger; Helidon cannot support the indicated health checks in the GraalVM native image environment, so with native image those health checks do not appear in the health output.
 
 The following code adds the default built-in health checks to your application:
 


### PR DESCRIPTION
### Description
Fixes #9906 

[This was done for 4.x](https://github.com/helidon-io/helidon/pull/9807). It's better to do the same for 3.x I suppose.