### PR TITLE
4.x: Update jandex-maven-plugin version to match that of jandex lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <version.plugin.install>3.1.2</version.plugin.install>
         <version.plugin.invoker>3.2.2</version.plugin.invoker>
         <version.plugin.jacoco>0.8.5</version.plugin.jacoco>
-        <version.plugin.jandex>3.1.2</version.plugin.jandex>
+        <version.plugin.jandex>${version.lib.jandex}</version.plugin.jandex>
         <version.plugin.jar>3.3.0</version.plugin.jar>
         <version.plugin.javadoc>3.6.2</version.plugin.javadoc>
         <version.plugin.jaxb>2.5.0</version.plugin.jaxb>


### PR DESCRIPTION
### Description

Update jandex-maven-plugin version in root project pom to match that of jandex lib

See also #10080