### PR TITLE
4.x: Add docs about ability to use HelidonTest in a meta-annotation (#9944)

### DIFF
--- a/docs/src/main/asciidoc/mp/testing/testing-ng.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing-ng.adoc
@@ -70,12 +70,20 @@ I.e. By default, the test instance is re-used between test methods.
 NOTE: The test instance is not re-used between CDI container, using a dedicated CDI container implies a new test instance
 
 === Using meta-annotations
-`@HelidonTest` can be used in a meta-annotation:
+Meta-annotations are supported on both test classes and test methods and can be used as a composition mechanism.
 
 [source,java]
+.Class-level meta-annotation
 ----
 include::{sourcedir}/mp/testing/TestingNgSnippets.java[tag=snippet_2, indent=0]
 ----
+
+[source,java]
+.Method-level meta-annotation
+----
+include::{sourcedir}/mp/testing/TestingNgSnippets.java[tag=snippet_3, indent=0]
+----
+1. `org.testng.annotations.Test` is not inheritable and should be placed on methods
 
 == API
 

--- a/docs/src/main/asciidoc/mp/testing/testing-ng.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing-ng.adoc
@@ -69,6 +69,14 @@ I.e. By default, the test instance is re-used between test methods.
 
 NOTE: The test instance is not re-used between CDI container, using a dedicated CDI container implies a new test instance
 
+=== Using meta-annotations
+`@HelidonTest` can be used in a meta-annotation:
+
+[source,java]
+----
+include::{sourcedir}/mp/testing/TestingNgSnippets.java[tag=snippet_2, indent=0]
+----
+
 == API
 
 include::{rootdir}/mp/testing/testing-common.adoc[tag=api]

--- a/docs/src/main/asciidoc/mp/testing/testing.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing.adoc
@@ -90,11 +90,18 @@ include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_2, indent
 ----
 
 === Using meta-annotations
-`@HelidonTest` can be used in a meta-annotation:
+Meta-annotations are supported on both test classes and test methods and can be used as a composition mechanism.
 
 [source,java]
+.Class-level meta-annotation example
 ----
 include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_4, indent=0]
+----
+
+[source,java]
+.Method-level meta-annotation example
+----
+include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_5, indent=0]
 ----
 
 == API

--- a/docs/src/main/asciidoc/mp/testing/testing.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing.adoc
@@ -89,6 +89,14 @@ NOTE: The test instance is not re-used between CDI container, using a dedicated 
 include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_2, indent=0]
 ----
 
+=== Using meta-annotations
+`@HelidonTest` can be used in a meta-annotation:
+
+[source,java]
+----
+include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_4, indent=0]
+----
+
 == API
 
 include::{rootdir}/mp/testing/testing-common.adoc[tag=api]

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
@@ -142,5 +142,28 @@ class TestingJunit5Snippets {
         class MyTest {
         }
         // end::snippet_4[]
+
+        // tag::snippet_5[]
+        @Test
+        @AddBean(FirstBean.class)
+        @AddBean(SecondBean.class)
+        @DisableDiscovery
+        @Target(ElementType.METHOD)
+        @Retention(RetentionPolicy.RUNTIME)
+        public @interface MyTestMethod {
+        }
+
+        @HelidonTest
+        class MyTest {
+
+            @MyTestMethod
+            void testOne() {
+            }
+
+            @MyTestMethod
+            void testTwo() {
+            }
+        }
+        // end::snippet_5[]
     }
 }

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
@@ -140,7 +140,6 @@ class TestingJunit5Snippets {
 
         @CustomMetaAnnotation
         class MyTest {
-
         }
         // end::snippet_4[]
     }

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
@@ -139,7 +139,7 @@ class TestingJunit5Snippets {
         }
 
         @CustomMetaAnnotation
-        class MyTest {
+        class AnnotationOnClass {
         }
         // end::snippet_4[]
 
@@ -154,7 +154,7 @@ class TestingJunit5Snippets {
         }
 
         @HelidonTest
-        class MyTest {
+        class AnnotationOnMethod {
 
             @MyTestMethod
             void testOne() {

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
@@ -16,6 +16,14 @@
 package io.helidon.docs.mp.testing;
 
 import io.helidon.microprofile.testing.junit5.HelidonTest;
+import io.helidon.microprofile.testing.AddBean;
+import io.helidon.microprofile.testing.DisableDiscovery;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -112,5 +120,28 @@ class TestingJunit5Snippets {
             }
         }
         // end::snippet_3[]
+    }
+
+    class Snippet4 {
+
+        class FirstBean {}
+
+        class SecondBean {}
+
+        // tag::snippet_4[]
+        @HelidonTest
+        @AddBean(FirstBean.class)
+        @AddBean(SecondBean.class)
+        @DisableDiscovery
+        @Target(ElementType.TYPE)
+        @Retention(RetentionPolicy.RUNTIME)
+        public @interface CustomMetaAnnotation {
+        }
+
+        @CustomMetaAnnotation
+        class MyTest {
+
+        }
+        // end::snippet_4[]
     }
 }

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingNgSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingNgSnippets.java
@@ -118,5 +118,29 @@ class TestingNgSnippets {
         class MyTest {
         }
         // end::snippet_2[]
+
+        // tag::snippet_3[]
+        @AddBean(FirstBean.class)
+        @AddBean(SecondBean.class)
+        @DisableDiscovery
+        @Target(ElementType.METHOD)
+        @Retention(RetentionPolicy.RUNTIME)
+        public @interface MyTestMethod {
+        }
+
+        @HelidonTest
+        class MyTest {
+
+            @Test // <1>
+            @MyTestMethod
+            void testOne() {
+            }
+
+            @Test // <1>
+            @MyTestMethod
+            void testTwo() {
+            }
+        }
+        // end::snippet_3[]
     }
 }

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingNgSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingNgSnippets.java
@@ -115,7 +115,7 @@ class TestingNgSnippets {
         }
 
         @CustomMetaAnnotation
