### PR TITLE
Helidon Data: update to configuration

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -54,7 +54,7 @@ Note that the PU must be of the same type as the Provider
 There are the following new nodes of configuration:
 
 - `data-sources` - a section for data sources
-- `data-sources.sql` - a list of SQL data sources (implement `javax.sql.DataSource`)
+- `data.sources.sql` - a list of SQL data sources (implement `javax.sql.DataSource`)
 - `persistence-units` - a section for persistence units
 - `persistence-units.jakarta` - a list of JPA Persistence unit configurations
 
@@ -65,7 +65,7 @@ Always
 - Repository instance annotated with `@Data.Repository`, named with provider name, or unnamed
 
 When `helidon-data-sql-datasource` is on classpath (and at least one provider of it, such as `hikari` or `ucp`)
-- `javax.sql.DataSource` for each `data-sources.sql` configuration (named or unnamed) `io.helidon.data.sql.datasource.DataSourceConfigFactory.SQL_DATA_SOURCES_CONFIG_KEY`
+- `javax.sql.DataSource` for each `data.sources.sql` configuration (named or unnamed) `io.helidon.data.sql.datasource.DataSourceConfigFactory.SQL_DATA_SOURCES_CONFIG_KEY`
 
 When `helidon-data-jakarta-persistence` is on classpath
 - `jakarta.persistence.EntityManagerFactory` for each `persistence-untis.jakarta` configuration (named or unnamed) `io.helidon.data.jakarta.persistence.PersistenceUnitFactory.JPA_PU_CONFIG_KEY`

