### PR TITLE
Manage REST request metrics for resource methods on a superclass

### DIFF
--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -131,6 +131,7 @@
                                 <exclude>**/TestSelectivelyDisabledMetrics.java</exclude>
                                 <exclude>**/TestConfigProcessing.java</exclude>
                                 <exclude>**/TestDistributionCustomizationsNoInit.java</exclude>
+                                <exclude>**/TestRestServiceInheritance.java</exclude>
                             </excludes>
                             <systemPropertyVariables>
                                 <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
@@ -206,6 +207,17 @@
                         <configuration>
                             <includes>
                                 <include>**/TestDistributionCustomizationsNoInit.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-rest-service-inheritance</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestRestServiceInheritance.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -219,6 +219,7 @@
                             <includes>
                                 <include>**/TestRestServiceInheritance.java</include>
                             </includes>
+                            <reuseForks>false</reuseForks>
                         </configuration>
                     </execution>
                 </executions>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -205,18 +205,6 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension {
     /**
      * Creates or looks up the {@code Timer} instance for measuring REST requests on any JAX-RS method.
      *
-     * @param method the {@code Method} for which the Timer instance is needed
-     * @return the located or created {@code Timer}
-     * @deprecated Use {@link #restEndpointTimer(Class, java.lang.reflect.Method)} instead.
-     */
-    @Deprecated(since = "4.2.3", forRemoval = true)
-    static Timer restEndpointTimer(Method method) {
-        return restEndpointTimer(method.getDeclaringClass(), method);
-    }
-
-    /**
-     * Creates or looks up the {@code Timer} instance for measuring REST requests on any JAX-RS method.
-     *
      * @param clazz The {@code Class} on which the method to be timed exists
      * @param method the {@code Method} for which the Timer instance is needed
      * @return the located or created {@code Timer}
@@ -228,17 +216,6 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension {
                                        method.getName()));
         return getRegistryForSyntheticRestRequestMetrics()
                 .timer(SYNTHETIC_TIMER_METADATA, syntheticRestRequestMetricTags(clazz, method));
-    }
-
-    /**
-     * Creates or looks up the {@code Counter} instance for measuring REST requests on any JAX-RS method.
-     *
-     * @param method the {@code Method} for which the Counter instance is needed
-     * @return the located or created {@code Counter}
-     * @deprecated Use {@link #restEndpointCounter(Class, java.lang.reflect.Method)} instead.
-     */
-    static Counter restEndpointCounter(Method method) {
-        return restEndpointCounter(method.getDeclaringClass(), method);
     }
 
     /**
@@ -259,18 +236,6 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension {
     /**
      * Creates the {@link MetricID} for the synthetic {@link Timed} metric we add to each JAX-RS method.
      *
-     * @param method Java method of interest
-     * @return {@code MetricID} for the simpletimer for this Java method
-     * @deprecated Use {@link #restEndpointTimerMetricID(Class, java.lang.reflect.Method)} instead.
-     */
-    @Deprecated(since = "4.2.3", forRemoval = true)
-    static MetricID restEndpointTimerMetricID(Method method) {
-        return restEndpointTimerMetricID(method.getDeclaringClass(), method);
-    }
-
-    /**
-     * Creates the {@link MetricID} for the synthetic {@link Timed} metric we add to each JAX-RS method.
-     *
      * @param clazz Java class on which the method exists
      * @param method Java method of interest
      * @return {@code MetricID} for the simpletimer for this Java method
@@ -282,36 +247,12 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension {
     /**
      * Creates the {@link MetricID} for the synthetic {@link Counter} metric we add to each JAX-RS method.
      *
-     * @param method Java method of interest
-     * @return {@code MetricID} for the counter for this Java method
-     * @deprecated Use {@link #restEndpointCounterMetricID(Class, java.lang.reflect.Method)} instead.
-     */
-    @Deprecated(since = "4.2.3", forRemoval = true)
-    MetricID restEndpointCounterMetricID(Method method) {
-        return restEndpointCounterMetricID(method.getDeclaringClass(), method);
-    }
-
-    /**
-     * Creates the {@link MetricID} for the synthetic {@link Counter} metric we add to each JAX-RS method.
-     *
      * @param clazz Java class on which the method exists
      * @param method Java method of interest
      * @return {@code MetricID} for the counter for this Java method
      */
     MetricID restEndpointCounterMetricID(Class<?> clazz, Method method) {
         return new MetricID(syntheticTimerMetricUnmappedExceptionName, syntheticRestRequestMetricTags(clazz, method));
-    }
-
-    /**
-     * Returns the {@code Tag} array for a synthetic {@code SimplyTimed} annotation.
-     *
-     * @param method the Java method of interest
-     * @return the {@code Tag}s indicating the class and method
-     * @deprecated Use {@link #syntheticRestRequestMetricTags(Class, java.lang.reflect.Method)} instead.
-     */
-    @Deprecated(since = "4.2.3", forRemoval = true)
-    static Tag[] syntheticRestRequestMetricTags(Method method) {
-        return syntheticRestRequestMetricTags(method.getDeclaringClass(), method);
     }
 
     /**

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,8 @@ public class HelloWorldAsyncResponseTest {
     @Test
     public void test() throws Exception {
         MetricID metricID = MetricsCdiExtension
-                .restEndpointTimerMetricID(HelloWorldResource.class.getMethod("slowMessage",
+                .restEndpointTimerMetricID(HelloWorldResource.class,
+                                           HelloWorldResource.class.getMethod("slowMessage",
                                                                               AsyncResponse.class,
                                                                               ServerResponse.class));
 
@@ -142,6 +143,7 @@ public class HelloWorldAsyncResponseTest {
         MetricID metricID = null;
         try {
             metricID = MetricsCdiExtension.restEndpointTimerMetricID(
+                    HelloWorldResource.class,
                     HelloWorldResource.class.getMethod("slowMessageWithArg",
                     String.class, AsyncResponse.class));
         } catch (NoSuchMethodException e) {

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseWithRestRequestTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseWithRestRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ class HelloWorldAsyncResponseWithRestRequestTest {
     void checkForAsyncMethodRESTRequestMetric() throws NoSuchMethodException {
 
         MetricID idForRestRequestTimer = MetricsCdiExtension.restEndpointTimerMetricID(
+                HelloWorldResource.class,
                 HelloWorldResource.class.getMethod("getAsync", AsyncResponse.class));
         Timer restRequestTimerForGetAsyncMethod = baseRegistry.getTimer(idForRestRequestTimer);
 

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ class HelloWorldTest {
     }
 
     Timer getSyntheticTimer(Method method) {
-            return getSyntheticTimer(MetricsCdiExtension.restEndpointTimerMetricID(method));
+            return getSyntheticTimer(MetricsCdiExtension.restEndpointTimerMetricID(HelloWorldResource.class, method));
     }
 
     Timer getSyntheticTimer(MetricID metricID) {

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestRestServiceInheritance.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestRestServiceInheritance.java
@@ -33,7 +33,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MediaType;
-import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestRestServiceInheritance.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestRestServiceInheritance.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.metrics;
+
+import java.util.Set;
+import java.util.SortedMap;
+
+import io.helidon.microprofile.testing.AddBean;
+import io.helidon.microprofile.testing.AddConfig;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.Timer;
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@HelidonTest
+@AddBean(TestRestServiceInheritance.BaseService.class)
+@AddBean(TestRestServiceInheritance.ConcreteService.class)
+@AddBean(TestRestServiceInheritance.App.class)
+@AddConfig(key = "metrics." + MetricsCdiExtension.REST_ENDPOINTS_METRIC_ENABLED_PROPERTY_NAME, value = "true")
+
+public class TestRestServiceInheritance {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Inject
+    @RegistryScope(scope = "base")
+    private MetricRegistry metricRegistry;
+
+    @ApplicationScoped
+    @ApplicationPath("/testRestInh")
+    public static class App extends Application {
+
+        @Override
+        public Set<Class<?>> getClasses() {
+            return Set.of(ConcreteService.class);
+        }
+
+    }
+
+    public static abstract class BaseService {
+
+        @GET
+        @Path("/base")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getFromBase() {
+            return "base";
+        }
+    }
+
+    @RequestScoped
+    @Path("/testRestResource")
+    public static class ConcreteService extends BaseService {
+
+        @GET
+        @Path("/concrete")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getFromConcrete() {
+            return "concrete";
+        }
+    }
+
+    @Test
+    void ensureRestRequestMetricsIncludedInheritedMethod() {
+        // Access the resources at the base and the concrete level to make sure they work so the REST request metrics
+        // should truly be present and to make sure the metrics are updated correctly.
+        webTarget.path("testRestInh/testRestResource/concrete").request(MediaType.TEXT_PLAIN).get(String.class);
+        webTarget.path("testRestInh/testRestResource/base").request(MediaType.TEXT_PLAIN).get(String.class);
+
+        Timer getFromBaseTimer = metricRegistry.getTimer(
+                new MetricID("REST.request",
+                             new Tag("class",
+                                     "io.helidon.microprofile.metrics.TestRestServiceInheritance$ConcreteService"),
+                             new Tag("method", "getFromBase")));
+        assertThat("Timer from base", getFromBaseTimer, notNullValue());
+        assertThat("Timer from base count", getFromBaseTimer.getCount(), is(1L));
+
+        Timer getFromConcreteTimer = metricRegistry.getTimer(
+                new MetricID("REST.request",
+                             new Tag("class",
+                                     "io.helidon.microprofile.metrics.TestRestServiceInheritance$ConcreteService"),
+                             new Tag("method", "getFromConcrete")));
+        assertThat("Timer from base", getFromConcreteTimer, notNullValue());
+        assertThat("Timer from base count", getFromConcreteTimer.getCount(), is(1L));
+
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestVetoedResource.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestVetoedResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public class TestVetoedResource extends MetricsMpServiceTest {
                         + "method with an explicit metrics annotation",
                 syntheticTimerTimerRegistry()
                         .getTimers()
-                        .containsKey(MetricsCdiExtension.restEndpointTimerMetricID(method)),
+                        .containsKey(MetricsCdiExtension.restEndpointTimerMetricID(VetoedResource.class, method)),
                 is(false));
     }
 
@@ -68,7 +68,8 @@ public class TestVetoedResource extends MetricsMpServiceTest {
                         + VetoedJaxRsButOtherwiseUnmeasuredResource.class.getName() + "#" + method.getName(),
                 MetricsCdiExtension.getRegistryForSyntheticRestRequestMetrics()
                         .getTimers()
-                        .containsKey(MetricsCdiExtension.restEndpointTimerMetricID(method)),
+                        .containsKey(MetricsCdiExtension.restEndpointTimerMetricID(VetoedJaxRsButOtherwiseUnmeasuredResource.class,
+                                                                                   method)),
                 is(false));
     }
 }


### PR DESCRIPTION
### Description
Resolves #10196

## Release note
____
Helidon MP, if so configured, automatically measures REST request methods. Helidon MP did not--but now does--register and update these metrics for REST resource methods _inherited from a superclass_. 
____

## PR Overview
Formerly, the metrics to be updated for REST request measurements failed to handle inherited methods in two ways:
* REST request methods that were inherited from an abstract superclass were simply ignored during annotation handling for REST resource methods.
* The REST request metrics were registered with a metric ID tag based on the _declaring_ class of the method rather than the _executing_ class.

This PR fixes both of those problems (both in the metrics CDI extension).

A data structure holding REST request methods is now also qualified by the executing class (instead of just the `Method` which ties to the declaring class) so, when the data structure is used later to actually register metrics, the correct execution class is available (not just the declaring class of each method).

Several non-public methods gained a new `Class` parameter. Internal uses in the extension class and several tests changed to align with the new signatures.

The PR also includes a new test to check that the inheritance use case works.

### Documentation
bug fix - no doc impact