### PR TITLE
Support for metrics in gRPC client

### DIFF
--- a/webclient/grpc/pom.xml
+++ b/webclient/grpc/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>helidon-webclient-http2</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcChannel.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcChannel.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcChannel.java
@@ -59,9 +59,18 @@ public class GrpcChannel extends Channel {
 
     @Override
     public String authority() {
-        ClientUri clientUri = grpcClient.prototype()
+        return baseUri().authority();
+    }
+
+    /**
+     * Gets base URI for this gRPC client.
+     *
+     * @return the base URI
+     * @throws java.lang.IllegalArgumentException if no base URI is defined
+     */
+    public ClientUri baseUri() {
+        return grpcClient.prototype()
                 .baseUri()
                 .orElseThrow(() -> new IllegalArgumentException("No base URI provided for GrpcClient"));
-        return clientUri.authority();
     }
 }

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
@@ -200,12 +200,13 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
                         continue;
                     }
                     if (frameData != null) {
-                        receivingQueue.add(frameData.data());
-                        socket().log(LOGGER, DEBUG, "[Reading thread] adding bufferData to receiving queue");
+                        BufferData bufferData = frameData.data();
                         // update bytes received excluding prefix
                         if (enableMetrics()) {
-                            bytesRcvd().addAndGet(frameData.data().available() - DATA_PREFIX_LENGTH);
+                            bytesRcvd().addAndGet(bufferData.available() - DATA_PREFIX_LENGTH);
                         }
+                        receivingQueue.add(bufferData);
+                        socket().log(LOGGER, DEBUG, "[Reading thread] adding bufferData to receiving queue");
                     }
                 }
 

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
@@ -148,12 +148,11 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
                         endOfStream = (sendingQueue.peek() == EMPTY_BUFFER_DATA);
                         boolean lastEndOfStream = endOfStream;
                         socket().log(LOGGER, DEBUG, "[Writing thread] writing bufferData %b", lastEndOfStream);
-                        clientStream().writeData(bufferData, endOfStream);
-
                         // update bytes sent
                         if (enableMetrics()) {
                             bytesSent().addAndGet(bufferData.available());
                         }
+                        clientStream().writeData(bufferData, endOfStream);
                     }
                 }
             } catch (Throwable e) {
@@ -203,7 +202,6 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
                     if (frameData != null) {
                         receivingQueue.add(frameData.data());
                         socket().log(LOGGER, DEBUG, "[Reading thread] adding bufferData to receiving queue");
-
                         // update bytes received excluding prefix
                         if (enableMetrics()) {
                             bytesRcvd().addAndGet(frameData.data().available() - DATA_PREFIX_LENGTH);

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
         // serialize and queue message for writing
         byte[] serialized = serializeMessage(message);
         BufferData messageData = BufferData.createReadOnly(serialized, 0, serialized.length);
-        BufferData headerData = BufferData.create(5);
+        BufferData headerData = BufferData.create(DATA_PREFIX_LENGTH);
         headerData.writeInt8(0);                                // no compression
         headerData.writeUnsignedInt32(messageData.available());         // length prefixed
         sendingQueue.add(BufferData.create(headerData, messageData));
@@ -149,6 +149,11 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
                         boolean lastEndOfStream = endOfStream;
                         socket().log(LOGGER, DEBUG, "[Writing thread] writing bufferData %b", lastEndOfStream);
                         clientStream().writeData(bufferData, endOfStream);
+
+                        // update bytes sent
+                        if (enableMetrics()) {
+                            bytesSent().addAndGet(bufferData.available());
+                        }
                     }
                 }
             } catch (Throwable e) {
@@ -198,6 +203,11 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
                     if (frameData != null) {
                         receivingQueue.add(frameData.data());
                         socket().log(LOGGER, DEBUG, "[Reading thread] adding bufferData to receiving queue");
+
+                        // update bytes received excluding prefix
+                        if (enableMetrics()) {
+                            bytesRcvd().addAndGet(frameData.data().available() - DATA_PREFIX_LENGTH);
+                        }
                     }
                 }
 
@@ -222,6 +232,15 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
         clientStream().cancel();
         connection().close();
         unblockUnaryExecutor();
