### PR TITLE
Fixes problems cancelling a client-streaming gRPC call

### DIFF
--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -43,7 +43,6 @@ import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2RstStream;
-import io.helidon.http.http2.Http2Settings;
 import io.helidon.http.http2.Http2StreamState;
 import io.helidon.http.http2.Http2StreamWriter;
 import io.helidon.http.http2.Http2WindowUpdate;
@@ -119,8 +118,6 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                         Http2Headers headers,
                         Http2StreamWriter streamWriter,
                         int streamId,
-                        Http2Settings serverSettings,
-                        Http2Settings clientSettings,
                         StreamFlowControl flowControl,
                         Http2StreamState currentStreamState,
                         GrpcRouteHandler<REQ, RES> route,

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
@@ -86,8 +86,6 @@ public class GrpcProtocolSelector implements Http2SubProtocolSelector {
                                                                        headers,
                                                                        streamWriter,
                                                                        streamId,
-                                                                       serverSettings,
-                                                                       clientSettings,
                                                                        flowControl,
                                                                        currentStreamState,
                                                                        route,

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -20,7 +20,6 @@ import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2Headers;
-import io.helidon.http.http2.Http2Settings;
 import io.helidon.http.http2.Http2StreamState;
 
 import org.junit.jupiter.api.Test;
@@ -41,8 +40,6 @@ class GrpcProtocolHandlerTest {
                                                               Http2Headers.create(headers),
                                                               null,
                                                               1,
-                                                              Http2Settings.builder().build(),
-                                                              Http2Settings.builder().build(),
                                                               null,
                                                               Http2StreamState.OPEN,
                                                               null,
@@ -60,8 +57,6 @@ class GrpcProtocolHandlerTest {
                                                               Http2Headers.create(headers),
                                                               null,
                                                               1,
-                                                              Http2Settings.builder().build(),
-                                                              Http2Settings.builder().build(),
                                                               null,
                                                               Http2StreamState.OPEN,
                                                               null,

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -196,7 +196,9 @@ class Http2ServerStream implements Runnable, Http2Stream {
                                      "Received RST_STREAM for stream "
                                              + streamId + " in IDLE state");
         }
-
+        if (subProtocolHandler != null) {
+            subProtocolHandler.rstStream(rstStream);
+        }
         boolean rapidReset = writeState.get() == WriteState.INIT;
         this.state = Http2StreamState.CLOSED;
         return rapidReset;

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/CancelCallTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/CancelCallTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.grpc;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.grpc.strings.StringServiceGrpc;
+import io.helidon.webserver.grpc.strings.Strings;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class CancelCallTest extends BaseServiceTest {
+
+    protected StringServiceGrpc.StringServiceStub stub;
+
+    CancelCallTest(WebServer server) {
+        super(server);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        super.beforeEach();
+        stub = StringServiceGrpc.newStub(channel);
+    }
+
+    @AfterEach
+    void afterEach() throws InterruptedException {
+        super.afterEach();
+        stub = null;
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new StringService()));
+    }
+
+    @Test
+    void testClientStream() throws Throwable {
+        CountDownLatch latch = new CountDownLatch(1);
+        StreamObserver<Strings.StringMessage> requests = stub.join(new StreamObserver<>() {
+            @Override
+            public void onNext(Strings.StringMessage value) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+        requests.onNext(Strings.StringMessage.newBuilder().setText("helidon").build());
+        requests.onError(new RuntimeException("cancel"));
+        assertThat(latch.await(5, TimeUnit.SECONDS), is(true));
+    }
+}


### PR DESCRIPTION
### Description

Fixes problems cancelling a client-streaming gRPC call. Here is a summary of the changes in this PR:

1. If a client-streaming call is cancelled before any data is sent, make sure final trailers frame includes gRPC type and status for compatibility (Postman)
2. When a gRPC server receives an EOS (end of stream), its internal state should be set to HALF_CLOSED_REMOTE (it was incorrectly set to HALF_CLOSED_LOCAL, causing it to exit the processing loop in the underlying HTTP/2 layer)
3. A RST_STREAM received for an HTTP/2 stream must be propagate to the corresponding sub-protocol handler

In addition to the new test in this PR, I've done some manual testing with Postman and grpcurl using client-streaming and bidi calls to ensure that proper cancellations are correctly handled. See issue #9496.

### Documentation

None