### PR TITLE
4.x: http module updates (constants for annotations, dependency plugin, javadocs fail on warning)

### DIFF
--- a/common/media-type/src/main/java/io/helidon/common/media/type/MediaTypes.java
+++ b/common/media-type/src/main/java/io/helidon/common/media/type/MediaTypes.java
@@ -135,6 +135,111 @@ public final class MediaTypes {
      */
     public static final MediaType APPLICATION_HOCON = MediaTypeEnum.APPLICATION_HOCON;
 
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String WILDCARD_VALUE = "*/*";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_XML_VALUE = "application/xml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_ATOM_XML_VALUE = "application/atom+xml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_XHTML_XML_VALUE = "application/xhtml+xml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_SVG_XML_VALUE = "application/svg+xml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_JSON_VALUE = "application/json";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_JSON_PATCH_JSON_VALUE = "application/json-patch+json";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_STREAM_JSON_VALUE = "application/stream+json";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_FORM_URLENCODED_VALUE = "application/x-www-form-urlencoded";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String MULTIPART_FORM_DATA_VALUE = "multipart/form-data";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String MULTIPART_BYTERANGES_VALUE = "multipart/byteranges";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_OCTET_STREAM_VALUE = "application/octet-stream";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String TEXT_PLAIN_VALUE = "text/plain";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String TEXT_XML_VALUE = "text/xml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String TEXT_HTML_VALUE = "text/html";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_OPENMETRICS_TEXT_VALUE = "application/openmetrics-text";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_OPENAPI_YAML_VALUE = "application/vnd.oai.openapi";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_OPENAPI_JSON_VALUE = "application/vnd.oai.openapi+json";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_X_YAML_VALUE = "application/x-yaml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_YAML_VALUE = "application/yaml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String TEXT_X_YAML_VALUE = "text/x-yaml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String TEXT_YAML_VALUE = "text/yaml";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_JAVASCRIPT_VALUE = "application/javascript";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String TEXT_EVENT_STREAM_VALUE = "text/event-stream";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_X_NDJSON_VALUE = "application/x-ndjson";
+    /**
+     * String value of media type: {@value}.
+     */
+    public static final String APPLICATION_HOCON_VALUE = "application/hocon";
+
     // prevent instantiation of utility class
     private MediaTypes() {
     }

--- a/common/media-type/src/test/java/io/helidon/common/media/type/MediaTypesTest.java
+++ b/common/media-type/src/test/java/io/helidon/common/media/type/MediaTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.common.testing.junit5.OptionalMatcher.optionalPresent;
@@ -50,6 +51,7 @@ class MediaTypesTest {
             .filter(it -> Modifier.isStatic(it.getModifiers()))
             .filter(it -> Modifier.isFinal(it.getModifiers()))
             .filter(it -> Modifier.isPublic(it.getModifiers()))
+            .filter(it -> it.getType().equals(MediaType.class))
             .map(Field::getName)
             .collect(Collectors.toSet());
 
@@ -83,7 +85,20 @@ class MediaTypesTest {
                     () -> assertThat(value.subtype(), notNullValue()),
                     () -> assertThat(value.type(), notNullValue())
             );
+        }
+    }
 
+    @Test
+    @DisplayName("Test all MediaType constants have matching String value constant")
+    void testAllConstantsHaveValue() throws Exception {
+        for (String constant : constants) {
+            MediaType mediaType = (MediaType) clazz.getField(constant)
+                    .get(null);
+            String value = (String) clazz.getField(constant + "_VALUE")
+                    .get(null);
+            assertThat("String value must match text of the MediaType constant for: " + constant,
+                       value,
+                       is(mediaType.text()));
         }
     }
 

--- a/http/encoding/deflate/pom.xml
+++ b/http/encoding/deflate/pom.xml
@@ -29,6 +29,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http.encoding</groupId>
             <artifactId>helidon-http-encoding</artifactId>
         </dependency>

