### PR TITLE
3.x: Docs: Do not use --short with kubectl version (#10016)

### DIFF
--- a/docs/about/kubernetes.adoc
+++ b/docs/about/kubernetes.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -57,6 +57,6 @@ set correctly to use docker-for-desktop.
 kubectl config get-contexts
 kubectl config use-context docker-for-desktop
 kubectl cluster-info
-kubectl version --short
+kubectl version
 kubectl get nodes
 ----

--- a/docs/about/prerequisites.adoc
+++ b/docs/about/prerequisites.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ include::{rootdir}/about/introduction.adoc[tag=prereqs]
 java -version
 mvn --version
 docker --version
-kubectl version --short
+kubectl version
 ----
 
 == Setting `JAVA_HOME`

--- a/docs/includes/prerequisites.adoc
+++ b/docs/includes/prerequisites.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ xref:{rootdir}/about/kubernetes.adoc[install one on your desktop].
 java -version
 mvn --version
 docker --version
-kubectl version --short
+kubectl version
 ----
 
 
@@ -89,7 +89,7 @@ include::prerequisites.adoc[tag=prerequisites-table-contents]
 java -version
 mvn --version
 docker --version
-kubectl version --short
+kubectl version
 ----
 
 
@@ -121,7 +121,7 @@ include::prerequisites.adoc[tag=prerequisites-table-contents]
 java -version
 mvn --version
 docker --version
-kubectl version --short
+kubectl version
 ----
 
 
@@ -155,7 +155,7 @@ include::prerequisites.adoc[tag=prerequisites-table-contents]
 java -version
 mvn --version
 docker --version
-kubectl version --short
+kubectl version
 ----
 
 


### PR DESCRIPTION
### Description
Fixes #10016 

The same [was done for 4.x](https://github.com/helidon-io/helidon/pull/9614)
