### PR TITLE
gRPC Improvements

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/BufferData.java
@@ -651,4 +651,20 @@ public interface BufferData {
         read(bytes);
         return bytes;
     }
+
+    /**
+     * Converts this buffer into an {@link java.io.InputStream} that reads
+     * all available bytes from the buffer. This method never resets
+     * or rewinds the buffer.
+     *
+     * @return an input stream backed by this buffer
+     */
+    default InputStream asInputStream() {
+        return new InputStream() {
+            @Override
+            public int read() {
+                return BufferData.this.available() > 0 ? BufferData.this.read() : -1;
+            }
+        };
+    }
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -55,6 +55,8 @@ interface GrpcConfigBlueprint extends ProtocolConfig {
      * Whether to support compression if requested by a client. If explicitly
      * disabled, no compression will be ever be used by the server even if a
      * client-compatible compressor is found.
+     *
+     * @return true if compression is enabled
      */
     @Option.Configured
     @Option.DefaultBoolean(true)

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -50,4 +50,13 @@ interface GrpcConfigBlueprint extends ProtocolConfig {
     @Option.Configured
     @Option.DefaultBoolean(false)
     boolean enableMetrics();
+
+    /**
+     * Whether to support compression if requested by a client. If explicitly
+     * disabled, no compression will be ever be used by the server even if a
+     * client-compatible compressor is found.
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(true)
+    boolean enableCompression();
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolSelector.java
@@ -82,8 +82,7 @@ public class GrpcProtocolSelector implements Http2SubProtocolSelector {
                                                  new GrpcProtocolHandlerNotFound(streamWriter, streamId, currentStreamState));
                 }
                 return new SubProtocolResult(true,
-                                             new GrpcProtocolHandler<>(prologue,
-                                                                       headers,
+                                             new GrpcProtocolHandler<>(headers,
                                                                        streamWriter,
                                                                        streamId,
                                                                        flowControl,

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -82,32 +82,16 @@ class GrpcProtocolHandlerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void testFromHalfCloseLocalTransition() {
-        WritableHeaders<?> headers = WritableHeaders.create();
-        GrpcProtocolHandler handler = new GrpcProtocolHandler(Http2Headers.create(headers),
-                                                              null,
-                                                              1,
-                                                              null,
-                                                              Http2StreamState.HALF_CLOSED_LOCAL,
-                                                              null,
-                                                              GrpcConfig.create());
-        Http2StreamState next = handler.nextStreamState(Http2StreamState.HALF_CLOSED_REMOTE);
+        Http2StreamState next = GrpcProtocolHandler.nextStreamState(
+                Http2StreamState.HALF_CLOSED_LOCAL, Http2StreamState.HALF_CLOSED_REMOTE);
         assertThat(next, is(Http2StreamState.CLOSED));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void testFromHalfCloseRemoteTransition() {
-        WritableHeaders<?> headers = WritableHeaders.create();
-        GrpcProtocolHandler handler = new GrpcProtocolHandler(Http2Headers.create(headers),
-                                                              null,
-                                                              1,
-                                                              null,
-                                                              Http2StreamState.HALF_CLOSED_REMOTE,
-                                                              null,
-                                                              GrpcConfig.create());
-        Http2StreamState next = handler.nextStreamState(Http2StreamState.HALF_CLOSED_LOCAL);
+        Http2StreamState next = GrpcProtocolHandler.nextStreamState(
+                Http2StreamState.HALF_CLOSED_REMOTE, Http2StreamState.HALF_CLOSED_LOCAL);
         assertThat(next, is(Http2StreamState.CLOSED));
     }
 }

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -36,8 +36,7 @@ class GrpcProtocolHandlerTest {
     void testIdentityCompressorFlag() {
         WritableHeaders<?> headers = WritableHeaders.create();
         headers.add(GRPC_ACCEPT_ENCODING, "identity");
-        GrpcProtocolHandler handler = new GrpcProtocolHandler(null,
-                                                              Http2Headers.create(headers),
+        GrpcProtocolHandler handler = new GrpcProtocolHandler(Http2Headers.create(headers),
                                                               null,
                                                               1,
                                                               null,
@@ -45,7 +44,7 @@ class GrpcProtocolHandlerTest {
                                                               null,
                                                               GrpcConfig.create());
         handler.initCompression(null, headers);
-        assertThat(handler.isIdentityCompressor(), is(true));
+        assertThat(handler.identityCompressor(), is(true));
     }
 
     @Test
@@ -53,8 +52,7 @@ class GrpcProtocolHandlerTest {
     void testGzipCompressor() {
         WritableHeaders<?> headers = WritableHeaders.create();
         headers.add(GRPC_ACCEPT_ENCODING, "gzip");
-        GrpcProtocolHandler handler = new GrpcProtocolHandler(null,
-                                                              Http2Headers.create(headers),
+        GrpcProtocolHandler handler = new GrpcProtocolHandler(Http2Headers.create(headers),
                                                               null,
                                                               1,
                                                               null,
@@ -62,6 +60,24 @@ class GrpcProtocolHandlerTest {
                                                               null,
                                                               GrpcConfig.create());
         handler.initCompression(null, headers);
-        assertThat(handler.isIdentityCompressor(), is(false));
+        assertThat(handler.identityCompressor(), is(false));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testIgnoreGzipCompressor() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(GRPC_ACCEPT_ENCODING, "gzip");
+        GrpcProtocolHandler handler = new GrpcProtocolHandler(Http2Headers.create(headers),
+                                                              null,
+                                                              1,
+                                                              null,
+                                                              Http2StreamState.OPEN,
+                                                              null,
+                                                              GrpcConfig.builder()
+                                                                      .enableCompression(false)
+                                                                      .build());
+        handler.initCompression(null, headers);
+        assertThat(handler.identityCompressor(), is(true));
     }
 }

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -80,4 +80,34 @@ class GrpcProtocolHandlerTest {
         handler.initCompression(null, headers);
         assertThat(handler.identityCompressor(), is(true));
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testFromHalfCloseLocalTransition() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        GrpcProtocolHandler handler = new GrpcProtocolHandler(Http2Headers.create(headers),
+                                                              null,
+                                                              1,
+                                                              null,
+                                                              Http2StreamState.HALF_CLOSED_LOCAL,
+                                                              null,
+                                                              GrpcConfig.create());
+        Http2StreamState next = handler.nextStreamState(Http2StreamState.HALF_CLOSED_REMOTE);
+        assertThat(next, is(Http2StreamState.CLOSED));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testFromHalfCloseRemoteTransition() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        GrpcProtocolHandler handler = new GrpcProtocolHandler(Http2Headers.create(headers),
+                                                              null,
+                                                              1,
+                                                              null,
+                                                              Http2StreamState.HALF_CLOSED_REMOTE,
+                                                              null,
+                                                              GrpcConfig.create());
+        Http2StreamState next = handler.nextStreamState(Http2StreamState.HALF_CLOSED_LOCAL);
+        assertThat(next, is(Http2StreamState.CLOSED));
+    }
 }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/spi/Http2SubProtocolSelector.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/spi/Http2SubProtocolSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,8 @@ public interface Http2SubProtocolSelector {
      */
     interface SubProtocolHandler {
         /**
-         * Called once the sub-protocol handler is available.
+         * Called once the sub-protocol handler is available. Always dispatched on the
+         * HTTP/2 stream thread.
          */
         void init();
 
@@ -82,25 +83,27 @@ public interface Http2SubProtocolSelector {
         Http2StreamState streamState();
 
         /**
-         * RST stream was received.
+         * RST stream was received. Note that this method will be dispatched on the
+         * HTTP/2 connection thread, not the stream thread.
          *
          * @param rstStream RST stream frame
          */
         void rstStream(Http2RstStream rstStream);
 
         /**
-         * Window update was received.
+         * Window update was received. Note that this method will be dispatched on the
+         * HTTP/2 connection thread, not the stream thread.
          *
          * @param update window update frame
          */
         void windowUpdate(Http2WindowUpdate update);
 
         /**
-         * Data was received.
+         * Data was received. Always dispatched on the HTTP/2 stream thread.
          * The data may be empty. Check the
          * {@link io.helidon.http.http2.Http2FrameHeader#flags(io.helidon.http.http2.Http2FrameTypes)}
-         * if this is {@link io.helidon.http.http2.Http2Flag.DataFlags#END_OF_STREAM} to identify if this is the last data
-         * incoming.
+         * if this is {@link io.helidon.http.http2.Http2Flag.DataFlags#END_OF_STREAM} to identify if
+         * this is the last data incoming.
          *
          * @param header frame header
          * @param data   frame data

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -18,6 +18,7 @@ package io.helidon.webserver;
 
 import java.io.UncheckedIOException;
 import java.net.Socket;
+import java.net.SocketException;
 import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.List;
@@ -183,6 +184,13 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         } catch (CloseConnectionException e) {
             // end of request stream - safe to close the connection, as it was requested by our client
             helidonSocket.log(LOGGER, TRACE, "connection close requested", e);
+        } catch (UncheckedIOException e) {
+            if (e.getCause() instanceof SocketException) {
+                // socket exception - the socket failed, probably killed by OS, proxy or client
+                helidonSocket.log(LOGGER, TRACE, "server I/O issue", e);
+            } else {
+                helidonSocket.log(LOGGER, WARNING, "unexpected I/O exception", e);
+            }
         } catch (Exception e) {
             helidonSocket.log(LOGGER, WARNING, "unexpected exception", e);
         } finally {


### PR DESCRIPTION
### Description

Some improvements:

1. Avoids some buffer copies when sending and receiving gRPC payloads
2. New config property to completely disable compression that can be useful for perf testing

```
server:
  protocols:
    grpc:
      enable-compression: false
```

3. Ensures underlying HTTP/2 streams are properly removed from data structures after reaching CLOSED state
4. Logs all socket exceptions (e.g. broken pipes) in log level TRACE (see issue #10109)
5.  Proper synchronization for when an RST frame is received at connection level

### Documentation

None
