### PR TITLE
Use ofNullable for matching pattern

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerRequest.java
@@ -198,7 +198,7 @@ class Http2ServerRequest implements RoutingRequest {
 
     @Override
     public Optional<String> matchingPattern() {
-        return Optional.of(matchingPattern);
+        return Optional.ofNullable(matchingPattern);
     }
 
     @Override

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/MatchingPatternRoutingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/MatchingPatternRoutingTest.java
@@ -16,7 +16,12 @@
 
 package io.helidon.webserver.tests;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.testing.junit5.RoutingTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
@@ -29,8 +34,14 @@ class MatchingPatternRoutingTest extends MatchingPatternBase {
     }
 
     @SetUpRoute
-    static void routing(HttpRules rules) {
-        rules.get("/", HANDLER)
+    static void routing(HttpRouting.Builder builder) {
+        builder.addFilter(
+                (chain, req, res) -> {
+                  assertThat(req.matchingPattern().orElse(null), nullValue());
+                  chain.proceed();
+                  assertThat(req.matchingPattern().orElse(null), notNullValue());
+                })
+                .get("/", HANDLER)
                 .get("/foo", HANDLER)
                 .get("/foo/bar", HANDLER)
                 .get("/foo/bar/baz", HANDLER)

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/MatchingPatternRoutingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/MatchingPatternRoutingTest.java
@@ -19,6 +19,8 @@ package io.helidon.webserver.tests;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalPresent;
 
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.http.HttpRouting;
@@ -37,9 +39,9 @@ class MatchingPatternRoutingTest extends MatchingPatternBase {
     static void routing(HttpRouting.Builder builder) {
         builder.addFilter(
                 (chain, req, res) -> {
-                  assertThat(req.matchingPattern().orElse(null), nullValue());
+                  assertThat(req.matchingPattern(), optionalEmpty());
                   chain.proceed();
-                  assertThat(req.matchingPattern().orElse(null), notNullValue());
+                  assertThat(req.matchingPattern(), optionalPresent());
                 })
                 .get("/", HANDLER)
                 .get("/foo", HANDLER)

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
@@ -219,7 +219,7 @@ abstract class Http1ServerRequest implements RoutingRequest {
 
     @Override
     public Optional<String> matchingPattern() {
-        return Optional.of(matchingPattern);
+        return Optional.ofNullable(matchingPattern);
     }
 
     @Override


### PR DESCRIPTION
### Description

When the matching pattern is not present, it seems that calling `ServerRequest#matchingPattern` throws an NPE.

```java
      WebServer.builder()
          .routing(
              b ->
                  b.addFilter(
                      (chain, req, res) -> {
                        req.matchingPattern();// throws NPE here
                        chain.proceed();
                      }))
          .port(8080)
          .build()
          .start();
```

part of #10051 
