### PR TITLE
Support for gRPC server metrics

### DIFF
--- a/webserver/grpc/pom.xml
+++ b/webserver/grpc/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -41,4 +41,13 @@ interface GrpcConfigBlueprint extends ProtocolConfig {
      */
     @Option.Default(GrpcProtocolProvider.CONFIG_NAME)
     String type();
+
+    /**
+     * Whether to collect metrics for gRPC server calls.
+     *
+     * @return metrics flag
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean enableMetrics();
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -404,37 +404,35 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
      * of started calls, but not record any of the other metrics.
      */
     private void initMetrics() {
-        if (grpcConfig.enableMetrics()) {
-            String methodName = route.method().getFullMethodName();
-            methodMetrics = METHOD_METRICS.get().computeIfAbsent(methodName, name -> {
-                MeterRegistry meterRegistry = Metrics.globalRegistry();
-                Tag grpcMethod = Tag.create("grpc.method", name);
+        String methodName = route.method().getFullMethodName();
+        methodMetrics = METHOD_METRICS.get().computeIfAbsent(methodName, name -> {
+            MeterRegistry meterRegistry = Metrics.globalRegistry();
+            Tag grpcMethod = Tag.create("grpc.method", name);
 
-                Counter.Builder callStartedBuilder = Counter.builder("grpc.server.call.started")
-                        .scope(VENDOR)
-                        .tags(List.of(grpcMethod));
-                Counter callStarted = meterRegistry.getOrCreate(callStartedBuilder);
+            Counter.Builder callStartedBuilder = Counter.builder("grpc.server.call.started")
+                    .scope(VENDOR)
+                    .tags(List.of(grpcMethod));
+            Counter callStarted = meterRegistry.getOrCreate(callStartedBuilder);
 
-                Timer.Builder callDurationOkBuilder = Timer.builder("grpc.server.call.duration")
-                        .scope(VENDOR)
-                        .baseUnit(Timer.BaseUnits.MILLISECONDS)
-                        .tags(List.of(grpcMethod, OK_TAG));
-                Timer callDuration = meterRegistry.getOrCreate(callDurationOkBuilder);
+            Timer.Builder callDurationOkBuilder = Timer.builder("grpc.server.call.duration")
+                    .scope(VENDOR)
+                    .baseUnit(Timer.BaseUnits.MILLISECONDS)
+                    .tags(List.of(grpcMethod, OK_TAG));
+            Timer callDuration = meterRegistry.getOrCreate(callDurationOkBuilder);
 
-                DistributionSummary.Builder sendMessageSizeBuilder = DistributionSummary.builder(
-                                "grpc.server.call.sent_total_compressed_message_size")
-                        .scope(VENDOR)
-                        .tags(List.of(grpcMethod, OK_TAG));
-                DistributionSummary sentMessageSize = meterRegistry.getOrCreate(sendMessageSizeBuilder);
+            DistributionSummary.Builder sendMessageSizeBuilder = DistributionSummary.builder(
+                            "grpc.server.call.sent_total_compressed_message_size")
+                    .scope(VENDOR)
+                    .tags(List.of(grpcMethod, OK_TAG));
+            DistributionSummary sentMessageSize = meterRegistry.getOrCreate(sendMessageSizeBuilder);
 
-                DistributionSummary.Builder recvMessageSizeBuilder = DistributionSummary.builder(
-                                "grpc.server.call.rcvd_total_compressed_message_size")
-                        .scope(VENDOR)
-                        .tags(List.of(grpcMethod, OK_TAG));
-                DistributionSummary recvMessageSize = meterRegistry.getOrCreate(recvMessageSizeBuilder);
+            DistributionSummary.Builder recvMessageSizeBuilder = DistributionSummary.builder(
+                            "grpc.server.call.rcvd_total_compressed_message_size")
+                    .scope(VENDOR)
+                    .tags(List.of(grpcMethod, OK_TAG));
+            DistributionSummary recvMessageSize = meterRegistry.getOrCreate(recvMessageSizeBuilder);
 
-                return new MethodMetrics(callStarted, callDuration, sentMessageSize, recvMessageSize);
-            });
-        }
+            return new MethodMetrics(callStarted, callDuration, sentMessageSize, recvMessageSize);
+        });
     }
 }

