### PR TITLE
4.x: Restore existing configuration on test container close

### DIFF
--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestConfig.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestConfig.java
@@ -88,4 +88,13 @@ class HelidonTestConfig extends HelidonTestConfigDelegate {
             delegate = syntheticConfig;
         }
     }
+
+    /**
+     * Restore the original config.
+     */
+    void restore() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ConfigProviderResolver resolver = ConfigProviderResolver.instance();
+        resolver.registerConfig(originalConfig, cl);
+    }
 }

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestExtension.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestExtension.java
@@ -426,7 +426,11 @@ public abstract class HelidonTestExtension implements Extension {
                            @Destroyed(ApplicationScoped.class)
                            Object ignored) {
 
-        afterStop.forEach(m -> invoke(Void.class, m, null));
+        try {
+            afterStop.forEach(m -> invoke(Void.class, m, null));
+        } finally {
+            testConfig.restore();
+        }
     }
 
     private void processAnnotated(Annotated elt, Set<Class<? extends Annotation>> types, Consumer<Annotation> action) {

--- a/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/ClassContext.java
+++ b/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/ClassContext.java
@@ -34,6 +34,7 @@ import io.helidon.microprofile.testing.HelidonTestInfo;
 import io.helidon.microprofile.testing.HelidonTestInfo.ClassInfo;
 import io.helidon.microprofile.testing.HelidonTestInfo.MethodInfo;
 
+import org.testng.IClass;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 
@@ -62,7 +63,7 @@ class ClassContext {
     ClassContext(ITestClass tc, Semaphore semaphore, HelidonTestNgListenerBase listener) {
         this.listener = listener;
         this.semaphore = semaphore;
-        this.classInfo = classInfo(tc.getRealClass());
+        this.classInfo = classInfo(realClass(tc));
         this.methods = methodInfos(classInfo,
                 tc.getTestMethods(),
                 tc.getBeforeTestMethods(),
@@ -219,5 +220,12 @@ class ClassContext {
 
     private static Method realMethod(ITestNGMethod tm) {
         return tm.getConstructorOrMethod().getMethod();
+    }
+
+    private static Class<?> realClass(IClass tc) {
+        if (tc instanceof ClassDecorator(ITestClass delegate)) {
+            return delegate.getRealClass();
+        }
+        return tc.getRealClass();
     }
 }

--- a/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListener.java
+++ b/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListener.java
@@ -176,9 +176,7 @@ public class HelidonTestNgListener extends HelidonTestNgListenerBase implements 
     @Override
     public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
         LOGGER.log(Level.DEBUG, () -> "intercept - methods: " + methods.stream()
-                .map(m -> m.getMethod().getConstructorOrMethod().getMethod())
-                .map(m -> m.getDeclaringClass().getName() + "#" + m.getName())
-                .collect(joining(",")));
+                .map(this::name).collect(joining(",")));
 
         // group the methods that share the same container
         List<IMethodInstance> shared = new ArrayList<>();
@@ -199,9 +197,7 @@ public class HelidonTestNgListener extends HelidonTestNgListenerBase implements 
             result.sort(Comparator.comparingInt(e -> e.getMethod().getPriority()));
 
             LOGGER.log(Level.DEBUG, () -> "intercept - sorted methods: " + result.stream()
-                    .map(m -> m.getMethod().getConstructorOrMethod().getMethod())
-                    .map(m -> m.getDeclaringClass().getName() + "#" + m.getName())
-                    .collect(joining(",")));
+                    .map(this::name).collect(joining(",")));
 
             return result;
         }
@@ -308,5 +304,10 @@ public class HelidonTestNgListener extends HelidonTestNgListenerBase implements 
                 () -> ServiceRegistryManager.create().registry());
 
         return context;
+    }
+
+    private String name(IMethodInstance mi) {
+        ITestNGMethod tm = mi.getMethod();
+        return tm.getTestClass().getName() + "#" + tm.getMethodName();
     }
 }

--- a/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListenerBase.java
+++ b/microprofile/testing/testng/src/main/java/io/helidon/microprofile/testing/testng/HelidonTestNgListenerBase.java
@@ -24,6 +24,7 @@ import io.helidon.microprofile.testing.HelidonTestInfo;
 import io.helidon.microprofile.testing.HelidonTestInfo.ClassInfo;
 import io.helidon.microprofile.testing.HelidonTestInfo.MethodInfo;
 
+import org.testng.IClass;
 import org.testng.IClassListener;
 import org.testng.IConfigurationListener;
 import org.testng.IInvokedMethod;
