### PR TITLE
Initial support for gRPC server metrics

### DIFF
--- a/webserver/grpc/pom.xml
+++ b/webserver/grpc/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.grpc;
 
+import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.webserver.spi.ProtocolConfig;
 import io.helidon.webserver.spi.ProtocolConfigProvider;
@@ -26,11 +27,27 @@ import io.helidon.webserver.spi.ProtocolConfigProvider;
 interface GrpcConfigBlueprint extends ProtocolConfig {
 
     /**
+     * Protocol configuration name.
+     *
+     * @return name of this configuration
+     */
+    @Option.Default(GrpcProtocolProvider.CONFIG_NAME)
+    String name();
+
+    /**
      * Protocol configuration type.
      *
      * @return type of this configuration
      */
-    default String type() {
-        return GrpcProtocolProvider.CONFIG_NAME;
-    }
+    @Option.Default(GrpcProtocolProvider.CONFIG_NAME)
+    String type();
+
+    /**
+     * Whether to collect metrics for gRPC server calls.
+     *
+     * @return metrics flag
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean enableMetrics();
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -42,6 +44,13 @@ import io.helidon.http.http2.Http2StreamState;
 import io.helidon.http.http2.Http2StreamWriter;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.http.http2.StreamFlowControl;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.Timer;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 
 import io.grpc.Codec;
@@ -60,6 +69,7 @@ import static io.helidon.http.http2.Http2Flag.DataFlags;
 import static io.helidon.http.http2.Http2Flag.END_OF_HEADERS;
 import static io.helidon.http.http2.Http2Flag.END_OF_STREAM;
 import static io.helidon.http.http2.Http2Flag.HeaderFlags;
+import static io.helidon.metrics.api.Meter.Scope.VENDOR;
 import static java.lang.System.Logger.Level.ERROR;
 
 class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProtocolHandler {
@@ -75,6 +85,8 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private static final DecompressorRegistry DECOMPRESSOR_REGISTRY = DecompressorRegistry.getDefaultInstance();
     private static final CompressorRegistry COMPRESSOR_REGISTRY = CompressorRegistry.getDefaultInstance();
 
+    private static final Tag OK_TAG = Tag.create("grpc.status", "OK");
+
     private final HttpPrologue prologue;
     private final Http2Headers headers;
     private final Http2StreamWriter streamWriter;
@@ -85,6 +97,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private final AtomicInteger numMessages = new AtomicInteger();
     private final LinkedBlockingQueue<REQ> listenerQueue = new LinkedBlockingQueue<>();
     private final StreamFlowControl flowControl;
+    private final GrpcConfig config;
 
     private Http2StreamState currentStreamState;
     private ServerCall.Listener<REQ> listener;
@@ -92,6 +105,15 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private Compressor compressor;
     private Decompressor decompressor;
     private boolean isIdentityCompressor;
+    private long bytesReceived;
+
+    record MetricsData(Counter callStarted,
+                       Timer callDuration,
+                       DistributionSummary sentMessageSize,
+                       DistributionSummary recvMessageSize,
+                       long startMillis) { }
+
+    private MetricsData metricsData;
 
     GrpcProtocolHandler(HttpPrologue prologue,
                         Http2Headers headers,
@@ -101,7 +123,8 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                         Http2Settings clientSettings,
                         StreamFlowControl flowControl,
                         Http2StreamState currentStreamState,
-                        GrpcRouteHandler<REQ, RES> route) {
+                        GrpcRouteHandler<REQ, RES> route,
+                        GrpcConfig config) {
         this.prologue = prologue;
         this.headers = headers;
         this.streamWriter = streamWriter;
@@ -111,6 +134,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         this.flowControl = flowControl;
         this.currentStreamState = currentStreamState;
         this.route = route;
+        this.config = config;
     }
 
     @Override
@@ -122,10 +146,17 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
             // setup compression
             initCompression(serverCall, httpHeaders);
 
+            // init metrics
+            if (config.enableMetrics()) {
+                initMetrics();
+                metricsData.callStarted.increment();
+            }
+
             // initiate server call
             ServerCallHandler<REQ, RES> callHandler = route.callHandler();
             listener = callHandler.startCall(serverCall, GrpcHeadersUtil.toMetadata(headers));
             listener.onReady();
+            bytesReceived = 0L;
         } catch (Throwable e) {
             LOGGER.log(ERROR, "Failed to initialize grpc protocol handler", e);
             throw e;
@@ -170,7 +201,9 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                     }
 
                     // read and possibly decompress data
-                    byte[] bytes = new byte[entityBytes.available()];
+                    int readLength = entityBytes.available();
+                    bytesReceived += readLength;
+                    byte[] bytes = new byte[readLength];
                     entityBytes.read(bytes);
                     ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
                     REQ request = route.method().parseRequest(isCompressed ? decompressor.decompress(bais) : bais);
@@ -184,6 +217,11 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
             if (header.flags(Http2FrameTypes.DATA).endOfStream()) {
                 listener.onHalfClose();
                 currentStreamState = Http2StreamState.HALF_CLOSED_LOCAL;
+
+                // update metrics
+                if (config.enableMetrics()) {
+                    metricsData.recvMessageSize.record(bytesReceived);
+                }
             }
         } catch (Exception e) {
             listener.onCancel();
@@ -204,7 +242,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                 Metadata metadata = new Metadata();
                 Set<String> encodings = DECOMPRESSOR_REGISTRY.getAdvertisedMessageEncodings();
                 metadata.put(Metadata.Key.of(GRPC_ACCEPT_ENCODING.defaultCase(), Metadata.ASCII_STRING_MARSHALLER),
-                        String.join(",", encodings));
+                             String.join(",", encodings));
                 serverCall.close(Status.UNIMPLEMENTED, metadata);
                 currentStreamState = Http2StreamState.CLOSED;       // stops processing
                 return;
@@ -247,6 +285,9 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
     private ServerCall<REQ, RES> createServerCall() {
         return new ServerCall<>() {
+
+            private long bytesSent;
+
             @Override
             public void request(int numMessages) {
                 addNumMessages(numMessages);
@@ -300,13 +341,15 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                     }
 
                     // create data frame, EOS sent in close with trailers
-                    Http2FrameHeader header = Http2FrameHeader.create(bufferData.available(),
-                            Http2FrameTypes.DATA,
-                            DATA_FLAGS_ZERO,
-                            streamId);
+                    int writeLength = bufferData.available();
+                    Http2FrameHeader header = Http2FrameHeader.create(writeLength,
+                                                                      Http2FrameTypes.DATA,
+                                                                      DATA_FLAGS_ZERO,
+                                                                      streamId);
 
                     // write data frame
                     streamWriter.writeData(new Http2FrameData(header, bufferData), flowControl.outbound());
+                    bytesSent += writeLength;
                 } catch (Exception e) {
                     listener.onCancel();
                     LOGGER.log(ERROR, "Failed to respond to grpc request: " + route.method(), e);
@@ -331,6 +374,13 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                                           HeaderFlags.create(END_OF_HEADERS | END_OF_STREAM),
                                           flowControl.outbound());
                 currentStreamState = Http2StreamState.HALF_CLOSED_LOCAL;
+
+                // update metrics
+                if (status.isOk() && config.enableMetrics()) {
+                    metricsData.sentMessageSize.record(bytesSent);
+                    metricsData.callDuration.record(
+                            Duration.ofMillis(System.currentTimeMillis() - metricsData.startMillis));
+                }
             }
 
             @Override
@@ -343,5 +393,47 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                 return route.method();
             }
         };
+    }
+
+    private void initMetrics() {
+        if (config.enableMetrics()) {
+            MetricsFactory metricsFactory = MetricsFactory.getInstance();
+            MeterRegistry meterRegistry = Metrics.globalRegistry();
+
+            Tag grpcMethod = Tag.create("grpc.method", route.method().getFullMethodName());
+
+            Counter.Builder callStartedBuilder = metricsFactory.counterBuilder(
+                            "grpc.server.call.started")
+                            .scope(VENDOR);
+            callStartedBuilder.tags(List.of(grpcMethod));
+            Counter callStarted = meterRegistry.getOrCreate(callStartedBuilder);
+
+            Timer.Builder callDurationOkBuilder = metricsFactory.timerBuilder(
+                            "grpc.server.call.duration")
+                            .scope(VENDOR)
+                            .baseUnit(Timer.BaseUnits.MILLISECONDS);
+            callDurationOkBuilder.tags(List.of(grpcMethod, OK_TAG));
+            Timer callDuration = meterRegistry.getOrCreate(callDurationOkBuilder);
+
+            DistributionSummary.Builder sendMessageSizeBuilder = metricsFactory.distributionSummaryBuilder(
+                            "grpc.server.call.sent_total_compressed_message_size",
+                            metricsFactory.distributionStatisticsConfigBuilder())
+                            .scope(VENDOR);
+            sendMessageSizeBuilder.tags(List.of(grpcMethod, OK_TAG));
+            DistributionSummary sentMessageSize = meterRegistry.getOrCreate(sendMessageSizeBuilder);
+
+            DistributionSummary.Builder recvMessageSizeBuilder = metricsFactory.distributionSummaryBuilder(
+                            "grpc.server.call.rcvd_total_compressed_message_size",
+                            metricsFactory.distributionStatisticsConfigBuilder())
+                            .scope(VENDOR);
+            recvMessageSizeBuilder.tags(List.of(grpcMethod, OK_TAG));
+            DistributionSummary recvMessageSize = meterRegistry.getOrCreate(recvMessageSizeBuilder);
+
+            metricsData = new MetricsData(callStarted,
+                                          callDuration,
+                                          sentMessageSize,
+                                          recvMessageSize,
+                                          System.currentTimeMillis());
+        }
     }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolProvider.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,6 @@ public class GrpcProtocolProvider implements Http2SubProtocolProvider<GrpcConfig
 
     @Override
     public Http2SubProtocolSelector create(GrpcConfig config, ProtocolConfigs configs) {
-        return GrpcProtocolSelector.create();
+        return GrpcProtocolSelector.create(config);
     }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,16 +35,20 @@ import io.helidon.webserver.http2.spi.SubProtocolResult;
  */
 public class GrpcProtocolSelector implements Http2SubProtocolSelector {
 
-    private GrpcProtocolSelector() {
+    private final GrpcConfig grpcConfig;
+
+    private GrpcProtocolSelector(GrpcConfig gprcConfig) {
+        this.grpcConfig = gprcConfig;
     }
 
     /**
      * Create a new grpc protocol selector (default).
      *
+     * @param grpcConfig gRPC configuration
      * @return a new default grpc protocol selector for HTTP/2
      */
-    public static GrpcProtocolSelector create() {
-        return new GrpcProtocolSelector();
+    public static GrpcProtocolSelector create(GrpcConfig grpcConfig) {
+        return new GrpcProtocolSelector(grpcConfig);
     }
 
     @Override
@@ -79,14 +83,15 @@ public class GrpcProtocolSelector implements Http2SubProtocolSelector {
                 }
                 return new SubProtocolResult(true,
                                              new GrpcProtocolHandler<>(prologue,
-                                                                     headers,
-                                                                     streamWriter,
-                                                                     streamId,
-                                                                     serverSettings,
-                                                                     clientSettings,
-                                                                     flowControl,
-                                                                     currentStreamState,
-                                                                     route));
+                                                                       headers,
+                                                                       streamWriter,
+                                                                       streamId,
+                                                                       serverSettings,
+                                                                       clientSettings,
+                                                                       flowControl,
+                                                                       currentStreamState,
+                                                                       route,
+                                                                       grpcConfig));
             }
         }
         return NOT_SUPPORTED;