--- a/webserver/grpc/src/main/java/module-info.java
+++ b/webserver/grpc/src/main/java/module-info.java
@@ -34,6 +34,7 @@ module io.helidon.webserver.grpc {
     requires io.helidon.webserver.http2;
     requires io.helidon.tracing;
     requires io.helidon.common.config;
+    requires io.helidon.metrics.api;
 
     requires io.grpc;
     requires io.grpc.stub;

--- a/webserver/tests/grpc/pom.xml
+++ b/webserver/tests/grpc/pom.xml
@@ -46,6 +46,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcBaseMetricsTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcBaseMetricsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.grpc;
+
+import java.util.List;
+
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.BeforeAll;
+
+abstract class GrpcBaseMetricsTest extends BaseStringServiceTest {
+
+    static final Tag OK_TAG = Tag.create("grpc.status", "OK");
+    static final Tag[] METHOD_TAGS = {
+            Tag.create("grpc.method", "StringService/Upper"),
+            Tag.create("grpc.method", "StringService/Lower"),
+            Tag.create("grpc.method", "StringService/Echo"),
+            Tag.create("grpc.method", "StringService/Split"),
+            Tag.create("grpc.method", "StringService/Join")
+    };
+    static final String CALL_STARTED = "grpc.server.call.started";
+    static final String CALL_DURATION = "grpc.server.call.duration";
+    static final String SENT_MESSAGE_SIZE = "grpc.server.call.sent_total_compressed_message_size";
+    static final String RCVD_MESSAGE_SIZE = "grpc.server.call.rcvd_total_compressed_message_size";
+
+    GrpcBaseMetricsTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new StringService()));
+    }
+
+    @BeforeAll
+    static void initialize() {
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+        for (Tag tag : METHOD_TAGS) {
+            meterRegistry.remove(CALL_STARTED, List.of(tag));
+            meterRegistry.remove(CALL_DURATION, List.of(tag, OK_TAG));
+            meterRegistry.remove(SENT_MESSAGE_SIZE, List.of(tag, OK_TAG));
+            meterRegistry.remove(RCVD_MESSAGE_SIZE, List.of(tag, OK_TAG));
+        }
+    }
+}

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcDisabledMetricsTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcDisabledMetricsTest.java
@@ -25,49 +25,27 @@ import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
-import io.helidon.webserver.Router;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.grpc.GrpcConfig;
-import io.helidon.webserver.grpc.GrpcRouting;
 import io.helidon.webserver.testing.junit5.ServerTest;