@@ -130,15 +131,14 @@ abstract class HelidonTestNgListenerBase implements IInvokedMethodListener,
 
     @Override
     public void onBeforeClass(ITestClass tc) {
-        Class<?> cls = tc.getRealClass();
-        if (filterClass(cls)) {
+        if (filterClass(realClass(tc))) {
             classContext(tc).beforeClass();
         }
     }
 
     @Override
     public void onAfterClass(ITestClass tc) {
-        if (filterClass(tc.getRealClass())) {
+        if (filterClass(realClass(tc))) {
             classContext(tc).afterClass();
         }
     }
@@ -149,6 +149,13 @@ abstract class HelidonTestNgListenerBase implements IInvokedMethodListener,
     }
 
     private static Class<?> realClass(ITestResult tr) {
-        return tr.getTestClass().getRealClass();
+        return realClass(tr.getTestClass());
+    }
+
+    private static Class<?> realClass(IClass tc) {
+        if (tc instanceof ClassDecorator(ITestClass delegate)) {
+            return delegate.getRealClass();
+        }
+        return tc.getRealClass();
     }
 }

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestConfigRestore.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestConfigRestore.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testing.junit5;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.List;
+
+import io.helidon.microprofile.testing.AddConfigBlock;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+@SuppressWarnings("ALL")
+class TestConfigRestore {
+
+    @Test
+    void testConfigRestore() {
+        Events events = EngineTestKit.engine("junit-jupiter")
+                .configurationParameter("TestConfigRestore", "true")
+                .selectors(
+                        selectClass(TestCase1.class),
+                        selectClass(TestCase2.class),
+                        selectClass(TestCase3.class))
+                .execute()
+                .allEvents();
+
+        List<Throwable> errors = events.stream()
+                .flatMap(e -> e.getPayload(TestExecutionResult.class).stream())
+                .flatMap(r -> r.getThrowable().stream())
+                .toList();
+
+        if (!errors.isEmpty()) {
+            throw new MultiException(errors);
+        }
+    }
+
+    @EnabledIfParameter(key = "TestConfigRestore", value = "true")
+    static class TestCase1 {
+
+        @Test
+        void testExisting() {
+            Config config = ConfigProvider.getConfig();
+            assertThat(config.getValue("foo", String.class), is("systemProperty"));
+        }
+    }
+
+    @EnabledIfParameter(key = "TestConfigRestore", value = "true")
+    @HelidonTest
+    @AddConfigBlock(value = """
+        foo=configBlock
+        config_ordinal=1000
+        """)
+    static class TestCase2 {
+
+        @Inject
+        @ConfigProperty(name = "foo")
+        String value;
+
+        @Test
+        void testSynthetic() {
+            assertThat(value, is("configBlock"));
+        }
+    }
+
+    @EnabledIfParameter(key = "TestConfigRestore", value = "true")
+    static class TestCase3 {
+
+        @Test
+        void testExisting() {
+            Config config = ConfigProvider.getConfig();
+            assertThat(config.getValue("foo", String.class), is("systemProperty"));
+        }
+    }
+
+    static class MultiException extends AssertionError {
+        final List<Throwable> throwables;
+
+        MultiException(List<Throwable> ths) {
+            super(ths.getFirst().getMessage(), ths.getFirst());
+            throwables = ths;
+        }
+
+        @Override
+        public String getMessage() {
+            StringBuffer sb = new StringBuffer(String.format(
+                    "A MultiException has %d exceptions. They are:%n",
+                    throwables.size()));
+            int i = 1;
+            for (Throwable th : throwables) {
+                String msg = th.getMessage() != null ? ": " + th.getMessage() : "";
+                sb.append(String.format(
+                        "%d.%s.%s%n",
+                        i++, th.getClass().getName(), msg));
+            }
+            return sb.toString();
+        }
+
+        @Override
+        public void printStackTrace(PrintStream s) {
+            if (throwables.size() <= 0) {
+                super.printStackTrace(s);
+            } else {
+                int i = 1;
+                for (Throwable th : throwables) {
+                    s.println(String.format(
+                            "MultiException stack %d of %d",
+                            i++, throwables.size()));
+                    th.printStackTrace(s);
+                }
+            }
+        }
+
+        @Override
+        public void printStackTrace(PrintWriter s) {
+            if (throwables.size() <= 0) {
+                super.printStackTrace(s);
+            } else {
+                int i = 1;
+                for (Throwable th : throwables) {
+                    s.println(String.format(
+                            "MultiException stack %d of %d",
+                            i++, throwables.size()));
+                    th.printStackTrace(s);
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return getMessage();
+        }
+    }
+}

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestConfigRestore.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestConfigRestore.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testing.testng;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.List;
+
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("ALL")
+public class TestConfigRestore {
+
+    @Test(priority = Integer.MAX_VALUE)
+    void testConfigRestore() {
+        TestListenerAdapter tla = new TestNGRunner()
+                .name("TestConfigRestore")
+                .parameter("TestConfigRestore", "true")
+                .testClasses(
+                        TestConfigRestoreCase1.class,
+                        TestConfigRestoreCase2.class,
+                        TestConfigRestoreCase3.class)
+                .printErrors(false)
+                .run();
+
+        List<Throwable> errors = tla.getFailedTests().stream()
+                .map(ITestResult::getThrowable)
+                .toList();
+
+        if (!errors.isEmpty()) {
+            throw new MultiException(errors);
+        }
+
+        assertThat(tla.getPassedTests().size(), is(3));
+    }
+
+    static class MultiException extends AssertionError {
+        final List<Throwable> throwables;
+
+        MultiException(List<Throwable> ths) {
+            super(ths.getFirst().getMessage(), ths.getFirst());
+            throwables = ths;
+        }
+
+        @Override
+        public String getMessage() {
+            StringBuffer sb = new StringBuffer(String.format(
+                    "A MultiException has %d exceptions. They are:%n",
+                    throwables.size()));
+            int i = 1;
+            for (Throwable th : throwables) {
+                String msg = th.getMessage() != null ? ": " + th.getMessage() : "";
+                sb.append(String.format(
+                        "%d.%s.%s%n",
+                        i++, th.getClass().getName(), msg));
+            }
+            return sb.toString();
+        }
+
+        @Override
+        public void printStackTrace(PrintStream s) {
+            if (throwables.size() <= 0) {
+                super.printStackTrace(s);
+            } else {
+                int i = 1;
+                for (Throwable th : throwables) {
+                    s.println(String.format(
+                            "MultiException stack %d of %d",
+                            i++, throwables.size()));
+                    th.printStackTrace(s);
+                }
+            }
+        }
+
+        @Override
+        public void printStackTrace(PrintWriter s) {
+            if (throwables.size() <= 0) {
+                super.printStackTrace(s);
+            } else {
+                int i = 1;
+                for (Throwable th : throwables) {
+                    s.println(String.format(
+                            "MultiException stack %d of %d",
+                            i++, throwables.size()));
+                    th.printStackTrace(s);
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return getMessage();
+        }
+    }
+}

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestConfigRestoreCase1.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestConfigRestoreCase1.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testing.testng;
+
+import io.helidon.microprofile.testing.Configuration;
+import io.helidon.microprofile.testing.testng.HelidonTest;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@Configuration(useExisting = true)
+@EnabledIfParameter(key = "TestConfigRestore", value = "true")
+public class TestConfigRestoreCase1 {
+
+    @Test
+    void testExisting() {
+        Config config = ConfigProvider.getConfig();
+        assertThat(config.getValue("foo", String.class), is("systemProperty"));
+    }
+}

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestConfigRestoreCase2.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestConfigRestoreCase2.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testing.testng;
+
+import io.helidon.microprofile.testing.AddConfigBlock;
+import io.helidon.microprofile.testing.testng.HelidonTest;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@EnabledIfParameter(key = "TestConfigRestore", value = "true")
+@HelidonTest
+@AddConfigBlock(value = """
+        foo=configBlock
+        config_ordinal=1000
+        """)
+public class TestConfigRestoreCase2 {
+
+    @Inject
+    @ConfigProperty(name = "foo")
+    String value;
+
+    @Test
+    void testSynthetic() {
+        assertThat(value, is("configBlock"));
+    }
+}

--- a/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestConfigRestoreCase3.java
+++ b/microprofile/tests/testing/testng/src/test/java/io/helidon/microprofile/tests/testing/testng/TestConfigRestoreCase3.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testing.testng;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@EnabledIfParameter(key = "TestConfigRestore", value = "true")
+public class TestConfigRestoreCase3 {
+
+    @Test
+    void testExisting() {
+        Config config = ConfigProvider.getConfig();
+        assertThat(config.getValue("foo", String.class), is("systemProperty"));
+    }
+}


### PR DESCRIPTION
### Description

Restore existing configuration on test container close

- Add HelidonTestConfig.restore() to restore the original config (pre CDI container start)
- Call HelidonTestConfig.restore() as part of the CDI container shutdown.
- Update testng integration to aggressively hide the instrumented class in test results.

Fixes #9987

### Documentation

None.
