### PR TITLE
4.x: Fix messaging documentation snippets (#9856)

### DIFF
--- a/docs/src/main/java/io/helidon/docs/mp/reactivemessaging/AqSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/reactivemessaging/AqSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class AqSnippets {
     // tag::snippet_3[]
     @Incoming("from-aq")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
-    public CompletionStage<?> consumeAq(AqMessage<String> msg) {
+    public CompletionStage<Void> consumeAq(AqMessage<String> msg) {
         // direct commit
         //msg.getDbConnection().commit();
         System.out.println("Oracle AQ says: " + msg.getPayload());

--- a/docs/src/main/java/io/helidon/docs/mp/reactivemessaging/JmsSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/reactivemessaging/JmsSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ class JmsSnippets {
         // tag::snippet_3[]
         @Incoming("from-jms")
         @Acknowledgment(Acknowledgment.Strategy.MANUAL)
-        public CompletionStage<?> consumeJms(JmsMessage<String> msg) {
+        public CompletionStage<Void> consumeJms(JmsMessage<String> msg) {
             System.out.println("JMS says: " + msg.getPayload());
             return msg.ack();
         }

--- a/docs/src/main/java/io/helidon/docs/mp/reactivemessaging/WeblogicSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/reactivemessaging/WeblogicSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class WeblogicSnippets {
         // tag::snippet_2[]
         @Incoming("from-wls")
         @Acknowledgment(Acknowledgment.Strategy.MANUAL)
-        public CompletionStage<?> consumewls(JmsMessage<String> msg) {
+        public CompletionStage<Void> consumewls(JmsMessage<String> msg) {
             System.out.println("WebLogic says: " + msg.getPayload());
             return msg.ack();
         }


### PR DESCRIPTION
### Description
Fixes #9856 

I fixed all files in this section
<img width="1728" alt="Screenshot 2025-03-18 at 22 25 51" src="https://github.com/user-attachments/assets/0a165e83-967a-4b94-98c4-703a2eceb1ed" />

If it's ok, then I'll create PR for 3.x. Is it should be backported, right?