### PR TITLE
Update MP OpenAPI to 3.1.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -118,7 +118,7 @@
         <version.lib.microprofile-health>4.0.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>2.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics-api>5.1.2</version.lib.microprofile-metrics-api>
-        <version.lib.microprofile-openapi-api>3.1.1</version.lib.microprofile-openapi-api>
+        <version.lib.microprofile-openapi-api>3.1.2</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-reactive-messaging-api>3.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>3.0</version.lib.microprofile-reactive-streams-operators-api>
         <version.lib.microprofile-reactive-streams-operators-core>3.0</version.lib.microprofile-reactive-streams-operators-core>


### PR DESCRIPTION
### Description
Partially addresses #9981 

See notes on the issue for more information.

This PR updates the MP OpenAPI release from 3.1.1 to 3.1.2.

### Documentation
No impact.