--- a/webserver/grpc/src/main/java/module-info.java
+++ b/webserver/grpc/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ module io.helidon.webserver.grpc {
     requires io.helidon.webserver.http2;
     requires io.helidon.tracing;
     requires io.helidon.common.config;
+    requires io.helidon.metrics.api;
 
     requires io.grpc;
     requires io.grpc.stub;

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,8 @@ class GrpcProtocolHandlerTest {
                 Http2Settings.builder().build(),
                 null,
                 Http2StreamState.OPEN,
-                null);
+                null,
+                GrpcConfig.create());
         handler.initCompression(null, headers);
         assertThat(handler.isIdentityCompressor(), is(true));
     }
@@ -62,7 +63,8 @@ class GrpcProtocolHandlerTest {
                 Http2Settings.builder().build(),
                 null,
                 Http2StreamState.OPEN,
-                null);
+                null,
+                GrpcConfig.create());
         handler.initCompression(null, headers);
         assertThat(handler.isIdentityCompressor(), is(false));
     }

--- a/webserver/tests/grpc/pom.xml
+++ b/webserver/tests/grpc/pom.xml
@@ -46,6 +46,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMetricsTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMetricsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.grpc;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.Timer;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.grpc.GrpcConfig;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.AfterAll;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class GrpcMetricsTest extends BaseStringServiceTest {
+
+    private static final Tag OK_TAG = Tag.create("grpc.status", "OK");
+    private static final Tag[] METHOD_TAGS = {
+            Tag.create("grpc.method", "StringService/Upper"),
+            Tag.create("grpc.method", "StringService/Lower"),
+            Tag.create("grpc.method", "StringService/Echo"),
+            Tag.create("grpc.method", "StringService/Split"),
+            Tag.create("grpc.method", "StringService/Join")
+    };
+    private static final String CALL_STARTED = "grpc.server.call.started";
+    private static final String CALL_DURATION = "grpc.server.call.duration";
+    private static final String SENT_MESSAGE_SIZE = "grpc.server.call.sent_total_compressed_message_size";
+    private static final String RCVD_MESSAGE_SIZE = "grpc.server.call.rcvd_total_compressed_message_size";
+
+    GrpcMetricsTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder serverBuilder) {
+        serverBuilder.addProtocol(GrpcConfig.builder().enableMetrics(true).build());
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new StringService()));
+    }
+
+    @AfterAll
+    static void checkMetrics() {
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+
+        for (Tag tag : METHOD_TAGS) {
+            Optional<Counter> counter = meterRegistry.counter(CALL_STARTED, List.of(tag));
+            assertThat(counter.isPresent(), is(true));
+            assertThat(counter.get().count(), is(20L));
+
+            Optional<Timer> timer = meterRegistry.timer(CALL_DURATION, List.of(tag, OK_TAG));
+            assertThat(timer.isPresent(), is(true));
+            assertThat(timer.get().count(), is(20L));
+
+            Optional<DistributionSummary> summary = meterRegistry.summary(SENT_MESSAGE_SIZE, List.of(tag, OK_TAG));
+            assertThat(summary.isPresent(), is(true));
+            assertThat(summary.get().count(), is(20L));
+            assertThat(summary.get().max(), greaterThan(0.0));
+
+            summary = meterRegistry.summary(RCVD_MESSAGE_SIZE, List.of(tag, OK_TAG));
+            assertThat(summary.isPresent(), is(true));
+            assertThat(summary.get().count(), is(20L));
+            assertThat(summary.get().max(), greaterThan(0.0));
+        }
+    }
+}


### PR DESCRIPTION
### Description

Support for gRPC-specific server metrics. Only records metrics when invocations are uccessfull (status is OK). Metrics disabled by default, and enabled via config. See https://grpc.io/docs/guides/opentelemetry-metrics/. 
 
### Documentation

TODO
