### PR TITLE
3.x Describe adding dependency for built-in health checks

### DIFF
--- a/docs/mp/guides/health.adoc
+++ b/docs/mp/guides/health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -60,6 +60,16 @@ health check statuses that are commonly used:
 
 The following example will demonstrate how to use the built-in health checks.  These examples are all executed
 from the root directory of your project (helidon-quickstart-mp).
+
+[source,xml]
+.Add a dependency to your `pom.xml` file to include the built-in health checks:
+----
+<dependency>
+    <groupId>io.helidon.health</groupId>
+    <artifactId>helidon-health-checks</artifactId>
+    <scope>runtime</scope>
+</dependency>
+----
 
 [source,bash]
 .Build the application, skipping unit tests, then run it:

--- a/docs/mp/guides/quickstart.adoc
+++ b/docs/mp/guides/quickstart.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -60,6 +60,21 @@ cd helidon-quickstart-mp
 TIP: If you want to use the generated project as a starter
 for your own application, then you can replace groupId, artifactId
 and package with values appropriate for your application.
+
+The <<Health and Metrics,Health and Metrics>> section below describes how Helidon supports
+those observability features. Helidon further provides some optional built-in health checks.
+To include them in your application add the following dependency to your project's
+`pom.xml` file:
+
+[source.xml]
+.Addition to `pom.xml` for Helidon-provided built-in health checks
+----
+<dependency>
+    <groupId>io.helidon.health</groupId>
+    <artifactId>helidon-health-checks</artifactId>
+    <scope>runtime</scope>
+</dependency>
+----
 
 [source,bash]
 .Build the Application


### PR DESCRIPTION
### Description
Resolves #9925 

The MP doc for the Quickstart app and the health doc page do not mention that, after using the archetype to create the app, users must add a dependency on the Helidon built-in health checks component to have those checks present.

Interestingly, the generated _SE_ Quickstart app already includes the required dependency.

### Documentation
The PR updates the doc.