### PR TITLE
3.x: Update path matchers to honor quantifiers in Regular expressions (#10082)

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/PathPattern.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/PathPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -212,10 +212,14 @@ final class PathPattern {
             switch (ch) {
             case '{':
                 subSeqCounter++;
+                // nested curly braces should be added
+                builder.append('{');
                 break;
             case '}':
                 if (subSeqCounter > 0) {
                     subSeqCounter--;
+                    // nested curly braces should be added (except for the last one, because that is end of parameter)
+                    builder.append(ch);
                 } else {
                     return builder.toString();
                 }
@@ -411,6 +415,10 @@ final class PathPattern {
                 }
             }
             return params;
+        }
+
+        Pattern pattern() {
+            return pattern;
         }
 
         @Override

--- a/webserver/webserver/src/test/java/io/helidon/webserver/PathPatternTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/PathPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,16 @@ public class PathPatternTest {
 
     private void assertPrefixMatchWithParams(String path, String pattern, String remainingPart, String... nameValue) {
         doAssertMatchWithParams(true, path, pattern, remainingPart, nameValue);
+    }
+
+    @Test
+    void testRegexQuantifier() {
+        var matcher = PathPattern.compile("/{id:\\w{2}}/name");
+        var patternMatcher = (PathPattern.RegexpPathMatcher) matcher;
+
+        var actualPattern = patternMatcher.pattern();
+
+        assertThat(actualPattern.pattern(), is("/(?<gfXdbHQlk0>\\w{2})/name"));
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes #10082 

The same changes [were done](https://github.com/helidon-io/helidon/pull/9976) for 4.x . I think, it can be backported.