### PR TITLE
3.x: Upgrade bytebuddy to 1.17.5 and asm to 9.8 for Java 25 support

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -42,14 +42,14 @@
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <!-- Force upgrade byte-buddy latest Java -->
-        <version.lib.byte-buddy>1.15.10</version.lib.byte-buddy>
+        <version.lib.byte-buddy>1.17.5</version.lib.byte-buddy>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.2.1</version.lib.cron-utils>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
         <version.lib.eclipselink>3.0.3</version.lib.eclipselink>
         <!-- Force upgrade to ASM 9.7.0 Once eclipselink is upgraded this can be removed -->
         <!-- Needed to support Java 23 -->
-        <version.lib.eclipselink.asm>9.7.0</version.lib.eclipselink.asm>
+        <version.lib.eclipselink.asm>9.8.0</version.lib.eclipselink.asm>
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.arquillian>1.7.0.Alpha10</version.lib.arquillian>
-        <version.lib.asm>9.7.1</version.lib.asm>
+        <version.lib.asm>9.8</version.lib.asm>
         <version.lib.checkstyle>9.1</version.lib.checkstyle>
         <version.lib.commons-io>2.11.0</version.lib.commons-io>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>


### PR DESCRIPTION
### Description

3.x: Upgrade bytebuddy to 1.17.5 and asm to 9.8 for Java 25 support