+
+        // update metrics
+        if (enableMetrics()) {
+            MethodMetrics methodMetrics = methodMetrics();
+            methodMetrics.callDuration().record(
+                    Duration.ofMillis(System.currentTimeMillis() - startMillis()));
+            methodMetrics.recvMessageSize().record(bytesRcvd().get());
+            methodMetrics.sentMessageSize().record(bytesSent().get());
+        }
     }
 
     private void drainReceivingQueue() {

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientConfigBlueprint.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,5 +45,14 @@ interface GrpcClientConfigBlueprint extends HttpClientConfig, Prototype.Factory<
      * @return a supplier for zero or more client URIs
      */
     Optional<ClientUriSupplier> clientUriSupplier();
+
+    /**
+     * Whether to collect metrics for gRPC client calls.
+     *
+     * @return metrics flag
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean enableMetrics();
 }
 

--- a/webclient/grpc/src/main/java/module-info.java
+++ b/webclient/grpc/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ module io.helidon.webclient.grpc {
     requires transitive io.helidon.webclient.http2;
     requires transitive io.helidon.webclient;
 
+    requires io.helidon.metrics.api;
     requires io.helidon.grpc.core;
 
     exports io.helidon.webclient.grpc;

--- a/webclient/tests/grpc/pom.xml
+++ b/webclient/tests/grpc/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>helidon-logging-jul</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcBaseMetricsTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcBaseMetricsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.grpc.tests;
+
+import java.util.Iterator;
+
+import io.helidon.metrics.api.Tag;
+import io.helidon.webclient.grpc.GrpcClient;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+abstract class GrpcBaseMetricsTest extends GrpcBaseTest {
+
+    static final Tag OK_TAG = Tag.create("grpc.status", "OK");
+    static final Tag[] METHOD_TAGS = {
+            Tag.create("grpc.method", "StringService/Upper"),
+            Tag.create("grpc.method", "StringService/Split")
+    };
+    static final String ATTEMPT_STARTED = "grpc.client.attempt.started";
+    static final String ATTEMPT_DURATION = "grpc.client.attempt.duration";
+    static final String SENT_MESSAGE_SIZE = "grpc.client.attempt.sent_total_compressed_message_size";
+    static final String RCVD_MESSAGE_SIZE = "grpc.client.attempt.rcvd_total_compressed_message_size";
+
+    static GrpcClient grpcClient;
+
+    @RepeatedTest(20)
+    void testUnaryUpper() {
+        StringServiceGrpc.StringServiceBlockingStub service = StringServiceGrpc.newBlockingStub(grpcClient.channel());
+        Strings.StringMessage res = service.upper(newStringMessage("hello"));
+        assertThat(res.getText(), is("HELLO"));
+    }
+
+    @RepeatedTest(20)
+    void testServerStreamingSplit() {
+        StringServiceGrpc.StringServiceBlockingStub service = StringServiceGrpc.newBlockingStub(grpcClient.channel());
+        Iterator<Strings.StringMessage> res = service.split(newStringMessage("hello world"));
+        assertThat(res.next().getText(), is("hello"));
+        assertThat(res.next().getText(), is("world"));
+        assertThat(res.hasNext(), is(false));
+    }
+}

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcDisabledMetricsTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcDisabledMetricsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.grpc.tests;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.tls.Tls;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.Timer;
+import io.helidon.webclient.grpc.GrpcClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import org.junit.jupiter.api.AfterAll;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class GrpcDisabledMetricsTest extends GrpcBaseMetricsTest {
+
+    GrpcDisabledMetricsTest(WebServer server) {
+        Tls clientTls = Tls.builder()
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+        grpcClient = GrpcClient.builder()
+                .tls(clientTls)
+                .baseUri("https://localhost:" + server.port())
+                .build();       // metrics disabled by default
+    }
+
+    @AfterAll
+    static void checkMetrics() {
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+        Tag grpcTarget = Tag.create("grpc.target", grpcClient.prototype().baseUri().orElseThrow().toString());
+
+        for (Tag grpcMethod : METHOD_TAGS) {
+            Optional<Counter> counter = meterRegistry.counter(ATTEMPT_STARTED, List.of(grpcMethod, grpcTarget));
+            assertThat(counter.isEmpty(), is(true));
+
+            Optional<Timer> timer = meterRegistry.timer(ATTEMPT_DURATION, List.of(grpcMethod, grpcTarget, OK_TAG));
+            assertThat(timer.isEmpty(), is(true));
+
+            Optional<DistributionSummary> summary;
+            summary = meterRegistry.summary(SENT_MESSAGE_SIZE, List.of(grpcMethod, grpcTarget, OK_TAG));
+            assertThat(summary.isEmpty(), is(true));
+
+            summary = meterRegistry.summary(RCVD_MESSAGE_SIZE, List.of(grpcMethod, grpcTarget, OK_TAG));
+            assertThat(summary.isEmpty(), is(true));
+        }
+    }
+}

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcMetricsTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcMetricsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.grpc.tests;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.tls.Tls;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+import io.helidon.metrics.api.Timer;
+import io.helidon.webclient.grpc.GrpcClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ServerTest
+class GrpcMetricsTest extends GrpcBaseTest {
+
+    static final Tag OK_TAG = Tag.create("grpc.status", "OK");
+    static final Tag[] METHOD_TAGS = {
+            Tag.create("grpc.method", "StringService/Upper"),
+            Tag.create("grpc.method", "StringService/Split")
+    };
+    static final String CALL_STARTED = "grpc.client.attempt.started";
+    static final String CALL_DURATION = "grpc.client.attempt.duration";
+    static final String SENT_MESSAGE_SIZE = "grpc.client.attempt.sent_total_compressed_message_size";
+    static final String RCVD_MESSAGE_SIZE = "grpc.client.attempt.rcvd_total_compressed_message_size";
+
+    private static GrpcClient grpcClient;
+
+    private GrpcMetricsTest(WebServer server) {
+        Tls clientTls = Tls.builder()
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+        grpcClient = GrpcClient.builder()
+                .tls(clientTls)
+                .baseUri("https://localhost:" + server.port())
+                .enableMetrics(true)
+                .build();
+    }
+
+    @RepeatedTest(20)
+    void testUnaryUpper() {
+        StringServiceGrpc.StringServiceBlockingStub service = StringServiceGrpc.newBlockingStub(grpcClient.channel());
+        Strings.StringMessage res = service.upper(newStringMessage("hello"));
+        assertThat(res.getText(), is("HELLO"));
+    }
+
+    @RepeatedTest(20)
+    void testServerStreamingSplit() {
+        StringServiceGrpc.StringServiceBlockingStub service = StringServiceGrpc.newBlockingStub(grpcClient.channel());
+        Iterator<Strings.StringMessage> res = service.split(newStringMessage("hello world"));
+        assertThat(res.next().getText(), is("hello"));
+        assertThat(res.next().getText(), is("world"));
+        assertThat(res.hasNext(), is(false));
+    }
+
+    @AfterAll
+    static void checkMetrics() {
+        MeterRegistry meterRegistry = MetricsFactory.getInstance().globalRegistry();
+        Tag grpcTarget = Tag.create("grpc.target", grpcClient.prototype().baseUri().orElseThrow().toString());
+
+        for (Tag grpcMethod : METHOD_TAGS) {
+            Optional<Counter> counter = meterRegistry.counter(CALL_STARTED, List.of(grpcMethod, grpcTarget));
+            assertThat(counter.isPresent(), is(true));
+            assertThat(counter.get().count(), is(20L));
+
+            Optional<Timer> timer = meterRegistry.timer(CALL_DURATION, List.of(grpcMethod, grpcTarget, OK_TAG));
+            assertThat(timer.isPresent(), is(true));
+            assertThat(timer.get().count(), is(20L));
+
+            Optional<DistributionSummary> summary;
+            summary = meterRegistry.summary(SENT_MESSAGE_SIZE, List.of(grpcMethod, grpcTarget, OK_TAG));
+            assertThat(summary.isPresent(), is(true));
+            assertThat(summary.get().count(), is(20L));
+            assertThat(summary.get().max(), greaterThan(0.0));
+
+            summary = meterRegistry.summary(RCVD_MESSAGE_SIZE, List.of(grpcMethod, grpcTarget, OK_TAG));
+            assertThat(summary.isPresent(), is(true));
+            assertThat(summary.get().count(), is(20L));
+            assertThat(summary.get().max(), greaterThan(0.0));
+        }
+    }
+}


### PR DESCRIPTION
### Description

Initial support for gRPC client metrics. Implements _Client Per-Attempt Instruments_ section from this document https://grpc.io/docs/guides/opentelemetry-metrics/, except that it only records sizes and durations for successful invocations (i.e., status tag is always OK). 

The following metrics are created for each gRPC method (if invoked):

grpc.client.attempt.started (counter for all invocations)
grpc.client.attempt.duration (timer)
grpc.client.attempt.sent_total_compressed_message_size (distribution summary)
grpc.client.attempt.rcvd_total_compressed_message_size (distribution summary)

Metrics are disabled by default and can be enabled via config. Partly addresses issue https://github.com/helidon-io/helidon/issues/9806.

### Documentation

In a follow-up PR