### PR TITLE
4.2.3: Add project names to langchain4j modules. Add urls to application poms

### DIFF
--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -294,11 +294,11 @@
     </profiles>
 
     <!-- Remove the Helidon specific info from the effective pom. -->
-    <url/>
+    <url>https://example.com</url>
     <scm>
         <connection/>
         <developerConnection/>
-        <url/>
+        <url>https://example.com</url>
     </scm>
     <inceptionYear/>
     <organization/>

--- a/integrations/langchain4j/codegen/pom.xml
+++ b/integrations/langchain4j/codegen/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>helidon-integrations-langchain4j-codegen</artifactId>
+    <name>Helidon Integrations Langchain4j Codegen</name>
 
     <dependencies>
         <dependency>

--- a/integrations/langchain4j/langchain4j/pom.xml
+++ b/integrations/langchain4j/langchain4j/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>helidon-integrations-langchain4j</artifactId>
+    <name>Helidon Integrations Langchain4j</name>
 
     <dependencies>
         <dependency>

--- a/integrations/langchain4j/providers/cohere/pom.xml
+++ b/integrations/langchain4j/providers/cohere/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>helidon-integrations-langchain4j-providers-cohere</artifactId>
+    <name>Helidon Integrations Langchain4j Providers Cohere</name>
 
     <dependencies>
         <dependency>

--- a/integrations/langchain4j/providers/ollama/pom.xml
+++ b/integrations/langchain4j/providers/ollama/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>helidon-integrations-langchain4j-providers-ollama</artifactId>
+    <name>Helidon Integrations Langchain4j Providers Ollama</name>
 
     <dependencies>
         <dependency>

--- a/integrations/langchain4j/providers/open-ai/pom.xml
+++ b/integrations/langchain4j/providers/open-ai/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>helidon-integrations-langchain4j-providers-open-ai</artifactId>
+    <name>Helidon Integrations Langchain4j Providers OpenAI</name>
 
     <dependencies>
         <dependency>

--- a/integrations/langchain4j/providers/oracle/pom.xml
+++ b/integrations/langchain4j/providers/oracle/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>helidon-integrations-langchain4j-providers-oracle</artifactId>
+    <name>Helidon Integrations Langchain4j Providers Oracle</name>
 
     <dependencies>
         <dependency>

--- a/integrations/langchain4j/providers/pom.xml
+++ b/integrations/langchain4j/providers/pom.xml
@@ -31,6 +31,7 @@
 
     <groupId>io.helidon.integrations.langchain4j.providers</groupId>
     <artifactId>helidon-integrations-langchain4j-providers-project</artifactId>
+    <name>Helidon Integrations Langchain4j Providers Project</name>
 
     <modules>
         <module>open-ai</module>


### PR DESCRIPTION
Backport #10182 to Helidon 4.2.3

### Description

Add project names to langchain4j modules. Add urls to application poms.

This is needed to satisfy artifact validation by central publishing portal (https://central.sonatype.org/publish/requirements/)
