### PR TITLE
Allow user error handling of `BadRequestException` when thrown from routing

### DIFF
--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -92,6 +92,8 @@ class MetricsFeature {
                 postRequestProcessing(prms, req, res, null, kpiContext);
             } catch (Exception e) {
                 postRequestProcessing(prms, req, res, e, kpiContext);
+                // we cannot just consume an exception and ignore error handling
+                throw e;
             }
         });
     }


### PR DESCRIPTION
Resolves #9935 

Documentation change not required, as the new behavior seems to be documented right now.