--- a/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncodingProvider.java
+++ b/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncodingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,12 @@ import io.helidon.http.encoding.spi.ContentEncodingProvider;
  * Support for {@code deflate} content encoding.
  */
 public class DeflateEncodingProvider implements ContentEncodingProvider {
+    /**
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
+     */
+    public DeflateEncodingProvider() {
+    }
+
     @Override
     public String configKey() {
         return "deflate";

--- a/http/encoding/encoding/pom.xml
+++ b/http/encoding/encoding/pom.xml
@@ -30,6 +30,10 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-config</artifactId>
         </dependency>
         <dependency>
@@ -37,18 +41,8 @@
             <artifactId>helidon-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-uri</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.builder</groupId>
             <artifactId>helidon-builder-api</artifactId>
-        </dependency>
-        <dependency>
-            <!-- @Generated -->
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.features</groupId>

--- a/http/encoding/encoding/src/main/java/module-info.java
+++ b/http/encoding/encoding/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 import io.helidon.common.features.api.Feature;
 import io.helidon.common.features.api.HelidonFlavor;
-import io.helidon.http.encoding.spi.ContentEncodingProvider;
 
 /**
  * Content encoding support.
@@ -32,7 +31,6 @@ module io.helidon.http.encoding {
     requires io.helidon.common;
 
     requires static io.helidon.common.features.api;
-    requires static jakarta.annotation;
 
     requires transitive io.helidon.common.config;
     requires transitive io.helidon.http;
@@ -40,6 +38,6 @@ module io.helidon.http.encoding {
     exports io.helidon.http.encoding;
     exports io.helidon.http.encoding.spi;
 
-    uses ContentEncodingProvider;
+    uses io.helidon.http.encoding.spi.ContentEncodingProvider;
 
 }

--- a/http/encoding/gzip/pom.xml
+++ b/http/encoding/gzip/pom.xml
@@ -29,6 +29,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http.encoding</groupId>
             <artifactId>helidon-http-encoding</artifactId>
         </dependency>

--- a/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncodingProvider.java
+++ b/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncodingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ import io.helidon.http.encoding.spi.ContentEncodingProvider;
  * Support for gzip content encoding.
  */
 public class GzipEncodingProvider implements ContentEncodingProvider, Weighted {
+    /**
+     * Default constructor required by Java {@link java.util.ServiceLoader}.
+     */
+    public GzipEncodingProvider() {
+    }
+
     @Override
     public String configKey() {
         return "gzip";

--- a/http/http/pom.xml
+++ b/http/http/pom.xml
@@ -56,6 +56,14 @@
             <artifactId>helidon-common-uri</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-parameters</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>

--- a/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,80 +26,80 @@ import io.helidon.common.buffers.Ascii;
  * will slightly increase the memory used by each HTTP request.
  */
 enum HeaderNameEnum implements HeaderName {
-    ACCEPT("Accept"),
-    ACCEPT_CHARSET("Accept-Charset"),
-    ACCEPT_ENCODING("Accept-Encoding"),
-    ACCEPT_LANGUAGE("Accept-Language"),
-    ACCEPT_DATETIME("Accept-Datetime"),
-    ACCESS_CONTROL_ALLOW_CREDENTIALS("Access-Control-Allow-Credentials"),
-    ACCESS_CONTROL_ALLOW_HEADERS("Access-Control-Allow-Headers"),
-    ACCESS_CONTROL_ALLOW_METHODS("Access-Control-Allow-Methods"),
-    ACCESS_CONTROL_ALLOW_ORIGIN("Access-Control-Allow-Origin"),
-    ACCESS_CONTROL_EXPOSE_HEADERS("Access-Control-Expose-Headers"),
-    ACCESS_CONTROL_MAX_AGE("Access-Control-Max-Age"),
-    ACCESS_CONTROL_REQUEST_HEADERS("Access-Control-Request-Headers"),
-    ACCESS_CONTROL_REQUEST_METHOD("Access-Control-Request-Method"),
-    AUTHORIZATION("Authorization"),
-    COOKIE("Cookie"),
-    EXPECT("Expect"),
-    FORWARDED("Forwarded"),
-    FROM("From"),
-    HOST(HeaderNames.HOST_STRING),
-    IF_MATCH("If-Match"),
-    IF_MODIFIED_SINCE("If-Modified-Since"),
-    IF_NONE_MATCH("If-None-Match"),
-    IF_RANGE("If-Range"),
-    IF_UNMODIFIED_SINCE("If-Unmodified-Since"),
-    MAX_FORWARDS("Max-Forwards"),
-    ORIGIN("Origin"),
-    PROXY_AUTHENTICATE("Proxy-Authenticate"),
-    PROXY_AUTHORIZATION("Proxy-Authorization"),
-    RANGE("Range"),
-    REFERER("Referer"),
-    REFRESH("Refresh"),
-    TE("TE"),
-    USER_AGENT("User-Agent"),
-    VIA("Via"),
-    ACCEPT_PATCH("Accept-Patch"),
-    ACCEPT_RANGES("Accept-Ranges"),
-    AGE("Age"),
-    ALLOW("Allow"),
-    ALT_SVC("Alt-Svc"),
-    CACHE_CONTROL("Cache-Control"),
-    CONNECTION("Connection"),
-    CONTENT_DISPOSITION("Content-Disposition"),
-    CONTENT_ENCODING("Content-Encoding"),
-    CONTENT_LANGUAGE("Content-Language"),
-    CONTENT_LENGTH("Content-Length"),
-    CONTENT_LOCATION("aa"),
-    CONTENT_RANGE("Content-Range"),
-    CONTENT_TYPE("Content-Type"),
-    DATE("Date"),
-    ETAG("ETag"),
-    EXPIRES("Expires"),
-    LAST_MODIFIED("Last-Modified"),
-    LINK("Link"),
-    LOCATION("Location"),
-    PRAGMA("Pragma"),
-    PUBLIC_KEY_PINS("Public-Key-Pins"),
-    RETRY_AFTER("Retry-After"),
-    SERVER("Server"),
-    SET_COOKIE("Set-Cookie"),
-    SET_COOKIE2("Set-Cookie2"),
-    STRICT_TRANSPORT_SECURITY("Strict-Transport-Security"),
-    TRAILER("Trailer"),
-    TRANSFER_ENCODING("Transfer-Encoding"),
-    TSV("TSV"),
-    UPGRADE("Upgrade"),
-    VARY("Vary"),
-    WARNING("Warning"),
-    WWW_AUTHENTICATE("WWW-Authenticate"),
-    X_FORWARDED_FOR("X-Forwarded-For"),
-    X_FORWARDED_HOST("X-Forwarded-Host"),
-    X_FORWARDED_PORT("X-Forwarded-Port"),
-    X_FORWARDED_PREFIX("X-Forwarded-Prefix"),
-    X_FORWARDED_PROTO("X-Forwarded-Proto"),
-    X_HELIDON_CN("X-HELIDON-CN");
+    ACCEPT(Strings.ACCEPT_NAME),
+    ACCEPT_CHARSET(Strings.ACCEPT_CHARSET_NAME),
+    ACCEPT_ENCODING(Strings.ACCEPT_ENCODING_NAME),
+    ACCEPT_LANGUAGE(Strings.ACCEPT_LANGUAGE_NAME),
+    ACCEPT_DATETIME(Strings.ACCEPT_DATETIME_NAME),
+    ACCESS_CONTROL_ALLOW_CREDENTIALS(Strings.ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME),
+    ACCESS_CONTROL_ALLOW_HEADERS(Strings.ACCESS_CONTROL_ALLOW_HEADERS_NAME),
+    ACCESS_CONTROL_ALLOW_METHODS(Strings.ACCESS_CONTROL_ALLOW_METHODS_NAME),
+    ACCESS_CONTROL_ALLOW_ORIGIN(Strings.ACCESS_CONTROL_ALLOW_ORIGIN_NAME),
+    ACCESS_CONTROL_EXPOSE_HEADERS(Strings.ACCESS_CONTROL_EXPOSE_HEADERS_NAME),
+    ACCESS_CONTROL_MAX_AGE(Strings.ACCESS_CONTROL_MAX_AGE_NAME),
+    ACCESS_CONTROL_REQUEST_HEADERS(Strings.ACCESS_CONTROL_REQUEST_HEADERS_NAME),
+    ACCESS_CONTROL_REQUEST_METHOD(Strings.ACCESS_CONTROL_REQUEST_METHOD_NAME),
+    AUTHORIZATION(Strings.AUTHORIZATION_NAME),
+    COOKIE(Strings.COOKIE_NAME),
+    EXPECT(Strings.EXPECT_NAME),
+    FORWARDED(Strings.FORWARDED_NAME),
+    FROM(Strings.FROM_NAME),
+    HOST(Strings.HOST_NAME),
+    IF_MATCH(Strings.IF_MATCH_NAME),
+    IF_MODIFIED_SINCE(Strings.IF_MODIFIED_SINCE_NAME),
+    IF_NONE_MATCH(Strings.IF_NONE_MATCH_NAME),
+    IF_RANGE(Strings.IF_RANGE_NAME),
+    IF_UNMODIFIED_SINCE(Strings.IF_UNMODIFIED_SINCE_NAME),
+    MAX_FORWARDS(Strings.MAX_FORWARDS_NAME),
+    ORIGIN(Strings.ORIGIN_NAME),
+    PROXY_AUTHENTICATE(Strings.PROXY_AUTHENTICATE_NAME),
+    PROXY_AUTHORIZATION(Strings.PROXY_AUTHORIZATION_NAME),
+    RANGE(Strings.RANGE_NAME),
+    REFERER(Strings.REFERER_NAME),
+    REFRESH(Strings.REFRESH_NAME),
+    TE(Strings.TE_NAME),
+    USER_AGENT(Strings.USER_AGENT_NAME),
+    VIA(Strings.VIA_NAME),
+    ACCEPT_PATCH(Strings.ACCEPT_PATCH_NAME),
+    ACCEPT_RANGES(Strings.ACCEPT_RANGES_NAME),
+    AGE(Strings.AGE_NAME),
+    ALLOW(Strings.ALLOW_NAME),
+    ALT_SVC(Strings.ALT_SVC_NAME),
+    CACHE_CONTROL(Strings.CACHE_CONTROL_NAME),
+    CONNECTION(Strings.CONNECTION_NAME),
+    CONTENT_DISPOSITION(Strings.CONTENT_DISPOSITION_NAME),
+    CONTENT_ENCODING(Strings.CONTENT_ENCODING_NAME),
+    CONTENT_LANGUAGE(Strings.CONTENT_LANGUAGE_NAME),
+    CONTENT_LENGTH(Strings.CONTENT_LENGTH_NAME),
+    CONTENT_LOCATION(Strings.CONTENT_LOCATION_NAME),
+    CONTENT_RANGE(Strings.CONTENT_RANGE_NAME),
+    CONTENT_TYPE(Strings.CONTENT_TYPE_NAME),
+    DATE(Strings.DATE_NAME),
+    ETAG(Strings.ETAG_NAME),
+    EXPIRES(Strings.EXPIRES_NAME),
+    LAST_MODIFIED(Strings.LAST_MODIFIED_NAME),
+    LINK(Strings.LINK_NAME),
+    LOCATION(Strings.LOCATION_NAME),
+    PRAGMA(Strings.PRAGMA_NAME),
+    PUBLIC_KEY_PINS(Strings.PUBLIC_KEY_PINS_NAME),
+    RETRY_AFTER(Strings.RETRY_AFTER_NAME),
+    SERVER(Strings.SERVER_NAME),
+    SET_COOKIE(Strings.SET_COOKIE_NAME),
+    SET_COOKIE2(Strings.SET_COOKIE2_NAME),
+    STRICT_TRANSPORT_SECURITY(Strings.STRICT_TRANSPORT_SECURITY_NAME),
+    TRAILER(Strings.TRAILER_NAME),
+    TRANSFER_ENCODING(Strings.TRANSFER_ENCODING_NAME),
+    TSV(Strings.TSV_NAME),
+    UPGRADE(Strings.UPGRADE_NAME),
+    VARY(Strings.VARY_NAME),
+    WARNING(Strings.WARNING_NAME),
+    WWW_AUTHENTICATE(Strings.WWW_AUTHENTICATE_NAME),
+    X_FORWARDED_FOR(Strings.X_FORWARDED_FOR_NAME),
+    X_FORWARDED_HOST(Strings.X_FORWARDED_HOST_NAME),
+    X_FORWARDED_PORT(Strings.X_FORWARDED_PORT_NAME),
+    X_FORWARDED_PREFIX(Strings.X_FORWARDED_PREFIX_NAME),
+    X_FORWARDED_PROTO(Strings.X_FORWARDED_PROTO_NAME),
+    X_HELIDON_CN(Strings.X_HELIDON_CN_NAME);
 
     private static final Map<String, HeaderName> BY_NAME;
     private static final Map<String, HeaderName> BY_CAP_NAME;
@@ -150,5 +150,85 @@ enum HeaderNameEnum implements HeaderName {
     @Override
     public int index() {
         return index;
+    }
+
+    static class Strings {
+        static final String ACCEPT_NAME = "Accept";
+        static final String ACCEPT_CHARSET_NAME = "Accept-Charset";
+        static final String ACCEPT_ENCODING_NAME = "Accept-Encoding";
+        static final String ACCEPT_LANGUAGE_NAME = "Accept-Language";
+        static final String ACCEPT_DATETIME_NAME = "Accept-Datetime";
+        static final String ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME = "Access-Control-Allow-Credentials";
+        static final String ACCESS_CONTROL_ALLOW_HEADERS_NAME = "Access-Control-Allow-Headers";
+        static final String ACCESS_CONTROL_ALLOW_METHODS_NAME = "Access-Control-Allow-Methods";
+        static final String ACCESS_CONTROL_ALLOW_ORIGIN_NAME = "Access-Control-Allow-Origin";
+        static final String ACCESS_CONTROL_EXPOSE_HEADERS_NAME = "Access-Control-Expose-Headers";
+        static final String ACCESS_CONTROL_MAX_AGE_NAME = "Access-Control-Max-Age";
+        static final String ACCESS_CONTROL_REQUEST_HEADERS_NAME = "Access-Control-Request-Headers";
+        static final String ACCESS_CONTROL_REQUEST_METHOD_NAME = "Access-Control-Request-Method";
+        static final String AUTHORIZATION_NAME = "Authorization";
+        static final String COOKIE_NAME = "Cookie";
+        static final String EXPECT_NAME = "Expect";
+        static final String FORWARDED_NAME = "Forwarded";
+        static final String FROM_NAME = "From";
+        static final String HOST_NAME = "Host";
+        static final String IF_MATCH_NAME = "If-Match";
+        static final String IF_MODIFIED_SINCE_NAME = "If-Modified-Since";
+        static final String IF_NONE_MATCH_NAME = "If-None-Match";
+        static final String IF_RANGE_NAME = "If-Range";
+        static final String IF_UNMODIFIED_SINCE_NAME = "If-Unmodified-Since";
+        static final String MAX_FORWARDS_NAME = "Max-Forwards";
+        static final String ORIGIN_NAME = "Origin";
+        static final String PROXY_AUTHENTICATE_NAME = "Proxy-Authenticate";
+        static final String PROXY_AUTHORIZATION_NAME = "Proxy-Authorization";
+        static final String RANGE_NAME = "Range";
+        static final String REFERER_NAME = "Referer";
+        static final String REFRESH_NAME = "Refresh";
+        static final String TE_NAME = "TE";
+        static final String USER_AGENT_NAME = "User-Agent";
+        static final String VIA_NAME = "Via";
+        static final String ACCEPT_PATCH_NAME = "Accept-Patch";
+        static final String ACCEPT_RANGES_NAME = "Accept-Ranges";
+        static final String AGE_NAME = "Age";
+        static final String ALLOW_NAME = "Allow";
+        static final String ALT_SVC_NAME = "Alt-Svc";
+        static final String CACHE_CONTROL_NAME = "Cache-Control";
+        static final String CONNECTION_NAME = "Connection";
+        static final String CONTENT_DISPOSITION_NAME = "Content-Disposition";
+        static final String CONTENT_ENCODING_NAME = "Content-Encoding";
+        static final String CONTENT_LANGUAGE_NAME = "Content-Language";
+        static final String CONTENT_LENGTH_NAME = "Content-Length";
+        static final String CONTENT_LOCATION_NAME = "aa";
+        static final String CONTENT_RANGE_NAME = "Content-Range";
+        static final String CONTENT_TYPE_NAME = "Content-Type";
+        static final String DATE_NAME = "Date";
+        static final String ETAG_NAME = "ETag";
+        static final String EXPIRES_NAME = "Expires";
+        static final String LAST_MODIFIED_NAME = "Last-Modified";
+        static final String LINK_NAME = "Link";
+        static final String LOCATION_NAME = "Location";
+        static final String PRAGMA_NAME = "Pragma";
+        static final String PUBLIC_KEY_PINS_NAME = "Public-Key-Pins";
+        static final String RETRY_AFTER_NAME = "Retry-After";
+        static final String SERVER_NAME = "Server";
+        static final String SET_COOKIE_NAME = "Set-Cookie";
+        static final String SET_COOKIE2_NAME = "Set-Cookie2";
+        static final String STRICT_TRANSPORT_SECURITY_NAME = "Strict-Transport-Security";
+        static final String TRAILER_NAME = "Trailer";
+        static final String TRANSFER_ENCODING_NAME = "Transfer-Encoding";
+        static final String TSV_NAME = "TSV";
+        static final String UPGRADE_NAME = "Upgrade";
+        static final String VARY_NAME = "Vary";
+        static final String WARNING_NAME = "Warning";
+        static final String WWW_AUTHENTICATE_NAME = "WWW-Authenticate";
+        static final String X_FORWARDED_FOR_NAME = "X-Forwarded-For";
+        static final String X_FORWARDED_HOST_NAME = "X-Forwarded-Host";
+        static final String X_FORWARDED_PORT_NAME = "X-Forwarded-Port";
+        static final String X_FORWARDED_PREFIX_NAME = "X-Forwarded-Prefix";
+        static final String X_FORWARDED_PROTO_NAME = "X-Forwarded-Proto";
+        static final String X_HELIDON_CN_NAME = "X-HELIDON-CN";
+
+        private Strings() {
+        }
     }
 }

--- a/http/http/src/main/java/io/helidon/http/HeaderNames.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,167 +17,319 @@
 package io.helidon.http;
 
 import io.helidon.common.buffers.Ascii;
+import io.helidon.http.HeaderNameEnum.Strings;
 
 /**
  * Utility class with a list of names of standard HTTP headers and related tooling methods.
  */
 public final class HeaderNames {
     /**
-     * The {@code Accept} header name.
+     * The {@value} header name.
+     * Content-Types that are acceptedTypes for the response.
+     */
+    public static final String ACCEPT_NAME = Strings.ACCEPT_NAME;
+    /**
+     * The {@value #ACCEPT_NAME} header name.
      * Content-Types that are acceptedTypes for the response.
      */
     public static final HeaderName ACCEPT = HeaderNameEnum.ACCEPT;
     /**
-     * The {@code Accept-Charset} header name.
+     * The {@value} header name.
+     * Character sets that are acceptedTypes.
+     */
+    public static final String ACCEPT_CHARSET_NAME = Strings.ACCEPT_CHARSET_NAME;
+    /**
+     * The {@value #ACCEPT_CHARSET_NAME} header name.
      * Character sets that are acceptedTypes.
      */
     public static final HeaderName ACCEPT_CHARSET = HeaderNameEnum.ACCEPT_CHARSET;
     /**
-     * The {@code Accept-Encoding} header name.
+     * The {@value} header name.
+     * List of acceptedTypes encodings.
+     */
+    public static final String ACCEPT_ENCODING_NAME = Strings.ACCEPT_ENCODING_NAME;
+    /**
+     * The {@value #ACCEPT_ENCODING_NAME} header name.
      * List of acceptedTypes encodings.
      */
     public static final HeaderName ACCEPT_ENCODING = HeaderNameEnum.ACCEPT_ENCODING;
     /**
-     * The {@code Accept-Language} header name.
+     * The {@value} header name.
+     * List of acceptedTypes human languages for response.
+     */
+    public static final String ACCEPT_LANGUAGE_NAME = Strings.ACCEPT_LANGUAGE_NAME;
+    /**
+     * The {@value #ACCEPT_LANGUAGE_NAME} header name.
      * List of acceptedTypes human languages for response.
      */
     public static final HeaderName ACCEPT_LANGUAGE = HeaderNameEnum.ACCEPT_LANGUAGE;
     /**
-     * The {@code Accept-Datetime} header name.
+     * The {@value} header name.
+     * Acceptable version in time.
+     */
+    public static final String ACCEPT_DATETIME_NAME = Strings.ACCEPT_DATETIME_NAME;
+    /**
+     * The {@value #ACCEPT_DATETIME_NAME} header name.
      * Acceptable version in time.
      */
     public static final HeaderName ACCEPT_DATETIME = HeaderNameEnum.ACCEPT_DATETIME;
     /**
-     * The {@code Access-Control-Allow-Credentials} header name.
+     * The {@value} header name.
+     * CORS configuration.
+     */
+    public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME = Strings.ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME;
+    /**
+     * The {@value #ACCESS_CONTROL_ALLOW_CREDENTIALS_NAME} header name.
      * CORS configuration.
      */
     public static final HeaderName ACCESS_CONTROL_ALLOW_CREDENTIALS = HeaderNameEnum.ACCESS_CONTROL_ALLOW_CREDENTIALS;
     /**
-     * The {@code Access-Control-Allow-Headers} header name.
+     * The {@value} header name.
+     * CORS configuration
+     */
+    public static final String ACCESS_CONTROL_ALLOW_HEADERS_NAME = Strings.ACCESS_CONTROL_ALLOW_HEADERS_NAME;
+    /**
+     * The {@value #ACCESS_CONTROL_ALLOW_HEADERS_NAME} header name.
      * CORS configuration
      */
     public static final HeaderName ACCESS_CONTROL_ALLOW_HEADERS = HeaderNameEnum.ACCESS_CONTROL_ALLOW_HEADERS;
     /**
-     * The {@code Access-Control-Allow-Methods} header name.
+     * The {@value} header name.
+     * CORS configuration
+     */
+    public static final String ACCESS_CONTROL_ALLOW_METHODS_NAME = Strings.ACCESS_CONTROL_ALLOW_METHODS_NAME;
+    /**
+     * The {@value #ACCESS_CONTROL_ALLOW_METHODS_NAME} header name.
      * CORS configuration
      */
     public static final HeaderName ACCESS_CONTROL_ALLOW_METHODS = HeaderNameEnum.ACCESS_CONTROL_ALLOW_METHODS;
     /**
-     * The {@code Access-Control-Allow-Origin} header name.
+     * The {@value} header name.
+     * CORS configuration.
+     */
+    public static final String ACCESS_CONTROL_ALLOW_ORIGIN_NAME = Strings.ACCESS_CONTROL_ALLOW_ORIGIN_NAME;
+    /**
+     * The {@value #ACCESS_CONTROL_ALLOW_ORIGIN_NAME} header name.
      * CORS configuration.
      */
     public static final HeaderName ACCESS_CONTROL_ALLOW_ORIGIN = HeaderNameEnum.ACCESS_CONTROL_ALLOW_ORIGIN;
     /**
-     * The {@code Access-Control-Expose-Headers} header name.
+     * The {@value} header name.
+     * CORS configuration.
+     */
+    public static final String ACCESS_CONTROL_EXPOSE_HEADERS_NAME = Strings.ACCESS_CONTROL_EXPOSE_HEADERS_NAME;
+    /**
+     * The {@value #ACCESS_CONTROL_EXPOSE_HEADERS_NAME} header name.
      * CORS configuration.
      */
     public static final HeaderName ACCESS_CONTROL_EXPOSE_HEADERS = HeaderNameEnum.ACCESS_CONTROL_EXPOSE_HEADERS;
     /**
-     * The {@code Access-Control-Max-Age} header name.
+     * The {@value} header name.
+     * CORS configuration.
+     */
+    public static final String ACCESS_CONTROL_MAX_AGE_NAME = Strings.ACCESS_CONTROL_MAX_AGE_NAME;
+    /**
+     * The {@value #ACCESS_CONTROL_MAX_AGE_NAME} header name.
      * CORS configuration.
      */
     public static final HeaderName ACCESS_CONTROL_MAX_AGE = HeaderNameEnum.ACCESS_CONTROL_MAX_AGE;
     /**
-     * The {@code Access-Control-Request-Headers} header name.
+     * The {@value} header name.
+     * CORS configuration.
+     */
+    public static final String ACCESS_CONTROL_REQUEST_HEADERS_NAME = Strings.ACCESS_CONTROL_REQUEST_HEADERS_NAME;
+    /**
+     * The {@value #ACCESS_CONTROL_REQUEST_HEADERS_NAME} header name.
      * CORS configuration.
      */
     public static final HeaderName ACCESS_CONTROL_REQUEST_HEADERS = HeaderNameEnum.ACCESS_CONTROL_REQUEST_HEADERS;
     /**
-     * The {@code Access-Control-Request-Method} header name.
+     * The {@value} header name.
+     * CORS configuration.
+     */
+    public static final String ACCESS_CONTROL_REQUEST_METHOD_NAME = Strings.ACCESS_CONTROL_REQUEST_METHOD_NAME;
+    /**
+     * The {@value #ACCESS_CONTROL_REQUEST_METHOD_NAME} header name.
      * CORS configuration.
      */
     public static final HeaderName ACCESS_CONTROL_REQUEST_METHOD = HeaderNameEnum.ACCESS_CONTROL_REQUEST_METHOD;
     /**
-     * The {@code Authorization} header name.
+     * The {@value} header name.
+     * Authentication credentials for HTTP authentication.
+     */
+    public static final String AUTHORIZATION_NAME = Strings.AUTHORIZATION_NAME;
+    /**
+     * The {@value #AUTHORIZATION_NAME} header name.
      * Authentication credentials for HTTP authentication.
      */
     public static final HeaderName AUTHORIZATION = HeaderNameEnum.AUTHORIZATION;
     /**
-     * The {@code Cookie} header name.
-     * An HTTP cookie previously sent by the server with {@code Set-Cookie}.
+     * The {@value} header name.
+     * An HTTP cookie previously sent by the server with {@value #SET_COOKIE_NAME}.
+     */
+    public static final String COOKIE_NAME = Strings.COOKIE_NAME;
+    /**
+     * The {@value #COOKIE_NAME} header name.
+     * An HTTP cookie previously sent by the server with {@value #SET_COOKIE_NAME}.
      */
     public static final HeaderName COOKIE = HeaderNameEnum.COOKIE;
     /**
-     * The {@code Expect} header name.
+     * The {@value} header name.
+     * Indicates that particular server behaviors are required by the client.
+     */
+    public static final String EXPECT_NAME = Strings.EXPECT_NAME;
+    /**
+     * The {@value #EXPECT_NAME} header name.
      * Indicates that particular server behaviors are required by the client.
      */
     public static final HeaderName EXPECT = HeaderNameEnum.EXPECT;
     /**
-     * The {@code Forwarded} header name.
+     * The {@value} header name.
+     * Disclose original information of a client connecting to a web server through an HTTP proxy.
+     */
+    public static final String FORWARDED_NAME = Strings.FORWARDED_NAME;
+    /**
+     * The {@value #FORWARDED_NAME} header name.
      * Disclose original information of a client connecting to a web server through an HTTP proxy.
      */
     public static final HeaderName FORWARDED = HeaderNameEnum.FORWARDED;
     /**
-     * The {@code From} header name.
+     * The {@value} header name.
+     * The email address of the user making the request.
+     */
+    public static final String FROM_NAME = Strings.FROM_NAME;
+    /**
+     * The {@value #FROM_NAME} header name.
      * The email address of the user making the request.
      */
     public static final HeaderName FROM = HeaderNameEnum.FROM;
     /**
-     * The {@code Host} header name.
+     * The {@value} header name.
+     * The domain name of the server (for virtual hosting), and the TCP port number on which the server is listening.
+     * The port number may be omitted if the port is the standard port for the service requested.
+     */
+    public static final String HOST_NAME = Strings.HOST_NAME;
+    /**
+     * The {@value #HOST_NAME} header name.
      * The domain name of the server (for virtual hosting), and the TCP port number on which the server is listening.
      * The port number may be omitted if the port is the standard port for the service requested.
      */
     public static final HeaderName HOST = HeaderNameEnum.HOST;
     /**
-     * The {@value} header.
-     *
-     * @see #HOST
+     * The {@value} header name.
+     * Only perform the action if the client supplied entity matches the same entity on the server. This is mainly
+     * for methods like PUT to only update a resource if it has not been modified since the user last updated it.
      */
-    public static final String HOST_STRING = "Host";
+    public static final String IF_MATCH_NAME = Strings.IF_MATCH_NAME;
     /**
-     * The {@code If-Match} header name.
+     * The {@value #IF_MATCH_NAME} header name.
      * Only perform the action if the client supplied entity matches the same entity on the server. This is mainly
      * for methods like PUT to only update a resource if it has not been modified since the user last updated it.
      */
     public static final HeaderName IF_MATCH = HeaderNameEnum.IF_MATCH;
     /**
-     * The {@code If-Modified-Since} header name.
+     * The {@value} header name.
+     * Allows a 304 Not Modified to be returned if content is unchanged.
+     */
+    public static final String IF_MODIFIED_SINCE_NAME = Strings.IF_MODIFIED_SINCE_NAME;
+    /**
+     * The {@value #IF_MODIFIED_SINCE_NAME} header name.
      * Allows a 304 Not Modified to be returned if content is unchanged.
      */
     public static final HeaderName IF_MODIFIED_SINCE = HeaderNameEnum.IF_MODIFIED_SINCE;
     /**
-     * The {@code If-None-Match} header name.
+     * The {@value} header name.
+     * Allows a 304 Not Modified to be returned if content is unchanged, based on {@link #ETAG}.
+     */
+    public static final String IF_NONE_MATCH_NAME = Strings.IF_NONE_MATCH_NAME;
+    /**
+     * The {@value #IF_NONE_MATCH_NAME} header name.
      * Allows a 304 Not Modified to be returned if content is unchanged, based on {@link #ETAG}.
      */
     public static final HeaderName IF_NONE_MATCH = HeaderNameEnum.IF_NONE_MATCH;
     /**
-     * The {@code If-Range} header name.
+     * The {@value} header name.
+     * If the entity is unchanged, send me the part(s) that I am missing; otherwise, send me the entire new entity.
+     */
+    public static final String IF_RANGE_NAME = Strings.IF_RANGE_NAME;
+    /**
+     * The {@value #IF_RANGE_NAME} header name.
      * If the entity is unchanged, send me the part(s) that I am missing; otherwise, send me the entire new entity.
      */
     public static final HeaderName IF_RANGE = HeaderNameEnum.IF_RANGE;
     /**
-     * The {@code If-Unmodified-Since} header name.
+     * The {@value} header name.
+     * Only send The {@code response if The Entity} has not been modified since a specific time.
+     */
+    public static final String IF_UNMODIFIED_SINCE_NAME = Strings.IF_UNMODIFIED_SINCE_NAME;
+    /**
+     * The {@value #IF_UNMODIFIED_SINCE_NAME} header name.
      * Only send The {@code response if The Entity} has not been modified since a specific time.
      */
     public static final HeaderName IF_UNMODIFIED_SINCE = HeaderNameEnum.IF_UNMODIFIED_SINCE;
     /**
-     * The {@code Max-Forwards} header name.
+     * The {@value} header name.
+     * Limit the number of times the message can be forwarded through proxies or gateways.
+     */
+    public static final String MAX_FORWARDS_NAME = Strings.MAX_FORWARDS_NAME;
+    /**
+     * The {@value #MAX_FORWARDS_NAME} header name.
      * Limit the number of times the message can be forwarded through proxies or gateways.
      */
     public static final HeaderName MAX_FORWARDS = HeaderNameEnum.MAX_FORWARDS;
     /**
-     * The {@code <code>{@value}</code>} header name.
-     * Initiates a request for cross-origin resource sharing (asks server for an {@code 'Access-Control-Allow-Origin'}
+     * The {@value} header name.
+     * Initiates a request for cross-origin resource sharing (asks server for an
+     * {@value #ACCESS_CONTROL_ALLOW_ORIGIN_NAME} response field).
+     */
+    public static final String ORIGIN_NAME = Strings.ORIGIN_NAME;
+    /**
+     * The {@value #ORIGIN_NAME} header name.
+     * Initiates a request for cross-origin resource sharing (asks server for an
+     * {@value #ACCESS_CONTROL_ALLOW_ORIGIN_NAME}
      * response field).
      */
     public static final HeaderName ORIGIN = HeaderNameEnum.ORIGIN;
     /**
-     * The {@code Proxy-Authenticate} header name.
+     * The {@value} header name.
+     * Proxy authentication information.
+     */
+    public static final String PROXY_AUTHENTICATE_NAME = Strings.PROXY_AUTHENTICATE_NAME;
+    /**
+     * The {@value #PROXY_AUTHENTICATE_NAME} header name.
      * Proxy authentication information.
      */
     public static final HeaderName PROXY_AUTHENTICATE = HeaderNameEnum.PROXY_AUTHENTICATE;
     /**
-     * The {@code Proxy-Authorization} header name.
+     * The {@value} header name.
+     * Proxy authorization information.
+     */
+    public static final String PROXY_AUTHORIZATION_NAME = Strings.PROXY_AUTHORIZATION_NAME;
+    /**
+     * The {@value #PROXY_AUTHORIZATION_NAME} header name.
      * Proxy authorization information.
      */
     public static final HeaderName PROXY_AUTHORIZATION = HeaderNameEnum.PROXY_AUTHORIZATION;
     /**
-     * The {@code Range} header name.
+     * The {@value} header name.
+     * Request only part of an entity. Bytes are numbered from 0.
+     */
+    public static final String RANGE_NAME = Strings.RANGE_NAME;
+    /**
+     * The {@value #RANGE_NAME} header name.
      * Request only part of an entity. Bytes are numbered from 0.
      */
     public static final HeaderName RANGE = HeaderNameEnum.RANGE;
     /**
-     * The {@code <code>{@value}</code>} header name.
+     * The {@value} header name.
+     * This is the address of the previous web page from which a link to the currently requested page was followed.
+     * (The {@code word <i>referrer</i>} has been misspelled in The
+     * {@code RFC as well as in most implementations to the point that it} has
+     * become standard usage and is considered correct terminology.)
+     */
+    public static final String REFERER_NAME = Strings.REFERER_NAME;
+    /**
+     * The {@value #REFERER_NAME} header name.
      * This is the address of the previous web page from which a link to the currently requested page was followed.
      * (The {@code word <i>referrer</i>} has been misspelled in The
      * {@code RFC as well as in most implementations to the point that it} has
@@ -185,235 +337,468 @@ public final class HeaderNames {
      */
     public static final HeaderName REFERER = HeaderNameEnum.REFERER;
     /**
-     * The {@code <code>{@value}</code>} header name.
+     * The {@value} header name.
+     */
+    public static final String REFRESH_NAME = Strings.REFRESH_NAME;
+    /**
+     * The {@value #REFERER_NAME} header name.
      */
     public static final HeaderName REFRESH = HeaderNameEnum.REFRESH;
     /**
-     * The {@code <code>{@value}</code>} header name.
+     * The {@value} header name.
      * The {@code transfer encodings the user agent is willing to acceptedTypes: the same values as for The Response} header
      * field
-     * {@code Transfer-Encoding} can be used, plus the <i>trailers</i> value (related to the <i>chunked</i> transfer method)
+     * {@value #TRANSFER_ENCODING_NAME} can be used, plus the <i>trailers</i> value
+     * (related to the <i>chunked</i> transfer method)
+     * to notify the server it expects to receive additional fields in the trailer after the last, zero-sized, chunk.
+     */
+    public static final String TE_NAME = Strings.TE_NAME;
+    /**
+     * The {@value #TE_NAME} header name.
+     * The {@code transfer encodings the user agent is willing to acceptedTypes: the same values as for The Response} header
+     * field
+     * {@value #TRANSFER_ENCODING_NAME} can be used, plus the <i>trailers</i> value
+     * (related to the <i>chunked</i> transfer method)
      * to notify the server it expects to receive additional fields in the trailer after the last, zero-sized, chunk.
      */
     public static final HeaderName TE = HeaderNameEnum.TE;
     /**
-     * The {@code User-Agent} header name.
+     * The {@value} header name.
+     * The user agent string of the user agent.
+     */
+    public static final String USER_AGENT_NAME = Strings.USER_AGENT_NAME;
+    /**
+     * The {@value #USER_AGENT_NAME} header name.
      * The user agent string of the user agent.
      */
     public static final HeaderName USER_AGENT = HeaderNameEnum.USER_AGENT;
     /**
-     * The {@code Via} header name.
+     * The {@value} header name.
+     * Informs the server of proxies through which the request was sent.
+     */
+    public static final String VIA_NAME = Strings.VIA_NAME;
+    /**
+     * The {@value #VIA_NAME} header name.
      * Informs the server of proxies through which the request was sent.
      */
     public static final HeaderName VIA = HeaderNameEnum.VIA;
     /**
-     * The {@code Accept-Patch} header name.
+     * The {@value} header name.
+     * Specifies which patch document formats this server supports.
+     */
+    public static final String ACCEPT_PATCH_NAME = Strings.ACCEPT_PATCH_NAME;
+    /**
+     * The {@value #ACCEPT_PATCH_NAME} header name.
      * Specifies which patch document formats this server supports.
      */
     public static final HeaderName ACCEPT_PATCH = HeaderNameEnum.ACCEPT_PATCH;
     /**
-     * The {@code Accept-Ranges} header name.
+     * The {@value} header name.
+     * What partial content range types this server supports via byte serving.
+     */
+    public static final String ACCEPT_RANGES_NAME = Strings.ACCEPT_RANGES_NAME;
+    /**
+     * The {@value #ACCEPT_RANGES_NAME} header name.
      * What partial content range types this server supports via byte serving.
      */
     public static final HeaderName ACCEPT_RANGES = HeaderNameEnum.ACCEPT_RANGES;
     /**
-     * The {@code Age} header name.
+     * The {@value} header name.
+     * The {@code age The Object} has been in a proxy cache in seconds.
+     */
+    public static final String AGE_NAME = Strings.AGE_NAME;
+    /**
+     * The {@value #AGE_NAME} header name.
      * The {@code age The Object} has been in a proxy cache in seconds.
      */
     public static final HeaderName AGE = HeaderNameEnum.AGE;
     /**
-     * The {@code Allow} header name.
+     * The {@value} header name.
+     * Valid actions for a specified resource. To be used for a 405 Method not allowed.
+     */
+    public static final String ALLOW_NAME = Strings.ALLOW_NAME;
+    /**
+     * The {@value #ALLOW_NAME} header name.
      * Valid actions for a specified resource. To be used for a 405 Method not allowed.
      */
     public static final HeaderName ALLOW = HeaderNameEnum.ALLOW;
     /**
-     * The {@code <code>{@value}</code>} header name.
+     * The {@value} header name.
+     * A server uses <i>Alt-Svc</i> header (meaning Alternative Services) to indicate that its resources can also be
+     * accessed at a different network location (host or port) or using a different protocol.
+     */
+    public static final String ALT_SVC_NAME = Strings.ALT_SVC_NAME;
+    /**
+     * The {@value #ALT_SVC_NAME} header name.
      * A server uses <i>Alt-Svc</i> header (meaning Alternative Services) to indicate that its resources can also be
      * accessed at a different network location (host or port) or using a different protocol.
      */
     public static final HeaderName ALT_SVC = HeaderNameEnum.ALT_SVC;
     /**
-     * The {@code Cache-Control} header name.
+     * The {@value} header name.
+     * Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds.
+     */
+    public static final String CACHE_CONTROL_NAME = Strings.CACHE_CONTROL_NAME;
+    /**
+     * The {@value #CACHE_CONTROL_NAME} header name.
      * Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds.
      */
     public static final HeaderName CACHE_CONTROL = HeaderNameEnum.CACHE_CONTROL;
     /**
-     * The {@code Connection} header name.
+     * The {@value} header name.
+     * Control options for The {@code current connection and list of} hop-by-hop response fields.
+     */
+    public static final String CONNECTION_NAME = Strings.CONNECTION_NAME;
+    /**
+     * The {@value #CONNECTION_NAME} header name.
      * Control options for The {@code current connection and list of} hop-by-hop response fields.
      */
     public static final HeaderName CONNECTION = HeaderNameEnum.CONNECTION;
     /**
-     * The {@code <code>{@value}</code>} header name.
+     * The {@value} header name.
+     * An opportunity to raise a <i>File Download</i> dialogue box for a known MIME type with binary format or suggest
+     * a filename for dynamic content. Quotes are necessary with special characters.
+     */
+    public static final String CONTENT_DISPOSITION_NAME = Strings.CONTENT_DISPOSITION_NAME;
+    /**
+     * The {@value #CONTENT_DISPOSITION_NAME} header name.
      * An opportunity to raise a <i>File Download</i> dialogue box for a known MIME type with binary format or suggest
      * a filename for dynamic content. Quotes are necessary with special characters.
      */
     public static final HeaderName CONTENT_DISPOSITION = HeaderNameEnum.CONTENT_DISPOSITION;
     /**
-     * The {@code Content-Encoding} header name.
+     * The {@value} header name.
+     * The type of encoding used on the data.
+     */
+    public static final String CONTENT_ENCODING_NAME = Strings.CONTENT_ENCODING_NAME;
+    /**
+     * The {@value #CONTENT_ENCODING_NAME} header name.
      * The type of encoding used on the data.
      */
     public static final HeaderName CONTENT_ENCODING = HeaderNameEnum.CONTENT_ENCODING;
     /**
-     * The {@code Content-Language} header name.
+     * The {@value} header name.
+     * The natural language or languages of the intended audience for the enclosed content.
+     */
+    public static final String CONTENT_LANGUAGE_NAME = Strings.CONTENT_LANGUAGE_NAME;
+    /**
+     * The {@value #CONTENT_LANGUAGE_NAME} header name.
      * The natural language or languages of the intended audience for the enclosed content.
      */
     public static final HeaderName CONTENT_LANGUAGE = HeaderNameEnum.CONTENT_LANGUAGE;
     /**
-     * The {@code Content-Length} header name.
+     * The {@value} header name.
+     * The length of the response body in octets.
+     */
+    public static final String CONTENT_LENGTH_NAME = Strings.CONTENT_LENGTH_NAME;
+    /**
+     * The {@value #CONTENT_LENGTH_NAME} header name.
      * The length of the response body in octets.
      */
     public static final HeaderName CONTENT_LENGTH = HeaderNameEnum.CONTENT_LENGTH;
     /**
-     * The {@code Content-Location} header name.
+     * The {@value} header name.
+     * An alternate location for the returned data.
+     */
+    public static final String CONTENT_LOCATION_NAME = Strings.CONTENT_LOCATION_NAME;
+    /**
+     * The {@value #CONTENT_LOCATION_NAME} header name.
      * An alternate location for the returned data.
      */
     public static final HeaderName CONTENT_LOCATION = HeaderNameEnum.CONTENT_LOCATION;
     /**
-     * The {@code Content-Range} header name.
+     * The {@value} header name.
+     * Where in a full body message this partial message belongs.
+     */
+    public static final String CONTENT_RANGE_NAME = Strings.CONTENT_RANGE_NAME;
+    /**
+     * The {@value #CONTENT_RANGE_NAME} header name.
      * Where in a full body message this partial message belongs.
      */
     public static final HeaderName CONTENT_RANGE = HeaderNameEnum.CONTENT_RANGE;
     /**
-     * The {@code Content-Type} header name.
+     * The {@value} header name.
+     * The MIME type of this content.
+     */
+    public static final String CONTENT_TYPE_NAME = Strings.CONTENT_TYPE_NAME;
+    /**
+     * The {@value #CONTENT_TYPE_NAME} header name.
      * The MIME type of this content.
      */
     public static final HeaderName CONTENT_TYPE = HeaderNameEnum.CONTENT_TYPE;
     /**
-     * The {@code Date} header name.
+     * The {@value} header name.
+     * The date and time that the message was sent (in <i>HTTP-date</i> format as defined by RFC 7231).
+     */
+    public static final String DATE_NAME = Strings.DATE_NAME;
+    /**
+     * The {@value #DATE_NAME} header name.
      * The date and time that the message was sent (in <i>HTTP-date</i> format as defined by RFC 7231).
      */
     public static final HeaderName DATE = HeaderNameEnum.DATE;
     /**
-     * The {@code Etag} header name.
+     * The {@value} header name.
+     * An identifier for a specific version of a resource, often a message digest.
+     */
+    public static final String ETAG_NAME = Strings.ETAG_NAME;
+    /**
+     * The {@value #ETAG_NAME} header name.
      * An identifier for a specific version of a resource, often a message digest.
      */
     public static final HeaderName ETAG = HeaderNameEnum.ETAG;
     /**
-     * The {@code Expires} header name.
+     * The {@value} header name.
+     * Gives the date/time after which the response is considered stale (in <i>HTTP-date</i> format as defined by RFC 7231)
+     */
+    public static final String EXPIRES_NAME = Strings.EXPIRES_NAME;
+    /**
+     * The {@value #EXPIRES_NAME} header name.
      * Gives the date/time after which the response is considered stale (in <i>HTTP-date</i> format as defined by RFC 7231)
      */
     public static final HeaderName EXPIRES = HeaderNameEnum.EXPIRES;
     /**
-     * The {@code Last-Modified} header name.
+     * The {@value} header name.
+     * The last modified date for the requested object (in <i>HTTP-date</i> format as defined by RFC 7231)
+     */
+    public static final String LAST_MODIFIED_NAME = Strings.LAST_MODIFIED_NAME;
+    /**
+     * The {@value #LAST_MODIFIED_NAME} header name.
      * The last modified date for the requested object (in <i>HTTP-date</i> format as defined by RFC 7231)
      */
     public static final HeaderName LAST_MODIFIED = HeaderNameEnum.LAST_MODIFIED;
     /**
-     * The {@code Link} header name.
+     * The {@value} header name.
+     * Used to express a typed relationship with another resource, where the relation type is defined by RFC 5988.
+     */
+    public static final String LINK_NAME = Strings.LINK_NAME;
+    /**
+     * The {@value #LINK_NAME} header name.
      * Used to express a typed relationship with another resource, where the relation type is defined by RFC 5988.
      */
     public static final HeaderName LINK = HeaderNameEnum.LINK;
     /**
-     * The {@code Location} header name.
+     * The {@value} header name.
+     * Used in redirection, or whenRequest a new resource has been created.
+     */
+    public static final String LOCATION_NAME = Strings.LOCATION_NAME;
+    /**
+     * The {@value #LOCATION_NAME} header name.
      * Used in redirection, or whenRequest a new resource has been created.
      */
     public static final HeaderName LOCATION = HeaderNameEnum.LOCATION;
     /**
-     * The {@code Pragma} header name.
+     * The {@value} header name.
+     * Implementation-specific fields that may have various effects anywhere along the request-response chain.
+     */
+    public static final String PRAGMA_NAME = Strings.PRAGMA_NAME;
+    /**
+     * The {@value #PRAGMA_NAME} header name.
      * Implementation-specific fields that may have various effects anywhere along the request-response chain.
      */
     public static final HeaderName PRAGMA = HeaderNameEnum.PRAGMA;
     /**
-     * The {@code Public-Key-Pins} header name.
+     * The {@value} header name.
+     * HTTP Public Key Pinning, announces hash of website's authentic TLS certificate.
+     */
+    public static final String PUBLIC_KEY_PINS_NAME = Strings.PUBLIC_KEY_PINS_NAME;
+    /**
+     * The {@value #PUBLIC_KEY_PINS_NAME} header name.
      * HTTP Public Key Pinning, announces hash of website's authentic TLS certificate.
      */
     public static final HeaderName PUBLIC_KEY_PINS = HeaderNameEnum.PUBLIC_KEY_PINS;
     /**
-     * The {@code <code>{@value}</code>} header name.
+     * The {@value} header name.
+     * If an entity is temporarily unavailable, this instructs the client to try again later. Value could be a specified
+     * period of time (in seconds) or an HTTP-date.
+     */
+    public static final String RETRY_AFTER_NAME = Strings.RETRY_AFTER_NAME;
+    /**
+     * The {@value #RETRY_AFTER_NAME} header name.
      * If an entity is temporarily unavailable, this instructs the client to try again later. Value could be a specified
      * period of time (in seconds) or an HTTP-date.
      */
     public static final HeaderName RETRY_AFTER = HeaderNameEnum.RETRY_AFTER;
     /**
-     * The {@code Server} header name.
+     * The {@value} header name.
+     * A name for the server.
+     */
+    public static final String SERVER_NAME = Strings.SERVER_NAME;
+    /**
+     * The {@value #SERVER_NAME} header name.
      * A name for the server.
      */
     public static final HeaderName SERVER = HeaderNameEnum.SERVER;
     /**
-     * The {@code Set-Cookie} header name.
+     * The {@value} header name.
+     * An HTTP cookie set directive.
+     */
+    public static final String SET_COOKIE_NAME = Strings.SET_COOKIE_NAME;
+    /**
+     * The {@value #SET_COOKIE_NAME} header name.
      * An HTTP cookie set directive.
      */
     public static final HeaderName SET_COOKIE = HeaderNameEnum.SET_COOKIE;
     /**
-     * The {@code Set-Cookie2} header name.
+     * The {@value} header name.
+     * An HTTP cookie set directive.
+     */
+    public static final String SET_COOKIE2_NAME = Strings.SET_COOKIE2_NAME;
+    /**
+     * The {@value #SET_COOKIE2_NAME} header name.
      * An HTTP cookie set directive.
      */
     public static final HeaderName SET_COOKIE2 = HeaderNameEnum.SET_COOKIE2;
     /**
-     * The {@code Strict-Transport-Security} header name.
+     * The {@value} header name.
+     * A HSTS Policy informing The {@code HTTP client} how long to cache the HTTPS only policy and whether this applies to
+     * subdomains.
+     */
+    public static final String STRICT_TRANSPORT_SECURITY_NAME = Strings.STRICT_TRANSPORT_SECURITY_NAME;
+    /**
+     * The {@value #STRICT_TRANSPORT_SECURITY_NAME} header name.
      * A HSTS Policy informing The {@code HTTP client} how long to cache the HTTPS only policy and whether this applies to
      * subdomains.
      */
     public static final HeaderName STRICT_TRANSPORT_SECURITY = HeaderNameEnum.STRICT_TRANSPORT_SECURITY;
     /**
-     * The {@code Trailer} header name.
+     * The {@value} header name.
+     * The Trailer general field value indicates that the given set of} header fields is present in the trailer of
+     * a message encoded with chunked transfer coding.
+     */
+    public static final String TRAILER_NAME = Strings.TRAILER_NAME;
+    /**
+     * The {@value #TRAILER_NAME} header name.
      * The Trailer general field value indicates that the given set of} header fields is present in the trailer of
      * a message encoded with chunked transfer coding.
      */
     public static final HeaderName TRAILER = HeaderNameEnum.TRAILER;
     /**
-     * The {@code Transfer-Encoding} header name.
+     * The {@value} header name.
+     * The form of encoding used to safely transfer the entity to the user. Currently defined methods are:
+     * {@code chunked, compress, deflate, gzip, identity}.
+     */
+    public static final String TRANSFER_ENCODING_NAME = Strings.TRANSFER_ENCODING_NAME;
+    /**
+     * The {@value #TRANSFER_ENCODING_NAME} header name.
      * The form of encoding used to safely transfer the entity to the user. Currently defined methods are:
      * {@code chunked, compress, deflate, gzip, identity}.
      */
     public static final HeaderName TRANSFER_ENCODING = HeaderNameEnum.TRANSFER_ENCODING;
     /**
-     * The {@code Tsv} header name.
+     * The {@value} header name.
+     * Tracking Status Value, value suggested to be sent in response to a DNT(do-not-track).
+     */
+    public static final String TSV_NAME = Strings.TSV_NAME;
+    /**
+     * The {@value #TSV_NAME} header name.
      * Tracking Status Value, value suggested to be sent in response to a DNT(do-not-track).
      */
     public static final HeaderName TSV = HeaderNameEnum.TSV;
     /**
-     * The {@code Upgrade} header name.
+     * The {@value} header name.
+     * Ask to upgrade to another protocol.
+     */
+    public static final String UPGRADE_NAME = Strings.UPGRADE_NAME;
+    /**
+     * The {@value #UPGRADE_NAME} header name.
      * Ask to upgrade to another protocol.
      */
     public static final HeaderName UPGRADE = HeaderNameEnum.UPGRADE;
     /**
-     * The {@code Vary} header name.
+     * The {@value} header name.
+     * Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather
+     * than requesting a fresh one from the origin server.
+     */
+    public static final String VARY_NAME = Strings.VARY_NAME;
+    /**
+     * The {@value #VARY_NAME} header name.
      * Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather
      * than requesting a fresh one from the origin server.
      */
     public static final HeaderName VARY = HeaderNameEnum.VARY;
     /**
-     * The {@code Warning} header name.
+     * The {@value} header name.
+     * A general warning about possible problems with the entity body.
+     */
+    public static final String WARNING_NAME = Strings.WARNING_NAME;
+    /**
+     * The {@value #WARNING_NAME} header name.
      * A general warning about possible problems with the entity body.
      */
     public static final HeaderName WARNING = HeaderNameEnum.WARNING;
     /**
-     * The {@code WWW-Authenticate} header name.
+     * The {@value} header name.
+     * Indicates the authentication scheme that should be used to access the requested entity.
+     */
+    public static final String WWW_AUTHENTICATE_NAME = Strings.WWW_AUTHENTICATE_NAME;
+    /**
+     * The {@value #WWW_AUTHENTICATE_NAME} header name.
      * Indicates the authentication scheme that should be used to access the requested entity.
      */
     public static final HeaderName WWW_AUTHENTICATE = HeaderNameEnum.WWW_AUTHENTICATE;
     /**
-     * The {@code X_HELIDON_CN} header name.
+     * The {@value} header name.
+     * Corresponds to the certificate CN subject value when client authentication enabled.
+     * This header will be removed if it is part of the request.
+     */
+    public static final String X_HELIDON_CN_NAME = Strings.X_HELIDON_CN_NAME;
+    /**
+     * The {@value #X_HELIDON_CN_NAME} header name.
      * Corresponds to the certificate CN subject value when client authentication enabled.
      * This header will be removed if it is part of the request.
      */
     public static final HeaderName X_HELIDON_CN = HeaderNameEnum.X_HELIDON_CN;
     /**
-     * The {@code X-Forwarded-For} header name.
+     * The {@value} header name.
+     * Represents the originating client and intervening proxies when the request has passed through one or more proxies.
+     */
+    public static final String X_FORWARDED_FOR_NAME = Strings.X_FORWARDED_FOR_NAME;
+    /**
+     * The {@value #X_FORWARDED_FOR_NAME} header name.
      * Represents the originating client and intervening proxies when the request has passed through one or more proxies.
      */
     public static final HeaderName X_FORWARDED_FOR = HeaderNameEnum.X_FORWARDED_FOR;
     /**
-     * The {@code X_FORWARDED_HOST} header name.
+     * The {@value} header name.
+     * Represents the host specified by the originating client when the request has passed through one or more proxies.
+     */
+    public static final String X_FORWARDED_HOST_NAME = Strings.X_FORWARDED_HOST_NAME;
+    /**
+     * The {@value #X_FORWARDED_HOST_NAME} header name.
      * Represents the host specified by the originating client when the request has passed through one or more proxies.
      */
     public static final HeaderName X_FORWARDED_HOST = HeaderNameEnum.X_FORWARDED_HOST;
 
     /**
-     * The {@code X_FORWARDED_PORT} header name.
+     * The {@value} header name.
+     * Represents the port specified by the originating client when the request has passed through one or more proxies.
+     */
+    public static final String X_FORWARDED_PORT_NAME = Strings.X_FORWARDED_PORT_NAME;
+    /**
+     * The {@value #X_FORWARDED_PORT_NAME} header name.
      * Represents the port specified by the originating client when the request has passed through one or more proxies.
      */
     public static final HeaderName X_FORWARDED_PORT = HeaderNameEnum.X_FORWARDED_PORT;
 
     /**
-     * The {@code X_FORWARDED_PREFIX} header name.
+     * The {@value} header name.
+     * Represents the path prefix to be applied to relative paths resolved against this request when the request has passed
+     * through one or more proxies.
+     */
+    public static final String X_FORWARDED_PREFIX_NAME = Strings.X_FORWARDED_PREFIX_NAME;
+    /**
+     * The {@value #X_FORWARDED_PREFIX_NAME} header name.
      * Represents the path prefix to be applied to relative paths resolved against this request when the request has passed
      * through one or more proxies.
      */
     public static final HeaderName X_FORWARDED_PREFIX = HeaderNameEnum.X_FORWARDED_PREFIX;
     /**
-     * The {@code X_FORWARDED_PROTO} header name.
+     * The {@value} header name.
+     * Represents the protocol specified by the originating client when the request has passed through one or more proxies.
+     */
+    public static final String X_FORWARDED_PROTO_NAME = Strings.X_FORWARDED_PROTO_NAME;
+    /**
+     * The {@value #X_FORWARDED_PROTO_NAME} header name.
      * Represents the protocol specified by the originating client when the request has passed through one or more proxies.
      */
     public static final HeaderName X_FORWARDED_PROTO = HeaderNameEnum.X_FORWARDED_PROTO;

--- a/http/http/src/main/java/io/helidon/http/HttpException.java
+++ b/http/http/src/main/java/io/helidon/http/HttpException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,17 @@ package io.helidon.http;
  * before the status code is sent.
  */
 public class HttpException extends RuntimeException {
-
+    /**
+     * HTTP status to return.
+     */
     private final Status status;
+    /**
+     * Whether the connection can be kept alive.
+     */
     private final boolean keepAlive;
+    /**
+     * Header to return with the response.
+     */
     private final ServerResponseHeaders headers = ServerResponseHeaders.create();
 
     /**

--- a/http/http/src/main/java/io/helidon/http/HttpPrologue.java
+++ b/http/http/src/main/java/io/helidon/http/HttpPrologue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/http/src/main/java/io/helidon/http/Method.java
+++ b/http/http/src/main/java/io/helidon/http/Method.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,25 +22,60 @@ import java.util.Objects;
 import io.helidon.common.buffers.Ascii;
 
 /**
- * Interface representing an HTTP request method, all standard methods are in {@link Method}
- * enumeration.
+ * HTTP request methods.
  * <p>
  * Although the constants are instances of this class, they can be compared using instance equality, as the only
  * way to obtain an instance is through method {@link #create(String)}, which ensures the same instance is returned for
  * known methods.
  * <p>
  * Methods that are not known (e.g. there is no constant for them) must be compared using {@link #equals(Object)} as usual.
- *
- * @see Method
+ * <p>
+ * This class also contains string method names, such as {@link #GET_NAME} to allow usage in annotations.
  */
 public final class Method {
-    private static final String GET_STRING = "GET";
+    /**
+     * {@value} method name.
+     */
+    public static final String GET_NAME = "GET";
+    /**
+     * {@value} method name.
+     */
+    public static final String POST_NAME = "POST";
+    /**
+     * {@value} method name.
+     */
+    public static final String PUT_NAME = "PUT";
+    /**
+     * {@value} method name.
+     */
+    public static final String DELETE_NAME = "DELETE";
+    /**
+     * {@value} method name.
+     */
+    public static final String HEAD_NAME = "HEAD";
+    /**
+     * {@value} method name.
+     */
+    public static final String PATCH_NAME = "PATCH";
+    /**
+     * {@value} method name.
+     */
+    public static final String OPTIONS_NAME = "OPTIONS";
+    /**
+     * {@value} method name.
+     */
+    public static final String TRACE_NAME = "TRACE";
+    /**
+     * {@value} method name.
+     */
+    public static final String CONNECT_NAME = "CONNECT";
+
     /**
      * The GET method means retrieve whatever information (in the form of an entity) is identified by the Request-URI.
      * If the Request-URI refers to a data-producing process, it is the produced data which shall be returned as the entity
      * in the response and not the source text of the process, unless that text happens to be the output of the tryProcess.
      */
-    public static final Method GET = new Method(GET_STRING, true);
+    public static final Method GET = new Method(GET_NAME, true);
     /**
      * The POST method is used to request that the origin server acceptedTypes the entity enclosed in the request
      * as a new subordinate of the resource identified by the Request-URI in the Request-Line.
@@ -49,7 +84,7 @@ public final class Method {
      * containing it, a news article is subordinate to a newsgroup to which it is posted, or a record is subordinate
      * to a database.
      */
-    public static final Method POST = new Method("POST", true);
+    public static final Method POST = new Method(POST_NAME, true);
     /**
      * The PUT method requests that the enclosed entity be stored under the supplied Request-URI. If the Request-URI refers
      * to an already existing resource, the enclosed entity SHOULD be considered as a modified version of the one residing
@@ -62,7 +97,7 @@ public final class Method {
      * MUST NOT ignore any Content-* (e.g. Content-Range) headers that it does not understand or implement and MUST return
      * a 501 (Not Implemented) response in such cases.
      */
-    public static final Method PUT = new Method("PUT", true);
+    public static final Method PUT = new Method(PUT_NAME, true);
     /**
      * The DELETE method requests that the origin server delete the resource identified by the Request-URI.
      * This method MAY be overridden by human intervention (or other means) on the origin server. The client cannot
@@ -70,7 +105,7 @@ public final class Method {
      * indicates that the action has been completed successfully. However, the server SHOULD NOT indicate success unless,
      * at the time the response is given, it intends to delete the resource or move it to an inaccessible location.
      */
-    public static final Method DELETE = new Method("DELETE", true);
+    public static final Method DELETE = new Method(DELETE_NAME, true);
     /**
      * The HEAD method is identical to {@link #GET} except that the server MUST NOT return a message-body in the response.
      * The metainformation contained in the HTTP headers in response to a HEAD request SHOULD be identical to the information
@@ -78,21 +113,21 @@ public final class Method {
      * by the request without transferring the entity-body itself. This method is often used for testing hypertext links
      * for validity, accessibility, and recent modification.
      */
-    public static final Method HEAD = new Method("HEAD", true);
+    public static final Method HEAD = new Method(HEAD_NAME, true);
     /**
      * The OPTIONS method represents a request for information about the communication options available
      * on the request/response chain identified by the Request-URI. This method allows the client to determine the options
      * and/or requirements  associated with a resource, or the capabilities of a server, without implying a resource action
      * or initiating a resource retrieval.
      */
-    public static final Method OPTIONS = new Method("OPTIONS", true);
+    public static final Method OPTIONS = new Method(OPTIONS_NAME, true);
     /**
-     * The TRACE method is used to invoke a remote, application-layer loop- back of the request message.
+     * The TRACE method is used to invoke a remote, application-layer loop-back of the request message.
      * The final recipient of the request SHOULD reflect the message received back to the client as the entity-body
      * of a 200 (OK) response. The final recipient is either the origin server or the first proxy or gateway to receive
      * a Max-Forwards value of zero (0) in the request (see section 14.31). A TRACE request MUST NOT include an entity.
      */
-    public static final Method TRACE = new Method("TRACE", true);
+    public static final Method TRACE = new Method(TRACE_NAME, true);
     /**
      * The PATCH method as described in RFC 5789 is used to perform an update to an existing resource, where the request
      * payload only has to contain the instructions on how to perform the update. This is in contrast to PUT which
@@ -100,12 +135,12 @@ public final class Method {
      * If an existing resource is modified, either the 200 (OK) or 204 (No Content) response codes SHOULD be sent to indicate
      * successful completion of the request.
      */
-    public static final Method PATCH = new Method("PATCH", true);
+    public static final Method PATCH = new Method(PATCH_NAME, true);
 
     /**
      * The HTTP CONNECT method starts two-way communications with the requested resource. It can be used to open a tunnel.
      */
-    public static final Method CONNECT = new Method("CONNECT", true);
+    public static final Method CONNECT = new Method(CONNECT_NAME, true);
 
     static {
         // THIS MUST BE AFTER THE LAST CONSTANT
@@ -139,7 +174,7 @@ public final class Method {
      * @throws IllegalArgumentException In case of illegal method name or in case the name is empty or {@code null}.
      */
     public static Method create(String name) {
-        if (name.equals(GET_STRING)) {
+        if (name.equals(GET_NAME)) {
             return GET;
         }
 

--- a/http/http/src/main/java/io/helidon/http/RequestException.java
+++ b/http/http/src/main/java/io/helidon/http/RequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,29 @@ package io.helidon.http;
  * This exception is not used by clients.
  */
 public class RequestException extends RuntimeException {
+    /**
+     * Type of this event.
+     */
     private final DirectHandler.EventType eventType;
+    /**
+     * HTTP status to return.
+     */
     private final Status status;
+    /**
+     * Request as far as it could have been parsed.
+     */
     private final DirectHandler.TransportRequest transportRequest;
+    /**
+     * Whether the connection can be kept alive.
+     */
     private final boolean keepAlive;
+    /**
+     * Header to return with the response.
+     */
     private final ServerResponseHeaders responseHeaders;
+    /**
+     * Whether the message is safe to be shown in logs and messages.
+     */
     private final boolean safeMessage;
 
     /**

--- a/http/http/src/main/java/io/helidon/http/Status.java
+++ b/http/http/src/main/java/io/helidon/http/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,310 +31,678 @@ import java.util.Objects;
  * <p>
  * A good reference is the IANA list of HTTP Status Codes (we may not cover all of them in this type):
  * <a href="https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml">IANA HTTP Status Codes</a>
+ * <p>
+ * For each status, there is also a constant with the status code (int), to allow usage in annotations.
  */
 public class Status {
     /**
      * 100 Continue,
      * see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.1.1">HTTP/1.1 documentations</a>.
      */
-    public static final Status CONTINUE_100 = new Status(100, "Continue", true);
+    public static final int CONTINUE_100_CODE = 100;
+    /**
+     * 100 Continue,
+     * see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.1.1">HTTP/1.1 documentations</a>.
+     */
+    public static final Status CONTINUE_100 = new Status(CONTINUE_100_CODE, "Continue", true);
     /**
      * 101 Switching Protocols,
      * see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.1.2">HTTP/1.1 documentations</a>.
      */
-    public static final Status SWITCHING_PROTOCOLS_101 = new Status(101, "Switching Protocols", true);
+    public static final int SWITCHING_PROTOCOLS_101_CODE = 101;
+    /**
+     * 101 Switching Protocols,
+     * see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.1.2">HTTP/1.1 documentations</a>.
+     */
+    public static final Status SWITCHING_PROTOCOLS_101 = new Status(SWITCHING_PROTOCOLS_101_CODE, "Switching Protocols", true);
+
     /**
      * 200 OK, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1">HTTP/1.1 documentation</a>.
      */
-    public static final Status OK_200 = new Status(200, "OK", true);
+    public static final int OK_200_CODE = 200;
+    /**
+     * 200 OK, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1">HTTP/1.1 documentation</a>.
+     */
+    public static final Status OK_200 = new Status(OK_200_CODE, "OK", true);
+
     /**
      * 201 Created, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2">HTTP/1.1 documentation</a>.
      */
-    public static final Status CREATED_201 = new Status(201, "Created", true);
+    public static final int CREATED_201_CODE = 201;
     /**
-     * 202 Accepted, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.3">HTTP/1.1 documentation</a>
-     * .
+     * 201 Created, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2">HTTP/1.1 documentation</a>.
      */
-    public static final Status ACCEPTED_202 = new Status(202, "Accepted", true);
+    public static final Status CREATED_201 = new Status(CREATED_201_CODE, "Created", true);
+
+    /**
+     * 202 Accepted, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.3">HTTP/1.1 documentation</a>.
+     */
+    public static final int ACCEPTED_202_CODE = 202;
+    /**
+     * 202 Accepted, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.3">HTTP/1.1 documentation</a>.
+     */
+    public static final Status ACCEPTED_202 = new Status(ACCEPTED_202_CODE, "Accepted", true);
+
     /**
      * 203 Non-Authoritative Information, see
      * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.4">HTTP/1.1 documentation</a>.
      *
      * @since 4.0.6
      */
-    public static final Status NON_AUTHORITATIVE_INFORMATION_203 = new Status(203, "Non-Authoritative Information", true);
+    public static final int NON_AUTHORITATIVE_INFORMATION_203_CODE = 203;
+    /**
+     * 203 Non-Authoritative Information, see
+     * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.4">HTTP/1.1 documentation</a>.
+     *
+     * @since 4.0.6
+     */
+    public static final Status NON_AUTHORITATIVE_INFORMATION_203 = new Status(NON_AUTHORITATIVE_INFORMATION_203_CODE,
+                                                                              "Non-Authoritative Information",
+                                                                              true);
 
     /**
      * 204 No Content, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5">HTTP/1.1 documentation</a>.
      */
-    public static final Status NO_CONTENT_204 = new Status(204, "No Content", true);
+    public static final int NO_CONTENT_204_CODE = 204;
+    /**
+     * 204 No Content, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5">HTTP/1.1 documentation</a>.
+     */
+    public static final Status NO_CONTENT_204 = new Status(NO_CONTENT_204_CODE, "No Content", true);
+
     /**
      * 205 Reset Content, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.6">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status RESET_CONTENT_205 = new Status(205, "Reset Content", true);
+    public static final int RESET_CONTENT_205_CODE = 205;
+    /**
+     * 205 Reset Content, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.6">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status RESET_CONTENT_205 = new Status(RESET_CONTENT_205_CODE, "Reset Content", true);
+
     /**
      * 206 Reset Content, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.7">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status PARTIAL_CONTENT_206 = new Status(206, "Partial Content", true);
+    public static final int PARTIAL_CONTENT_206_CODE = 206;
+    /**
+     * 206 Reset Content, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.7">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status PARTIAL_CONTENT_206 = new Status(PARTIAL_CONTENT_206_CODE, "Partial Content", true);
+
     /**
      * 207 Multi-Status, see
      * <a href="https://www.rfc-editor.org/rfc/rfc4918.html#section-13">RFC 4918 - HTTP Extensions for WebDAV</a>.
      *
      * @since 4.0.6
      */
-    public static final Status MULTI_STATUS_207 = new Status(207, "Multi-Status", true);
+    public static final int MULTI_STATUS_207_CODE = 207;
+    /**
+     * 207 Multi-Status, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc4918.html#section-13">RFC 4918 - HTTP Extensions for WebDAV</a>.
+     *
+     * @since 4.0.6
+     */
+    public static final Status MULTI_STATUS_207 = new Status(MULTI_STATUS_207_CODE, "Multi-Status", true);
+
     /**
      * 301 Moved Permanently, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">HTTP/1.1 documentation</a>.
      */
-    public static final Status MOVED_PERMANENTLY_301 = new Status(301, "Moved Permanently", true);
+    public static final int MOVED_PERMANENTLY_301_CODE = 301;
+    /**
+     * 301 Moved Permanently, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">HTTP/1.1 documentation</a>.
+     */
+    public static final Status MOVED_PERMANENTLY_301 = new Status(MOVED_PERMANENTLY_301_CODE, "Moved Permanently", true);
+
     /**
      * 302 Found, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status FOUND_302 = new Status(302, "Found", true);
+    public static final int FOUND_302_CODE = 302;
+    /**
+     * 302 Found, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status FOUND_302 = new Status(FOUND_302_CODE, "Found", true);
+
     /**
      * 303 See Other, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4">HTTP/1.1 documentation</a>.
      */
-    public static final Status SEE_OTHER_303 = new Status(303, "See Other", true);
+    public static final int SEE_OTHER_303_CODE = 303;
+    /**
+     * 303 See Other, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4">HTTP/1.1 documentation</a>.
+     */
+    public static final Status SEE_OTHER_303 = new Status(SEE_OTHER_303_CODE, "See Other", true);
+
     /**
      * 304 Not Modified, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1 documentation</a>.
      */
-    public static final Status NOT_MODIFIED_304 = new Status(304, "Not Modified", true);
+    public static final int NOT_MODIFIED_304_CODE = 304;
+    /**
+     * 304 Not Modified, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">HTTP/1.1 documentation</a>.
+     */
+    public static final Status NOT_MODIFIED_304 = new Status(NOT_MODIFIED_304_CODE, "Not Modified", true);
+
     /**
      * 305 Use Proxy, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.6">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status USE_PROXY_305 = new Status(305, "Use Proxy", true);
+    public static final int USE_PROXY_305_CODE = 305;
+    /**
+     * 305 Use Proxy, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.6">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status USE_PROXY_305 = new Status(USE_PROXY_305_CODE, "Use Proxy", true);
+
     /**
      * 307 Temporary Redirect, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8">HTTP/1.1 documentation</a>.
      */
-    public static final Status TEMPORARY_REDIRECT_307 = new Status(307, "Temporary Redirect", true);
+    public static final int TEMPORARY_REDIRECT_307_CODE = 307;
+    /**
+     * 307 Temporary Redirect, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.8">HTTP/1.1 documentation</a>.
+     */
+    public static final Status TEMPORARY_REDIRECT_307 = new Status(TEMPORARY_REDIRECT_307_CODE, "Temporary Redirect", true);
+
     /**
      * 308 Permanent Redirect, see
      * <a href="https://www.rfc-editor.org/rfc/rfc7538">HTTP Status Code 308 documentation</a>.
      */
-    public static final Status PERMANENT_REDIRECT_308 = new Status(308, "Permanent Redirect", true);
+    public static final int PERMANENT_REDIRECT_308_CODE = 308;
+    /**
+     * 308 Permanent Redirect, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc7538">HTTP Status Code 308 documentation</a>.
+     */
+    public static final Status PERMANENT_REDIRECT_308 = new Status(PERMANENT_REDIRECT_308_CODE, "Permanent Redirect", true);
+
     /**
      * 400 Bad Request, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">HTTP/1.1 documentation</a>.
      */
-    public static final Status BAD_REQUEST_400 = new Status(400, "Bad Request", true);
+    public static final int BAD_REQUEST_400_CODE = 400;
+    /**
+     * 400 Bad Request, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">HTTP/1.1 documentation</a>.
+     */
+    public static final Status BAD_REQUEST_400 = new Status(BAD_REQUEST_400_CODE, "Bad Request", true);
+
     /**
      * 401 Unauthorized, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2">HTTP/1.1 documentation</a>.
      */
-    public static final Status UNAUTHORIZED_401 = new Status(401, "Unauthorized", true);
+    public static final int UNAUTHORIZED_401_CODE = 401;
+    /**
+     * 401 Unauthorized, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2">HTTP/1.1 documentation</a>.
+     */
+    public static final Status UNAUTHORIZED_401 = new Status(UNAUTHORIZED_401_CODE, "Unauthorized", true);
+
     /**
      * 402 Payment Required, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.3">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status PAYMENT_REQUIRED_402 = new Status(402, "Payment Required", true);
+    public static final int PAYMENT_REQUIRED_402_CODE = 402;
+    /**
+     * 402 Payment Required, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.3">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status PAYMENT_REQUIRED_402 = new Status(PAYMENT_REQUIRED_402_CODE, "Payment Required", true);
+
     /**
      * 403 Forbidden, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4">HTTP/1.1 documentation</a>.
      */
-    public static final Status FORBIDDEN_403 = new Status(403, "Forbidden", true);
+    public static final int FORBIDDEN_403_CODE = 403;
+    /**
+     * 403 Forbidden, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4">HTTP/1.1 documentation</a>.
+     */
+    public static final Status FORBIDDEN_403 = new Status(FORBIDDEN_403_CODE, "Forbidden", true);
+
     /**
      * 404 Not Found, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">HTTP/1.1 documentation</a>.
      */
-    public static final Status NOT_FOUND_404 = new Status(404, "Not Found", true);
+    public static final int NOT_FOUND_404_CODE = 404;
+    /**
+     * 404 Not Found, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">HTTP/1.1 documentation</a>.
+     */
+    public static final Status NOT_FOUND_404 = new Status(NOT_FOUND_404_CODE, "Not Found", true);
+
     /**
      * 405 Method Not Allowed, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status METHOD_NOT_ALLOWED_405 = new Status(405, "Method Not Allowed", true);
+    public static final int METHOD_NOT_ALLOWED_405_CODE = 405;
+    /**
+     * 405 Method Not Allowed, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status METHOD_NOT_ALLOWED_405 = new Status(METHOD_NOT_ALLOWED_405_CODE, "Method Not Allowed", true);
+
     /**
      * 406 Not Acceptable, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7">HTTP/1.1 documentation</a>.
      */
-    public static final Status NOT_ACCEPTABLE_406 = new Status(406, "Not Acceptable", true);
+    public static final int NOT_ACCEPTABLE_406_CODE = 406;
+    /**
+     * 406 Not Acceptable, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7">HTTP/1.1 documentation</a>.
+     */
+    public static final Status NOT_ACCEPTABLE_406 = new Status(NOT_ACCEPTABLE_406_CODE, "Not Acceptable", true);
+
     /**
      * 407 Proxy Authentication Required, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.8">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status PROXY_AUTHENTICATION_REQUIRED_407 = new Status(407, "Proxy Authentication Required", true);
+    public static final int PROXY_AUTHENTICATION_REQUIRED_407_CODE = 407;
+    /**
+     * 407 Proxy Authentication Required, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.8">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status PROXY_AUTHENTICATION_REQUIRED_407 = new Status(PROXY_AUTHENTICATION_REQUIRED_407_CODE,
+                                                                              "Proxy Authentication Required",
+                                                                              true);
+
     /**
      * 408 Request Timeout, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.9">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status REQUEST_TIMEOUT_408 = new Status(408, "Request Timeout", true);
+    public static final int REQUEST_TIMEOUT_408_CODE = 408;
+    /**
+     * 408 Request Timeout, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.9">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status REQUEST_TIMEOUT_408 = new Status(REQUEST_TIMEOUT_408_CODE, "Request Timeout", true);
+
     /**
      * 409 Conflict, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10">HTTP/1.1 documentation</a>.
      */
-    public static final Status CONFLICT_409 = new Status(409, "Conflict", true);
+    public static final int CONFLICT_409_CODE = 409;
+    /**
+     * 409 Conflict, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10">HTTP/1.1 documentation</a>.
+     */
+    public static final Status CONFLICT_409 = new Status(CONFLICT_409_CODE, "Conflict", true);
+
     /**
      * 410 Gone, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.11">HTTP/1.1 documentation</a>.
      */
-    public static final Status GONE_410 = new Status(410, "Gone", true);
+    public static final int GONE_410_CODE = 410;
+    /**
+     * 410 Gone, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.11">HTTP/1.1 documentation</a>.
+     */
+    public static final Status GONE_410 = new Status(GONE_410_CODE, "Gone", true);
+
     /**
      * 411 Length Required, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.12">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status LENGTH_REQUIRED_411 = new Status(411, "Length Required", true);
+    public static final int LENGTH_REQUIRED_411_CODE = 411;
+    /**
+     * 411 Length Required, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.12">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status LENGTH_REQUIRED_411 = new Status(LENGTH_REQUIRED_411_CODE, "Length Required", true);
+
     /**
      * 412 Precondition Failed, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.13">HTTP/1.1 documentation</a>.
      */
-    public static final Status PRECONDITION_FAILED_412 = new Status(412, "Precondition Failed", true);
+    public static final int PRECONDITION_FAILED_412_CODE = 412;
+    /**
+     * 412 Precondition Failed, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.13">HTTP/1.1 documentation</a>.
+     */
+    public static final Status PRECONDITION_FAILED_412 = new Status(PRECONDITION_FAILED_412_CODE, "Precondition Failed", true);
+
     /**
      * 413 Request Entity Too Large, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.14">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status REQUEST_ENTITY_TOO_LARGE_413 = new Status(413, "Request Entity Too Large", true);
+    public static final int REQUEST_ENTITY_TOO_LARGE_413_CODE = 413;
+    /**
+     * 413 Request Entity Too Large, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.14">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status REQUEST_ENTITY_TOO_LARGE_413 = new Status(REQUEST_ENTITY_TOO_LARGE_413_CODE,
+                                                                         "Request Entity Too Large",
+                                                                         true);
+
     /**
      * 414 Request-URI Too Long, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.15">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status REQUEST_URI_TOO_LONG_414 = new Status(414, "Request-URI Too Long", true);
+    public static final int REQUEST_URI_TOO_LONG_414_CODE = 414;
+    /**
+     * 414 Request-URI Too Long, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.15">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status REQUEST_URI_TOO_LONG_414 = new Status(REQUEST_URI_TOO_LONG_414_CODE, "Request-URI Too Long", true);
+
     /**
      * 415 Unsupported Media Type, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16">HTTP/1.1 documentation</a>.
      */
-    public static final Status UNSUPPORTED_MEDIA_TYPE_415 = new Status(415, "Unsupported Media Type", true);
+    public static final int UNSUPPORTED_MEDIA_TYPE_415_CODE = 415;
+    /**
+     * 415 Unsupported Media Type, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16">HTTP/1.1 documentation</a>.
+     */
+    public static final Status UNSUPPORTED_MEDIA_TYPE_415 = new Status(UNSUPPORTED_MEDIA_TYPE_415_CODE,
+                                                                       "Unsupported Media Type",
+                                                                       true);
+
     /**
      * 416 Requested Range Not Satisfiable, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.17">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status REQUESTED_RANGE_NOT_SATISFIABLE_416 = new Status(416, "Requested Range Not Satisfiable", true);
+    public static final int REQUESTED_RANGE_NOT_SATISFIABLE_416_CODE = 416;
+    /**
+     * 416 Requested Range Not Satisfiable, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.17">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status REQUESTED_RANGE_NOT_SATISFIABLE_416 = new Status(REQUESTED_RANGE_NOT_SATISFIABLE_416_CODE,
+                                                                                "Requested Range Not Satisfiable",
+                                                                                true);
+
     /**
      * 417 Expectation Failed, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.18">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status EXPECTATION_FAILED_417 = new Status(417, "Expectation Failed", true);
+    public static final int EXPECTATION_FAILED_417_CODE = 417;
+    /**
+     * 417 Expectation Failed, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.18">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status EXPECTATION_FAILED_417 = new Status(EXPECTATION_FAILED_417_CODE, "Expectation Failed", true);
+
     /**
      * 418 I'm a teapot, see
      * <a href="https://tools.ietf.org/html/rfc2324#section-2.3.2">Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0)</a>.
      */
-    public static final Status I_AM_A_TEAPOT_418 = new Status(418, "I'm a teapot", true);
+    public static final int I_AM_A_TEAPOT_418_CODE = 418;
+    /**
+     * 418 I'm a teapot, see
+     * <a href="https://tools.ietf.org/html/rfc2324#section-2.3.2">Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0)</a>.
+     */
+    public static final Status I_AM_A_TEAPOT_418 = new Status(I_AM_A_TEAPOT_418_CODE, "I'm a teapot", true);
+
     /**
      * Misdirected request, see
      * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request">RFC 9110 - Http Semantics</a>.
      */
-    public static final Status MISDIRECTED_REQUEST_421 = new Status(421, "Misdirected Request", true);
+    public static final int MISDIRECTED_REQUEST_421_CODE = 421;
+    /**
+     * Misdirected request, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request">RFC 9110 - Http Semantics</a>.
+     */
+    public static final Status MISDIRECTED_REQUEST_421 = new Status(MISDIRECTED_REQUEST_421_CODE, "Misdirected Request", true);
+
     /**
      * Unprocessable content, see
      * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content">RFC 9110 - Http Semantics</a>.
      */
-    public static final Status UNPROCESSABLE_CONTENT_422 = new Status(422, "Unprocessable Content", true);
+    public static final int UNPROCESSABLE_CONTENT_422_CODE = 422;
+    /**
+     * Unprocessable content, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content">RFC 9110 - Http Semantics</a>.
+     */
+    public static final Status UNPROCESSABLE_CONTENT_422 = new Status(UNPROCESSABLE_CONTENT_422_CODE,
+                                                                      "Unprocessable Content",
+                                                                      true);
+
     /**
      * Locked, see
      * <a href="https://www.rfc-editor.org/rfc/rfc4918.html#page-78">RFC 4918 - HTTP Extensions for WebDAV</a>.
      */
-    public static final Status LOCKED_423 = new Status(423, "Locked", true);
+    public static final int LOCKED_423_CODE = 423;
+    /**
+     * Locked, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc4918.html#page-78">RFC 4918 - HTTP Extensions for WebDAV</a>.
+     */
+    public static final Status LOCKED_423 = new Status(LOCKED_423_CODE, "Locked", true);
+
     /**
      * Failed dependency, see
      * <a href="https://www.rfc-editor.org/rfc/rfc4918.html#section-11.4">RFC 4918 - HTTP Extensions for WebDAV</a>.
      */
-    public static final Status FAILED_DEPENDENCY_424 = new Status(424, "Failed Dependency", true);
+    public static final int FAILED_DEPENDENCY_424_CODE = 424;
+    /**
+     * Failed dependency, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc4918.html#section-11.4">RFC 4918 - HTTP Extensions for WebDAV</a>.
+     */
+    public static final Status FAILED_DEPENDENCY_424 = new Status(FAILED_DEPENDENCY_424_CODE, "Failed Dependency", true);
+
     /**
      * Upgrade required, see
      * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-426-upgrade-required">RFC 9110 - Http Semantics</a>.
      */
-    public static final Status UPGRADE_REQUIRED_426 = new Status(426, "Upgrade Required", true);
+    public static final int UPGRADE_REQUIRED_426_CODE = 426;
+    /**
+     * Upgrade required, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-426-upgrade-required">RFC 9110 - Http Semantics</a>.
+     */
+    public static final Status UPGRADE_REQUIRED_426 = new Status(UPGRADE_REQUIRED_426_CODE, "Upgrade Required", true);
+
     /**
      * Precondition required, see
      * <a href="https://www.rfc-editor.org/rfc/rfc6585.html#page-2">RFC 6585 - Additional HTTP Status Codes</a>.
      */
-    public static final Status PRECONDITION_REQUIRED_428 = new Status(428, "Precondition Required", true);
+    public static final int PRECONDITION_REQUIRED_428_CODE = 428;
+    /**
+     * Precondition required, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc6585.html#page-2">RFC 6585 - Additional HTTP Status Codes</a>.
+     */
+    public static final Status PRECONDITION_REQUIRED_428 = new Status(PRECONDITION_REQUIRED_428_CODE,
+                                                                      "Precondition Required",
+                                                                      true);
+
     /**
      * Too many requests, see
      * <a href="https://www.rfc-editor.org/rfc/rfc6585.html#page-3">RFC 6585 - Additional HTTP Status Codes</a>.
      */
-    public static final Status TOO_MANY_REQUESTS_429 = new Status(429, "Too Many Requests", true);
+    public static final int TOO_MANY_REQUESTS_429_CODE = 429;
+    /**
+     * Too many requests, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc6585.html#page-3">RFC 6585 - Additional HTTP Status Codes</a>.
+     */
+    public static final Status TOO_MANY_REQUESTS_429 = new Status(TOO_MANY_REQUESTS_429_CODE, "Too Many Requests", true);
+
     /**
      * 500 Internal Server Error, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1">HTTP/1.1 documentation</a>.
      */
-    public static final Status INTERNAL_SERVER_ERROR_500 = new Status(500, "Internal Server Error", true);
+    public static final int INTERNAL_SERVER_ERROR_500_CODE = 500;
+    /**
+     * 500 Internal Server Error, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1">HTTP/1.1 documentation</a>.
+     */
+    public static final Status INTERNAL_SERVER_ERROR_500 = new Status(INTERNAL_SERVER_ERROR_500_CODE,
+                                                                      "Internal Server Error",
+                                                                      true);
+
     /**
      * 501 Not Implemented, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status NOT_IMPLEMENTED_501 = new Status(501, "Not Implemented", true);
+    public static final int NOT_IMPLEMENTED_501_CODE = 501;
+    /**
+     * 501 Not Implemented, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.2">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status NOT_IMPLEMENTED_501 = new Status(NOT_IMPLEMENTED_501_CODE, "Not Implemented", true);
+
     /**
      * 502 Bad Gateway, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.3">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status BAD_GATEWAY_502 = new Status(502, "Bad Gateway", true);
+    public static final int BAD_GATEWAY_502_CODE = 502;
+    /**
+     * 502 Bad Gateway, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.3">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status BAD_GATEWAY_502 = new Status(BAD_GATEWAY_502_CODE, "Bad Gateway", true);
+
     /**
      * 503 Service Unavailable, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4">HTTP/1.1 documentation</a>.
      */
-    public static final Status SERVICE_UNAVAILABLE_503 = new Status(503, "Service Unavailable", true);
+    public static final int SERVICE_UNAVAILABLE_503_CODE = 503;
+    /**
+     * 503 Service Unavailable, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4">HTTP/1.1 documentation</a>.
+     */
+    public static final Status SERVICE_UNAVAILABLE_503 = new Status(SERVICE_UNAVAILABLE_503_CODE, "Service Unavailable", true);
+
     /**
      * 504 Gateway Timeout, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.5">HTTP/1.1 documentation</a>.
      *
      * @since 2.0
      */
-    public static final Status GATEWAY_TIMEOUT_504 = new Status(504, "Gateway Timeout", true);
+    public static final int GATEWAY_TIMEOUT_504_CODE = 504;
+    /**
+     * 504 Gateway Timeout, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.5">HTTP/1.1 documentation</a>.
+     *
+     * @since 2.0
+     */
+    public static final Status GATEWAY_TIMEOUT_504 = new Status(GATEWAY_TIMEOUT_504_CODE, "Gateway Timeout", true);
+
     /**
      * 505 HTTP Version Not Supported, see
      * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.6">HTTP/1.1 documentation</a>.
      *
      * @since 3.0.3
      */
-    public static final Status HTTP_VERSION_NOT_SUPPORTED_505 = new Status(505, "HTTP Version Not Supported", true);
+    public static final int HTTP_VERSION_NOT_SUPPORTED_505_CODE = 505;
+    /**
+     * 505 HTTP Version Not Supported, see
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.6">HTTP/1.1 documentation</a>.
+     *
+     * @since 3.0.3
+     */
+    public static final Status HTTP_VERSION_NOT_SUPPORTED_505 = new Status(HTTP_VERSION_NOT_SUPPORTED_505_CODE,
+                                                                           "HTTP Version Not Supported",
+                                                                           true);
+
     /**
      * 507 Insufficient Storage, see
      * <a href="http://www.ietf.org/rfc/rfc4918.txt">WebDAV documentation</a>.
      *
      * @since 4.0.6
      */
-    public static final Status INSUFFICIENT_STORAGE_507 = new Status(507, "Insufficient Storage", true);
+    public static final int INSUFFICIENT_STORAGE_507_CODE = 507;
+    /**
+     * 507 Insufficient Storage, see
+     * <a href="http://www.ietf.org/rfc/rfc4918.txt">WebDAV documentation</a>.
+     *
+     * @since 4.0.6
+     */
+    public static final Status INSUFFICIENT_STORAGE_507 = new Status(INSUFFICIENT_STORAGE_507_CODE, "Insufficient Storage", true);
+
     /**
      * 508 Loop Detected, see
-     * <a href="https://www.rfc-editor.org/rfc/rfc5842#section-7.2">RFC 5842 - Bindings for the Constrained Application Protocol (CoAP)</a>.
+     * <a href="https://www.rfc-editor.org/rfc/rfc5842#section-7.2">RFC 5842 - Bindings for the Constrained Application Protocol
+     * (CoAP)</a>.
      *
-     *  @since 4.0.6
+     * @since 4.0.6
      */
-    public static final Status LOOP_DETECTED_508 = new Status(508, "Loop Detected", true);
+    public static final int LOOP_DETECTED_508_CODE = 508;
+    /**
+     * 508 Loop Detected, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc5842#section-7.2">RFC 5842 - Bindings for the Constrained Application Protocol
+     * (CoAP)</a>.
+     *
+     * @since 4.0.6
+     */
+    public static final Status LOOP_DETECTED_508 = new Status(LOOP_DETECTED_508_CODE, "Loop Detected", true);
 
     /**
      * 510 Not Extended, see
      * <a href="https://www.rfc-editor.org/rfc/rfc2774#section-7">RFC 2774 - An HTTP Extension Framework</a>.
      *
-     *  @since 4.0.6
+     * @since 4.0.6
      */
-    public static final Status NOT_EXTENDED_510 = new Status(510, "Not Extended", true);
+    public static final int NOT_EXTENDED_510_CODE = 510;
+    /**
+     * 510 Not Extended, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc2774#section-7">RFC 2774 - An HTTP Extension Framework</a>.
+     *
+     * @since 4.0.6
+     */
+    public static final Status NOT_EXTENDED_510 = new Status(NOT_EXTENDED_510_CODE, "Not Extended", true);
 
     /**
      * 511 Network Authentication Required, see
@@ -342,8 +710,16 @@ public class Status {
      *
      * @since 4.0.6
      */
-    public static final Status NETWORK_AUTHENTICATION_REQUIRED_511 = new Status(511, "Network Authentication Required", true);
-
+    public static final int NETWORK_AUTHENTICATION_REQUIRED_511_CODE = 511;
+    /**
+     * 511 Network Authentication Required, see
+     * <a href="https://www.rfc-editor.org/rfc/rfc6585#section-6">RFC 6585 - Additional HTTP Status Codes</a>.
+     *
+     * @since 4.0.6
+     */
+    public static final Status NETWORK_AUTHENTICATION_REQUIRED_511 = new Status(NETWORK_AUTHENTICATION_REQUIRED_511_CODE,
+                                                                                "Network Authentication Required",
+                                                                                true);
 
     static {
         // THIS MUST BE AFTER THE LAST CONSTANT
@@ -420,10 +796,6 @@ public class Status {
         return createNew(found.family(), statusCode, reasonPhrase, found.codeText());
     }
 
-    private static Status createNew(Family family, int statusCode, String reasonPhrase, String codeText) {
-        return new Status(statusCode, reasonPhrase, family, codeText);
-    }
-
     /**
      * Get the associated integer value representing the status code.
      *
@@ -494,6 +866,10 @@ public class Status {
     @Override
     public int hashCode() {
         return Objects.hash(code, reason);
+    }
+
+    private static Status createNew(Family family, int statusCode, String reasonPhrase, String codeText) {
+        return new Status(statusCode, reasonPhrase, family, codeText);
     }
 
     /**

--- a/http/http/src/test/java/io/helidon/http/HttpMethodTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,41 +18,77 @@ package io.helidon.http;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class HttpMethodTest {
-    private static final Class<Method> clazz = Method.class;
-    private static final Set<String> constants = Stream.of(clazz.getDeclaredFields())
+    private static final Class<Method> CLASS = Method.class;
+    private static final Set<String> METHOD_CONSTANTS = Stream.of(CLASS.getDeclaredFields())
             .filter(it -> Modifier.isStatic(it.getModifiers()))
             .filter(it -> Modifier.isFinal(it.getModifiers()))
             .filter(it -> Modifier.isPublic(it.getModifiers()))
+            .filter(it -> it.getType().equals(Method.class))
+            .map(Field::getName)
+            .collect(Collectors.toSet());
+    private static final Set<String> STRING_CONSTANTS = Stream.of(CLASS.getDeclaredFields())
+            .filter(it -> Modifier.isStatic(it.getModifiers()))
+            .filter(it -> Modifier.isFinal(it.getModifiers()))
+            .filter(it -> Modifier.isPublic(it.getModifiers()))
+            .filter(it -> it.getType().equals(String.class))
             .map(Field::getName)
             .collect(Collectors.toSet());
 
-
     @Test
-    void testAllConstantsAreValid() throws NoSuchFieldException, IllegalAccessException {
+    void testAllMethodConstantsAreValid() throws NoSuchFieldException, IllegalAccessException {
         // this is to test correct initialization (there may be an issue when the constants
         // are defined on the interface and implemented by enum outside of it)
-        for (String constant : constants) {
-            Method value = (Method) clazz.getField(constant)
+        for (String constant : METHOD_CONSTANTS) {
+            Method value = (Method) CLASS.getField(constant)
                     .get(null);
 
             assertAll(
-                    () -> assertThat(value, notNullValue()),
-                    () -> assertThat(value.text(), notNullValue()),
-                    () -> assertThat(value.length(), not(0))
+                    () -> assertThat(constant, value, notNullValue()),
+                    () -> assertThat(constant, value.text(), notNullValue()),
+                    () -> assertThat(constant, value.length(), not(0))
             );
 
+            // make sure the string constant exists for this value
+            String stringConstant = (String) CLASS.getField(constant + "_NAME")
+                    .get(null);
+            assertAll(
+                    () -> assertThat(constant, stringConstant, notNullValue()),
+                    () -> assertThat(constant, stringConstant.length(), not(0)),
+                    () -> assertThat(constant, stringConstant, is(value.text()))
+            );
+
+        }
+    }
+
+    @Test
+    void testAllStringConstantsAreValid() throws NoSuchFieldException, IllegalAccessException {
+        Set<String> allValues = new HashSet<>();
+
+        for (String constant : STRING_CONSTANTS) {
+            String value = (String) CLASS.getField(constant)
+                    .get(null);
+
+            assertAll(
+                    () -> assertThat(constant, value, notNullValue()),
+                    () -> assertThat(constant, value, notNullValue()),
+                    () -> assertThat(constant, value.length(), not(0))
+            );
+
+            assertThat(constant + " has duplicate value: " + value, allValues.add(value), is(true));
         }
     }
 }

--- a/http/http/src/test/java/io/helidon/http/HttpStatusTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.http;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,11 +36,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class HttpStatusTest {
-    private static final Class<Status> clazz = Status.class;
-    private static final Set<String> constants = Stream.of(clazz.getDeclaredFields())
+    private static final Class<Status> CLASS = Status.class;
+    private static final Set<String> STATUS_CONSTANTS = Stream.of(CLASS.getDeclaredFields())
             .filter(it -> Modifier.isStatic(it.getModifiers()))
             .filter(it -> Modifier.isFinal(it.getModifiers()))
             .filter(it -> Modifier.isPublic(it.getModifiers()))
+            .filter(it -> it.getType().equals(Status.class))
+            .map(Field::getName)
+            .collect(Collectors.toSet());
+    private static final Set<String> INT_CONSTANTS = Stream.of(CLASS.getDeclaredFields())
+            .filter(it -> Modifier.isStatic(it.getModifiers()))
+            .filter(it -> Modifier.isFinal(it.getModifiers()))
+            .filter(it -> Modifier.isPublic(it.getModifiers()))
+            .filter(it -> it.getType().equals(int.class))
             .map(Field::getName)
             .collect(Collectors.toSet());
 
@@ -67,11 +76,11 @@ class HttpStatusTest {
     }
 
     @Test
-    void testAllConstantsAreValid() throws NoSuchFieldException, IllegalAccessException {
+    void testAllStatusConstantsAreValid() throws NoSuchFieldException, IllegalAccessException {
         // this is to test correct initialization (there may be an issue when the constants
         // are defined on the interface and implemented by enum outside of it)
-        for (String constant : constants) {
-            Status value = (Status) clazz.getField(constant)
+        for (String constant : STATUS_CONSTANTS) {
+            Status value = (Status) CLASS.getField(constant)
                     .get(null);
 
             assertAll(
@@ -93,6 +102,25 @@ class HttpStatusTest {
                     }
             );
 
+            // make sure the int constant exists for this value
+            int intConstant = (int) CLASS.getField(constant + "_CODE")
+                    .get(null);
+
+            assertThat(constant, intConstant, is(value.code()));
+        }
+    }
+
+    @Test
+    void testAllIntConstantsAreValid() throws NoSuchFieldException, IllegalAccessException {
+        Set<Integer> allValues = new HashSet<>();
+
+        for (String constant : INT_CONSTANTS) {
+            int value = (int) CLASS.getField(constant)
+                    .get(null);
+
+            assertThat(value, not(0));
+
+            assertThat(constant + " has duplicate value: " + value, allValues.add(value), is(true));
         }
     }
 }

--- a/http/http2/pom.xml
+++ b/http/http2/pom.xml
@@ -29,6 +29,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-buffers</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http</groupId>
             <artifactId>helidon-http</artifactId>
         </dependency>
@@ -49,6 +57,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-common</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,8 +174,18 @@ public class ConnectionFlowControl {
         return timeout;
     }
 
-    enum Type {
-        SERVER, CLIENT;
+    /**
+     * Type of the flow control.
+     */
+    public enum Type {
+        /**
+         * Flow control for the server.
+         */
+        SERVER,
+        /**
+         * Flow control for the client.
+         */
+        CLIENT;
     }
 
     /**

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Exception.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Exception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@ package io.helidon.http.http2;
  * HTTP/2 exception.
  */
 public class Http2Exception extends RuntimeException {
+    /**
+     * Type of the HTTP/2 error.
+     */
     private final Http2ErrorCode type;
 
     /**

--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSize.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,8 @@ public interface WindowSize {
     /**
      * Create inbound window size container with initial window size set.
      *
-     * @param type
-     * @param streamId
+     * @param type               type of the flow control
+     * @param streamId           id of the stream the size is created for
      * @param initialWindowSize  initial window size
      * @param maxFrameSize       maximal frame size
      * @param windowUpdateWriter writer method for HTTP/2 WINDOW_UPDATE frame

--- a/http/media/jackson/pom.xml
+++ b/http/media/jackson/pom.xml
@@ -29,8 +29,28 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http</groupId>
+            <artifactId>helidon-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-media-type</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/http/media/jackson/pom.xml
+++ b/http/media/jackson/pom.xml
@@ -27,6 +27,12 @@
     <artifactId>helidon-http-media-jackson</artifactId>
     <name>Helidon HTTP Media Jackson</name>
 
+    <properties>
+        <!-- this must be disabled, as jars contain module-info.java, but Javadoc is generated without modules,
+         so generated links were invalid -->
+        <javadoc.fail-on-warnings>false</javadoc.fail-on-warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/http/media/jsonb/pom.xml
+++ b/http/media/jsonb/pom.xml
@@ -29,6 +29,22 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http</groupId>
+            <artifactId>helidon-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-media-type</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media</artifactId>
         </dependency>

--- a/http/media/jsonp/pom.xml
+++ b/http/media/jsonp/pom.xml
@@ -29,6 +29,22 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http</groupId>
+            <artifactId>helidon-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-media-type</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media</artifactId>
         </dependency>

--- a/http/media/media/pom.xml
+++ b/http/media/media/pom.xml
@@ -34,6 +34,18 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-media-type</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-parameters</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-uri</artifactId>
         </dependency>
         <dependency>

--- a/http/media/media/src/main/java/io/helidon/http/media/ReadableEntityBase.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/ReadableEntityBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,14 @@ public abstract class ReadableEntityBase implements ReadableEntity {
         this.entityProcessedRunnable = new EntityProcessedRunnable(entityProcessedRunnable, entityProcessed);
     }
 
+    /**
+     * Create a new base.
+     *
+     * @param entityRequestedCallback callback invoked when entity is requested
+     * @param readEntityFunction      accepts estimate of needed bytes, returns buffer data (the length of buffer data may differ
+     *                                from the estimate)
+     * @param entityProcessedRunnable runnable to run when entity is fully read
+     */
     protected ReadableEntityBase(Consumer<Boolean> entityRequestedCallback,
                                  Function<Integer, BufferData> readEntityFunction,
                                  Runnable entityProcessedRunnable) {
@@ -154,6 +162,13 @@ public abstract class ReadableEntityBase implements ReadableEntity {
         return true;
     }
 
+    /**
+     * Read entity as a specific generic type.
+     *
+     * @param type type the entity should be coerced into
+     * @return entity value
+     * @param <T> type of the entity
+     */
     protected abstract <T> T entityAs(GenericType<T> type);
 
     /**

--- a/http/media/multipart/pom.xml
+++ b/http/media/multipart/pom.xml
@@ -29,6 +29,26 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http</groupId>
+            <artifactId>helidon-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-buffers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-media-type</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media</artifactId>
         </dependency>

--- a/http/media/multipart/src/main/java/io/helidon/http/media/multipart/MultiPart.java
+++ b/http/media/multipart/src/main/java/io/helidon/http/media/multipart/MultiPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,4 +30,10 @@ public abstract class MultiPart implements Iterator<ReadablePart> {
      * Generic type of {@link MultiPart}.
      */
     public static final GenericType<MultiPart> GENERIC_TYPE = GenericType.create(MultiPart.class);
+
+    /**
+     * This class is empty, this constructor does nothing.
+     */
+    public MultiPart() {
+    }
 }

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -33,6 +33,10 @@
 
     <packaging>pom</packaging>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <modules>
         <module>encoding</module>
         <module>http</module>
@@ -49,4 +53,19 @@
             </modules>
         </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-dependencies</id>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/http/tests/pom.xml
+++ b/http/tests/pom.xml
@@ -47,5 +47,6 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.sources.skip>true</maven.sources.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
     </properties>
 </project>


### PR DESCRIPTION
Switched fail on javadoc warning to true for http module

Switched dependency check plugin on for http module Fixed all discovered problems

Introduced constants for Method, MediaType, Status and Header names that can be used in annotations.

Related to #9872 

Resolves part of changes in #9915 to make review easier.
