### PR TITLE
4.x Use `Timer` base units to format `Timer#toString` and JSON output

### DIFF
--- a/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
@@ -412,7 +412,7 @@ endif::mp-flavor[]
 <1> For _units_ specify any valid name for a
 link:{jdk-javadoc-url}/java.base/java/util/concurrent/TimeUnit.html[`TimeUnit`] value (`SECONDS`, `MILLISECONDS`, etc.)
 
-Helidon formats each timer's data as follows:
+If you have configured `json-units-default`, Helidon formats each timer's data as follows:
 
 1. If code set `baseUnit` on the timer, Helidon uses those units for that timer.
 2. Otherwise, Helidon uses the default units you configured.

--- a/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-shared.adoc
@@ -172,6 +172,7 @@ Clients can request a particular output format.
 | JSON | Header `Accept: application/json`
 |====
 
+[[scope-specific-retrieval]]
 Clients can also limit the report by specifying the scope as a query parameter in the request URL:
 
 * `{metrics-endpoint}?scope=base`
@@ -267,6 +268,156 @@ ifdef::mp-flavor[`Histogram`]
 |====
 ^1^ The OpenMetrics/Prometheus output format reports a timer as a `summary` with units of `seconds`.
 
+==== JSON Format
+Unlike OpenMetrics/Prometheus output, which combines the data and the metadata in a single response,
+you use an HTTP `GET` request to retrieve metrics JSON _data_ and an `OPTIONS` request to retrieve _metadata_ in JSON
+format.
+
+Helidon groups {metrics} in the same scope together in JSON output as shown in the following example.
+
+.JSON metrics output structured by scope (partial)
+[source,json]
+----
+{
+  "application": {  <1>
+    "getTimer": {
+      "type": "timer",
+      "unit": "seconds",
+      "description": "Timer for getting the default greeting"
+    }
+  },
+  "vendor": {       <1>
+    "requests.count": {
+      "type": "counter",
+      "description": "Each request (regardless of HTTP method) will increase this counter"
+    }
+  },
+  "base": {         <1>
+    "cpu.systemLoadAverage": {
+      "type": "gauge",
+      "description": "Displays the system load average for the last minute."
+    },
+    "classloader.loadedClasses.count": {
+      "type": "gauge",
+      "description": "Displays the number of classes that are currently loaded in the Java virtual machine."
+    }
+  }
+}
+----
+<1> Note the `application`, `vendor`, and `base` sections.
+
+If an HTTP request <<scope-specific-retrieval,selects by scope>>, the output omits the extra level of structure that identifies
+the scope as shown in the following example.
+
+.JSON metrics output for the `base` scope (partial)
+[source,json]
+----
+{
+  "cpu.systemLoadAverage": {
+    "type": "gauge",
+     "description": "Displays the system load average for the last minute."
+  },
+  "classloader.loadedClasses.count": {
+    "type": "gauge",
+    "description": "Displays the number of classes that are currently loaded in the Java virtual machine."
+  }
+}
+----
+
+===== Understanding the JSON Metrics Data Format
+The Helidon JSON format expresses each {metric} as either a single value (for example, a counter) or a structure
+with multiple values (for example, a timer).
+
+.JSON output for a single-valued {metric} (for example, `Counter`)
+[source,json]
+----
+"requests.count": 5
+----
+
+.JSON output for a multi-valued {metric} (for example, `Timer`)
+[source,json]
+----
+"getTimer": {
+  "count": 3,
+  "max": 0.0030455,
+  "mean": 0.0011060836666666666,
+  "elapsedTime": 0.003318251,
+  "p0.5": 0.000151552,
+  "p0.75": 0.003141632,
+  "p0.95": 0.003141632,
+  "p0.98": 0.003141632,
+  "p0.99": 0.003141632,
+  "p0.999": 0.003141632
+}
+----
+
+By default, Helidon formats time values contained in JSON output as seconds. You can change this
+behavior <<controlling_timer_output,as described below>>.
+
+===== Understanding the JSON Metrics Metadata Format
+Access the metrics endpoint with an HTTP `OPTIONS` request and the `Accept: application/json` header to
+retrieve metadata in JSON format.
+
+.Example `Counter` metadata
+[source,json]
+----
+"requests.count": {
+  "type": "counter",
+  "description": "Each request (regardless of HTTP method) will increase this counter"
+    }
+----
+
+.Example `Timer` metadata
+[source,json]
+----
+"getTimer": {
+  "type": "timer",
+  "unit": "seconds",
+  "description": "Timer for getting the default greeting"
+}
+----
+Generally, the output for a given {metric} reflects only the metadata that the application or Helidon code explicitly
+set on that {metric}.
+
+One exception is that metadata for a timer always includes the `unit` field.
+By default, Helidon formats timer data in JSON output as seconds, regardless of any explicit `baseUnit` setting
+applied to the timers.
+But as <<controlling_timer_output,described below>> you can change this behavior which can lead to different timers being
+formatted using different units. Checking the metadata is the only way to know for sure what units Helidon used to
+express a given timer, so Helidon always includes `unit` in timer metadata.
+
+[[controlling_timer_output]]
+===== Controlling JSON Timer Output
+By default, Helidon expresses timer data as seconds.
+
+You can change this using configuration:
+ifdef::se-flavor[]
+
+.Setting default timer units for JSON in `application.yaml`
+[source,yaml,subs=+quotes]
+----
+metrics:
+  timers:
+    json-units-default: _units_ <1>
+----
+endif::se-flavor[]
+ifdef::mp-flavor[]
+
+.Setting default timer units for JSON in `META-INF/microprofile-config.properties`
+[source.properties,subs=+quotes]
+----
+metrics.timers.json-units-default=_units_ # <1>
+----
+endif::mp-flavor[]
+<1> For _units_ specify any valid name for a
+link:{jdk-javadoc-url}/java.base/java/util/concurrent/TimeUnit.html[`TimeUnit`] value (`SECONDS`, `MILLISECONDS`, etc.)
+
+Helidon formats each timer's data as follows:
+
+1. If code set `baseUnit` on the timer, Helidon uses those units for that timer.
+2. Otherwise, Helidon uses the default units you configured.
+
+To enable the JSON output behavior from Helidon 3, specify `json-units-default` as `NANOSECONDS`.
 // end::usage-retrieving[]
 
 // tag::metric-registry-api[]

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 import io.helidon.builder.api.Option;
@@ -60,6 +61,8 @@ interface MetricsConfigBlueprint {
      * Config key for KPI metrics settings.
      */
     String KEY_PERFORMANCE_INDICATORS_CONFIG_KEY = "key-performance-indicators";
+
+    TimeUnit DEFAULT_JSON_UNITS_DEFAULT = TimeUnit.SECONDS;
 
     @Prototype.FactoryMethod
     static List<Tag> createTags(Config globalTagExpression) {
@@ -249,6 +252,18 @@ interface MetricsConfigBlueprint {
     @Option.Configured
     @Option.Default(BuiltInMeterNameFormat.DEFAULT)
     BuiltInMeterNameFormat builtInMeterNameFormat();
+
+    /**
+     * Default units for timer output in JSON if not specified on a given timer.
+     * <p>
+     * If the configuration key is absent, the Helidon JSON output uses {@link java.util.concurrent.TimeUnit#SECONDS}.
+     * If the configuration key is present, Helidon formats each timer using that timer's specific units (if set) and
+     * the config value otherwise.
+     *
+     * @return default {@link java.util.concurrent.TimeUnit} to use for JSON timer output
+     */
+    @Option.Configured("timers.json-units-default")
+    Optional<TimeUnit> jsonUnitsDefault();
 
     /**
      * Reports whether the specified scope is enabled, according to any scope configuration that

--- a/metrics/providers/micrometer/pom.xml
+++ b/metrics/providers/micrometer/pom.xml
@@ -69,6 +69,11 @@
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_tracer_common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestTimer.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
@@ -66,5 +67,20 @@ class TestTimer {
         assertThat("Updated Micrometer value",
                    t.totalTime(TimeUnit.MILLISECONDS),
                    is(fromMicrometer));
+    }
+
+    @Test
+    void testUnitsInToStringMicrometer() {
+        Timer defaultedUnitTimer = meterRegistry.getOrCreate(Timer.builder("defaultedUnitTimer"));
+
+        defaultedUnitTimer.record(Duration.ofMillis(4256));
+
+        String defaultedOutput = defaultedUnitTimer.toString();
+        try {
+            assertThat("Defaulted unit timer toString", defaultedOutput, containsString("PT4.256S"));
+        } finally {
+            meterRegistry.remove(defaultedUnitTimer);
+        }
+
     }
 }

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestJsonFormatting.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestJsonFormatting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.helidon.webserver.observe.metrics;
 
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -115,6 +116,86 @@ class TestJsonFormatting {
         assertThat("Timer", app.getJsonObject("t2"), nullValue());
 
     }
+
+    @Test
+    void testTimerUnits() {
+        // Prepare metrics config with no setting for the timer JSON output default. THe output should be in seconds.
+        MetricsConfig metricsConfig = MetricsConfig.builder()
+                .scoping(ScopingConfig.builder()
+                                 .tagName(SCOPE_TAG_NAME)
+                                 .defaultValue("application"))
+                .build();
+
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry(metricsConfig);
+        SystemTagsManager.instance(metricsConfig);
+
+        Timer t = meterRegistry.getOrCreate(Timer.builder("timerWithMilliseconds")
+                                                    .baseUnit("milliseconds"));
+        t.record(Duration.ofMillis(256));
+
+        JsonFormatter formatter = JsonFormatter.builder(metricsConfig, meterRegistry)
+                .meterNameSelection(Set.of("timerWithMilliseconds"))
+                .build();
+        JsonObject jsonOutput = checkAndCast(formatter.format());
+        JsonObject metadata = checkAndCast(formatter.formatMetadata());
+
+        JsonObject app = jsonOutput.getJsonObject("application");
+        JsonObject timerJson = app.getJsonObject("timerWithMilliseconds");
+        assertThat("Timer", timerJson.getJsonNumber("elapsedTime").doubleValue(), is(0.256d));
+
+        JsonObject metaApp = metadata.getJsonObject("application");
+        JsonObject metaTimerJson = metaApp.getJsonObject("timerWithMilliseconds");
+
+        // We did not set the default JSON output units in config, so it should be seconds even though the timer was set
+        // to milliseconds.
+        assertThat("Timer units metadata", metaTimerJson.getString("unit"), is("SECONDS"));
+    }
+
+    @Test
+    void testTimerUnitsWithConfigSetting() {
+        // Prepare metrics config with no setting for the timer JSON output default. THe output should be in seconds.
+        MetricsConfig metricsConfig = MetricsConfig.builder()
+                .scoping(ScopingConfig.builder()
+                                 .tagName(SCOPE_TAG_NAME)
+                                 .defaultValue("application"))
+                .jsonUnitsDefault(TimeUnit.MILLISECONDS)
+                .build();
+
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry(metricsConfig);
+        SystemTagsManager.instance(metricsConfig);
+
+        Timer timerWithMicroSeconds = meterRegistry.getOrCreate(Timer.builder("timerWithMicroSeconds")
+                                                    .baseUnit("microseconds"));
+        timerWithMicroSeconds.record(Duration.ofMillis(3256));
+
+        Timer timerWithNoUnits = meterRegistry.getOrCreate(Timer.builder("timerWithNoUnits"));
+        timerWithNoUnits.record(Duration.ofMillis(128));
+
+        JsonFormatter formatter = JsonFormatter.builder(metricsConfig, meterRegistry)
+                .meterNameSelection(Set.of("timerWithMicroSeconds", "timerWithNoUnits"))
+                .build();
+        JsonObject jsonOutput = checkAndCast(formatter.format());
+        JsonObject metadata = checkAndCast(formatter.formatMetadata());
+
+        JsonObject app = jsonOutput.getJsonObject("application");
+        JsonObject timerWithMicroSecondsJson = app.getJsonObject("timerWithMicroSeconds");
+        JsonObject timerWithNoUnitsJson = app.getJsonObject("timerWithNoUnits");
+
+        JsonObject metadataApp = metadata.getJsonObject("application");
+        JsonObject metadataTimerWithMicroSecondsJson = metadataApp.getJsonObject("timerWithMicroSeconds");
+        JsonObject metadataTimerWithNoUnitsJson = metadataApp.getJsonObject("timerWithNoUnits");
+
+        assertThat("Timer with explicit microseconds units", timerWithMicroSecondsJson.getJsonNumber("elapsedTime").doubleValue(), is(3256000d));
+        assertThat("Timer with no explicit units", timerWithNoUnitsJson.getJsonNumber("elapsedTime").doubleValue(), is(128d));
+
+        assertThat("Timer with explicit microseconds metadata units",
+                   metadataTimerWithMicroSecondsJson.getString("unit"), is("MICROSECONDS"));
+        assertThat("Timer with no explicit units metadata units",
+                   metadataTimerWithNoUnitsJson.getString("unit"), is("MILLISECONDS"));
+
+    }
+
+
 
     private static JsonObject checkAndCast(Optional<Object> metricsOutput) {
         assertThat("Result", metricsOutput, OptionalMatcher.optionalPresent());


### PR DESCRIPTION
### Description
Resolves #9717 

## Release note
____
This change addresses two ways timer values are output:
* `MTimer#toString` continues to use `Duration` format but now shows as much precision as possible, regardless of any `baseUnit` setting on the timer.
* So users can control JSON output for timers, Helidon adds the new optional config setting `metrics.timers.json-units-default` which can have any `TimeUnit` value name.
   - If the config key is _absent_, Helidon expresses all timer values in seconds.
   - If the config key is _present_, Helidon uses the timer's explicit units setting if any was set and the config value otherwise.
   
   The default JSON output for timers in Helidon 4.x remains unchanged: JSON output for all timers is in seconds.
   
   For JSON output as in Helidon 3.x set `metrics.timers.json-units-default` to `NANOSECONDS`.
____

## Background
Helidon 4.x implements metrics using Micrometer, and although most Micrometer meters accept a `baseUnit` for storing the meter's values the `Timer` type does not. Instead, when code _retrieves_ a timer's value it specifies what Java `TimeUnit` the value should be scaled to. 

Helidon did not consistently deal with timer units.

## PR Overview

1. The `MTImer` class is the Helidon implementation of our `Timer` interface which delegates to Micrometer's `Timer`.
   * `MTimer` now stores the `baseUnit` setting if user code sets it and returns that value when asked. (It used to just use our superclass `MMeter#baseUnit` implementation which would return the `baseUnit` from the Micrometer delegate. Micrometer timers return seconds.)
   * `MTimer#toString` now retrieves the total time from the timer with as much precision as possible and (as before) formats it using `Duration`. (It used to retrieve the timer's `baseUnit` and retrieve the timer's value using that precision which was always seconds, leading to sometimes confusing output.)
   * Testing for this PR revealed an unrelated bug in the `Builder#buckets` method that is fixed.
2. The `MetricsConfigBlueprint` now has a new optional setting `metrics.timers.json-units-default`.
3. The `JsonFormatter` code now checks config for the new setting and computes the units to use for each timer accordingly (as described above).

### Documentation
Doc updates are included in the PR.