### PR TITLE
4.x: Added support for `@Service.Replacement` to allow replacing list of services

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -687,6 +687,26 @@ So if we supported `List<Supplier<Contract>>`, we would still need to resolve al
 for this purpose. If a supplier is need to break dependency cycle, use `Supplier<List<Contract>>`, and you will get instances
 resolved only once you call `get()` on the supplier.
 
+## Replacing implementations
+
+To replace an implementation for injection points that expect zero or one instance, simply create a service with a higher weight than the one existing in the system.
+
+There may be cases where we want to replace implementations where a `List` is requested.
+For such cases introducing a higher-weight service would not yield the expected result - we would get a combined list.
+For these cases, you can create a `@Service.Replacement` service (this is not a scope!).
+Default weight for services annotated with `@Service.Replacement` is `Weighted.DEFAULT_WEIGHT + 10`.
+
+The resolution of services works as follows:
+- find all service descriptors that satisfy the lookup (i.e. the contract requested)
+- order them by weight (secondary ordering via `TypeName.compare(TypeName)`)
+- use all services up to (and including) the first service that is a replacement
+
+As a result, if there is a single replacement service with the highest weight, only results from that service will be used
+(this is the expected use case for replacement).
+This can be used in tests, or in production if a replacement of a service that is always on classpath is needed.
+
+There is also an alternative to disable service discovery and list all service descriptors in `ServiceRegistryConfig`.
+
 # Glossary
 
 | Term            | Description                                                                                                                                                                                                   |

--- a/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/DescribedService.java
@@ -37,6 +37,7 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER
 import static io.helidon.service.codegen.ServiceCodegenTypes.INTERCEPT_G_WRAPPER_SUPPLIER_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_QUALIFIER;
