### PR TITLE
Adds support for new request processing event called beforeTrailers

### DIFF
--- a/http/http/src/main/java/io/helidon/http/ServerResponseTrailers.java
+++ b/http/http/src/main/java/io/helidon/http/ServerResponseTrailers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,5 +38,17 @@ public interface ServerResponseTrailers extends WritableHeaders<ServerResponseTr
      */
     static ServerResponseTrailers create(Headers existing) {
         return new ServerResponseTrailersImpl(WritableHeaders.create(existing));
+    }
+
+    /**
+     * Create a new instance of mutable server response trailers by wrapping
+     * existing writable trailers. Any updates to this class will also impact
+     * the underlying trailers.
+     *
+     * @param existing trailers to wrap
+     * @return new server response trailers
+     */
+    static ServerResponseTrailers wrap(WritableHeaders<?> existing) {
+        return new ServerResponseTrailersImpl(existing);
     }
 }

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/BeforeTrailersTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/BeforeTrailersTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class BeforeTrailersTest {
+    static private final AtomicBoolean CALLED = new AtomicBoolean();
+
+    private final WebClient webClient;
+
+    BeforeTrailersTest(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
+        builder.addFilter((chain, req, res) -> {
+                    if (req.path().path().equals("/trailers")) {
+                        res.header(HeaderNames.TRAILER, "helidon");
+                        res.beforeTrailers(trailers -> {
+                            trailers.add(HeaderNames.create("helidon"), "rocks");
+                            CALLED.set(true);
+                        });
+                    }
+                    chain.proceed();
+                })
+                .any((req, res) -> res.send("hello"));
+    }
+
+    @BeforeEach
+    void reset() {
+        CALLED.set(false);
+    }
+
+    @Test
+    void testNoBeforeTrailers() {
+        Http2Client http2Client = webClient.client(Http2Client.PROTOCOL);
+        try (HttpClientResponse res = http2Client.get("/noTrailers").request()) {
+            assertThat(res.status().code(), is(200));
+            assertThat(CALLED.get(), is(false));
+        }
+    }
+
+    @Test
+    void testBeforeTrailers() {
+        Http2Client http2Client = webClient.client(Http2Client.PROTOCOL);
+        try (HttpClientResponse res = http2Client.get("/trailers").request()) {
+            assertThat(res.status().code(), is(200));
+            assertThat(CALLED.get(), is(true));
+            assertThat(res.entity().as(String.class), is("hello"));     // need to read entity
+            Header trailer = res.trailers().get(HeaderNames.create("helidon"));
+            assertThat(trailer.get(), is("rocks"));
+        }
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BeforeTrailersTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BeforeTrailersTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class BeforeTrailersTest {
+    static private final AtomicBoolean CALLED = new AtomicBoolean();
+
+    private final WebClient client;
+
+    BeforeTrailersTest(WebClient client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder builder) {
+        builder.addFilter((chain, req, res) -> {
+                    if (req.path().path().equals("/trailers")) {
+                        res.header(HeaderNames.TRAILER, "helidon");
+                        res.beforeTrailers(trailers -> {
+                            trailers.add(HeaderNames.create("helidon"), "rocks");
+                            CALLED.set(true);
+                        });
+                    }
+                    chain.proceed();
+                })
+                .any((req, res) -> res.send("hello"));
+    }
+
+    @BeforeEach
+    void reset() {
+        CALLED.set(false);
+    }
+
+    @Test
+    void testNoBeforeTrailers() {
+        try (HttpClientResponse res = client.get("/noTrailers").request()) {
+            assertThat(res.status().code(), is(200));
+            assertThat(CALLED.get(), is(false));
+        }
+    }
+
+    @Test
+    void testBeforeTrailers() {
+        try (HttpClientResponse res = client.get("/trailers").request()) {
+            assertThat(res.status().code(), is(200));
+            assertThat(CALLED.get(), is(true));
+            assertThat(res.entity().as(String.class), is("hello"));     // need to read entity
+            Header trailer = res.trailers().get(HeaderNames.create("helidon"));
+            assertThat(trailer.get(), is("rocks"));
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.webserver.http;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import io.helidon.common.GenericType;
@@ -213,6 +214,17 @@ public interface ServerResponse {
      * or response doesn't contain trailer declaration headers {@code Trailer: <trailer-name>}
      */
     ServerResponseTrailers trailers();
+
+    /**
+     * Callback to update any last minute trailers before they are written to the
+     * output stream.
+     *
+     * @param beforeTrailers consumer of mutable trailers
+     * @return this instance
+     */
+    default ServerResponse beforeTrailers(Consumer<ServerResponseTrailers> beforeTrailers) {
+        return this;
+    }
 
     /**
      * Description of the result of output stream processing.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
@@ -33,6 +34,7 @@ import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpException;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.ServerResponseTrailers;
 import io.helidon.http.Status;
 import io.helidon.http.encoding.ContentEncoder;
 import io.helidon.http.encoding.ContentEncodingContext;
@@ -71,6 +73,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     private boolean reroute;
     private UriQuery rerouteQuery;
     private String reroutePath;
+    private Consumer<ServerResponseTrailers> beforeTrailers;
 
     /**
      * Create server response.
@@ -185,6 +188,16 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     @Override
     public boolean isNexted() {
         return nexted;
+    }
+
+    @Override
+    public ServerResponse beforeTrailers(Consumer<ServerResponseTrailers> beforeTrailers) {
+        this.beforeTrailers = beforeTrailers;
+        return this;
+    }
+
+    protected Consumer<ServerResponseTrailers> beforeTrailers() {
+        return beforeTrailers;
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -196,6 +196,11 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
         return this;
     }
 
+    /**
+     * Gets consumer for server response trailers if registered on this response.
+     *
+     * @return consumer if registered or {@code null} otherwise
+     */
     protected Consumer<ServerResponseTrailers> beforeTrailers() {
         return beforeTrailers;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -538,8 +538,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                                                    sendListener,
                                                                    writer,
                                                                    request,
-                                                                   !request.headers()
-                                                                           .contains(HeaderValues.CONNECTION_CLOSE),
+                                                                   !headers.contains(HeaderValues.CONNECTION_CLOSE),
                                                                    http1Config.validateResponseHeaders());
 
             routing.route(ctx, request, response);


### PR DESCRIPTION
### Description

Adds support for new event called `beforeTrailers`. The consumer registered for this event has a last-minute chance to add HTTP trailers to a response. This can be useful in filters for example. Issue #9905.

### Documentation

None