### PR TITLE
 4.2.3: migrate release workflow to use Central Publishing Portal

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -91,6 +91,7 @@ runs:
       with:
         distribution: ${{ env.JAVA_DISTRO }}
         java-version: ${{ env.JAVA_VERSION }}
+        overwrite-settings: false
     - name: Cache local Maven repository (read-write)
       if: ${{ inputs.maven-cache == 'read-write' }}
       uses: actions/cache@v4.2.0
@@ -128,6 +129,15 @@ runs:
         restore-keys: |
           build-cache-${{ github.run_id }}-${{ github.run_attempt }}-
           build-cache-${{ github.run_id }}-
+    - name: Build cache (write-only)
+      if: ${{ inputs.build-cache == 'write-only' }}
+      uses: actions/cache@v4.2.0
+      with:
+        path: |
+          ./**/target/**
+          .m2/repository/io/helidon/**
+        enableCrossOsArchive: true
+        key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.build-cache-id }}
     - name: Build cache (read-only)
       if: ${{ inputs.build-cache == 'read-only' }}
       uses: actions/cache/restore@v4.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,10 +105,10 @@ jobs:
           merge-multiple: true
       - shell: bash
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
         run: |
-          etc/scripts/nexus.sh deploy_release \
+          etc/scripts/upload.sh upload_release \
             --dir="staging" \
             --description="Helidon v%{version}"
       - uses: actions/upload-artifact@v4
@@ -119,22 +119,31 @@ jobs:
     needs: [ create-tag, deploy ]
     timeout-minutes: 30
     runs-on: ubuntu-22.04
-    name: resolve-all
+    environment: release
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           ref: ${{ needs.create-tag.outputs.tag }}
+      - shell: bash
+        env:
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+        run: |
+          ./etc/scripts/setup-central-settings.sh
       - uses: ./.github/actions/common
         with:
+          build-cache: write-only
+          build-cache-id: resolve-all
           run: |
             mvn ${MVN_ARGS} -N \
-              -Possrh-staging \
+              -Pcentral.manual.testing \
               -Dartifact=io.helidon:helidon-all:${{ needs.create-tag.outputs.version }}:pom \
               dependency:get
   smoketest:
-    needs: [ create-tag, deploy ]
+    needs: [ resolve-all, create-tag, deploy ]
     timeout-minutes: 30
+    environment: release
     strategy:
       matrix:
         archetype:
@@ -151,11 +160,19 @@ jobs:
         with:
           fetch-depth: '0'
           ref: ${{ needs.create-tag.outputs.tag }}
+      - shell: bash
+        env:
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+        run: |
+          ./etc/scripts/setup-central-settings.sh
       - uses: ./.github/actions/common
         with:
+          build-cache: read-only
+          build-cache-id: resolve-all
+          maven-cache: read-only
           run: |
             ./etc/scripts/smoketest.sh \
-              --clean \
               --staged \
               --version=${{ needs.create-tag.outputs.version }} \
               --archetype=${{ matrix.archetype }}

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -103,10 +103,10 @@ jobs:
           merge-multiple: true
       - shell: bash
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
         run: |
-          etc/scripts/nexus.sh deploy_snapshots \
+          etc/scripts/upload.sh upload_snapshot \
             --dir="staging"
       - uses: actions/upload-artifact@v4
         with:

--- a/etc/scripts/setup-central-settings.sh
+++ b/etc/scripts/setup-central-settings.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o pipefail || true  # trace ERR through pipes
+set -o errtrace || true # trace ERR through commands and functions
+set -o errexit || true  # exit the script if any statement returns a non-true return value
+
+on_error(){
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}" >&2
+}
+trap on_error ERR
+
+usage(){
+    cat <<EOF
+
+DESCRIPTION: Create a Maven settings.xml file that includes central staging repo so we can use it for testing.
+
+USAGE:
+
+$(basename "${0}") --dir=D
+
+  --dir=path
+        Directory to place settings.xml file in. Defaults to ${HOME}/.m2
+EOF
+}
+
+# parse command line args
+ARGS=( "${@}" )
+for ((i=0;i<${#ARGS[@]};i++))
+{
+  ARG=${ARGS[${i}]}
+  case ${ARG} in
+  "--dir="*)
+    DESTINATION_DIRECTORY=${ARG#*=}
+    ;;
+  *)
+    echo "ERROR: unknown argument: ${ARG}"
+    exit 1
+    ;;
+  esac
+}
+
+if [ -z "${CENTRAL_USER}" ] ; then
+    echo "ERROR: environment variable CENTRAL_USER is required." >&2
+    usage
+    exit 1
+fi
+
+if [ -z "${CENTRAL_PASSWORD}" ] ; then
+    echo "ERROR: environment variable CENTRAL_PASSWORD is required." >&2
+    usage
+    exit 1
+fi
+
+if [ -z "${DESTINATION_DIRECTORY}" ] ; then
+    DESTINATION_DIRECTORY="${HOME}/.m2"
+    mkdir -p "${DESTINATION_DIRECTORY}"
+fi
+
+if [ ! -d "${DESTINATION_DIRECTORY}" ] ; then
+    echo "ERROR: destination directory ${DESTINATION_DIRECTORY} does not exist or is not a directory" >&2
+    usage
+    exit 1
+fi
+
+readonly DESTINATION_DIRECTORY
+
+if [ -e "${DESTINATION_DIRECTORY}/settings.xml" ]; then
+    echo "WARNING: ${DESTINATION_DIRECTORY}/settings.xml already exists. Copying to ${DESTINATION_DIRECTORY}/settings.xml.bk" >&2
+    cp  "${DESTINATION_DIRECTORY}/settings.xml" "${DESTINATION_DIRECTORY}/settings.xml.bk"
+fi
+
+# Create credential needed to access Maven Central Publishing portal
+BEARER=$(printf "%s:%s" "${CENTRAL_USER}" "${CENTRAL_PASSWORD}" | base64)
+readonly BEARER
+
+maven_settings() {
+ cat <<EOF
+ <settings>
+   <servers>
+     <server>
+       <id>central.manual.testing</id>
+       <configuration>
+         <httpHeaders>
+           <property>
+             <name>Authorization</name>
+             <value>Bearer ${BEARER}</value>
+           </property>
+         </httpHeaders>
+       </configuration>
+     </server>
+   </servers>
+   <profiles>
+       <profile>
+         <id>central.manual.testing</id>
+         <repositories>
+           <repository>
+             <id>central.manual.testing</id>
+             <name>Central Testing repository</name>
+             <url>https://central.sonatype.com/api/v1/publisher/deployments/download</url>
+           </repository>
+         </repositories>
+         <pluginRepositories>
+             <pluginRepository>
+                 <id>central.manual.testing</id>
+                 <name>Central Testing repository</name>
+                 <url>https://central.sonatype.com/api/v1/publisher/deployments/download</url>
+             </pluginRepository>
+         </pluginRepositories>
+       </profile>
+   </profiles>
+</settings>
+EOF
+}
+
+setup_central_settings() {
+  echo "INFO: creating settings.xml in ${DESTINATION_DIRECTORY}"
+  maven_settings > "${DESTINATION_DIRECTORY}/settings.xml"
+}
+
+setup_central_settings

--- a/etc/scripts/upload.sh
+++ b/etc/scripts/upload.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o pipefail || true  # trace ERR through pipes
+set -o errtrace || true # trace ERR through commands and functions
+set -o errexit || true  # exit the script if any statement returns a non-true return value
+
+on_error(){
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}" >&2
+}
+trap on_error ERR
+
+usage(){
+    cat <<EOF
+
+DESCRIPTION: Upload staged artifacts to the Central Portal
+
+USAGE:
+
+$(basename "${0}") [OPTIONS] --directory=DIR CMD
+
+  --dir=DIR
+      Set the staging directory to use.
+
+  --description=DESCRIPTION
+        Set the staging repository description to use.
+        %{version} can be used to subsitute the release version.
+
+  --help
+        Prints the usage and exits.
+
+  CMD:
+
+    upload_release
+        Upload staging directory to a release repository
+
+    upload_snapshot
+        Uploading staging directory to a snapshots repository
+EOF
+}
+
+# parse command line args
+ARGS=( )
+while (( ${#} > 0 )); do
+  case ${1} in
+  "--dir="*)
+    STAGING_DIR=${1#*=}
+    shift
+    ;;
+  "--description="*)
+    DESCRIPTION=${1#*=}
+    shift
+    ;;
+  "--help")
+    usage
+    exit 0
+    ;;
+  "upload_release"|"upload_snapshot")
+    COMMAND="${1}"
+    shift
+    ;;
+  *)
+    ARGS+=( "${1}" )
+    shift
+    ;;
+  esac
+done
+readonly ARGS
+readonly COMMAND
+
+# copy stdout as fd 6 and redirect stdout to stderr
+# this allows us to use fd 6 for returning data
+exec 6>&1 1>&2
+
+case ${COMMAND} in
+"upload_release")
+  if [ -z "${DESCRIPTION}" ] ; then
+    echo "ERROR: description required" >&2
+    usage
+    exit 1
+  fi
+  ;;
+"upload_snapshot")
+  # no-op
+  ;;
+"")
+  echo "ERROR: no command provided" >&2
+  usage
+  exit 1
+  ;;
+*)
+  echo "ERROR: unknown command ${COMMAND}" >&2
+  usage
+  exit 1
+  ;;
+esac
+
+if [ -z "${STAGING_DIR}" ] ; then
+  echo "ERROR: --staging-dir is required" >&2
+  usage
+  exit 1
+fi
+
+if [ -z "${CENTRAL_USER}" ] ; then
+  echo "ERROR: CENTRAL_USER environment is not set" >&2
+  usage
+  exit 1
+fi
+if [ -z "${CENTRAL_PASSWORD}" ] ; then
+  echo "ERROR: CENTRAL_PASSWORD environment is not set" >&2
+  usage
+  exit 1
+fi
+
+if [ ! -d "${STAGING_DIR}" ] ; then
+  echo "ERROR: Invalid staging directory: ${STAGING_DIR}" >&2
+  exit 1
+fi
+
+# Central Portal URL for releases
+#readonly CENTRAL_URL="http://localhost:8080/api/v1/"
+readonly CENTRAL_URL="https://central.sonatype.com/api/v1"
+# Central SNAPSHOT URL
+readonly SNAPSHOT_URL="https://central.sonatype.com/repository/maven-snapshots"
+
+BEARER=$(printf "%s:%s" "${CENTRAL_USER}" "${CENTRAL_PASSWORD}" | base64)
+
+find_version() {
+  local versions version
+
+  # List the "version" directories
+  versions=$(while read -r v ; do
+   dirname "${v}" | xargs basename
+  done < <(find "${STAGING_DIR}" -type f -name "*.pom" -print) | sort | uniq)
+
+  # Enforce one version per staging directory
+  for v in ${versions} ; do
+    if [ -n "${version}" ] ; then
+      echo "ERROR: staging directory contains more than one version: ${versions}" >&2
+      return 1
+    fi
+    version="${v}"
+  done
+
+  if [ -z "${version}" ] ; then
+    echo "ERROR: version not found" >&2
+    return 1
+  fi
+  echo "${version}"
+}
+
+upload_snapshot() {
+  echo "Uploading SNAPSHOT..." >&2
+  local version
+  version=$(find_version)
+
+  # Make sure version ends in -SNAPSHOT
+  if [[ "${version}" != *-SNAPSHOT ]]; then
+    echo "ERROR: Version ${version} is NOT a SNAPSHOT version" >&2
+    exit 1
+  fi
+
+  nexus_upload "${SNAPSHOT_URL}" "${STAGING_DIR}"
+}
+
+upload_release() {
+  echo "Uploading release..." >&2
+  local version
+  version=$(find_version)
+
+  # Make sure version does NOT end in -SNAPSHOT
+  if [[ "${v}" = *-SNAPSHOT ]]; then
+    echo "ERROR: Version ${version} is a SNAPSHOT version" >&2
+    exit 1
+  fi
+
+  deployment_id="$(central_upload "${CENTRAL_URL}" "${STAGING_DIR}")"
+  central_finish "${deployment_id}"
+}
+
+# Upload contents of the staging directory to central portal
+# arg1: base URL of upload portal
+# arg2: staging directory
+# prints deployment ID
+central_upload() {
+  local version
+  version=$(find_version)
+
+  printf "Uploading artifacts...\n" >&2
+  readonly UPLOAD_BUNDLE=io-helidon-artifacts-${version}.zip
+  rm -f "${UPLOAD_BUNDLE}"
+  printf "Creating artifact bundle %s...\n" "${UPLOAD_BUNDLE}" >&2
+  (cd "${2}"; zip -ryq "../${UPLOAD_BUNDLE}" .)
+
+  local responseFile statusFile
+  responseFile=$(mktemp)
+  statusFile=$(mktemp)
+
+  printf "Uploading %s to %s...\n" "${UPLOAD_BUNDLE}" "${1}" >&2
+  # Upload bundle in one shot
+  # publishingType of USER_MANAGED acts like "staging". Artifacts are uploaded and verified but not published.
+  curl --request POST \
+    --retry 2 \
+    --header "Authorization: Bearer ${BEARER}" \
+    --write-out "%{stderr}%{http_code} %{url_effective}\n%{stdout}%{http_code}" \
+    --form bundle=@"${UPLOAD_BUNDLE}" \
+    -o  "${responseFile}" \
+    "${1}/publisher/upload?name=io-helidon-${version}&publishingType=USER_MANAGED" > "${statusFile}"
+
+  # handle errors
+  if [ "$(cat "${statusFile}")" != "201" ] ; then
+    printf "[ERROR] %s\n" "$(cat "${responseFile}")" >&2
+    exit 1
+  fi
+
+  # If success then output deployment ID
+  cat "${responseFile}"
+}
+
+# Poll deployment status until operation is complete.
+# arg1: deployment ID
+central_finish() {
+  printf "\n\nVerifying upload status of %s...\n\n" "$1" >&2
+
+  while true; do
+    local deploymentState
+    deploymentState=$(central_get_deployment_state "$1")
+    printf "%s...\n" "${deploymentState}" >&2
+    case ${deploymentState} in
+    "PENDING")
+      ;;
+    "VALIDATING")
+      ;;
+    "VALIDATED")
+      printf "Done. Bits are uploaded." >&2
+      exit
+      ;;
+    "PUBLISHING")
+      ;;
+    "PUBLISHED")
+      printf "!!!! Oh No! Artifacts have been published!!!! That should not have happened." >&2
+      exit
+      ;;
+    "FAILED")
+      exit
+      ;;
+    esac
+    sleep 10
+  done
+}
+
+# Gets the status of a deployment from central portal
+# arg1: deployment ID
+# Prints deployment state for the given ID:
+# PENDING, VALIDATING, VALIDATED, PUBLISHING, PUBLISHED, FAILED
+# Should never be PUBLISHING or PUBLISHED since our publishingType is USER_MANAGED
+central_get_deployment_state() {
+  curl --request POST \
+    -s \
+    --retry 3 \
+    --header "Authorization: Bearer ${BEARER}" \
+    "${CENTRAL_URL}/publisher/status?id=${1}" \
+    | jq -r ".deploymentState"
+}
+
+# Upload to a nexus repository. This is used to support SNAPSHOT releases
+# arg1: base URL
+# arg2: staging directory
+nexus_upload() {
+  printf "\nUploading artifacts...\n" >&2
+
+  local tmpfile
+  tmpfile=$(mktemp)
+
+  # Generate a curl config file for all files to deploy
+  # Use -T <file> --url <url> for each file
+  while read -r i ; do
+      echo "-T ${2}/${i}" >> "${tmpfile}"
+      echo "--url ${1}/${i}" >> "${tmpfile}"
+  done < <(find "${2}" -type f | cut -c $((${#2} + 2))-)
+
+  # Upload
+  curl -s \
+    --user "${CENTRAL_USER}:${CENTRAL_PASSWORD}" \
+    --write-out "%{stderr}%{http_code} %{url_effective}\n" \
+    --config "${tmpfile}" \
+    --parallel \
+    --parallel-max 10 \
+    --retry 3
+}
+
+${COMMAND}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -198,26 +198,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>ossrh-staging</id>
-            <repositories>
-                <repository>
-                    <id>ossrh-staging</id>
-                    <url>https://oss.sonatype.org/content/repositories/staging/</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>ossrh-staging</id>
-                    <url>https://oss.sonatype.org/content/repositories/staging/</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Backport #10114 to Helidon 4.2.3

### Description

This updates our release workflow to deploy artifacts using the Central Publishing Portal API:

1. Adds an `upload` script to handle uploading an artifact bundle to Central Publishing Portal
2. Adds `setup-cental-settings` script to handle creation of a `settings.xml` with Central Publishing Portal credentials
3. Updates release workflow to use upload script
4. Updates common action to support a `write-only` version of the build cache
5. Update resolve-all and smoketest tests so that the resolve-all test caches the majority of helidon artifacts downloaded from central publishing for re-use by smoketest.
6. Remove ossrh-staging profile from top pom since it is no longer used
7. Updates snapshot workflow to use upload script

The release workflow has been fully tested.
The snapshot workflow is work-in-progress

For more information about Maven Central Publishing Portal:

https://central.sonatype.org/publish/publish-portal-guide/

See #10034
