### PR TITLE
4.x: Config provider fix default profiled config sources

### DIFF
--- a/config/tests/pom.xml
+++ b/config/tests/pom.xml
@@ -68,5 +68,6 @@
         <module>test-no-config-sources</module>
         <module>test-default-config-source</module>
         <module>test-mp-se-meta</module>
+        <module>se-profile</module>
     </modules>
 </project>

--- a/config/tests/se-profile/pom.xml
+++ b/config/tests/se-profile/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.config.tests</groupId>
+        <artifactId>helidon-config-tests-project</artifactId>
+        <version>4.2.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-config-tests-config-profile</artifactId>
+    <name>Helidon Config Tests Config Profile</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.builder</groupId>
+            <artifactId>helidon-builder-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/config/tests/se-profile/src/main/resources/application.yaml
+++ b/config/tests/se-profile/src/main/resources/application.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property: "default"

--- a/config/tests/se-profile/src/test/java/io/helidon/config/tests/seprofile/ProfileTest.java
+++ b/config/tests/se-profile/src/test/java/io/helidon/config/tests/seprofile/ProfileTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.seprofile;
+
+import io.helidon.common.config.Config;
+import io.helidon.service.registry.Services;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ProfileTest {
+    private static Config config;
+
+    @BeforeAll
+    public static void setUpClass() {
+        System.setProperty("helidon.config.profile", "named");
+
+        config = Services.get(Config.class);
+    }
+
+    @Test
+    public void testConfigValue() {
+        String propertyValue = config.get("property")
+                .asString()
+                .get();
+
+        assertThat(propertyValue, is("profile-specific"));
+    }
+}

--- a/config/tests/se-profile/src/test/resources/application-named.yaml
+++ b/config/tests/se-profile/src/test/resources/application-named.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property: "profile-specific"


### PR DESCRIPTION
Updated config provider to only get default config sources in case there is no meta-configuration defined.

Do not ignore profile sources in default config sources. Added a profile test.

Resolves #10105 


The fix can only be seen if there is a "meta-config" defined that does not include the default configuration files (such as `application.yaml`, and the `application.yaml` actually exists on the classpath or file system. In such a case, we would pick it up as one of the last sources.
In case there would be a config propery ONLY in this file, then it would be seen by the application even though it should not. Also this only happens when using service registry to obtain the configuration.

