### PR TITLE
3.x: Fix deadlock health check if invoking the ThreadMXBean fails (#9910)

### DIFF
--- a/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
@@ -94,8 +94,6 @@ public class DeadlockHealthCheck implements HealthCheck {
                 LOGGER.log(Level.FINEST, "Health check observed deadlocked threads: " + Arrays.toString(deadlockedThreads));
             }
         } catch (Throwable e) {
-            // Throw HealthCheckException, not report DOWN, because we do not know that
-            // there are deadlocks which DOWN should imply; we simply cannot find out.
             throw new HealthCheckException("Error invoking ThreadMXBean to find deadlocks; cannot complete this healthcheck", e);
         }
         return builder.build();

--- a/health/health-checks/src/test/java/io/helidon/health/checks/DeadlockHealthCheckTest.java
+++ b/health/health-checks/src/test/java/io/helidon/health/checks/DeadlockHealthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.health.checks;
 
 import java.lang.management.ThreadMXBean;
 
+import io.helidon.health.HealthCheckException;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DeadlockHealthCheckTest {
     private ThreadMXBean threadBean;
@@ -57,5 +60,13 @@ class DeadlockHealthCheckTest {
         HealthCheckResponse response = check.call();
         MatcherAssert.assertThat(HealthCheckResponse.Status.UP, is(response.getStatus()));
         MatcherAssert.assertThat(response.getData().isPresent(), is(false));
+    }
+
+    @Test
+    void errorInvokingMBean() {
+        Mockito.when(threadBean.findDeadlockedThreads()).thenThrow(new RuntimeException("Simulated error invoking MBean"));
+        DeadlockHealthCheck check = new DeadlockHealthCheck(threadBean);
+        HealthCheckException exception = assertThrows(HealthCheckException.class, check::call);
+        assertEquals("Error invoking ThreadMXBean to find deadlocks; cannot complete this healthcheck", exception.getMessage());
     }
 }

--- a/health/health-checks/src/test/java/io/helidon/health/checks/DeadlockHealthCheckTest.java
+++ b/health/health-checks/src/test/java/io/helidon/health/checks/DeadlockHealthCheckTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DeadlockHealthCheckTest {
@@ -67,6 +66,6 @@ class DeadlockHealthCheckTest {
         Mockito.when(threadBean.findDeadlockedThreads()).thenThrow(new RuntimeException("Simulated error invoking MBean"));
         DeadlockHealthCheck check = new DeadlockHealthCheck(threadBean);
         HealthCheckException exception = assertThrows(HealthCheckException.class, check::call);
-        assertEquals("Error invoking ThreadMXBean to find deadlocks; cannot complete this healthcheck", exception.getMessage());
+        MatcherAssert.assertThat(exception.getMessage(), is("Error invoking ThreadMXBean to find deadlocks; cannot complete this healthcheck"));
     }
 }

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -212,6 +212,7 @@ public final class HealthSupport extends HelidonRestServiceSupport {
                 .collect(Collectors.toList());
 
         Status status = responses.stream()
+                .filter(this::internalErrorExcluded)
                 .map(HcResponse::status)
                 .filter(Status.DOWN::equals)
                 .findFirst()
@@ -255,6 +256,10 @@ public final class HealthSupport extends HelidonRestServiceSupport {
 
     private boolean notExcluded(HcResponse response) {
         return !excludedHealthChecks.contains(response.hcr.getName());
+    }
+
+    private boolean internalErrorExcluded(HcResponse response) {
+        return !response.internalError();
     }
 
     private HcResponse callHealthChecks(HealthCheck hc) {

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -212,7 +213,7 @@ public final class HealthSupport extends HelidonRestServiceSupport {
                 .collect(Collectors.toList());
 
         Status status = responses.stream()
-                .filter(this::internalErrorExcluded)
+                .filter(Predicate.not(HcResponse::internalError))
                 .map(HcResponse::status)
                 .filter(Status.DOWN::equals)
                 .findFirst()
@@ -256,10 +257,6 @@ public final class HealthSupport extends HelidonRestServiceSupport {
 
     private boolean notExcluded(HcResponse response) {
         return !excludedHealthChecks.contains(response.hcr.getName());
-    }
-
-    private boolean internalErrorExcluded(HcResponse response) {
-        return !response.internalError();
     }
 
     private HcResponse callHealthChecks(HealthCheck hc) {


### PR DESCRIPTION
### Description
Fixes #9910 

The similar logic [was done for 4.x](https://github.com/helidon-io/helidon/pull/9694). Is it better  to be consistent between 3.x and 4.x ?

Unfortunately, we can't return the status `ERROR`, because for 3.x exists only statuses `UP` and `DOWN`.  But we can throw `HealthCheckException`. I hope, that it's appropriate.  Return `UP` when app can't get `ThreadMXBean` is too optimistic.

P.S. `DiskSpaceHealthCheck` in 3.x does the similar thing:
```
try {
      this.fileStore = Files.getFileStore(builder.path);
 } catch (IOException e) {
      throw new HealthCheckException("Failed to obtain file store for path " + builder.path.toAbsolutePath(), e);
 }
```