### PR TITLE
4.2.3: Upgrade jgit to 7.2.1

### DIFF
--- a/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
+++ b/config/git/src/test/java/io/helidon/config/git/GitConfigSourceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
 import static io.helidon.config.PollingStrategies.regular;
@@ -64,13 +65,16 @@ public class GitConfigSourceBuilderTest extends RepositoryTestCase {
         String testMethodName = testInfo.getTestMethod()
                 .map(Method::getName)
                 .orElse(this.getClass().getName());
-        /* Hack to let us re-use setup from jgit 6's LocalDiskRepositoryTestCase */
+
+        /* Hacks to let us re-use setup from jgit 7's LocalDiskRepositoryTestCase */
         super.currentTest = new TestName() {
             @Override
             public String getMethodName() {
                 return testMethodName;
             }
         };
+        super.testRoot.create();
+        /* end of hacks */
 
         super.setUp();
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -93,7 +93,7 @@
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
         <version.lib.jaxb-runtime>4.0.3</version.lib.jaxb-runtime>
         <version.lib.jersey>3.1.10</version.lib.jersey>
-        <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
+        <version.lib.jgit>7.2.1.202505142326-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>
         <version.lib.junit-platform-testkit>1.11.3</version.lib.junit-platform-testkit>
         <version.lib.kafka>3.8.1</version.lib.kafka>


### PR DESCRIPTION
Backport #10148 to Helidon 4.2.3

### Description

 Upgrade jgit to 7.2.1
