### PR TITLE
Adjusts OCI vault config sources to read only secret versions that are extant and in the Current rotation state

### DIFF
--- a/integrations/oci/secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleLazyConfigSource.java
+++ b/integrations/oci/secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleLazyConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,10 +81,11 @@ public final class SecretBundleLazyConfigSource
         return Optional.empty();
     }
 
-    static GetSecretBundleByNameRequest request(String vaultOcid, String secretName) {
+    static GetSecretBundleByNameRequest secretBundleByNameRequest(String vaultOcid, String secretName) {
         return GetSecretBundleByNameRequest.builder()
                 .vaultId(vaultOcid)
                 .secretName(secretName)
+                .stage(GetSecretBundleByNameRequest.Stage.Current)
                 .build();
     }
 
@@ -116,7 +117,9 @@ public final class SecretBundleLazyConfigSource
             if (LOGGER.isLoggable(DEBUG)) {
                 LOGGER.log(DEBUG, "Getting SecretBundle with name " + secretName);
             }
-            return s.getSecretBundleByName(request(vaultOcid, secretName)).getSecretBundle().getSecretBundleContent();
+            return s.getSecretBundleByName(secretBundleByNameRequest(vaultOcid, secretName))
+                    .getSecretBundle()
+                    .getSecretBundleContent();
         } catch (BmcException e) {
             if (e.getStatusCode() == 404) {
                 return null;


### PR DESCRIPTION
This PR ensures that reads of OCI vault secrets are constrained to only those versions with the `Current` rotation state, and a lifecycle state that indicates current and ongoing existence.