+import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_REPLACEMENT;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_INJECTION_POINT_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIED_FACTORY;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_SERVICES_FACTORY;
@@ -65,6 +66,8 @@ class DescribedService {
     private final ServiceSuperType superType;
     // in case this service is a qualified provider, we also get the qualifier it handles
     private final TypeName qualifiedProviderQualifier;
+    // if marked as replacement
+    private final boolean isReplacement;
 
     private DescribedService(DescribedType serviceType,
                              DescribedType providedType,
@@ -73,7 +76,8 @@ class DescribedService {
                              TypeName descriptorType,
                              Set<Annotation> qualifiers,
                              FactoryType providerType,
-                             TypeName qualifiedProviderQualifier) {
+                             TypeName qualifiedProviderQualifier,
+                             boolean isReplacement) {
 
         this.serviceType = serviceType;
         this.providedType = providedType;
@@ -83,6 +87,7 @@ class DescribedService {
         this.qualifiers = Set.copyOf(qualifiers);
         this.providerType = providerType;
         this.qualifiedProviderQualifier = qualifiedProviderQualifier;
+        this.isReplacement = isReplacement;
     }
 
     static DescribedService create(RegistryCodegenContext ctx,
@@ -206,6 +211,8 @@ class DescribedService {
                                                    providedElements);
         }
 
+        boolean isReplacement = serviceInfo.hasAnnotation(SERVICE_ANNOTATION_REPLACEMENT);
+
         return new DescribedService(
                 serviceDescriptor,
                 providedDescriptor,
@@ -214,7 +221,8 @@ class DescribedService {
                 descriptorType,
                 gatherQualifiers(serviceInfo),
                 providerType,
-                qualifiedProviderQualifier
+                qualifiedProviderQualifier,
+                isReplacement
         );
     }
 
@@ -278,6 +286,10 @@ class DescribedService {
 
     TypeName qualifiedProviderQualifier() {
         return qualifiedProviderQualifier;
+    }
+
+    boolean isReplacement() {
+        return isReplacement;
     }
 
     private static TypeName createType(TypeName... types) {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
@@ -46,6 +46,11 @@ public final class ServiceCodegenTypes {
     public static final TypeName SERVICE_ANNOTATION_RUN_LEVEL =
             TypeName.create("io.helidon.service.registry.Service.RunLevel");
     /**
+     * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.Replacement}.
+     */
+    public static final TypeName SERVICE_ANNOTATION_REPLACEMENT = TypeName.create("io.helidon.service.registry.Service.Replacement");
+
+    /**
      * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.ScopeHandler}.
      */
     public static final TypeName SERVICE_SCOPE_HANDLER =

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
@@ -48,7 +48,8 @@ public final class ServiceCodegenTypes {
     /**
      * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.Replacement}.
      */
-    public static final TypeName SERVICE_ANNOTATION_REPLACEMENT = TypeName.create("io.helidon.service.registry.Service.Replacement");
+    public static final TypeName SERVICE_ANNOTATION_REPLACEMENT =
+            TypeName.create("io.helidon.service.registry.Service.Replacement");
 
     /**
      * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.ScopeHandler}.

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -498,6 +498,18 @@ public final class Service {
     }
 
     /**
+     * Replace all service contract implementations with instances provided by this service, if it has the highest weight.
+     * <p>
+     * Default weight of services annotated with this annotation is
+     * ({@link io.helidon.common.Weighted#DEFAULT_WEIGHT} + 10).
+     */
+    @Documented
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.TYPE)
+    public @interface Replacement {
+    }
+
+    /**
      * Provides an ability to create more than one service instance from a single service definition.
      * This is useful when the cardinality can only be determined at runtime.
      *

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceInfo.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceInfo.java
@@ -128,4 +128,13 @@ public interface ServiceInfo extends Weighted {
     default FactoryType factoryType() {
         return FactoryType.SERVICE;
     }
+
+    /**
+     * Is this service a replacement of other services.
+     *
+     * @return {@code true} if this should replace all services with lower order (weight + name), defaults to {@code false}
+     */
+    default boolean isReplacement() {
+        return false;
+    }
 }

--- a/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
+++ b/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
@@ -95,6 +95,7 @@ class ServiceCodegenTypesTest {
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_CONTRACT", Service.Contract.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_EXTERNAL_CONTRACTS", Service.ExternalContracts.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_DESCRIPTOR", Service.Descriptor.class);
+        checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_REPLACEMENT", Service.Replacement.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_GENERATE_BINDING", Service.GenerateBinding.class);
         checkField(toCheck, checked, fields, "SERVICE_DEPENDENCY", Dependency.class);
         checkField(toCheck, checked, fields, "SERVICE_DEPENDENCY_CONTEXT", DependencyContext.class);

--- a/service/tests/pom.xml
+++ b/service/tests/pom.xml
@@ -56,6 +56,7 @@
         <module>toolbox</module>
         <module>events</module>
         <module>maven-plugin</module>
+        <module>replacement</module>
     </modules>
 
 </project>

--- a/service/tests/replacement/pom.xml
+++ b/service/tests/replacement/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.service.tests</groupId>
+        <artifactId>helidon-service-tests-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-service-tests-replacement</artifactId>
+    <name>Helidon Service Tests Replacement</name>
+    <description>Tests for contract implementation replacement</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ContractA.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ContractA.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.service.registry.Service;
+
+@Service.Contract
+interface ContractA {
+    String message();
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ContractB.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ContractB.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.service.registry.Service;
+
+@Service.Contract
+interface ContractB {
+    String message();
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ContractC.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ContractC.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.service.registry.Service;
+
+@Service.Contract
+interface ContractC {
+    String message();
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ContractD.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ContractD.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.service.registry.Service;
+
+@Service.Contract
+interface ContractD {
+    String message();
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ReplacementAB.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ReplacementAB.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Replacement
+@Weight(Weighted.DEFAULT_WEIGHT + 10)
+class ReplacementAB implements ContractA, ContractB {
+    @Override
+    public String message() {
+        return "RAB";
+    }
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ReplacementABC.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ReplacementABC.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Replacement
+@Weight(Weighted.DEFAULT_WEIGHT + 9)
+class ReplacementABC implements ContractA, ContractB, ContractC {
+    @Override
+    public String message() {
+        return "RABC";
+    }
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ReplacementC.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ReplacementC.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Replacement
+@Weight(Weighted.DEFAULT_WEIGHT + 10)
+class ReplacementC implements ContractC {
+    @Override
+    public String message() {
+        return "RC";
+    }
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ReplacementD.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ReplacementD.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Service.Replacement // default weight for replacement is default + 10
+class ReplacementD implements ContractD {
+    @Override
+    public String message() {
+        return "RD";
+    }
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ServiceA.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ServiceA.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class ServiceA implements ContractA {
+    @Override
+    public String message() {
+        return "A";
+    }
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ServiceBC.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ServiceBC.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class ServiceBC implements ContractB, ContractC {
+    @Override
+    public String message() {
+        return "BC";
+    }
+}

--- a/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ServiceD.java
+++ b/service/tests/replacement/src/main/java/io/helidon/service/tests/replacement/ServiceD.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Weight(Weighted.DEFAULT_WEIGHT + 5)
+class ServiceD implements ContractD {
+    @Override
+    public String message() {
+        return "D";
+    }
+}

--- a/service/tests/replacement/src/main/java/module-info.java
+++ b/service/tests/replacement/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module io.helidon.service.tests.replacement {
+    requires io.helidon.service.registry;
+
+    exports io.helidon.service.tests.replacement;
+}

--- a/service/tests/replacement/src/test/java/io/helidon/service/tests/replacement/ReplacementTest.java
+++ b/service/tests/replacement/src/test/java/io/helidon/service/tests/replacement/ReplacementTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.replacement;
+
+import io.helidon.testing.junit5.Testing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Testing.Test
+public class ReplacementTest {
+    @Test
+    void testA(ContractA contract) {
+        assertThat(contract.message(), is("RAB"));
+    }
+
+    @Test
+    void testB(ContractB contract) {
+        assertThat(contract.message(), is("RAB"));
+    }
+
+    @Test
+    void testC(ContractC contract) {
+        assertThat(contract.message(), is("RC"));
+    }
+
+    @Test
+    void testD(ContractD contract) {
+        // should have higher weight as it is a replacement
+        assertThat(contract.message(), is("RD"));
+    }
+}


### PR DESCRIPTION
Resolves #9819 

Adds support for `@Service.Replacement`

To replace instance for single injection point, simply use a service with higher weight
To replace instances where a List is injected, replacement can be used. The list will contain services ordered by weight (descending) up to the first instance of a `@Replacement` service (inclusive).