### PR TITLE
4.2.2: Use `SetUpFeatures` annotation

### DIFF
--- a/docs/src/main/asciidoc/se/testing.adoc
+++ b/docs/src/main/asciidoc/se/testing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -101,7 +101,11 @@ and may have any name. The `@SetUpRoute` annotation has `value` with socket name
 
 |===
 
-In addition, a static method annotated with `@SetUpServer` can be defined for `@ServerTest`, which has a single parameter of link:{javadoc-base-url}/io.helidon.webserver/io/helidon/webserver/WebServerConfig.Builder.html[`WebServerConfig.Builder`].
+In addition:
+
+- a static method annotated with `@SetUpServer` can be defined for tests, which has a single parameter of link:{javadoc-base-url}/io.helidon.webserver/io/helidon/webserver/WebServerConfig.Builder.html[`WebServerConfig.Builder`].
+- a static method annotated with `@SetUpFeatures` can be defined for tests, which returns `List<? extends ServerFeature>` to configure additional features, or update discovered features, feature discovery can be disabled using the annotation `value()``
+
 
 The following table lists the injectable types (through constructor or method injection).
 

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/HelidonRoutingJunitExtension.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/HelidonRoutingJunitExtension.java
@@ -42,8 +42,6 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
-import static io.helidon.webserver.testing.junit5.Junit5Util.withStaticMethods;
-
 /**
  * JUnit5 extension to support Helidon WebServer in tests.
  */
@@ -80,7 +78,9 @@ class HelidonRoutingJunitExtension extends JunitExtensionBase
 
         extensions.forEach(it -> it.beforeAll(context));
 
+        setupFeatures(builder);
         setupServer(builder);
+
         serverConfig = builder.buildPrototype();
 
         initRoutings();
@@ -191,26 +191,6 @@ class HelidonRoutingJunitExtension extends JunitExtensionBase
                 handler.handle(method, socketName, value);
             }
         };
-    }
-
-    private void setupServer(WebServerConfig.Builder builder) {
-        withStaticMethods(testClass(), SetUpServer.class, (setUpServer, method) -> {
-            Class<?>[] parameterTypes = method.getParameterTypes();
-            if (parameterTypes.length != 1) {
-                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpServer.class.getSimpleName()
-                                                           + " does not have exactly one parameter (WebServerConfig.Builder)");
-            }
-            if (!parameterTypes[0].equals(WebServerConfig.Builder.class)) {
-                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpServer.class.getSimpleName()
-                                                           + " does not have exactly one parameter (WebServerConfig.Builder)");
-            }
-            try {
-                method.setAccessible(true);
-                method.invoke(null, builder);
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new IllegalStateException("Could not invoke method " + method, e);
-            }
-        });
     }
 
     private interface SetUpRouteHandler {

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/HelidonServerJunitExtension.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/HelidonServerJunitExtension.java
@@ -106,6 +106,7 @@ class HelidonServerJunitExtension extends JunitExtensionBase
             builder.port(0)
                     .shutdownHook(false);
 
+            setupFeatures(builder);
             setupServer(builder);
             addRouting(builder);
 
@@ -232,26 +233,6 @@ class HelidonServerJunitExtension extends JunitExtensionBase
                                                     + ", which is not available on the running webserver");
         }
         return uri;
-    }
-
-    private void setupServer(WebServerConfig.Builder builder) {
-        withStaticMethods(testClass(), SetUpServer.class, (setUpServer, method) -> {
-            Class<?>[] parameterTypes = method.getParameterTypes();
-            if (parameterTypes.length != 1) {
-                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpServer.class.getSimpleName()
-                                                           + " does not have exactly one parameter (WebServerConfig.Builder)");
-            }
-            if (!parameterTypes[0].equals(WebServerConfig.Builder.class)) {
-                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpServer.class.getSimpleName()
-                                                           + " does not have exactly one parameter (WebServerConfig.Builder)");
-            }
-            try {
-                method.setAccessible(true);
-                method.invoke(null, builder);
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new IllegalStateException("Could not invoke method " + method, e);
-            }
-        });
     }
 
     private void addRouting(WebServerConfig.Builder builder) {

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/JunitExtensionBase.java
@@ -16,15 +16,20 @@
 
 package io.helidon.webserver.testing.junit5;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
 import io.helidon.testing.junit5.TestJunitExtension;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.spi.ServerFeature;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static io.helidon.webserver.testing.junit5.Junit5Util.withStaticMethods;
 
 abstract class JunitExtensionBase extends TestJunitExtension implements AfterAllCallback {
     private Class<?> testClass;
@@ -37,6 +42,75 @@ abstract class JunitExtensionBase extends TestJunitExtension implements AfterAll
         callAfterStop();
         super.afterAll(extensionContext);
     }
+
+    void setupServer(WebServerConfig.Builder builder) {
+        withStaticMethods(testClass(), SetUpServer.class, (setUpServer, method) -> {
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            if (parameterTypes.length != 1) {
+                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpServer.class.getSimpleName()
+                                                           + " does not have exactly one parameter (WebServerConfig.Builder)");
+            }
+            if (!parameterTypes[0].equals(WebServerConfig.Builder.class)) {
+                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpServer.class.getSimpleName()
+                                                           + " does not have exactly one parameter (WebServerConfig.Builder)");
+            }
+            if (!Modifier.isStatic(method.getModifiers())) {
+                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpServer.class.getSimpleName()
+                                                           + " is not static");
+            }
+            try {
+                method.setAccessible(true);
+                method.invoke(null, builder);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new IllegalStateException("Could not invoke method " + method, e);
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    void setupFeatures(WebServerConfig.Builder builder) {
+        withStaticMethods(testClass(), SetUpFeatures.class, ((setUpFeatures, method) -> {
+            if (!setUpFeatures.value()) {
+                builder.featuresDiscoverServices(false);
+            }
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            if (parameterTypes.length != 0) {
+                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpFeatures.class.getSimpleName()
+                                                           + " has parameter(s), which is not allowed. It should return "
+                                                           + " List<ServerFeature>.");
+            }
+            if (!Modifier.isStatic(method.getModifiers())) {
+                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpFeatures.class.getSimpleName()
+                                                           + " is not static");
+            }
+            Object result;
+            try {
+                method.setAccessible(true);
+                result = method.invoke(null);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new IllegalStateException("Could not invoke method " + method, e);
+            }
+
+            List<ServerFeature> features;
+            try {
+                features = (List<ServerFeature>) result;
+            } catch (ClassCastException e) {
+                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpFeatures.class.getSimpleName()
+                                                           + " returned a result that is not a List. Supported is "
+                                                           + "List<? extends ServerFeature>.", e);
+            }
+            try {
+                for (ServerFeature feature : features) {
+                    builder.addFeature(feature);
+                }
+            } catch (ClassCastException e) {
+                throw new IllegalArgumentException("Method " + method + " annotated with " + SetUpFeatures.class.getSimpleName()
+                                                           + " returned a result that is a List, but an element was not "
+                                                           + "a ServerFeature.", e);
+            }
+        }));
+    }
+
 
     void testClass(Class<?> testClass) {
         this.testClass = testClass;

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/SetUpFeatures.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/SetUpFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ import java.lang.annotation.Target;
  * A static method configuring server features.
  * <p>
  * Supported signatures:
- * {@code static List<? extends ServerFeature> features()}
+ * {@code static List<? extends ServerFeature> features()}.
+ * <p>
+ * Method(s) annotated with this annotation will be invoked before methods annotated with
+ * {@link io.helidon.webserver.testing.junit5.SetUpServer}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/webserver/testing/junit5/junit5/src/test/java/io/helidon/webserver/testing/junit5/TestRoutingTest.java
+++ b/webserver/testing/junit5/junit5/src/test/java/io/helidon/webserver/testing/junit5/TestRoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,13 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.spi.ServerFeature;
 
 import org.junit.jupiter.api.Test;
 
@@ -88,6 +90,16 @@ class TestRoutingTest {
         router.get("/get", (req, res) -> res.send(ADMIN_ENTITY));
     }
 
+    @SetUpFeatures
+    static List<ServerFeature> features() {
+         return List.of(new TestFeature());
+    }
+
+    @Test
+    void testFeatureSetUp() {
+        assertThat(TestFeature.isSetUp(), is(true));
+    }
+
     @Test
     void testGet() {
         String response = client.get("/get")
@@ -146,6 +158,29 @@ class TestRoutingTest {
         @Override
         public String getName() {
             return name;
+        }
+    }
+
+    private static class TestFeature implements ServerFeature {
+        private static final AtomicBoolean SET_UP = new AtomicBoolean();
+
+        @Override
+        public void setup(ServerFeatureContext featureContext) {
+            SET_UP.set(true);
+        }
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public String type() {
+            return "test";
+        }
+
+        static boolean isSetUp() {
+            return SET_UP.get();
         }
     }
 }


### PR DESCRIPTION
Backport #10037 to Helidon 4.2.2

Resolves #9979 

* implemented `SetUpFeatures` annotation processing
* added a test for both ServerTest and RoutingTest
* updated documentation
