### PR TITLE
Update test OEL based docker images

### DIFF
--- a/tests/integration/dbclient/mongodb/etc/docker/Dockerfile
+++ b/tests/integration/dbclient/mongodb/etc/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,17 @@
 # limitations under the License.
 #
 
-FROM oraclelinux:9-slim
+FROM container-registry.oracle.com/os/oraclelinux:9-slim
 
-ADD mongodb-org-7.0.repo /etc/yum.repos.d/
-RUN microdnf install mongodb-org -y && microdnf clean all
+RUN echo "[mongodb-org-7.0]" >> .tmp && \
+    echo "name=MongoDB Repository" >> .tmp && \
+    echo "baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/7.0/$(uname -m)/" >> .tmp && \
+    echo "gpgcheck=1" >> .tmp && \
+    echo "enabled=1" >> .tmp && \
+    echo "gpgkey=https://pgp.mongodb.com/server-7.0.asc" >> .tmp && \
+    mv .tmp /etc/yum.repos.d/mongodb-org-7.0.repo
+
+RUN microdnf install mongodb-org && microdnf clean all
 ADD entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/tests/integration/dbclient/mongodb/etc/docker/entrypoint.sh
+++ b/tests/integration/dbclient/mongodb/etc/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 set -Eeom pipefail
 
 mkdir -p /data/db
+mkdir -p /var/log/mongodb
 
-# redirect stdout and stderr and stderr to log file
+# redirect stdout and stderr to log file
 : > /var/log/mongodb/mongod.log
 exec 2> >(tee -a /var/log/mongodb/mongod.log >&2) > >(tee -a /var/log/mongodb/mongod.log)
 

--- a/tests/integration/dbclient/mongodb/etc/docker/mongodb-org-7.0.repo
+++ b/tests/integration/dbclient/mongodb/etc/docker/mongodb-org-7.0.repo
@@ -1,6 +1,0 @@
-[mongodb-org-7.0]
-name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/7.0/x86_64/
-gpgcheck=1
-enabled=1
-gpgkey=https://pgp.mongodb.com/server-7.0.asc

--- a/tests/integration/dbclient/pgsql/etc/docker/Dockerfile
+++ b/tests/integration/dbclient/pgsql/etc/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM oraclelinux:9-slim
+FROM container-registry.oracle.com/os/oraclelinux:9-slim
 
 RUN microdnf install postgresql-server && microdnf clean all
 RUN mkdir -p /var/run/postgresql && \

--- a/tests/integration/jpa/pgsql/etc/docker/Dockerfile
+++ b/tests/integration/jpa/pgsql/etc/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM oraclelinux:9-slim
+FROM container-registry.oracle.com/os/oraclelinux:9-slim
 
 RUN microdnf install postgresql-server && microdnf clean all
 RUN mkdir -p /var/run/postgresql && \


### PR DESCRIPTION
### Description

Update test OEL based docker images

- Use container-registry.oracle.com instead of docker.io
- Use system architecture in mongodb instead of hardcoding x86_64

### Documentation

None.