--- a/data/data/src/main/java/io/helidon/data/Data.java
+++ b/data/data/src/main/java/io/helidon/data/Data.java
@@ -57,8 +57,9 @@ public final class Data {
     public @interface PersistenceUnit {
 
         /**
-         * Name of a named data source.
-         * When using configuration, this would a list of named configurations under {@code data}.
+         * Name of a named persistence unit.
+         * When using configuration, this is expected under {@code data.persistence-units.provider-type}, where provider-type
+         * is the provider of the persistence unit (such as {@code jakarta}).
          *
          * @return the name
          */
@@ -67,10 +68,10 @@ public final class Data {
         /**
          * Whether the named {@link io.helidon.data.Data.PersistenceUnit} is required.
          *
-         * @return value of {@code true} when the {@link #value()} named {@link io.helidon.data.Data.PersistenceUnit} is required,
+         * @return value of {@code true} when the {@link #value() named} {@link io.helidon.data.Data.PersistenceUnit} is required,
          *         {@code false} otherwise, to use the default configuration if a named one is not available
          */
-        boolean required() default false;
+        boolean required() default true;
     }
 
     /**

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/PersistenceUnitFactory.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/PersistenceUnitFactory.java
@@ -42,7 +42,7 @@ import jakarta.persistence.spi.PersistenceProvider;
 
 @Service.Singleton
 class PersistenceUnitFactory implements Service.ServicesFactory<EntityManagerFactory> {
-    static final String JPA_PU_CONFIG_KEY = "persistence-units.jakarta";
+    static final String JPA_PU_CONFIG_KEY = "data.persistence-units.jakarta";
     static final String PROVIDER_TYPE = "jakarta";
     /**
      * In Jakarta Persistence 3.1 transaction type is stored as {@link EntityManagerFactory} property.

--- a/data/sql/datasource/datasource/src/main/java/io/helidon/data/sql/datasource/DataSourceConfigFactory.java
+++ b/data/sql/datasource/datasource/src/main/java/io/helidon/data/sql/datasource/DataSourceConfigFactory.java
@@ -30,7 +30,7 @@ import io.helidon.service.registry.Service;
 @Service.Singleton
 class DataSourceConfigFactory implements Service.ServicesFactory<DataSourceConfig> {
 
-    private static final String SQL_DATA_SOURCES_CONFIG_KEY = "data-sources.sql";
+    private static final String SQL_DATA_SOURCES_CONFIG_KEY = "data.sources.sql";
 
     private final Supplier<Config> config;
 

--- a/data/tests/eclipselink/mysql-ds/src/test/resources/application.yaml
+++ b/data/tests/eclipselink/mysql-ds/src/test/resources/application.yaml
@@ -19,23 +19,23 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.hikari:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
-
-persistence-units:
-  jakarta:
-    - data-source: "test"
-      # EclipseLink properties
-      properties:
-        eclipselink.target-database: "MySQL"
-        eclipselink.target-server: "None"
-        eclipselink.weaving: false
-        eclipselink.logging.level: "FINEST"
-        eclipselink.logging.level.weaver: "OFF"
-        eclipselink.logging.parameters: true
-        jakarta.persistence.schema-generation.database.action: drop-and-create
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.hikari:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
+  persistence-units:
+    jakarta:
+      - data-source: "test"
+        # EclipseLink properties
+        properties:
+          eclipselink.target-database: "MySQL"
+          eclipselink.target-server: "None"
+          eclipselink.weaving: false
+          eclipselink.logging.level: "FINEST"
+          eclipselink.logging.level.weaver: "OFF"
+          eclipselink.logging.parameters: true
+          jakarta.persistence.schema-generation.database.action: drop-and-create

--- a/data/tests/eclipselink/mysql-jta/src/test/resources/application.yaml
+++ b/data/tests/eclipselink/mysql-jta/src/test/resources/application.yaml
@@ -19,23 +19,23 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.hikari:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
-
-persistence-units:
-  jakarta:
-    - data-source: "test"
-      # EclipseLink properties
-      properties:
-        eclipselink.target-database: "MySQL"
-        eclipselink.target-server: "None"
-        eclipselink.weaving: false
-        eclipselink.logging.level: "FINEST"
-        eclipselink.logging.level.weaver: "OFF"
-        eclipselink.logging.parameters: true
-        jakarta.persistence.schema-generation.database.action: drop-and-create
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.hikari:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
+  persistence-units:
+    jakarta:
+      - data-source: "test"
+        # EclipseLink properties
+        properties:
+          eclipselink.target-database: "MySQL"
+          eclipselink.target-server: "None"
+          eclipselink.weaving: false
+          eclipselink.logging.level: "FINEST"
+          eclipselink.logging.level.weaver: "OFF"
+          eclipselink.logging.parameters: true
+          jakarta.persistence.schema-generation.database.action: drop-and-create

--- a/data/tests/eclipselink/mysql-scripts/src/test/resources/application.yaml
+++ b/data/tests/eclipselink/mysql-scripts/src/test/resources/application.yaml
@@ -19,27 +19,28 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-persistence-units:
-  jakarta:
-    - connection:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
-        jdbc-driver-class-name: "com.mysql.cj.jdbc.Driver"
-      init-script: "init.sql"
-      # EclipseLink properties
-      properties:
-        eclipselink.target-database: "MySQL"
-        eclipselink.target-server: "None"
-        eclipselink.weaving: false
-        eclipselink.logging.level: "FINEST"
-        eclipselink.logging.level.weaver: "OFF"
-        eclipselink.logging.level.sql: "INFO"
-        eclipselink.logging.parameters: true
-  # Uncomment to let EclipseLink generate example DDL scripts
-  #      jakarta.persistence.schema-generation.create-script-source: "init-script.sql"
-  #      jakarta.persistence.schema-generation.create-source: "metadata"
-  #      jakarta.persistence.schema-generation.scripts.action: "drop-and-create"
-  #      jakarta.persistence.schema-generation.scripts.create-target: "init-ddl.sql"
-  #      jakarta.persistence.schema-generation.scripts.drop-target: "drop-ddl.sql"
-  #      jakarta.persistence.schema-generation.database.action: "drop-and-create"
+data:
+  persistence-units:
+    jakarta:
+      - connection:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
+          jdbc-driver-class-name: "com.mysql.cj.jdbc.Driver"
+        init-script: "init.sql"
+        # EclipseLink properties
+        properties:
+          eclipselink.target-database: "MySQL"
+          eclipselink.target-server: "None"
+          eclipselink.weaving: false
+          eclipselink.logging.level: "FINEST"
+          eclipselink.logging.level.weaver: "OFF"
+          eclipselink.logging.level.sql: "INFO"
+          eclipselink.logging.parameters: true
+# Uncomment to let EclipseLink generate example DDL scripts
+#        jakarta.persistence.schema-generation.create-script-source: "init-script.sql"
+#        jakarta.persistence.schema-generation.create-source: "metadata"
+#        jakarta.persistence.schema-generation.scripts.action: "drop-and-create"
+#        jakarta.persistence.schema-generation.scripts.create-target: "init-ddl.sql"
+#        jakarta.persistence.schema-generation.scripts.drop-target: "drop-ddl.sql"
+#        jakarta.persistence.schema-generation.database.action: "drop-and-create"

--- a/data/tests/eclipselink/mysql/src/test/resources/application.yaml
+++ b/data/tests/eclipselink/mysql/src/test/resources/application.yaml
@@ -19,19 +19,20 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-persistence-units:
-  jakarta:
-    - connection:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
-        jdbc-driver-class-name: "com.mysql.cj.jdbc.Driver"
-      # EclipseLink properties
-      properties:
-        eclipselink.target-database: "MySQL"
-        eclipselink.target-server: "None"
-        eclipselink.weaving: false
-        eclipselink.logging.level: "FINEST"
-        eclipselink.logging.level.weaver: "OFF"
-        eclipselink.logging.parameters: true
-        jakarta.persistence.schema-generation.database.action: drop-and-create
+data:
+  persistence-units:
+    jakarta:
+      - connection:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
+          jdbc-driver-class-name: "com.mysql.cj.jdbc.Driver"
+        # EclipseLink properties
+        properties:
+          eclipselink.target-database: "MySQL"
+          eclipselink.target-server: "None"
+          eclipselink.weaving: false
+          eclipselink.logging.level: "FINEST"
+          eclipselink.logging.level.weaver: "OFF"
+          eclipselink.logging.parameters: true
+          jakarta.persistence.schema-generation.database.action: drop-and-create

--- a/data/tests/eclipselink/ucp/src/test/resources/application.yaml
+++ b/data/tests/eclipselink/ucp/src/test/resources/application.yaml
@@ -19,24 +19,24 @@ test.database:
   password: "oracle123"
   url: "jdbc:oracle:thin:@localhost:1521/FREE"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.ucp:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
-        connection-factory-class-name: "oracle.jdbc.pool.OracleDataSource"
-
-persistence-units:
-  jakarta:
-    - data-source: "test"
-      # EclipseLink properties
-      properties:
-        eclipselink.target-database: "Oracle"
-        eclipselink.target-server: "None"
-        eclipselink.weaving: false
-        eclipselink.logging.level: "FINEST"
-        eclipselink.logging.level.weaver: "OFF"
-        eclipselink.logging.parameters: true
-        jakarta.persistence.schema-generation.database.action: drop-and-create
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.ucp:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
+          connection-factory-class-name: "oracle.jdbc.pool.OracleDataSource"
+  persistence-units:
+    jakarta:
+      - data-source: "test"
+        # EclipseLink properties
+        properties:
+          eclipselink.target-database: "Oracle"
+          eclipselink.target-server: "None"
+          eclipselink.weaving: false
+          eclipselink.logging.level: "FINEST"
+          eclipselink.logging.level.weaver: "OFF"
+          eclipselink.logging.parameters: true
+          jakarta.persistence.schema-generation.database.action: drop-and-create

--- a/data/tests/hibernate/mysql-ds/src/test/resources/application.yaml
+++ b/data/tests/hibernate/mysql-ds/src/test/resources/application.yaml
@@ -19,17 +19,17 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.hikari:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
-
-persistence-units:
-  jakarta:
-    - data-source: "test"
-      # Hibernate properties
-      properties:
-        jakarta.persistence.schema-generation.database.action: "create"
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.hikari:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
+  persistence-units:
+    jakarta:
+      - data-source: "test"
+        # Hibernate properties
+        properties:
+          jakarta.persistence.schema-generation.database.action: "create"

--- a/data/tests/hibernate/mysql-jta/src/test/resources/application.yaml
+++ b/data/tests/hibernate/mysql-jta/src/test/resources/application.yaml
@@ -19,17 +19,17 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.hikari:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
-
-persistence-units:
-  jakarta:
-    - data-source: "test"
-      # Hibernate properties
-      properties:
-          jakarta.persistence.schema-generation.database.action: "create"
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.hikari:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
+  persistence-units:
+    jakarta:
+      - data-source: "test"
+        # Hibernate properties
+        properties:
+            jakarta.persistence.schema-generation.database.action: "create"

--- a/data/tests/hibernate/mysql/src/test/resources/application.yaml
+++ b/data/tests/hibernate/mysql/src/test/resources/application.yaml
@@ -19,13 +19,14 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-persistence-units:
-  jakarta:
-    - connection:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
-        jdbc-driver-class-name: "com.mysql.cj.jdbc.Driver"
-      # Hibernate properties
-      properties:
-        jakarta.persistence.schema-generation.database.action: "create"
+data:
+  persistence-units:
+    jakarta:
+      - connection:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
+          jdbc-driver-class-name: "com.mysql.cj.jdbc.Driver"
+        # Hibernate properties
+        properties:
+          jakarta.persistence.schema-generation.database.action: "create"

--- a/data/tests/hibernate/ucp/src/test/resources/application.yaml
+++ b/data/tests/hibernate/ucp/src/test/resources/application.yaml
@@ -19,19 +19,19 @@ test.database:
   password: "oracle123"
   url: "jdbc:oracle:thin:@localhost:1521/FREE"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.ucp:
-          username: "${test.database.username}"
-          password: "${test.database.password}"
-          url: "${test.database.url}"
-          connection-factory-class-name: "oracle.jdbc.pool.OracleDataSource"
-
-persistence-units:
-  jakarta:
-    - data-source: "test"
-      # Hibernate properties
-      properties:
-        hibernate.dialect: "org.hibernate.dialect.OracleDialect"
-        jakarta.persistence.schema-generation.database.action: "create"
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.ucp:
+            username: "${test.database.username}"
+            password: "${test.database.password}"
+            url: "${test.database.url}"
+            connection-factory-class-name: "oracle.jdbc.pool.OracleDataSource"
+  persistence-units:
+    jakarta:
+      - data-source: "test"
+        # Hibernate properties
+        properties:
+          hibernate.dialect: "org.hibernate.dialect.OracleDialect"
+          jakarta.persistence.schema-generation.database.action: "create"

--- a/data/tests/sql/hikari/src/test/java/io/helidon/data/tests/sql/hikari/TestHikari.java
+++ b/data/tests/sql/hikari/src/test/java/io/helidon/data/tests/sql/hikari/TestHikari.java
@@ -41,16 +41,16 @@ class TestHikari {
     @Test
     void testDataSourceConfig(Config config) {
         assertThat(config.exists(), is(true));
-        DataSourceConfig dataSourceConfig = DataSourceConfig.create(config.get("data-sources.sql.0"));
+        DataSourceConfig dataSourceConfig = DataSourceConfig.create(config.get("data.sources.sql.0"));
         HikariDataSourceConfig hikariDataSourceConfig = (HikariDataSourceConfig) dataSourceConfig.provider();
         assertThat(hikariDataSourceConfig.username().isPresent(), is(true));
         assertThat(hikariDataSourceConfig.username().get(),
-                   is(config.get("data-sources.sql.0.provider.hikari.username").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.hikari.username").as(String.class).get()));
         assertThat(hikariDataSourceConfig.password().isPresent(), is(true));
         assertThat(new String(hikariDataSourceConfig.password().get()),
-                   is(config.get("data-sources.sql.0.provider.hikari.password").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.hikari.password").as(String.class).get()));
         assertThat(hikariDataSourceConfig.url(),
-                   is(config.get("data-sources.sql.0.provider.hikari.url").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.hikari.url").as(String.class).get()));
     }
 
     @Test

--- a/data/tests/sql/hikari/src/test/resources/application.yaml
+++ b/data/tests/sql/hikari/src/test/resources/application.yaml
@@ -19,11 +19,12 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.hikari:
-        # DataSource config
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.hikari:
+          # DataSource config
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"

--- a/data/tests/sql/jdbc/src/test/java/io/helidon/data/tests/sql/jdbc/TestJdbc.java
+++ b/data/tests/sql/jdbc/src/test/java/io/helidon/data/tests/sql/jdbc/TestJdbc.java
@@ -42,16 +42,16 @@ class TestJdbc {
     @Test
     void testDataSourceConfig(Config config) {
         assertThat(config.exists(), is(true));
-        DataSourceConfig dataSourceConfig = DataSourceConfig.create(config.get("data-sources.sql.0"));
+        DataSourceConfig dataSourceConfig = DataSourceConfig.create(config.get("data.sources.sql.0"));
         JdbcDataSourceConfig hikariDataSourceConfig = (JdbcDataSourceConfig) dataSourceConfig.provider();
         assertThat(hikariDataSourceConfig.username().isPresent(), is(true));
         assertThat(hikariDataSourceConfig.username().get(),
-                   is(config.get("data-sources.sql.0.provider.jdbc.username").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.jdbc.username").as(String.class).get()));
         assertThat(hikariDataSourceConfig.password().isPresent(), is(true));
         assertThat(new String(hikariDataSourceConfig.password().get()),
-                   is(config.get("data-sources.sql.0.provider.jdbc.password").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.jdbc.password").as(String.class).get()));
         assertThat(hikariDataSourceConfig.url(),
-                   is(config.get("data-sources.sql.0.provider.jdbc.url").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.jdbc.url").as(String.class).get()));
     }
 
     @Test

--- a/data/tests/sql/jdbc/src/test/resources/application.yaml
+++ b/data/tests/sql/jdbc/src/test/resources/application.yaml
@@ -19,11 +19,12 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.jdbc:
-        # DataSource config
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.jdbc:
+          # DataSource config
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"

--- a/data/tests/sql/ucp/src/test/java/io/helidon/data/tests/sql/ucp/TestUcp.java
+++ b/data/tests/sql/ucp/src/test/java/io/helidon/data/tests/sql/ucp/TestUcp.java
@@ -43,16 +43,16 @@ class TestUcp {
     @Test
     void testDataSourceConfig(Config config) {
         assertThat(config.exists(), is(true));
-        DataSourceConfig dataSourceConfig = DataSourceConfig.create(config.get("data-sources.sql.0"));
+        DataSourceConfig dataSourceConfig = DataSourceConfig.create(config.get("data.sources.sql.0"));
         UcpDataSourceConfig ucpDataSourceConfig = (UcpDataSourceConfig) dataSourceConfig.provider();
         assertThat(ucpDataSourceConfig.username().isPresent(), is(true));
         assertThat(ucpDataSourceConfig.username().get(),
-                   is(config.get("data-sources.sql.0.provider.ucp.username").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.ucp.username").as(String.class).get()));
         assertThat(ucpDataSourceConfig.password().isPresent(), is(true));
         assertThat(new String(ucpDataSourceConfig.password().get()),
-                   is(config.get("data-sources.sql.0.provider.ucp.password").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.ucp.password").as(String.class).get()));
         assertThat(ucpDataSourceConfig.url(),
-                   is(config.get("data-sources.sql.0.provider.ucp.url").as(String.class).get()));
+                   is(config.get("data.sources.sql.0.provider.ucp.url").as(String.class).get()));
     }
 
     @Test

--- a/data/tests/sql/ucp/src/test/resources/application.yaml
+++ b/data/tests/sql/ucp/src/test/resources/application.yaml
@@ -19,11 +19,12 @@ test.database:
   password: "oracle123"
   url: "jdbc:oracle:thin:@localhost:1521/FREE"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.ucp:
-        # DataSource config
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.ucp:
+          # DataSource config
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"

--- a/tests/integration/transaction/data-mp/eclipselink/src/test/resources/application.yaml
+++ b/tests/integration/transaction/data-mp/eclipselink/src/test/resources/application.yaml
@@ -21,35 +21,34 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.hikari:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.hikari:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
 # Another DataSource to be tested with CDI modules, does not work
-#  - name: "cditest"
-#    provider.hikari:
-#      username: "test"
-#      password: "password"
-#      url: "jdbc:mysql://localhost:3306/testdb"
+#    - name: "cditest"
+#      provider.hikari:
+#        username: "test"
+#        password: "password"
+#        url: "jdbc:mysql://localhost:3306/testdb"
+  persistence-units:
+    jakarta:
+      - data-source: "test"
+        # EclipseLink properties
+        properties:
+          eclipselink.target-database: "MySQL"
+          eclipselink.target-server: "None"
+          eclipselink.weaving: false
+          eclipselink.logging.level: "FINEST"
+          eclipselink.logging.level.weaver: "OFF"
+          eclipselink.logging.parameters: true
+          jakarta.persistence.schema-generation.database.action: "create"
 
-persistence-units:
-  jakarta:
-    - data-source: "test"
-      # EclipseLink properties
-      properties:
-        eclipselink.target-database: "MySQL"
-        eclipselink.target-server: "None"
-        eclipselink.weaving: false
-        eclipselink.logging.level: "FINEST"
-        eclipselink.logging.level.weaver: "OFF"
-        eclipselink.logging.parameters: true
-        jakarta.persistence.schema-generation.database.action: "create"
-
-  # MP configuration
-
+# MP configuration
 javax.sql.DataSource.cditest:
   dataSourceClassName: "com.mysql.cj.jdbc.MysqlDataSource"
   dataSource:

--- a/tests/integration/transaction/data-mp/hibernate/src/test/resources/application.yaml
+++ b/tests/integration/transaction/data-mp/hibernate/src/test/resources/application.yaml
@@ -21,30 +21,29 @@ test.database:
   password: "changeit"
   url: "jdbc:mysql://localhost:3306/testdb"
 
-data-sources:
-  sql:
-    - name: "test"
-      provider.hikari:
-        username: "${test.database.username}"
-        password: "${test.database.password}"
-        url: "${test.database.url}"
+data:
+  sources:
+    sql:
+      - name: "test"
+        provider.hikari:
+          username: "${test.database.username}"
+          password: "${test.database.password}"
+          url: "${test.database.url}"
 # Another DataSource to be tested with CDI modules, does not work
-#  - name: "cditest"
-#    provider.hikari:
-#      username: "test"
-#      password: "password"
-#      url: "jdbc:mysql://localhost:3306/testdb"
+#    - name: "cditest"
+#      provider.hikari:
+#        username: "test"
+#        password: "password"
+#        url: "jdbc:mysql://localhost:3306/testdb"
+  persistence-units:
+    jakarta:
+      - data-source: "test"
+        # EclipseLink properties
+        properties:
+          hibernate.dialect: "org.hibernate.dialect.MySQLDialect"
+          jakarta.persistence.schema-generation.database.action: "create"
 
-persistence-units:
-  jakarta:
-    - data-source: "test"
-      # EclipseLink properties
-      properties:
-        hibernate.dialect: "org.hibernate.dialect.MySQLDialect"
-        jakarta.persistence.schema-generation.database.action: "create"
-
-  # MP configuration
-
+# MP configuration
 javax.sql.DataSource.cditest:
   dataSourceClassName: "com.mysql.cj.jdbc.MysqlDataSource"
   dataSource:


### PR DESCRIPTION
Using root config node `data` for all new configurations (config sources, and persistence units)