### PR TITLE
Simplify ready loop in WebClient proxy tests

### DIFF
--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxy.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/HttpProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
We have seen cases where WebClient proxy tests are hanging in the validation pipeline and timing out after 30 minutes. See #10123

This PR simplifies the "ready" check for the test proxy server. Previously the ready check was a loop trying to repeatedly make connections to the proxy server until a connection was accepted. It then blocked on a latch to verify the connection has handled by the server.

The simplified version in this PR does away with the connection loop and simply blocks on the latch until the server decrements it after binding the server socket, but before accepting any connections.