### PR TITLE
4.x: Validate that named routing has an existing named listener.

### DIFF
--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/NamedRoutingValidationTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/NamedRoutingValidationTest.java
@@ -1,0 +1,118 @@
+package io.helidon.webserver.tests;
+
+import io.helidon.http.Status;
+import io.helidon.testing.junit5.Testing;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/*
+This test is aimed at validating that a named socket (listener) exists, if we configure a named routing.
+We should either:
+- warn
+- throw an exception
+ */
+@Testing.Test
+class NamedRoutingValidationTest {
+    @Test
+    void testValidSocket() {
+        var webServer = WebServer.builder()
+                .port(0)
+                .putSocket("admin", listener -> listener.port(0)
+                        .name("admin"))
+                .routing(rules -> rules.get("/greet", (req, res) -> res.send("Hello")))
+                .routing("admin", rules -> rules.get("/greet", (req, res) -> res.send("Admin")))
+                .build();
+
+        webServer.start();
+        int defaultPort = webServer.port();
+        int adminPort = webServer.port("admin");
+
+        WebClient webClient = null;
+        try {
+            webClient = WebClient.create();
+
+            String response = webClient.get("http://localhost:" + defaultPort + "/greet")
+                    .requestEntity(String.class);
+            assertThat(response, is("Hello"));
+
+            response = webClient.get("http://localhost:" + adminPort + "/greet")
+                    .requestEntity(String.class);
+            assertThat(response, is("Admin"));
+        } finally {
+            if (webClient != null) {
+                webClient.closeResource();
+            }
+        }
+    }
+
+    /*
+    Shows an accident of quoting a string in properties
+     */
+    @Test
+    void testInvalidSocket() {
+        var webServerBuilder = WebServer.builder()
+                .port(0)
+                .putSocket("admin", listener -> listener.port(0)
+                        .name("admin"))
+                .putSocket("internal", listener -> listener.port(0)
+                        .name("internal"))
+                .routing(rules -> rules.get("/greet", (req, res) -> res.send("Hello")))
+                .routing("\"admin\"", rules -> rules.get("/greet", (req, res) -> res.send("Admin")));
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, webServerBuilder::build);
+
+        String message = illegalStateException.getMessage();
+        assertThat("Message must contain quoted invalid name",
+                   message,
+                   containsString("\"\"admin\"\""));
+        assertThat("Message must contain quoted list of valid names",
+                   message,
+                   containsString("\"internal, admin, @default\""));
+    }
+
+    /*
+   Shows an accident of quoting a string in properties
+    */
+    @Test
+    void testInvalidSocketIgnored() {
+        var webServer = WebServer.builder()
+                .ignoreInvalidNamedRouting(true)
+                .port(0)
+                .putSocket("admin", listener -> listener.port(0)
+                        .name("admin"))
+                .putSocket("internal", listener -> listener.port(0)
+                        .name("internal"))
+                .routing(rules -> rules.get("/greet", (req, res) -> res.send("Hello")))
+                .routing("\"admin\"", rules -> rules.get("/greet", (req, res) -> res.send("Admin")))
+                .build();
+
+        webServer.start();
+        int defaultPort = webServer.port();
+        int adminPort = webServer.port("admin");
+
+        WebClient webClient = null;
+        try {
+            webClient = WebClient.create();
+
+            String response = webClient.get("http://localhost:" + defaultPort + "/greet")
+                    .requestEntity(String.class);
+            assertThat(response, is("Hello"));
+
+            // should not be found, as hte routing is invalid
+            var typedResponse = webClient.get("http://localhost:" + adminPort + "/greet")
+                    .request(String.class);
+            assertThat(typedResponse.status(), is(Status.NOT_FOUND_404));
+        } finally {
+            if (webClient != null) {
+                webClient.closeResource();
+            }
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ListenerConfigBlueprint.java
@@ -421,4 +421,13 @@ interface ListenerConfigBlueprint {
     @Option.Configured
     @Option.Default("true")
     boolean restoreResponseHeaders();
+
+    /**
+     * If set to {@code true}, any named routing configured that does not have an associated named listener will NOT
+     * cause an exception to be thrown (default behavior is to throw an exception).
+     *
+     * @return whether to ignore invalid routing name, defaults to {@code false}
+     */
+    @Option.Configured
+    boolean ignoreInvalidNamedRouting();
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/LoomServer.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -101,6 +102,8 @@ class LoomServer implements WebServer, Resumable {
                                                serverConfig.contentEncoding().orElseGet(ContentEncodingContext::create),
                                                serverConfig.directHandlers().orElseGet(DirectHandlers::create)));
         });
+
+        validateRoutingsHaveNamedListener(serverConfig, listenerMap.keySet());
 
         listeners = Map.copyOf(listenerMap);
         ResumableSupport.get().register(this);
@@ -189,6 +192,35 @@ class LoomServer implements WebServer, Resumable {
     @Override
     public Context context() {
         return context;
+    }
+
+    private static void validateRoutingsHaveNamedListener(WebServerConfig serverConfig, Set<String> namedListeners) {
+        var routingNames = serverConfig.namedRoutings()
+                .keySet();
+
+        List<String> invalidRoutingNames = new ArrayList<>();
+
+        for (String routingName : routingNames) {
+            if (!namedListeners.contains(routingName)) {
+                invalidRoutingNames.add(routingName);
+            }
+        }
+
+        if (!invalidRoutingNames.isEmpty()) {
+            String message = "WebServer has configured named routing, but its"
+                    + " named listener is not defined. Invalid names: \""
+                    + String.join(", ", invalidRoutingNames)
+                    + "\", configured listeners: \""
+                    + String.join(", ", namedListeners) + "\"";
+
+            if (serverConfig.ignoreInvalidNamedRouting()) {
+                if (LOGGER.isLoggable(System.Logger.Level.DEBUG)) {
+                    LOGGER.log(System.Logger.Level.DEBUG, message);
+                }
+            } else {
+                throw new IllegalStateException(message);
+            }
+        }
     }
 
     private void stopIt() {


### PR DESCRIPTION
Resolves #9041 

### Description
This PR adds a check that all named routes have an associated named listener. If this is not met, and exception is thrown when the web server is created.

There is an option for backward-compatibility behavior added to configuration of webserver (both config and builder).