### PR TITLE
2.x: Fix accept header handling in server request headers

### DIFF
--- a/webserver/test-support/src/test/java/io/helidon/webserver/testsupport/ClassPathContentHandlerTest.java
+++ b/webserver/test-support/src/test/java/io/helidon/webserver/testsupport/ClassPathContentHandlerTest.java
@@ -105,6 +105,19 @@ public class ClassPathContentHandlerTest {
     }
 
     @Test
+    public void badAcceptTypes() throws Exception {
+        Routing routing = Routing.builder()
+                .register("/some", StaticContentSupport.create("content"))
+                .build();
+        // /some/root-a.txt
+        TestResponse response = TestClient.create(routing)
+                .path("/some/root-a.txt")
+                .header("Accept", "86279333026148305409260801579029123580362081")
+                .get();
+        assertThat(response.status(), is(Http.Status.BAD_REQUEST_400));
+    }
+
+    @Test
     public void serveFromFilesWithWelcome() throws Exception {
         Routing routing = Routing.builder()
                 .register(StaticContentSupport.builder("content")

--- a/webserver/test-support/src/test/java/io/helidon/webserver/testsupport/ClassPathContentHandlerTest.java
+++ b/webserver/test-support/src/test/java/io/helidon/webserver/testsupport/ClassPathContentHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HashRequestHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HashRequestHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,14 @@ class HashRequestHeaders extends ReadOnlyParameters implements RequestHeaders {
                 result = LazyList.create(acceptValues.stream()
                         .flatMap(h -> Utils.tokenize(',', "\"", false, h).stream())
                         .map(String::trim)
-                        .map(s -> LazyValue.create(() -> MediaType.parse(s)))
+                        .map(s -> LazyValue.create(() -> {
+                            try {
+                                return MediaType.parse(s);
+                            } catch (IllegalArgumentException e) {
+                                // we must throw a bad request, as a header value we should understand is invalid
+                                throw new BadRequestException("Invalid Accept header", e);
+                            }
+                        }))
                         .collect(Collectors.toList()));
             }
 


### PR DESCRIPTION
, so it does not throw the underlying parsing exception, but rather a bad request exception.


### Description
Resolves #10201 

This is a backport