### PR TITLE
4.2.3: Add header to metrics, health, OpenAPI, info, and config output to discourage browsers from sniffing data to infer the content type

### DIFF
--- a/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
@@ -94,6 +94,7 @@ enum HeaderNameEnum implements HeaderName {
     VARY("Vary"),
     WARNING("Warning"),
     WWW_AUTHENTICATE("WWW-Authenticate"),
+    X_CONTENT_TYPE_OPTIONS("X-Content-Type-Options"),
     X_FORWARDED_FOR("X-Forwarded-For"),
     X_FORWARDED_HOST("X-Forwarded-Host"),
     X_FORWARDED_PORT("X-Forwarded-Port"),

--- a/http/http/src/main/java/io/helidon/http/HeaderNames.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/http/http/src/main/java/io/helidon/http/HeaderNames.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNames.java
@@ -418,6 +418,17 @@ public final class HeaderNames {
      */
     public static final HeaderName X_FORWARDED_PROTO = HeaderNameEnum.X_FORWARDED_PROTO;
 
+    /**
+     * The {@value} header name.
+     * Represents non-standard content type options (such as {@code nosniff}).
+     */
+    public static final String X_CONTENT_TYPE_OPTIONS_NAME = Strings.X_CONTENT_TYPE_OPTIONS_NAME;
+    /**
+     * The {@value #X_CONTENT_TYPE_OPTIONS_NAME} header name.
+     * Represents non-standard content type options (such as {@code nosniff}).
+     */
+    public static final HeaderName X_CONTENT_TYPE_OPTIONS = HeaderNameEnum.X_CONTENT_TYPE_OPTIONS;
+
     private HeaderNames() {
     }
 

--- a/http/http/src/main/java/io/helidon/http/HeaderNames.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNames.java
@@ -417,14 +417,8 @@ public final class HeaderNames {
      * Represents the protocol specified by the originating client when the request has passed through one or more proxies.
      */
     public static final HeaderName X_FORWARDED_PROTO = HeaderNameEnum.X_FORWARDED_PROTO;
-
     /**
-     * The {@value} header name.
-     * Represents non-standard content type options (such as {@code nosniff}).
-     */
-    public static final String X_CONTENT_TYPE_OPTIONS_NAME = Strings.X_CONTENT_TYPE_OPTIONS_NAME;
-    /**
-     * The {@value #X_CONTENT_TYPE_OPTIONS_NAME} header name.
+     * The {@code X_CONTENT_TYPE_OPTIONS} header name.
      * Represents non-standard content type options (such as {@code nosniff}).
      */
     public static final HeaderName X_CONTENT_TYPE_OPTIONS = HeaderNameEnum.X_CONTENT_TYPE_OPTIONS;

--- a/http/http/src/main/java/io/helidon/http/HeaderValues.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,6 +99,11 @@ public final class HeaderValues {
      * Cache control that allows caching with no transform.
      */
     public static final Header CACHE_NORMAL = createCached(HeaderNames.CACHE_CONTROL, "no-transform");
+
+    /**
+     * Discourage browsers from attempting to detect the content type by "sniffing" the data.
+     */
+    public static final Header X_CONTENT_TYPE_OPTIONS_NOSNIFF = createCached(HeaderNames.X_CONTENT_TYPE_OPTIONS, "nosniff");
 
     /**
      * TE header set to {@code trailers}, used to enable trailer headers.

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import io.helidon.common.LazyValue;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.BadRequestException;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.Status;
 import io.helidon.webserver.cors.CorsEnabledServiceHelper;
@@ -89,7 +90,8 @@ class OpenApiHttpFeature implements HttpFeature {
                         format, OpenApiFeature.SUPPORTED_FORMATS.keySet()));
             }
             res.status(Status.OK_200);
-            res.headers().contentType(contentType);
+            res.header(HeaderValues.X_CONTENT_TYPE_OPTIONS_NOSNIFF)
+                    .headers().contentType(contentType);
             res.send(content(contentType));
         } else {
             // check if we should delegate to a service
@@ -114,7 +116,8 @@ class OpenApiHttpFeature implements HttpFeature {
             }
 
             res.status(Status.OK_200);
-            res.headers().contentType(contentType);
+            res.header(HeaderValues.X_CONTENT_TYPE_OPTIONS_NOSNIFF)
+                    .headers().contentType(contentType);
             res.send(content(contentType));
         }
     }

--- a/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiFeatureTest.java
+++ b/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiFeatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.Status;
@@ -110,7 +111,9 @@ class OpenApiFeatureTest {
                 .accept(testMediaType)
                 .request(String.class);
         assertThat(response.status(), is(Status.OK_200));
-
+        assertThat("Response headers",
+                   response.headers(),
+                   HttpHeaderMatcher.hasHeader(HeaderNames.X_CONTENT_TYPE_OPTIONS, "nosniff"));
         HttpMediaType contentType = response.headers().contentType().orElseThrow();
 
         if (contentType.test(MediaTypes.APPLICATION_OPENAPI_YAML)

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigService.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 
 import io.helidon.common.config.ConfigValue;
 import io.helidon.common.config.GlobalConfig;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.NotFoundException;
 import io.helidon.http.media.EntityWriter;
 import io.helidon.http.media.jsonp.JsonpSupport;
@@ -106,6 +107,7 @@ class ConfigService implements HttpService {
     }
 
     private void write(ServerRequest req, ServerResponse res, JsonObject json) {
+        res.header(HeaderValues.X_CONTENT_TYPE_OPTIONS_NOSNIFF);
         WRITER.write(JsonpSupport.JSON_OBJECT_TYPE,
                      json,
                      res.outputStream(),

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthHandler.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthHandler.java
@@ -85,7 +85,8 @@ class HealthHandler implements Handler {
         };
 
         res.status(responseStatus);
-        res.header(HeaderValues.CACHE_NO_CACHE);
+        res.header(HeaderValues.CACHE_NO_CACHE)
+                .header(HeaderValues.X_CONTENT_TYPE_OPTIONS_NOSNIFF);
 
         if (details) {
             entityWriter.write(JsonpSupport.JSON_OBJECT_TYPE,

--- a/webserver/observe/health/src/test/java/io/helidon/webserver/observe/health/TestHeaders.java
+++ b/webserver/observe/health/src/test/java/io/helidon/webserver/observe/health/TestHeaders.java
@@ -15,8 +15,11 @@
  */
 package io.helidon.webserver.observe.health;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.testing.junit5.ServerTest;
@@ -25,13 +28,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
 
 @ServerTest
-class TestNoCacheHeaders {
+class TestHeaders {
 
     private final Http1Client client;
 
-    TestNoCacheHeaders(Http1Client client) {
+    TestHeaders(Http1Client client) {
         this.client = client;
     }
 
@@ -48,6 +52,17 @@ class TestNoCacheHeaders {
                                                          "no-store",
                                                          "must-revalidate",
                                                          "no-transform")));
+        }
+    }
+
+    @Test
+    void testNosniffHeader() {
+        try (HttpClientResponse response = client.get("/observe/health").accept(MediaTypes.APPLICATION_JSON)
+                .request()) {
+            assertThat("Response", response.status().code(), is(Status.NO_CONTENT_204.code()));
+            assertThat("Response headers",
+                       response.headers(),
+                       HttpHeaderMatcher.hasHeader(HeaderNames.X_CONTENT_TYPE_OPTIONS, "nosniff"));
         }
     }
 }

--- a/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoService.java
+++ b/webserver/observe/info/src/main/java/io/helidon/webserver/observe/info/InfoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.webserver.observe.info;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.helidon.http.HeaderValues;
 import io.helidon.http.NotFoundException;
 import io.helidon.http.media.EntityWriter;
 import io.helidon.http.media.jsonp.JsonpSupport;
@@ -69,6 +70,7 @@ class InfoService implements HttpService {
     }
 
     private void write(ServerRequest req, ServerResponse res, JsonObject json) {
+        res.header(HeaderValues.X_CONTENT_TYPE_OPTIONS_NOSNIFF);
         WRITER.write(JsonpSupport.JSON_OBJECT_TYPE,
                      json,
                      res.outputStream(),

--- a/webserver/observe/metrics/pom.xml
+++ b/webserver/observe/metrics/pom.xml
@@ -74,6 +74,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-http-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -185,7 +185,8 @@ class MetricsFeature {
                              Iterable<String> scopeSelection,
                              Iterable<String> nameSelection) {
         MediaType mediaType = bestAccepted(req);
-        res.header(HeaderValues.CACHE_NO_CACHE);
+        res.header(HeaderValues.CACHE_NO_CACHE)
+                .header(HeaderValues.X_CONTENT_TYPE_OPTIONS_NOSNIFF);
         if (mediaType == null) {
             res.status(Status.NOT_ACCEPTABLE_406);
             res.send();

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestNosniffHeader.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestNosniffHeader.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe.metrics;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.RoutingTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RoutingTest
+class TestNosniffHeader {
+
+    private final WebClient client;
+
+    TestNosniffHeader(WebClient client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void setUpRoute(HttpRouting.Builder routing) {
+    }
+
+    @Test
+    void testNosniffHeader() {
+        try (HttpClientResponse response = client.get("/observe/metrics").accept(MediaTypes.APPLICATION_JSON)
+                .request()) {
+            assertThat("Response", response.status().code(), is(Status.OK_200.code()));
+            assertThat("Response headers",
+                       response.headers(),
+                       HttpHeaderMatcher.hasHeader(HeaderNames.X_CONTENT_TYPE_OPTIONS, "nosniff"));
+        }
+    }
+
+}


### PR DESCRIPTION
Backport #10116 to Helidon 4.2.3

### Description
Resolves #9679 

## Release Note
____
The Helidon metrics, health, OpenAPI, info, and config HTTP responses now include the header `X-Content-Type-Options: nosniff` to discourage browsers from trying to infer the content type by sniffing the incoming data. 
____

## PR Overview
Some security checkers verify that `X-Content-Type-Options: nosniff` is present. (See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options).

This PR adds declarations for the new header name and value, and also updates the metrics, health, info, and config observer code and the OpenAPI handler code to add this header to the responses.

The PR also adds unit tests to metrics, health, and OpenAPI to make sure the header is present in the output.

### Documentation
No impact.