### PR TITLE
 4.2.2: Increase Linux runner free disk space

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -59,8 +59,17 @@ runs:
       name: Free disk space
       shell: bash
       run: |
-        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/microsoft
+        sudo rm -rf /usr/lib/google-cloud-sdk
+        sudo rm -rf /usr/lib/mono
+        sudo rm -rf /usr/local/aws-*
+        sudo rm -rf /usr/local/julia*
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/share/chromium
         sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/miniconda
+        sudo rm -rf /usr/share/swift
     - if: ${{ runner.os == 'Windows' }}
       name: Use GNU tar
       shell: cmd


### PR DESCRIPTION
Backport #10043 to Helidon 4.2.2

### Description

Update the free-space step to prune more aggressively.
Free-space went from 20G to 39G.

### Documentation

None.