### PR TITLE
4.x Tolerate if `PostRequestMetricsSupport` is missing from request context

### DIFF
--- a/tests/integration/mp-metrics-gh-9995/pom.xml
+++ b/tests/integration/mp-metrics-gh-9995/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025 Oracle and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+        <relativePath>../../../applications/mp/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.tests.integration</groupId>
+    <artifactId>helidon-tests-integration-mp-metrics-gh-9995</artifactId>
+    <name>Helidon Tests Integration MP Metrics GH 9995</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.testing</groupId>
+            <artifactId>helidon-microprofile-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+    </build>
+</project>

--- a/tests/integration/mp-metrics-gh-9995/src/main/java/io/helidon/tests/integration/mp/metrics/gh9995/GreetResource.java
+++ b/tests/integration/mp-metrics-gh-9995/src/main/java/io/helidon/tests/integration/mp/metrics/gh9995/GreetResource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.metrics.gh9995;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/greet")
+public class GreetResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String greet() {
+        return "Hello World!";
+    }
+}

--- a/tests/integration/mp-metrics-gh-9995/src/main/java/io/helidon/tests/integration/mp/metrics/gh9995/PrivateApplication.java
+++ b/tests/integration/mp-metrics-gh-9995/src/main/java/io/helidon/tests/integration/mp/metrics/gh9995/PrivateApplication.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.metrics.gh9995;
+
+import io.helidon.microprofile.server.RoutingName;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.Application;
+
+import java.util.Set;
+
+/**
+ * Application to expose private resource.
+ */
+@ApplicationScoped
+@RoutingName("private")
+public class PrivateApplication extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(PrivateResource.class);
+    }
+}

--- a/tests/integration/mp-metrics-gh-9995/src/main/java/io/helidon/tests/integration/mp/metrics/gh9995/PrivateResource.java
+++ b/tests/integration/mp-metrics-gh-9995/src/main/java/io/helidon/tests/integration/mp/metrics/gh9995/PrivateResource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.metrics.gh9995;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Simple resource.
+ */
+@RequestScoped
+@Path("/private")
+public class PrivateResource {
+
+    /**
+     * Return a private worldly greeting message.
+     *
+     * @return {@link String}
+     */
+    @Path("/hello")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String helloWorld() {
+        return "Private Hello World!!";
+    }
+}

--- a/tests/integration/mp-metrics-gh-9995/src/main/java/io/helidon/tests/integration/mp/metrics/gh9995/PublicApplication.java
+++ b/tests/integration/mp-metrics-gh-9995/src/main/java/io/helidon/tests/integration/mp/metrics/gh9995/PublicApplication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.metrics.gh9995;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.Application;
+
+import java.util.Set;
+
+/**
+ * Application to expose public resource.
+ */
+@ApplicationScoped
+public class PublicApplication extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(GreetResource.class);
+    }
+}

--- a/tests/integration/mp-metrics-gh-9995/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-metrics-gh-9995/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/mp-metrics-gh-9995/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/mp-metrics-gh-9995/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Microprofile server properties
+server.port=8080
+server.host=0.0.0.0
+server.sockets.0.port=8081
+server.sockets.0.name=private
+server.sockets.0.bind-address=0.0.0.0
+server.sockets.1.name=admin
+server.sockets.1.port=8082
+server.sockets.1.bind-address=0.0.0.0
+
+server.features.observe.sockets=admin
+
+metrics.rest-request.enabled=true

