### PR TITLE
4.x: Upgrade byte-buddy to 1.17.5 and asm to 9.8 for Java 25 support

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -40,7 +40,7 @@
         <version.lib.animal-sniffer>1.18</version.lib.animal-sniffer>
         <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
-        <version.lib.bytebuddy>1.15.10</version.lib.bytebuddy>
+        <version.lib.bytebuddy>1.17.5</version.lib.bytebuddy>
         <version.lib.commons-codec>1.16.0</version.lib.commons-codec>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.2.1</version.lib.cron-utils>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.arquillian>1.7.0.Final</version.lib.arquillian>
-        <version.lib.asm>9.7.1</version.lib.asm>
+        <version.lib.asm>9.8</version.lib.asm>
         <version.lib.checkstyle>10.12.5</version.lib.checkstyle>
         <version.lib.commons-io>2.14.0</version.lib.commons-io>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>


### PR DESCRIPTION
### Description

Upgrade byte-buddy to 1.17.5 and asm to 9.8 for Java 25 support

