### PR TITLE
4.x Encode paths before using `UriPath` in preparing `CrossOriginConfigMatchable`

### DIFF
--- a/cors/src/main/java/io/helidon/cors/Aggregator.java
+++ b/cors/src/main/java/io/helidon/cors/Aggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 
 import io.helidon.common.config.Config;
 import io.helidon.common.config.ConfigValue;
+import io.helidon.common.uri.UriEncoding;
 import io.helidon.common.uri.UriPath;
 import io.helidon.cors.LogHelper.MatcherChecks;
 import io.helidon.http.PathMatcher;
@@ -327,7 +328,8 @@ public class Aggregator {
         }
 
         boolean matches(String path, String method) {
-            return matcher.match(UriPath.create(path)).accepted() && get().matches(method);
+            return matcher.match(UriPath.create(UriEncoding.encode(path, UriEncoding.Type.PATH))).accepted()
+                    && get().matches(method);
         }
 
         PathMatcher matcher() {

--- a/cors/src/test/java/io/helidon/cors/AggregatorTest.java
+++ b/cors/src/test/java/io/helidon/cors/AggregatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,14 @@ class AggregatorTest {
         builder.addCrossOrigin("/greet", addToMap(2, CrossOriginConfig.builder()
                 .allowMethods("GET")
                 .build()));
+        builder.addCrossOrigin("/openintegration/v10/ui/space in path",
+                               addToMap(6, CrossOriginConfig.builder()
+                                       .allowMethods("GET", "PUT")
+                                       .build()));
+        builder.addCrossOrigin("/openintegration/v1.0/ui/dotInPath",
+                               addToMap(7, CrossOriginConfig.builder()
+                                       .allowMethods("GET", "PUT")
+                                       .build()));
         builder.addPathlessCrossOrigin(addToMap(3, CrossOriginConfig.builder()
                 .allowMethods("GET", "HEAD", "OPTIONS")
                 .build()));
@@ -51,6 +59,7 @@ class AggregatorTest {
         builder.addCrossOrigin("/greet/{+}", addToMap(5, CrossOriginConfig.builder()
                 .allowMethods("POST")
                 .build()));
+
 
         aggregator = builder.build();
     }
@@ -82,6 +91,19 @@ class AggregatorTest {
     void testWildcardedPath() {
         checkNoMatch("/greet", "POST");
         checkMatch("/greet/sub", "POST", 5);
+    }
+
+    @Test
+    void testSpecialCharacters() {
+        /*
+        The first two checks should match the entries added for those two specific paths (IDs 6 and 7 respectively).
+        The second two checks make sure that wildcarded matches--the "pathless" entry ID 3--work with paths containing
+        dots or spaces.
+         */
+        checkMatch("/openintegration/v10/ui/space in path", "GET", 6);
+        checkMatch("/openintegration/v1.0/ui/dotInPath", "GET", 7);
+        checkMatch("/openintegration/v20/ui/space in path", "GET", 3);
+        checkMatch("/openintegration/v2.0/ui/dot and space in path", "GET", 3);
     }
 
     private static CrossOriginConfig addToMap(int ID, CrossOriginConfig coc) {

--- a/cors/src/test/java/io/helidon/cors/AggregatorTest.java
+++ b/cors/src/test/java/io/helidon/cors/AggregatorTest.java
@@ -50,6 +50,11 @@ class AggregatorTest {
                                addToMap(7, CrossOriginConfig.builder()
                                        .allowMethods("GET", "PUT")
                                        .build()));
+        builder.addCrossOrigin("/openintegration/{+}",
+                               addToMap(8, CrossOriginConfig.builder()
+                                       .allowMethods("GET", "PUT")
+                                       .build()));
+
         builder.addPathlessCrossOrigin(addToMap(3, CrossOriginConfig.builder()
                 .allowMethods("GET", "HEAD", "OPTIONS")
                 .build()));
@@ -97,13 +102,12 @@ class AggregatorTest {
     void testSpecialCharacters() {
         /*
         The first two checks should match the entries added for those two specific paths (IDs 6 and 7 respectively).
-        The second two checks make sure that wildcarded matches--the "pathless" entry ID 3--work with paths containing
-        dots or spaces.
+        The second two checks make sure that wildcarded matches work with paths containing dots or spaces.
          */
         checkMatch("/openintegration/v10/ui/space in path", "GET", 6);
         checkMatch("/openintegration/v1.0/ui/dotInPath", "GET", 7);
-        checkMatch("/openintegration/v20/ui/space in path", "GET", 3);
-        checkMatch("/openintegration/v2.0/ui/dot and space in path", "GET", 3);
+        checkMatch("/openintegration/v20/ui/space in path", "GET", 8);
+        checkMatch("/openintegration/v2.0/ui/dot and space in path", "GET", 8);
     }
 
     private static CrossOriginConfig addToMap(int ID, CrossOriginConfig coc) {


### PR DESCRIPTION
### Description
Resolves #9936 

## Release Note
____
Helidon uses paths matching expressions to match incoming requests with CORS configuration. Previously the CORS logic would not encode the incoming request's path before using Helidon's `UriPath` type, and the presence in a path of special characters which are improper in URIs would trigger exceptions.

Helidon now encodes the path before attempting to match it.
____

The PR also enhances an existing test to verify that paths with improper characters work, both against exact matches and against wildcard expressions.

### Documentation
No doc impact. 