### PR TITLE
3.x: Path pattern matching fix - backport for 3.x

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -99,7 +99,7 @@
         <version.lib.jersey>3.0.14</version.lib.jersey>
         <version.lib.jgit>7.2.1.202505142326-r</version.lib.jgit>
         <version.lib.jsonp-impl>2.0.1</version.lib.jsonp-impl>
-        <version.lib.junit>5.7.0</version.lib.junit>
+        <version.lib.junit>5.9.3</version.lib.junit>
         <version.lib.kafka>3.8.1</version.lib.kafka>
         <version.lib.log4j>2.21.1</version.lib.log4j>
         <version.lib.logback>1.4.14</version.lib.logback>

--- a/docs/se/security/containers-integration.adoc
+++ b/docs/se/security/containers-integration.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ security.web-server:
   defaults:
     authenticate: true
   paths:
-    - path: "/service1/[/{*}]"
+    - path: "/service1[/{*}]"
       methods: ["get"]
       roles-allowed: ["user"]
 ----

--- a/docs/se/webserver.adoc
+++ b/docs/se/webserver.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -171,8 +171,9 @@ You can use *path pattern* instead of _path_ with the following syntax:
 * `/foo/{var}/baz` - Named regular expression segment `([^/]+)`
 * `/foo/{var:\d+}` - Named regular expression segment with a specified expression
 * `/foo/{:\d+}` - Unnamed regular expression segment with a specified expression
-* `/foo/{+var}` - Convenience shortcut for {var:.+}. A matcher is not a true URI template (as defined by RFC) but this convenience is in sync with the Apiary templates
-* `/foo/{+}` - Convenience shortcut for unnamed segment with regular expression {:.+}
+* `/foo/{\+var}` - Convenience shortcut for `{var:.+}`. A matcher is not a true URI template (as defined by RFC) but this convenience is in sync with the Apiary templates
+* `/foo/{\+}` - Convenience shortcut for unnamed segment with regular expression `{:.+}`
+* `/foo/{\*}` - Convenience shortcut for unnamed segment with regular expression `{:.*}`
 * `/foo[/bar]` - An optional block, which translates to the `/foo(/bar)?` regular expression
 * `/*` or `/foo*` - `*` Wildcard character can be matched with any number of characters.
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/PathPattern.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/PathPattern.java
@@ -191,6 +191,11 @@ final class PathPattern {
                 return r1;
             case '}':
                 String r2 = name.toString().trim();
+                if (r2.length() == 1 && r2.charAt(0) == '*') {
+                    // special case - {*} - matches empty string as well, and is an unnamed parameter
+                    builder.append(".*");
+                    return "";
+                }
                 addParamRegexp(builder,
                                r2.length() > 0 ? index : -1,
                                greedy ? ".+" : "[^/]+");


### PR DESCRIPTION
* Fix path pattern `{*}` to have the meaning we assigned to it in documentation (sequence of zero to many characters).
* Upgraded JUnit to same version as `main` branch, so we can cherry pick the tests.
* Fixed documentation usage of wrong pattern `/foo/[/{*}]`, as the slash after `foo` would cause this pattern not matching `/foo`.
* Fixed docs to correctly render leading + and * within {} in SE WebServer


Resolves #10165 
Related to ##10159 (3.x "main" branch task)
Backport of #10162 