-import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.AfterAll;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ServerTest
-class GrpcMetricsTest extends BaseStringServiceTest {
+class GrpcDisabledMetricsTest extends GrpcBaseMetricsTest {
 
-    private static final Tag OK_TAG = Tag.create("grpc.status", "OK");
-    private static final Tag[] METHOD_TAGS = {
-            Tag.create("grpc.method", "StringService/Upper"),
-            Tag.create("grpc.method", "StringService/Lower"),
-            Tag.create("grpc.method", "StringService/Echo"),
-            Tag.create("grpc.method", "StringService/Split"),
-            Tag.create("grpc.method", "StringService/Join")
-    };
-    private static final String CALL_STARTED = "grpc.server.call.started";
-    private static final String CALL_DURATION = "grpc.server.call.duration";
-    private static final String SENT_MESSAGE_SIZE = "grpc.server.call.sent_total_compressed_message_size";
-    private static final String RCVD_MESSAGE_SIZE = "grpc.server.call.rcvd_total_compressed_message_size";
-
-    GrpcMetricsTest(WebServer server) {
+    GrpcDisabledMetricsTest(WebServer server) {
         super(server);
     }
 
     @SetUpServer
     static void setup(WebServerConfig.Builder serverBuilder) {
-        serverBuilder.addProtocol(GrpcConfig.builder().enableMetrics(true).build());
-    }
-
-    @SetUpRoute
-    static void routing(Router.RouterBuilder<?> router) {
-        router.addRouting(GrpcRouting.builder().service(new StringService()));
+        serverBuilder.addProtocol(GrpcConfig.builder().build());        // default is false for gRPC metrics
     }
 
     @AfterAll
@@ -76,22 +54,16 @@ class GrpcMetricsTest extends BaseStringServiceTest {
 
         for (Tag tag : METHOD_TAGS) {
             Optional<Counter> counter = meterRegistry.counter(CALL_STARTED, List.of(tag));
-            assertThat(counter.isPresent(), is(true));
-            assertThat(counter.get().count(), is(20L));
+            assertThat(counter.isEmpty(), is(true));
 
             Optional<Timer> timer = meterRegistry.timer(CALL_DURATION, List.of(tag, OK_TAG));
-            assertThat(timer.isPresent(), is(true));
-            assertThat(timer.get().count(), is(20L));
+            assertThat(timer.isEmpty(), is(true));
 
             Optional<DistributionSummary> summary = meterRegistry.summary(SENT_MESSAGE_SIZE, List.of(tag, OK_TAG));
-            assertThat(summary.isPresent(), is(true));
-            assertThat(summary.get().count(), is(20L));
-            assertThat(summary.get().max(), greaterThan(0.0));
+            assertThat(summary.isEmpty(), is(true));
 
             summary = meterRegistry.summary(RCVD_MESSAGE_SIZE, List.of(tag, OK_TAG));
-            assertThat(summary.isPresent(), is(true));
-            assertThat(summary.get().count(), is(20L));
-            assertThat(summary.get().max(), greaterThan(0.0));
+            assertThat(summary.isEmpty(), is(true));
         }
     }
 }

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcEnabledMetricsTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcEnabledMetricsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.grpc;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.Timer;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.grpc.GrpcConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.AfterAll;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ServerTest
+class GrpcEnabledMetricsTest extends GrpcBaseMetricsTest {
+
+    GrpcEnabledMetricsTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder serverBuilder) {
+        serverBuilder.addProtocol(GrpcConfig.builder().enableMetrics(true).build());        // enable metrics
+    }
+
+    @AfterAll
+    static void checkMetrics() {
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+
+        for (Tag tag : METHOD_TAGS) {
+            Optional<Counter> counter = meterRegistry.counter(CALL_STARTED, List.of(tag));
+            assertThat(counter.isPresent(), is(true));
+            assertThat(counter.get().count(), is(20L));
+
+            Optional<Timer> timer = meterRegistry.timer(CALL_DURATION, List.of(tag, OK_TAG));
+            assertThat(timer.isPresent(), is(true));
+            assertThat(timer.get().count(), is(20L));
+
+            Optional<DistributionSummary> summary = meterRegistry.summary(SENT_MESSAGE_SIZE, List.of(tag, OK_TAG));
+            assertThat(summary.isPresent(), is(true));
+            assertThat(summary.get().count(), is(20L));
+            assertThat(summary.get().max(), greaterThan(0.0));
+
+            summary = meterRegistry.summary(RCVD_MESSAGE_SIZE, List.of(tag, OK_TAG));
+            assertThat(summary.isPresent(), is(true));
+            assertThat(summary.get().count(), is(20L));
+            assertThat(summary.get().max(), greaterThan(0.0));
+        }
+    }
+}

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMetricsTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMetricsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.grpc;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.Timer;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.grpc.GrpcConfig;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.AfterAll;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class GrpcMetricsTest extends BaseStringServiceTest {
+
+    private static final Tag OK_TAG = Tag.create("grpc.status", "OK");
+    private static final Tag[] METHOD_TAGS = {
+            Tag.create("grpc.method", "StringService/Upper"),
+            Tag.create("grpc.method", "StringService/Lower"),
+            Tag.create("grpc.method", "StringService/Echo"),
+            Tag.create("grpc.method", "StringService/Split"),
+            Tag.create("grpc.method", "StringService/Join")
+    };
+    private static final String CALL_STARTED = "grpc.server.call.started";
+    private static final String CALL_DURATION = "grpc.server.call.duration";
+    private static final String SENT_MESSAGE_SIZE = "grpc.server.call.sent_total_compressed_message_size";
+    private static final String RCVD_MESSAGE_SIZE = "grpc.server.call.rcvd_total_compressed_message_size";
+
+    GrpcMetricsTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder serverBuilder) {
+        serverBuilder.addProtocol(GrpcConfig.builder().enableMetrics(true).build());
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new StringService()));
+    }
+
+    @AfterAll
+    static void checkMetrics() {
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+
+        for (Tag tag : METHOD_TAGS) {
+            Optional<Counter> counter = meterRegistry.counter(CALL_STARTED, List.of(tag));
+            assertThat(counter.isPresent(), is(true));
+            assertThat(counter.get().count(), is(20L));
+
+            Optional<Timer> timer = meterRegistry.timer(CALL_DURATION, List.of(tag, OK_TAG));
+            assertThat(timer.isPresent(), is(true));
+            assertThat(timer.get().count(), is(20L));
+
+            Optional<DistributionSummary> summary = meterRegistry.summary(SENT_MESSAGE_SIZE, List.of(tag, OK_TAG));
+            assertThat(summary.isPresent(), is(true));
+            assertThat(summary.get().count(), is(20L));
+            assertThat(summary.get().max(), greaterThan(0.0));
+
+            summary = meterRegistry.summary(RCVD_MESSAGE_SIZE, List.of(tag, OK_TAG));
+            assertThat(summary.isPresent(), is(true));
+            assertThat(summary.get().count(), is(20L));
+            assertThat(summary.get().max(), greaterThan(0.0));
+        }
+    }
+}


### PR DESCRIPTION
### Description

Initial support for gRPC server metrics. Implements _Server Instruments_ section from this document  https://grpc.io/docs/guides/opentelemetry-metrics/, except that it only records sizes and durations for successful invocations (i.e., status tag is always OK). Frankly, it doesn't seem that useful to record these metrics for failed invocations, and it has the potential of creating a large number of metrics based on different status values.

The following metrics are created for each gRPC method (if invoked):

- grpc.server.call.started (counter for all invocations)
- grpc.server.call.duration (timer)
- grpc.server.call.sent_total_compressed_message_size (distribution summary)
- grpc.server.call.rcvd_total_compressed_message_size (distribution summary)

Metrics are _disabled_ by default and can be enabled via config. Partly addresses issue #9806.

### Documentation

In future PR.

