### PR TITLE
Clarifies that FT metrics can only be enabled programmatically 

### DIFF
--- a/docs/src/main/asciidoc/se/fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/se/fault-tolerance.adoc
@@ -263,13 +263,13 @@ in Helidon when a method is decorated with multiple annotations.
 
 The Helidon Fault Tolerance module has support for some basic metrics to monitor
 certain application conditions. Metrics are disabled by default, but can be enabled
-via config by setting the property `ft.metrics.enabled=true` and by including an actual
-metrics implementation in your classpath. For more information about metrics implementations
-see xref:{rootdir}/se/metrics/metrics.adoc[Helidon Metrics].
+programmatically as described in <<_enabling_metrics_programmatically>>,
+and by including an actual metrics implementation in your classpath. For more information
+about metrics implementations see xref:{rootdir}/se/metrics/metrics.adoc[Helidon Metrics].
 
 The following tables list all the metrics created by the Fault Tolerance module.
 Note that these metrics are generated per command instance, and that each instance _must_
-be identified by a unique name --assigned either programmatically by
+be identified by a unique name &mdash;assigned either programmatically by
 the application developer or automatically by the API.
 
 [cols="1,2,3"]


### PR DESCRIPTION
### Description

Clarifies that FT metrics can only be enabled programmatically at this time, either globally on `FaultTolerance` or individually for each command. Issue #9887.