--- a/tests/integration/mp-metrics-gh-9995/src/test/java/io/helidon/tests/integration/mp/metrics/gh9995/TestMultiPortWithSeRestRequestEnabled.java
+++ b/tests/integration/mp-metrics-gh-9995/src/test/java/io/helidon/tests/integration/mp/metrics/gh9995/TestMultiPortWithSeRestRequestEnabled.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.mp.metrics.gh9995;
+
+import io.helidon.microprofile.server.ServerCdiExtension;
+import io.helidon.microprofile.testing.junit5.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@HelidonTest
+@AddConfig(key = "server.sockets.0.port", value = "0")      // Force ports to be dynamically allocated
+@AddConfig(key = "server.sockets.1.port", value = "0")
+class TestMultiPortWithSeRestRequestEnabled {
+
+    // For non-public endpoints (admin).
+    private static Client client;
+
+    // For public endpoint(s).
+    private final WebTarget publicWebTarget;
+    private final ServerCdiExtension serverCdiExtension;
+
+    @BeforeAll
+    static void beforeAll() {
+        client = ClientBuilder.newClient();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        client.close();
+    }
+
+    @Inject
+    TestMultiPortWithSeRestRequestEnabled(WebTarget webTarget, ServerCdiExtension serverCdiExtension) {
+        this.publicWebTarget = webTarget;
+        this.serverCdiExtension = serverCdiExtension;
+    }
+
+    @Test
+    void testPublicEndpoint() {
+        Response response = publicWebTarget.path("/greet").request(MediaType.TEXT_PLAIN).get();
+
+        // Without the fix, accessing this resource fails in the server.
+        assertThat("Greet response status", response.getStatus(), equalTo(200));
+
+    }
+
+    @Test
+    void testSeFilteredMpRequest() {
+        int privatePort = serverCdiExtension.port("private");
+        WebTarget privateTarget = client.target("http://localhost:" + privatePort);
+        Response response = privateTarget.path("/private/hello").request(MediaType.TEXT_PLAIN).get();
+        assertThat("Private response status", response.getStatus(), equalTo(200));
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -71,6 +71,7 @@
         <module>mp-telemetry</module>
         <module>mp-jaxrs-preserve-headers</module>
         <module>crac</module>
+        <module>mp-metrics-gh-9995</module>
     </modules>
 
     <dependencyManagement>

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/PostRequestMetricsSupport.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/PostRequestMetricsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,11 +42,9 @@ public interface PostRequestMetricsSupport {
      * @param task the work to perform
      */
     static void recordPostProcessingWork(ServerRequest request, BiConsumer<ServerResponse, Throwable> task) {
-        PostRequestMetricsSupport prms = request.context()
+        request.context()
                 .get(PostRequestMetricsSupport.class)
-                .orElseThrow();
-
-        prms.registerPostRequestWork(task);
+                .ifPresent(prms -> prms.registerPostRequestWork(task));
     }
 
     /**

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/PostRequestMetricsSupport.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/PostRequestMetricsSupport.java
@@ -44,7 +44,8 @@ public interface PostRequestMetricsSupport {
     static void recordPostProcessingWork(ServerRequest request, BiConsumer<ServerResponse, Throwable> task) {
         request.context()
                 .get(PostRequestMetricsSupport.class)
-                .ifPresent(prms -> prms.registerPostRequestWork(task));
+                .ifPresentOrElse(prms -> prms.registerPostRequestWork(task),
+                                 PostRequestMetricsSupportImpl::logMessageAboutMissingKpiDataStructure);
     }
 
     /**

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/PostRequestMetricsSupportImpl.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/PostRequestMetricsSupportImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,25 @@ import io.helidon.webserver.http.ServerResponse;
 
 class PostRequestMetricsSupportImpl implements PostRequestMetricsSupport {
 
+    private static final System.Logger LOGGER = System.getLogger(PostRequestMetricsSupportImpl.class.getName());
+
+    private static boolean loggedMessageAboutMissingKpiDataStructure = false;
+
     static PostRequestMetricsSupportImpl create() {
         return new PostRequestMetricsSupportImpl();
+    }
+
+    // @Deprecated - We should be able to remote this and its call once we update how KPI metrics are handled on multiple sockets.
+    @Deprecated(forRemoval = true, since = "4.2.1")
+    static void logMessageAboutMissingKpiDataStructure() {
+        if (!loggedMessageAboutMissingKpiDataStructure) {
+            loggedMessageAboutMissingKpiDataStructure = true;
+            LOGGER.log(System.Logger.Level.WARNING,
+                       """
+                               An expected metrics data structure is missing from the request context;
+                               an MP application might have set metrics.rest-request.enabled=true instead of assigning the proper
+                               key mp.metrics.rest-request.enabled=true. This message will not be repeated.""");
+        }
     }
 
     private final List<BiConsumer<ServerResponse, Throwable>> tasks = new ArrayList<>();

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/PostRequestMetricsSupportImpl.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/PostRequestMetricsSupportImpl.java
@@ -32,8 +32,6 @@ class PostRequestMetricsSupportImpl implements PostRequestMetricsSupport {
         return new PostRequestMetricsSupportImpl();
     }
 
-    // @Deprecated - We should be able to remote this and its call once we update how KPI metrics are handled on multiple sockets.
-    @Deprecated(forRemoval = true, since = "4.2.1")
     static void logMessageAboutMissingKpiDataStructure() {
         if (!loggedMessageAboutMissingKpiDataStructure) {
             loggedMessageAboutMissingKpiDataStructure = true;


### PR DESCRIPTION
### Description
Resolves #9995 

## Release Note
____
Helidon MP apps now log a one-time warning instead of failing during request processing if multiple ports are configured and the SE setting `rest-request.enabled=true` is present.
____

## Background for reviewers
To support KPI metrics  on REST endpoints, Helidon MP adds a synthetic annotation to each REST endpoint and binds an interceptor (`InterceptorSyntheticRestRequest`) to that annotation. The interceptor (using `PostRequestMetricsSupport`) updates any KPI metrics measured on requests by fetching a metrics data structure from the request context to update.

That metrics data structure is placed into the request context by an SE-style filter.

If an MP app sets the SE-style setting `metrics.rest-request.enabled=true`--as opposed to the proper MP-style `mp.metrics.rest-request.enabled=true`--the filter is added only to the routing that also handles the metrics endpoint. (A separate enhancement request calls for a better approach to that; this PR addresses the current runtime failure in this scenario.) As a result, only requests on that socket have the metrics data structure in the request context. 

But, because _every_ REST request has the MP interceptor, the processing for all requests--regardless of socket--attempt to fetch the data structure.

The original code threw an exception if the expected data structure was missing from the request context.

The PR changes that so the code proceeds after logging a one-time warning message if it cannot find the data structure. 

Ideally we can remove the checking and the logging code once we redo how we handle KPI metrics on multiple sockets if  that update makes sure this situation cannot arise.

The PR adds an integration test for the failure scenario.

### Documentation
No impact.