### PR TITLE
3.x: Remove unused code from ResourceUtil

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/ResourceUtil.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ResourceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.logging.Logger;
 
 import io.helidon.config.Config;
 
@@ -39,8 +36,6 @@ import io.helidon.config.Config;
  */
 final class ResourceUtil {
     private static final int DEFAULT_PROXY_PORT = 80;
-    private static final Set<String> LOGGED_RESOURCES = new HashSet<>();
-    private static final Logger LOGGER = Logger.getLogger(ResourceUtil.class.getName());
 
     private ResourceUtil() {
     }
@@ -151,15 +146,5 @@ final class ResourceUtil {
     static Optional<Resource> fromConfigResourcePath(Config config) {
         return config.asString()
                 .map(Resource::create);
-    }
-
-    static void logPrefixed(Config config, String prefix, String type) {
-        String key = config.key().toString();
-        if (LOGGED_RESOURCES.add(key + "." + prefix)) {
-            LOGGER.warning("Configuration for resource on key '"
-                                   + key + "." + prefix + "-" + type
-                                   + "' uses old prefixed approach. Please remove the prefix and use '"
-                                   + key + "." + prefix + ".resource." + type + "'");
-        }
     }
 }


### PR DESCRIPTION
### Description
Unused code can be removed from `io.helidon.common.configurable.ResourceUtil` without breaking compatibility.