### PR TITLE
4.x: WebServer route can match based on request headers

### DIFF
--- a/http/http/src/main/java/io/helidon/http/Headers.java
+++ b/http/http/src/main/java/io/helidon/http/Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,19 @@ public interface Headers extends Iterable<Header> {
     }
 
     /**
+     * Find the first header.
+     *
+     * @param headerName the header name
+     * @return the header, or empty optional if the header is not defined
+     */
+    default Optional<Header> find(HeaderName headerName) {
+        if (contains(headerName)) {
+            return Optional.of(get(headerName));
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Returns an unmodifiable {@link java.util.List} of all comma separated header value parts - <b>Such segmentation is NOT
      * valid for
      * all header semantics, however it is very common</b>. Refer to actual header semantics standard/description before use.
@@ -187,10 +200,10 @@ public interface Headers extends Iterable<Header> {
      * Whether this media type is accepted by these headers.
      * As this method is useful only for server request headers, it returns {@code true } by default.
      *
-     * @param mediaType media type to test
+     * @param mediaTypes media type to test
      * @return {@code true} if this media type would be accepted
      */
-    default boolean isAccepted(MediaType mediaType) {
+    default boolean isAccepted(MediaType... mediaTypes) {
         return true;
     }
 

--- a/http/http/src/main/java/io/helidon/http/HeadersImpl.java
+++ b/http/http/src/main/java/io/helidon/http/HeadersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
 
     @Override
     public List<String> all(HeaderName name, Supplier<List<String>> defaultSupplier) {
-        Header headerValue = find(name);
+        Header headerValue = findOrNull(name);
         if (headerValue == null) {
             return defaultSupplier.get();
         }
@@ -59,12 +59,12 @@ class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
 
     @Override
     public boolean contains(HeaderName name) {
-        return find(name) != null;
+        return findOrNull(name) != null;
     }
 
     @Override
     public boolean contains(Header headerWithValue) {
-        Header headerValue = find(headerWithValue.headerName());
+        Header headerValue = findOrNull(headerWithValue.headerName());
         if (headerValue == null) {
             return false;
         }
@@ -77,7 +77,7 @@ class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
 
     @Override
     public Header get(HeaderName name) {
-        Header headerValue = find(name);
+        Header headerValue = findOrNull(name);
         if (headerValue == null) {
             throw new NoSuchElementException("Header " + name + " is not present in these headers");
         }
@@ -112,7 +112,7 @@ class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
 
     @Override
     public T setIfAbsent(Header header) {
-        Header found = find(header.headerName());
+        Header found = findOrNull(header.headerName());
         if (found == null) {
             set(header);
         }
@@ -123,7 +123,7 @@ class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
     @Override
     public T add(Header header) {
         HeaderName name = header.headerName();
-        Header headerValue = find(name);
+        Header headerValue = findOrNull(name);
         if (headerValue == null) {
             set(header);
         } else {
@@ -237,7 +237,7 @@ class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
         return customHeaders().remove(name);
     }
 
-    private Header find(HeaderName name) {
+    private Header findOrNull(HeaderName name) {
         int index = name.index();
 
         if (index > -1) {

--- a/http/http/src/main/java/io/helidon/http/ServerRequestHeaders.java
+++ b/http/http/src/main/java/io/helidon/http/ServerRequestHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,19 +106,23 @@ public interface ServerRequestHeaders extends Headers {
      * A media type is accepted if the {@code Accept} header is not present in the
      * request or if it contains the provided media type.
      *
-     * @param mediaType the media type to test
+     * @param mediaTypes the media type(s) to test
      * @return {@code true} if provided type is acceptable, {@code false} otherwise
      * @throws NullPointerException if the provided type is {@code null}.
      */
-    default boolean isAccepted(MediaType mediaType) {
+    @Override
+    default boolean isAccepted(MediaType... mediaTypes) {
         List<HttpMediaType> accepted = acceptedTypes();
         if (accepted.isEmpty()) {
             return true;
         }
         for (HttpMediaType acceptedType : accepted) {
-            if (acceptedType.test(mediaType)) {
-                return true;
+            for (MediaType type : mediaTypes) {
+                if (acceptedType.test(type)) {
+                    return true;
+                }
             }
+
         }
         return false;
     }
@@ -225,5 +229,33 @@ public interface ServerRequestHeaders extends Headers {
                     .map(URI::create);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Check if the content type provided over the network matches one of the content types.
+     * If any of the media types is {@link io.helidon.common.media.type.MediaTypes#WILDCARD}, this method always returns
+     * {@code true}.
+     * If {@link #contentType()} is not defined, this method returns false.
+     *
+     * @param mediaTypes media types that we check against
+     * @return {@code true} if any of the media types provided matches the {@link #contentType()}
+     */
+    default boolean testContentType(MediaType... mediaTypes) {
+        for (MediaType mediaType : mediaTypes) {
+            if (mediaType.isWildcardType() && mediaType.isWildcardSubtype()) {
+                return true;
+            }
+        }
+        Optional<HttpMediaType> httpMediaType = contentType();
+        if (httpMediaType.isEmpty()) {
+            return false;
+        }
+        HttpMediaType contentType = httpMediaType.get();
+        for (MediaType mediaType : mediaTypes) {
+            if (contentType.test(mediaType)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package io.helidon.webserver.tests;
 
-import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.Method;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRoute;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 @ServerTest
 class RoutingTest extends RoutingTestBase {
@@ -46,6 +49,18 @@ class RoutingTest extends RoutingTestBase {
                 .trace("/trace", (req, res) -> res.send("trace"))
                 .patch("/patch", (req, res) -> res.send("patch"))
                 .any("/any", (req, res) -> res.send("any"))
+                .route(HttpRoute.builder()
+                               .path("/header_based")
+                               .methods(Method.GET)
+                               .headers(headers -> headers.isAccepted(MediaTypes.APPLICATION_JSON))
+                               .handler((req, res) -> res.send("header_based_JSON"))
+                               .build())
+                .route(HttpRoute.builder()
+                               .path("/header_based")
+                               .methods(Method.GET)
+                               .headers(headers -> headers.isAccepted(MediaTypes.TEXT_PLAIN))
+                               .handler((req, res) -> res.send("header_based_TEXT"))
+                               .build())
                 // shortcut methods using multiple handlers
                 .get("/get_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("get_multi"))
                 .post("/post_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("post_multi"))

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.webserver.tests;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -80,6 +81,26 @@ abstract class RoutingTestBase {
             String message = response.as(String.class);
             assertThat(message, is("done"));
         }
+    }
+
+    @Test
+    void testRouteWithAcceptJson() {
+        var response = client.get("/header_based")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("header_based_JSON"));
+    }
+
+    @Test
+    void testRouteWithAcceptText() {
+        var response = client.get("/header_based")
+                .accept(MediaTypes.TEXT_PLAIN)
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("header_based_TEXT"));
     }
 
     @ParameterizedTest

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,13 @@
 
 package io.helidon.webserver.tests;
 
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.Method;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.http.HttpRoute;
+import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
-import io.helidon.webclient.http1.Http1Client;
-import io.helidon.webserver.http.HttpRules;
-
-import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @ServerTest
 class RulesTest extends RoutingTestBase {
@@ -50,6 +48,18 @@ class RulesTest extends RoutingTestBase {
                 .trace("/trace", (req, res) -> res.send("trace"))
                 .patch("/patch", (req, res) -> res.send("patch"))
                 .any("/any", (req, res) -> res.send("any"))
+                .route(HttpRoute.builder()
+                               .path("/header_based")
+                               .methods(Method.GET)
+                               .headers(headers -> headers.isAccepted(MediaTypes.APPLICATION_JSON))
+                               .handler((req, res) -> res.send("header_based_JSON"))
+                               .build())
+                .route(HttpRoute.builder()
+                               .path("/header_based")
+                               .methods(Method.GET)
+                               .headers(headers -> headers.isAccepted(MediaTypes.TEXT_PLAIN))
+                               .handler((req, res) -> res.send("header_based_TEXT"))
+                               .build())
                 // shortcut methods using multiple handlers
                 .get("/get_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("get_multi"))
                 .post("/post_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("post_multi"))

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoute.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoute.java
@@ -24,6 +24,7 @@ import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
+import io.helidon.http.ServerRequestHeaders;
 import io.helidon.webserver.Route;
 
 /**
@@ -35,7 +36,7 @@ public interface HttpRoute extends Route {
      *
      * @return builder
      */
-    static HttpRouteImpl.Builder builder() {
+    static HttpRoute.Builder builder() {
         return new Builder();
     }
 
@@ -47,6 +48,18 @@ public interface HttpRoute extends Route {
      * @see io.helidon.http.PathMatchers.MatchResult#notAccepted()
      */
     PathMatchers.MatchResult accepts(HttpPrologue prologue);
+
+    /**
+     * Whether this route accept the provided request.
+     *
+     * @param prologue prologue of the request
+     * @param headers headers of the request
+     * @return result of the validation
+     * @see io.helidon.http.PathMatchers.MatchResult#notAccepted()
+     */
+    default PathMatchers.MatchResult accepts(HttpPrologue prologue, ServerRequestHeaders headers) {
+        return accepts(prologue);
+    }
 
     /**
      * Handler of this route.
@@ -71,6 +84,7 @@ public interface HttpRoute extends Route {
         private Predicate<Method> methodPredicate = Method.predicate();
         private PathMatcher pathMatcher = PathMatchers.any();
         private Handler handler;
+        private Predicate<ServerRequestHeaders> headersPredicate = headers -> true;
 
         private Builder() {
         }
@@ -99,6 +113,17 @@ public interface HttpRoute extends Route {
          */
         public Builder methods(Predicate<Method> methodPredicate) {
             this.methodPredicate = methodPredicate;
+            return this;
+        }
+
+        /**
+         * HTTP Headers predicate to use.
+         *
+         * @param headersPredicate headers predicate
+         * @return updated builder
+         */
+        public Builder headers(Predicate<ServerRequestHeaders> headersPredicate) {
+            this.headersPredicate = headersPredicate;
             return this;
         }
 
@@ -144,6 +169,10 @@ public interface HttpRoute extends Route {
 
         Handler handler() {
             return handler;
+        }
+
+        Predicate<ServerRequestHeaders> headersPredicate() {
+            return headersPredicate;
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouteImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouteImpl.java
@@ -23,22 +23,37 @@ import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
+import io.helidon.http.ServerRequestHeaders;
 import io.helidon.webserver.WebServer;
 
 class HttpRouteImpl extends HttpRouteBase implements HttpRoute {
     private final Handler handler;
     private final Predicate<Method> methodPredicate;
     private final PathMatcher pathMatcher;
+    private final Predicate<ServerRequestHeaders> headersPredicate;
 
     HttpRouteImpl(HttpRoute.Builder builder) {
         this.handler = builder.handler();
         this.methodPredicate = builder.methodPredicate();
         this.pathMatcher = builder.pathPredicate();
+        this.headersPredicate = builder.headersPredicate();
     }
 
     @Override
     public PathMatchers.MatchResult accepts(HttpPrologue prologue) {
         if (!methodPredicate.test(prologue.method())) {
+            return PathMatchers.MatchResult.notAccepted();
+        }
+
+        return pathMatcher.match(prologue.uriPath());
+    }
+
+    @Override
+    public PathMatchers.MatchResult accepts(HttpPrologue prologue, ServerRequestHeaders headers) {
+        if (!methodPredicate.test(prologue.method())) {
+            return PathMatchers.MatchResult.notAccepted();
+        }
+        if (!headersPredicate.test(headers)) {
             return PathMatchers.MatchResult.notAccepted();
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RouteCrawler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RouteCrawler.java
@@ -110,7 +110,7 @@ class RouteCrawler {
                     subCrawler = null;
                 }
             } else {
-                PathMatchers.MatchResult accepts = nextRoute.accepts(prologue);
+                PathMatchers.MatchResult accepts = nextRoute.accepts(prologue, request.headers());
                 if (accepts.accepted()) {
                     PathMatcher pathMatcher = nextRoute.pathMatcher().orElse(null);
                     next = new CrawlerItem(accepts.path(),


### PR DESCRIPTION
Added support for matching server request headers in `HttpRoute`, to enable routes for specific content types, and/or Accept headers (and any other headers in the request).

Added a few convenience methods to headers for easier implementation. 

Added test.

This is one of the prerequisites for handling endpoints that only support a specific content type, or that can only handle specific `Accept` headers in request.

The implementation is more general - it can match any headers using a ServerRequestHeader predicate.

Pre-requisite for #9915 