-        class MyTest {
+        class AnnotationOnClass {
         }
         // end::snippet_2[]
 
@@ -129,7 +129,7 @@ class TestingNgSnippets {
         }
 
         @HelidonTest
-        class MyTest {
+        class AnnotationOnMethod {
 
             @Test // <1>
             @MyTestMethod

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingNgSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingNgSnippets.java
@@ -116,7 +116,6 @@ class TestingNgSnippets {
 
         @CustomMetaAnnotation
         class MyTest {
-
         }
         // end::snippet_2[]
     }

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingNgSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingNgSnippets.java
@@ -16,6 +16,14 @@
 package io.helidon.docs.mp.testing;
 
 import io.helidon.microprofile.testing.testng.HelidonTest;
+import io.helidon.microprofile.testing.AddBean;
+import io.helidon.microprofile.testing.DisableDiscovery;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -88,5 +96,28 @@ class TestingNgSnippets {
             }
         }
         // end::snippet_1[]
+    }
+
+    class Snippet2 {
+
+        class FirstBean {}
+
+        class SecondBean {}
+
+        // tag::snippet_2[]
+        @HelidonTest
+        @AddBean(FirstBean.class)
+        @AddBean(SecondBean.class)
+        @DisableDiscovery
+        @Target(ElementType.TYPE)
+        @Retention(RetentionPolicy.RUNTIME)
+        public @interface CustomMetaAnnotation {
+        }
+
+        @CustomMetaAnnotation
+        class MyTest {
+
+        }
+        // end::snippet_2[]
     }
 }

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestClassLevelMetaAnnotation.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestClassLevelMetaAnnotation.java
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-package io.helidon.microprofile.tests.testing.testng;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import jakarta.inject.Inject;
+package io.helidon.microprofile.tests.testing.junit5;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import io.helidon.microprofile.testing.testng.AddBean;
-import io.helidon.microprofile.testing.testng.AddConfig;
-import io.helidon.microprofile.testing.testng.AddConfigBlock;
-import io.helidon.microprofile.testing.testng.Configuration;
-import io.helidon.microprofile.testing.testng.HelidonTest;
+import jakarta.inject.Inject;
+
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.AddConfigBlock;
+import io.helidon.microprofile.testing.junit5.Configuration;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@TestMetaAnnotation.MetaAnnotation
-public class TestMetaAnnotation {
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@TestClassLevelMetaAnnotation.MetaAnnotation
+class TestClassLevelMetaAnnotation {
 
     @Inject
     MyBean bean;

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestMethodLevelMetaAnnotation.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestMethodLevelMetaAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,17 @@
 
 package io.helidon.microprofile.tests.testing.junit5;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
+import io.helidon.microprofile.testing.AddBean;
+import io.helidon.microprofile.testing.AddConfig;
+import io.helidon.microprofile.testing.AddConfigBlock;
+import io.helidon.microprofile.testing.Configuration;
 import jakarta.inject.Inject;
 
-import io.helidon.microprofile.testing.junit5.AddBean;
-import io.helidon.microprofile.testing.junit5.AddConfig;
-import io.helidon.microprofile.testing.junit5.AddConfigBlock;
-import io.helidon.microprofile.testing.junit5.Configuration;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -33,11 +35,11 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@TestMetaAnnotation.MetaAnnotation
-class TestMetaAnnotation {
+@HelidonTest
+class TestMethodLevelMetaAnnotation {
 
     @Inject
-    MyBean bean;
+    private MyBean bean;
 
     @Inject
     @ConfigProperty(name = "some.key1")
@@ -59,8 +61,8 @@ class TestMetaAnnotation {
     @ConfigProperty(name = "second-key")
     private String anotherValue;
 
-    @Test
-    void testIt() {
+    @MyTestMethod
+    void testAnnotationComposition() {
         assertThat(bean.hello(), is("hello"));
         assertThat(value1, is("some.value1"));
         assertThat(value2, is("some.value2"));
@@ -69,6 +71,10 @@ class TestMetaAnnotation {
         assertThat(anotherValue, is("test-custom-config-second-value"));
     }
 
+
+    @Test
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
     @AddBean(MyBean.class)
     @AddConfigBlock("""
             some.key1=some.value1
@@ -76,15 +82,13 @@ class TestMetaAnnotation {
         """)
     @AddConfig(key = "second-key", value = "test-custom-config-second-value")
     @Configuration(configSources = {"testConfigSources.properties", "testConfigSources.yaml"})
-    @HelidonTest
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface MetaAnnotation {
-    }
+    public @interface MyTestMethod { }
+
 
     static class MyBean {
-
-        String hello() {
+        public String hello() {
             return "hello";
         }
     }
+
 }

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestClassLevelMetaAnnotation.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestClassLevelMetaAnnotation.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testing.testng;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import jakarta.inject.Inject;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import io.helidon.microprofile.testing.testng.AddBean;
+import io.helidon.microprofile.testing.testng.AddConfig;
+import io.helidon.microprofile.testing.testng.AddConfigBlock;
+import io.helidon.microprofile.testing.testng.Configuration;
+import io.helidon.microprofile.testing.testng.HelidonTest;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+@TestClassLevelMetaAnnotation.MetaAnnotation
+public class TestClassLevelMetaAnnotation {
+
+    @Inject
+    MyBean bean;
+
+    @Inject
+    @ConfigProperty(name = "some.key1")
+    private String value1;
+
+    @Inject
+    @ConfigProperty(name = "some.key2")
+    private String value2;
+
+    @Inject
+    @ConfigProperty(name = "some.key")
+    private String someKey;
+
+    @Inject
+    @ConfigProperty(name = "another.key")
+    private String anotherKey;
+
+    @Inject
+    @ConfigProperty(name = "second-key")
+    private String anotherValue;
+
+    @Test
+    void testIt() {
+        assertThat(bean.hello(), is("hello"));
+        assertThat(value1, is("some.value1"));
+        assertThat(value2, is("some.value2"));
+        assertThat(someKey, is("some.value"));
+        assertThat(anotherKey, is("another.value"));
+        assertThat(anotherValue, is("test-custom-config-second-value"));
+    }
+
+    @AddBean(MyBean.class)
+    @AddConfigBlock("""
+            some.key1=some.value1
+            some.key2=some.value2
+        """)
+    @AddConfig(key = "second-key", value = "test-custom-config-second-value")
+    @Configuration(configSources = {"testConfigSources.properties", "testConfigSources.yaml"})
+    @HelidonTest
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MetaAnnotation {
+    }
+
+    static class MyBean {
+
+        String hello() {
+            return "hello";
+        }
+    }
+}

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestMethodLevelMetaAnnotation.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestMethodLevelMetaAnnotation.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testing.testng;
+
+import io.helidon.microprofile.testing.AddBean;
+import io.helidon.microprofile.testing.AddConfig;
+import io.helidon.microprofile.testing.AddConfigBlock;
+import io.helidon.microprofile.testing.Configuration;
+import io.helidon.microprofile.testing.testng.HelidonTest;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+public class TestMethodLevelMetaAnnotation {
+
+    @Inject
+    private MyBean bean;
+
+    @Inject
+    @ConfigProperty(name = "some.key1")
+    private String value1;
+
+    @Inject
+    @ConfigProperty(name = "some.key2")
+    private String value2;
+
+    @Inject
+    @ConfigProperty(name = "some.key")
+    private String someKey;
+
+    @Inject
+    @ConfigProperty(name = "another.key")
+    private String anotherKey;
+
+    @Inject
+    @ConfigProperty(name = "second-key")
+    private String anotherValue;
+
+    @Test // org.testng.annotations.Test is not inheritable and can't be used in meta-annotation
+    @MyTestMethod
+    void testAnnotationComposition() {
+        assertThat(bean.hello(), is("hello"));
+        assertThat(value1, is("some.value1"));
+        assertThat(value2, is("some.value2"));
+        assertThat(someKey, is("some.value"));
+        assertThat(anotherKey, is("another.value"));
+        assertThat(anotherValue, is("test-custom-config-second-value"));
+    }
+
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @AddBean(MyBean.class)
+    @AddConfigBlock("""
+            some.key1=some.value1
+            some.key2=some.value2
+        """)
+    @AddConfig(key = "second-key", value = "test-custom-config-second-value")
+    @Configuration(configSources = {"testConfigSources.properties", "testConfigSources.yaml"})
+    public @interface MyTestMethod { }
+
+
+    static class MyBean {
+        public String hello() {
+            return "hello";
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fixes #9944 

Added necessary docs. After [improving MP Testing](https://github.com/helidon-io/helidon/pull/9695#improved-meta-annotation-support) (see the section `Improved Meta Annotation Support`) the solution is even simpler than the explanation from [the original issue](https://github.com/helidon-io/helidon/issues/4918#issuecomment-2109870213).

Did I add docs in the right place? I'm not sure. Correct me if I'm wrong.

It looks like that:
<img width="812" alt="Screenshot 2025-04-07 at 19 53 22" src="https://github.com/user-attachments/assets/800f150d-d866-44ad-8e6a-90e7dee3ec0c" />

P.S. Sorry for typos. I did my best ))).
