### PR TITLE
Fix problems in tracing with headers that appear multiple times in an incoming request

### DIFF
--- a/microprofile/telemetry/pom.xml
+++ b/microprofile/telemetry/pom.xml
@@ -142,6 +142,20 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <!--
+                                Used by a test to send requests with repeating header names.
+                                -->
+                                <arg>--add-modules</arg>
+                                <arg>java.net.http</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -278,19 +278,20 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
     private void handleBaggage(ContainerRequestContext containerRequestContext, Context context) {
         List<String> baggageProperties = containerRequestContext.getHeaders().get("baggage");
         if (baggageProperties != null) {
+            var baggageBuilder = Baggage.builder();
             for (String b : baggageProperties) {
                 String[] split = b.split("=");
                 if (split.length == 2) {
                     String[] valueAndMetadata = split[1].split(";");
                     String value = valueAndMetadata.length > 0 ? valueAndMetadata[0] : "";
                     String metadata = valueAndMetadata.length > 1 ? valueAndMetadata[1] : "";
-                    Baggage.builder()
-                            .put(split[0], value, BaggageEntryMetadata.create(metadata))
-                            .build()
-                            .storeInContext(context)
-                            .makeCurrent();
+                    baggageBuilder
+                            .put(split[0], value, BaggageEntryMetadata.create(metadata));
                 }
             }
+            baggageBuilder.build()
+                    .storeInContext(context)
+                    .makeCurrent();
         }
     }
 

--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/RequestContextHeaderProvider.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/RequestContextHeaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.microprofile.telemetry;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.helidon.tracing.HeaderProvider;
@@ -35,7 +36,7 @@ record RequestContextHeaderProvider(MultivaluedMap<String, String> headers) impl
 
     @Override
     public Iterable<String> getAll(String key) {
-        return headers.get(key);
+        return headers.getOrDefault(key, List.of());
     }
 
     @Override

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/BaggageCheckingResource.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/BaggageCheckingResource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.telemetry;
+
+import java.util.StringJoiner;
+
+import io.opentelemetry.api.baggage.Baggage;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path(BaggageCheckingResource.PATH)
+public class BaggageCheckingResource {
+
+    static final String PATH = "/baggage";
+
+    @GET
+    public String extractBaggageSettings() {
+        StringJoiner joiner = new StringJoiner(",");
+        Baggage.current().forEach((key, baggageEntry) -> joiner.add(key + "=" + baggageEntry.getValue()));
+        return joiner.toString();
+    }
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestMultipleBaggageHeaders.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestMultipleBaggageHeaders.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.telemetry;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import io.helidon.microprofile.testing.AddBean;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddBean(BaggageCheckingResource.class)
+class TestMultipleBaggageHeaders {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void testMultipleBaggageHeaders() throws IOException, InterruptedException, URISyntaxException {
+        List<String> baggageSettings = List.of("k1=val1", "k2=val2");
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            URI uri = new URI(webTarget.getUri().getScheme(),
+                              webTarget.getUri().getUserInfo(),
+                              webTarget.getUri().getHost(),
+                              webTarget.getUri().getPort(),
+                              BaggageCheckingResource.PATH,
+                              null,
+                              null);
+            var requestBuilder = HttpRequest.newBuilder(uri)
+                    .GET();
+            // Set the Baggage header multiple times to trigger the error condition.
+            baggageSettings.forEach(setting -> requestBuilder.header("Baggage", setting));
+            var request = requestBuilder.build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat("Baggage-checking endpoint status", response.statusCode(), is(200));
+            assertThat("Baggage-checking endpoint response", response.body(), allOf(containsString("k1=val1"),
+                                                                                    containsString("k2=val2")));
+        }
+        //        String requestBody = new StringJoiner(System.lineSeparator())
+        //                .add("GET " + webTarget.getUri() + " HTTP/1.1")
+        //                .add("Host: localhost")
+        //                .add("Connection: close")
+        //                .add("Content-Type: application/json")
+        //                .add("Accept: text/plain")
+        //                .add("Accept-Language: en-US")
+        //                .add("Accept-Charset: utf-8")
+        //                .add("Baggage: k1=val1")
+        //                .add("Baggage: k2=val2")
+        //                .toString();
+        //         result = URI.create(webTarget.getUri().toString() + "/baggage").toURL().getContent();
+
+        //        assertThat("Response status from /baggage", response.statusCode(), is(equalTo(200)));
+        //        assertThat("Returned baggage settings",
+        //                   response.body(),
+        //                   allOf(containsString("k1=val1"),
+        //                         containsString("k2=val2")));
+    }
+
+}

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestMultipleBaggageHeaders.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestMultipleBaggageHeaders.java
@@ -65,24 +65,6 @@ class TestMultipleBaggageHeaders {
             assertThat("Baggage-checking endpoint response", response.body(), allOf(containsString("k1=val1"),
                                                                                     containsString("k2=val2")));
         }
-        //        String requestBody = new StringJoiner(System.lineSeparator())
-        //                .add("GET " + webTarget.getUri() + " HTTP/1.1")
-        //                .add("Host: localhost")
-        //                .add("Connection: close")
-        //                .add("Content-Type: application/json")
-        //                .add("Accept: text/plain")
-        //                .add("Accept-Language: en-US")
-        //                .add("Accept-Charset: utf-8")
-        //                .add("Baggage: k1=val1")
-        //                .add("Baggage: k2=val2")
-        //                .toString();
-        //         result = URI.create(webTarget.getUri().toString() + "/baggage").toURL().getContent();
-
-        //        assertThat("Response status from /baggage", response.statusCode(), is(equalTo(200)));
-        //        assertThat("Returned baggage settings",
-        //                   response.body(),
-        //                   allOf(containsString("k1=val1"),
-        //                         containsString("k2=val2")));
     }
 
 }

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracer.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetryTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.StringJoiner;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
@@ -214,7 +215,9 @@ class OpenTelemetryTracer implements Tracer {
 
         @Override
         public String get(HeaderProvider headerProvider, String s) {
-            return headerProvider.get(s).orElse(null);
+            StringJoiner joiner = new StringJoiner(",").setEmptyValue("");
+            headerProvider.getAll(s).forEach(joiner::add);
+            return joiner.toString();
         }
     }
 

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/MapHeaderProvider.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/MapHeaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ record MapHeaderProvider(Map<String, List<String>> values) implements HeaderProv
 
     @Override
     public Iterable<String> getAll(String key) {
-        return values.get(key);
+        return values.getOrDefault(key, List.of());
     }
 
     @Override


### PR DESCRIPTION
### Description
Resolves #9923 

#### Release Note
____
Helidon now correctly handles the case where incoming SE and MP requests contain the same tracing-related heading more than once. Previously the tracing context would be set up using only one of the occurrences of the header.
____

#### PR overview

Helidon uses a Jakarta REST filter to establish the current tracing context from inbound requests in MP and a Helidon filter to do the same for inbound SE requests.

Both of those failed to handle cases in which a tracing-related header itself (baggage in the original case) appears more than once in the request. Both filters would use only one of the occurrences.

The PR addresses this in the SE and the MP filters and adds tests for both.

There were other small fixes added that were revealed by the new tests.

### Documentation
Bug fix - no doc impact.