### PR TITLE
3.x: Adjusts OCI vault config sources to read only secret versions that are extant and in the Current rotation state

### DIFF
--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleLazyConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleLazyConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,9 @@ public final class SecretBundleLazyConfigSource
             if (LOGGER.isLoggable(DEBUG)) {
                 LOGGER.log(DEBUG, "Getting SecretBundle with name " + secretName);
             }
-            return s.getSecretBundleByName(request(vaultOcid, secretName)).getSecretBundle().getSecretBundleContent();
+            return s.getSecretBundleByName(secretBundleByNameRequest(vaultOcid, secretName))
+                    .getSecretBundle()
+                    .getSecretBundleContent();
         } catch (BmcException e) {
             if (e.getStatusCode() == 404) {
                 return null;
@@ -148,10 +150,11 @@ public final class SecretBundleLazyConfigSource
         return Optional.empty();
     }
 
-    static GetSecretBundleByNameRequest request(String vaultOcid, String secretName) {
+    static GetSecretBundleByNameRequest secretBundleByNameRequest(String vaultOcid, String secretName) {
         return GetSecretBundleByNameRequest.builder()
             .vaultId(vaultOcid)
             .secretName(secretName)
+            .stage(GetSecretBundleByNameRequest.Stage.Current)
             .build();
     }
 

--- a/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleNodeConfigSource.java
+++ b/integrations/oci/oci-secrets-config-source/src/main/java/io/helidon/integrations/oci/secrets/configsource/SecretBundleNodeConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -49,6 +51,7 @@ import io.helidon.config.spi.PollingStrategy;
 
 import com.oracle.bmc.secrets.Secrets;
 import com.oracle.bmc.secrets.model.Base64SecretBundleContentDetails;
+import com.oracle.bmc.secrets.model.SecretBundle;
 import com.oracle.bmc.secrets.requests.GetSecretBundleRequest;
 import com.oracle.bmc.secrets.responses.GetSecretBundleResponse;
 import com.oracle.bmc.vault.Vaults;
@@ -57,6 +60,9 @@ import com.oracle.bmc.vault.model.SecretSummary;
 import com.oracle.bmc.vault.model.SecretSummary.LifecycleState;
 import com.oracle.bmc.vault.requests.ListSecretsRequest;
 
+import static com.oracle.bmc.vault.model.SecretSummary.LifecycleState.Active;
+import static com.oracle.bmc.vault.model.SecretSummary.LifecycleState.CancellingDeletion;
+import static com.oracle.bmc.vault.model.SecretSummary.LifecycleState.Updating;
 import static java.lang.System.Logger.Level.WARNING;
 import static java.time.Instant.now;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -84,6 +90,11 @@ public final class SecretBundleNodeConfigSource
     private static final String COMPARTMENT_OCID_PROPERTY_NAME = "compartment-ocid";
 
     private static final Logger LOGGER = System.getLogger(SecretBundleNodeConfigSource.class.getName());
+
+    // Lifecycle states that a SecretSummary can have that indicate the secret version it represents either exists or
+    // will continue to exist.
+    private static final Collection<? extends LifecycleState> EXTANT_STATES =
+            Collections.unmodifiableCollection(EnumSet.of(Active, CancellingDeletion, Updating));
 
 
     /*
@@ -122,7 +133,7 @@ public final class SecretBundleNodeConfigSource
         } else {
             ListSecretsRequest listSecretsRequest = ListSecretsRequest.builder()
                 .compartmentId(b.compartmentOcid)
-                .lifecycleState(LifecycleState.Active)
+                .lifecycleState(Active)
                 .vaultId(vaultOcid)
                 .build();
             this.loader = () -> this.load(vaultsSupplier, secretsSupplier, listSecretsRequest);
@@ -229,7 +240,7 @@ public final class SecretBundleNodeConfigSource
         Collection<Callable<Void>> tasks = new ArrayList<>(secretSummaries.size());
         Secrets secrets = secretsSupplier.get();
         for (SecretSummary ss : secretSummaries) {
-            if (ss.getLifecycleState() == LifecycleState.Active) {
+            if (ss.getLifecycleState() == Active) {
                 tasks.add(() -> {
                         GetSecretBundleResponse response = secrets.getSecretBundle(request(ss.getId()));
                         eTags.add(response.getEtag());
@@ -253,7 +264,7 @@ public final class SecretBundleNodeConfigSource
         }
         Instant earliestExpiration = null;
         for (SecretSummary ss : secretSummaries) {
-            if (ss.getLifecycleState() == LifecycleState.Active) {
+            if (ss.getLifecycleState() == Active) {
                 java.util.Date d = ss.getTimeOfCurrentVersionExpiry();
                 if (d == null) {
                     d = ss.getTimeOfDeletion();
@@ -350,7 +361,10 @@ public final class SecretBundleNodeConfigSource
     }
 
     private static GetSecretBundleRequest request(String secretId) {
-        return GetSecretBundleRequest.builder().secretId(secretId).build();
+        return GetSecretBundleRequest.builder()
+                .secretId(secretId)
+                .stage(GetSecretBundleRequest.Stage.Current) // extremely important
+                .build();
     }
 
     // Suppress "[try] auto-closeable resource Vaults has a member method close() that could throw
@@ -359,7 +373,10 @@ public final class SecretBundleNodeConfigSource
     private static Collection<? extends SecretSummary> secretSummaries(Supplier<? extends Vaults> vaultsSupplier,
                                                                        ListSecretsRequest listSecretsRequest) {
         try (Vaults v = vaultsSupplier.get()) {
-            return v.listSecrets(listSecretsRequest).getItems();
+            return v.listSecrets(listSecretsRequest).getItems()
+                    .stream()
+                    .filter(ss -> EXTANT_STATES.contains(ss.getLifecycleState()))
+                    .toList();
         } catch (RuntimeException e) {
             throw e;
         } catch (InterruptedException e) {
@@ -393,7 +410,9 @@ public final class SecretBundleNodeConfigSource
                                    Consumer<? super String> eTags) {
         GetSecretBundleResponse response = f.apply(request);
         eTags.accept(response.getEtag());
-        return (Base64SecretBundleContentDetails) response.getSecretBundle().getSecretBundleContent();
+        SecretBundle sb = response.getSecretBundle();
+
+        return (Base64SecretBundleContentDetails) sb.getSecretBundleContent();
     }
 
     private static ValueNode valueNode(Function<? super GetSecretBundleRequest, ? extends Base64SecretBundleContentDetails> f,


### PR DESCRIPTION
### Description
It's backport for 3.x from [4.x](https://github.com/helidon-io/helidon/pull/10035) . As I can see, it can be done.

It's part of [this issue](https://github.com/helidon-io/helidon/issues/10012).

Should I create the separate issue for 3.x? Or it shouldn't be backported?