### PR TITLE
4.x: Update DB Column to support null values correctly.

### DIFF
--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbColumn.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,16 @@ import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.mapper.MapperException;
-import io.helidon.common.mapper.Value;
+import io.helidon.common.mapper.OptionalValue;
 
 /**
  * Column data and metadata.
+ * <p>
+ * Column may represent a {@code null} value. Get methods on this class would throw an exception if the
+ * value is null, use {@link #asOptional()}, or one of the mapping methods that support optional values, such as
+ * {@link #ifPresent(java.util.function.Consumer)} to consume such columns.
  */
-public interface DbColumn extends Value<Object> {
+public interface DbColumn extends OptionalValue<Object> {
 
     /**
      * Typed value of this column.
@@ -55,6 +59,12 @@ public interface DbColumn extends Value<Object> {
 
     /**
      * Untyped value of this column, returns java type as provided by the underlying database driver.
+     * <p>
+     * WARNING: for backward compatibility, this method MAY return {@code null} if the underlying column value is null.
+     * As this is not aligned with Helidon APIs, which forbid returns of {@code null}, this will change in future versions.
+     * If you need support for {@code nullable} columns, use the optional-like methods on this type, such as
+     * {@link #isEmpty()}, {@link #isPresent()}, {@link #ifPresent(java.util.function.Consumer)} etc. to handle
+     * {code null} values.
      *
      * @return value of this column
      */

--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbColumnBase.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbColumnBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import io.helidon.common.GenericType;
 import io.helidon.common.mapper.MapperException;
 import io.helidon.common.mapper.MapperManager;
-import io.helidon.common.mapper.Value;
+import io.helidon.common.mapper.OptionalValue;
 
 /**
  * Base {@link DbColumn} implementation.
@@ -80,47 +80,57 @@ public abstract class DbColumnBase implements DbColumn {
     }
 
     @Override
-    public <N> Value<N> as(Class<N> type) throws MapperException {
-        return Value.create(mapperManager, name(), get(type), "dbclient", "column");
+    public <N> OptionalValue<N> as(Class<N> type) throws MapperException {
+        if (value == null) {
+            return OptionalValue.create(mapperManager, name(), type, "dbclient", "column");
+        }
+        return OptionalValue.create(mapperManager, name(), get(type), "dbclient", "column");
     }
 
     @Override
-    public <N> Value<N> as(GenericType<N> type) throws MapperException {
-        return Value.create(mapperManager, name(), get(type), "dbclient", "column");
+    public <N> OptionalValue<N> as(GenericType<N> type) throws MapperException {
+        if (value == null) {
+            return OptionalValue.create(mapperManager, name(), type, "dbclient", "column");
+        }
+        return OptionalValue.create(mapperManager, name(), get(type), "dbclient", "column");
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public <N> Value<N> as(Function<? super Object, ? extends N> mapper) {
-        return Value.create(mapperManager, name(), mapper.apply(value), "dbclient", "column");
+    public <N> OptionalValue<N> as(Function<? super Object, ? extends N> mapper) {
+        if (value == null) {
+            return OptionalValue.create(mapperManager, name(), (Class<N>) javaType(), "dbclient", "column");
+        }
+        return OptionalValue.create(mapperManager, name(), mapper.apply(value), "dbclient", "column");
     }
 
     @Override
     public Optional<Object> asOptional() throws MapperException {
-        return Optional.of(value);
+        return Optional.ofNullable(value);
     }
 
     @Override
-    public Value<Boolean> asBoolean() {
+    public OptionalValue<Boolean> asBoolean() {
         return as(Boolean.class);
     }
 
     @Override
-    public Value<String> asString() {
+    public OptionalValue<String> asString() {
         return as(String.class);
     }
 
     @Override
-    public Value<Integer> asInt() {
+    public OptionalValue<Integer> asInt() {
         return as(Integer.class);
     }
 
     @Override
-    public Value<Long> asLong() {
+    public OptionalValue<Long> asLong() {
         return as(Long.class);
     }
 
     @Override
-    public Value<Double> asDouble() {
+    public OptionalValue<Double> asDouble() {
         return as(Double.class);
     }
 

--- a/dbclient/jdbc/src/test/java/io/helidon/dbclient/jdbc/JdbcColumnTest.java
+++ b/dbclient/jdbc/src/test/java/io/helidon/dbclient/jdbc/JdbcColumnTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.dbclient.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+import java.util.Optional;
+
+import io.helidon.common.mapper.MapperManager;
+import io.helidon.common.mapper.Value;
+import io.helidon.dbclient.DbColumn;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JdbcColumnTest {
+    @Test
+    void testNullColumn() throws Exception {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getObject(1))
+                .thenReturn(null);
+        ResultSetMetaData rsmd = mock(ResultSetMetaData.class);
+        when(rsmd.getColumnLabel(1))
+                .thenReturn("testColumn");
+        when(rsmd.getColumnType(1))
+                .thenReturn(Types.VARCHAR);
+        when(rsmd.getColumnClassName(1))
+                .thenReturn(String.class.getName());
+
+        JdbcColumn.MetaData metaData = JdbcColumn.MetaData.create(rsmd, 1);
+        DbColumn col = JdbcColumn.create(rs, metaData, MapperManager.global(), 1);
+
+        assertThat(col.asOptional(), is(Optional.empty()));
+        assertThat(col.as(String.class).asOptional(), is(Optional.empty()));
+        Value<String> value = col.asString();
+        assertThat(value.asOptional(), is(Optional.empty()));
+    }
+
+    @Test
+    void testValueColumn() throws Exception {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getObject(1))
+                .thenReturn("value");
+        ResultSetMetaData rsmd = mock(ResultSetMetaData.class);
+        when(rsmd.getColumnLabel(1))
+                .thenReturn("testColumn");
+        when(rsmd.getColumnType(1))
+                .thenReturn(Types.VARCHAR);
+        when(rsmd.getColumnClassName(1))
+                .thenReturn(String.class.getName());
+
+        JdbcColumn.MetaData metaData = JdbcColumn.MetaData.create(rsmd, 1);
+        DbColumn col = JdbcColumn.create(rs, metaData, MapperManager.global(), 1);
+
+        assertThat(col.asOptional(), is(Optional.of("value")));
+        assertThat(col.get(), is("value"));
+        assertThat(col.as(String.class).get(), is("value"));
+        Value<String> value = col.asString();
+        assertThat(value.asOptional(), is(Optional.of("value")));
+    }
+}


### PR DESCRIPTION
Resolves #9942 

### Description
DbColumn now uses `OptionalValue` instead of `Value`.
As the former extends the latter, the API should be backward compatible. Just fixed to correctly return `empty` values when the underlying `value` is null.

Added test to JDBC to validate this work.s