### PR TITLE
4.x: Upgrade google-api-java-client to 2.7.2 and address dep convergence

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -50,8 +50,9 @@
         <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>
-        <version.lib.google-api-client>1.34.1</version.lib.google-api-client>
-        <version.lib.google-oauth-client>1.33.3</version.lib.google-oauth-client>
+        <version.lib.google-api-client>2.7.2</version.lib.google-api-client>
+        <!-- For dependency convergence. ggogle-http-client version should match what is used by google-api-client -->
+        <version.lib.google-http-client>1.45.2</version.lib.google-http-client>
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.google-protobuf>3.25.5</version.lib.google-protobuf>
         <version.lib.graalvm>23.1.0</version.lib.graalvm>
@@ -563,32 +564,10 @@
                 <artifactId>google-api-client</artifactId>
                 <version>${version.lib.google-api-client}</version>
                 <exclusions>
-                    <!-- For dependency convergence. Defer to newer version from google-http-client -->
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
                     <exclusion>
                         <!-- should be optional -->
                         <groupId>com.google.code.findbugs</groupId>
                         <artifactId>jsr305</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <!-- For dependency convergence and force upgrade of oauth-client -->
-            <dependency>
-                <groupId>com.google.oauth-client</groupId>
-                <artifactId>google-oauth-client</artifactId>
-                <version>${version.lib.google-oauth-client}</version>
-                <!-- Defer to versions from google-api-client -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.http-client</groupId>
-                        <artifactId>google-http-client</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.http-client</groupId>
-                        <artifactId>google-http-client-gson</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1402,6 +1381,15 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${version.lib.netty}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- For dependency convergence. google-http-client is a transitive dependency of google-api-client
+                 via multiple (non-converging) paths. Version should match what is used by google-api-client -->
+            <dependency>
+                <groupId>com.google.http-client</groupId>
+                <artifactId>google-http-client-bom</artifactId>
+                <version>${version.lib.google-http-client}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/security/providers/google-login/pom.xml
+++ b/security/providers/google-login/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>google-api-client</artifactId>
             <exclusions>
                 <exclusion>
-                    <!-- For dep convergence. Guava wants newer version -->
+                    <!-- For dep convergence. -->
                     <groupId>com.google.j2objc</groupId>
                     <artifactId>j2objc-annotations</artifactId>
                 </exclusion>


### PR DESCRIPTION
### Description

Upgrade google-api-java-client to 2.7.2

Address dependency convergence for  google-http-client which is a transitive dependency of google-api-java-client via multiple paths.