### PR TITLE
4.2.3: Path pattern fix for WebServer

### DIFF
--- a/docs/src/main/asciidoc/includes/security/helidon-endpoints.adoc
+++ b/docs/src/main/asciidoc/includes/security/helidon-endpoints.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -53,14 +53,14 @@ security:
     defaults:
       authenticate: true # <3>
     paths:
-      - path: "/metrics[/{*}]" # <4>
+      - path: "/metrics/*" # <4>
         roles-allowed: "admin"
-      - path: "/health[/{*}]" # <5>
+      - path: "/health/*" # <5>
         roles-allowed: "monitor"
-      - path: "/openapi[/{*}]" # <6>
+      - path: "/openapi/*" # <6>
         abac:
           scopes: ["openapi"]
-      - path: "/static[/{*}]" # <7>
+      - path: "/static/*" # <7>
         roles-allowed: ["user", "monitor"]
 ----
 
@@ -81,8 +81,8 @@ can convert the file by using index based numbers for arrays, such as:
 security.providers.0.abac=
 security.providers.1.provider-key.optional=false
 security.web-server.defaults.authenticate=true
-security.web-server.paths.0.path=/metrics[/{*}]
+security.web-server.paths.0.path=/metrics/*
 security.web-server.paths.0.roles-allowed=admin
-security.web-server.paths.3.path=/static[/{*}]
+security.web-server.paths.3.path=/static/*
 security.web-server.paths.3.roles-allowed=user,monitor
 ----

--- a/docs/src/main/asciidoc/includes/security/providers/abac.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/abac.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ Annotations: `@RolesAllowed`, `@RoleValidator.Roles`
 ----
 security:
   web-server.paths:
-    - path: "/user[/{*}]"
+    - path: "/user/*"
       roles-allowed: ["user"]
 ----
 
@@ -161,7 +161,7 @@ Annotations: `@Scope`
 ----
 security:
   web-server.paths:
-    - path: "/user[/{*}]"
+    - path: "/user/*"
       abac.scopes:
         ["calendar_read", "calendar_edit"]
 ----
@@ -186,7 +186,7 @@ Example of a policy statement: `${env.time.year >= 2017}`
 ----
 security:
   web-server.paths:
-    - path: "/user[/{*}]"
+    - path: "/user/*"
       policy:
         statement: "hasScopes('calendar_read','calendar_edit') AND timeOfDayBetween('8:15', '17:30')"
 ----

--- a/docs/src/main/asciidoc/se/security/containers-integration.adoc
+++ b/docs/src/main/asciidoc/se/security/containers-integration.adoc
@@ -68,7 +68,7 @@ security:
       defaults:
         authenticate: true
       paths:
-        - path: "/service1/[/{*}]"
+        - path: "/service1/*"
           methods: ["get"]
           roles-allowed: ["user"]
 ----

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -246,10 +246,11 @@ You can use *path pattern* instead of _path_ with the following syntax:
 * `/foo/{var}/baz` - Named regular expression segment `([^/]+)`
 * `/foo/{var:\d+}` - Named regular expression segment with a specified expression
 * `/foo/{:\d+}` - Unnamed regular expression segment with a specified expression
-* `/foo/{+var}` - Convenience shortcut for `{var:.+}`
-* `/foo/{+}` - Convenience shortcut for unnamed segment with regular expression `{:.+}`
+* `/foo/{\+var}` - Convenience shortcut for `{var:.+}`
+* `/foo/{\+}` - Convenience shortcut for unnamed segment with regular expression `{:.+}`
+* `/foo/{\*}` - Convenience shortcut for unnamed segment with regular expression `{:.*}`
 * `/foo[/bar]` - An optional block, which translates to the `/foo(/bar)?` regular expression
-* `/*` or `/foo*` - `*` Wildcard character can be matched with any number of characters.
+* `/\*` or `/foo*` - `*` Wildcard character can be matched with any number of characters.
 
 
 IMPORTANT: Path (matcher) routing is *exact*. For example, a `/foo/bar` request is *not* routed to `.post('/foo', ...)`.

--- a/http/http/src/main/java/io/helidon/http/PathMatchers.java
+++ b/http/http/src/main/java/io/helidon/http/PathMatchers.java
@@ -110,7 +110,7 @@ public final class PathMatchers {
                     break;
                 case '{':
                     String name = parseParameter(iter, regexp, paramCounter);
-                    if (name.length() > 0) {
+                    if (!name.isEmpty()) {
                         paramToGroupName.put(name, PARAM_PREFIX + paramCounter);
                         paramCounter++;
                     }
@@ -141,7 +141,7 @@ public final class PathMatchers {
      * Create a path matcher from a path pattern.
      * This method will analyze the pattern and return appropriate path matcher.
      *
-     * @param pathPattern path pattern to match agains
+     * @param pathPattern path pattern to match against
      * @return path matcher
      */
     public static PathMatcher create(String pathPattern) {
@@ -210,13 +210,18 @@ public final class PathMatchers {
                                                             + ", index: " + (iter.index() - 1));
                 }
                 String r1 = name.toString().trim();
-                addParamRegexp(builder, r1.length() > 0 ? index : -1, parseParamRegexp(iter));
+                addParamRegexp(builder, !r1.isEmpty() ? index : -1, parseParamRegexp(iter));
                 return r1;
             }
             case '}' -> {
                 String r2 = name.toString().trim();
+                if (r2.length() == 1 && r2.charAt(0) == '*') {
+                    // special case - {*} - matches empty string as well, and is an unnamed parameter
+                    builder.append(".*");
+                    return "";
+                }
                 addParamRegexp(builder,
-                               r2.length() > 0 ? index : -1,
+                               !r2.isEmpty() ? index : -1,
                                greedy ? ".+" : "[^/]+");
                 return r2;
             }

--- a/http/http/src/test/java/io/helidon/http/PathMatchersTest.java
+++ b/http/http/src/test/java/io/helidon/http/PathMatchersTest.java
@@ -19,6 +19,7 @@ package io.helidon.http;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import io.helidon.common.uri.UriPath;
 
@@ -26,12 +27,78 @@ import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class PathMatchersTest {
+    static Stream<Arguments> subpathData() {
+        return Stream.of(
+                // DOCS: `/foo/{+}` - Convenience shortcut for unnamed segment with regular expression `{:.+}`
+                Arguments.arguments(named("Requires subpath with at least one character",
+                                          new TestData("/foo/{+}",
+                                                       "/foo",
+                                                       false,
+                                                       false,
+                                                       true,
+                                                       true,
+                                                       false))),
+                arguments(named("Regular expression - any string with optional slash",
+                                new TestData("/foo[/{:.*}]",
+                                             "/foo",
+                                             true,
+                                             true,
+                                             true,
+                                             true,
+                                             false))),
+                arguments(named("Subpath placeholder {*} with optional slash",
+                                new TestData("/foo[/{*}]",
+                                             "/foo",
+                                             true,
+                                             true,
+                                             true,
+                                             true,
+                                             false))),
+                arguments(named("Subpath wildcard /*",
+                                new TestData("/foo/*",
+                                             "/foo",
+                                             true,
+                                             true,
+                                             true,
+                                             true,
+                                             false)))
+
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("subpathData")
+    void testSubpathMatching(TestData testData) {
+        PathMatcher matcher = PathMatchers.create(testData.pattern);
+
+        String pathPrefix = testData.pathPrefix;
+        PathMatchers.MatchResult match = matcher.match(UriPath.create(pathPrefix));
+        assertThat("no trailing slash", match.accepted(), is(testData.noTrailing));
+
+        match = matcher.match(UriPath.create(pathPrefix + "/"));
+        assertThat("trailing slash", match.accepted(), is(testData.trailing));
+
+        match = matcher.match(UriPath.create(pathPrefix + "/first"));
+        assertThat("subpath", match.accepted(), is(testData.subpath));
+
+        match = matcher.match(UriPath.create(pathPrefix + "/first/second"));
+        assertThat("nested", match.accepted(), is(testData.nested));
+
+        match = matcher.match(UriPath.create(pathPrefix + "suffix"));
+        assertThat("suffix without slash", match.accepted(), is(testData.pathStartingWithString));
+    }
+
     @Test
     void testRegexQuantifier() {
         var matcher = PathMatchers.pattern("/{id:\\w{2}}/name");
@@ -149,5 +216,14 @@ class PathMatchersTest {
         for (Map.Entry<String, String> entry : stringMap.entrySet()) {
             assertThat(matcher.group(entry.getKey()), Is.is(entry.getValue()));
         }
+    }
+
+    record TestData(String pattern,
+                    String pathPrefix,
+                    boolean noTrailing,
+                    boolean trailing,
+                    boolean subpath,
+                    boolean nested,
+                    boolean pathStartingWithString) {
     }
 }

--- a/tests/integration/security/gh2297/src/main/resources/application.yaml
+++ b/tests/integration/security/gh2297/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ server:
   features:
     security:
       paths:
-        - path: "/metrics[/{*}]"
+        - path: "/metrics/*"
           authenticate: true
           authorize: true
           abac:

--- a/webserver/security/src/main/java/io/helidon/webserver/security/SecurityHttpFeature.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/SecurityHttpFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ import io.helidon.webserver.http.ServerResponse;
  * <pre>
  * // continue from example above...
  * // create a gate for method GET: authenticate all paths under /user and require role "user" for authorization
- * .get("/user[/{*}]", WebSecurity.{@link SecurityFeature#rolesAllowed(String...)
+ * .get("/user/*", WebSecurity.{@link SecurityFeature#rolesAllowed(String...)
  * rolesAllowed("user")})
  * </pre>
  */
@@ -119,7 +119,7 @@ public final class SecurityHttpFeature implements HttpSecurity, HttpFeature, Wei
      * This method is to be used together with other routing methods to protect web resources programmatically.
      * Example:
      * <pre>
-     * .get("/user[/{*}]", WebSecurity.authenticate()
+     * .get("/user/*", WebSecurity.authenticate()
      * .rolesAllowed("user"))
      * </pre>
      *

--- a/webserver/security/src/main/java/io/helidon/webserver/security/package-info.java
+++ b/webserver/security/src/main/java/io/helidon/webserver/security/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
  * .register({@link io.helidon.webserver.security.SecurityHttpFeature}.{@link
  * io.helidon.webserver.security.SecurityHttpFeature#create(io.helidon.security.Security) from(security)})
  * // authenticate all paths under /user and require role "user"
- * .get("/user[/{*}]", WebSecurity.{@link io.helidon.webserver.security.SecurityFeature#authenticate() authenticate()}
+ * .get("/user/*", WebSecurity.{@link io.helidon.webserver.security.SecurityFeature#authenticate() authenticate()}
  * .{@link io.helidon.webserver.security.SecurityFeature#rolesAllowed(String...) rolesAllowed("user")})
  * // authenticate "/admin" path and require role "admin"
  * .get("/admin", WebSecurity.rolesAllowed("admin")

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityBuilderGateDefaultsTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityBuilderGateDefaultsTest.java
@@ -99,7 +99,7 @@ class WebSecurityBuilderGateDefaultsTest {
                 .routing(builder -> builder
                         // will only accept admin (due to gate defaults)
                         .get("/noRoles", SecurityFeature.authenticate())
-                        .get("/user[/{*}]", SecurityFeature.rolesAllowed("user"))
+                        .get("/user/*", SecurityFeature.rolesAllowed("user"))
                         .get("/admin", SecurityFeature.rolesAllowed("admin"))
                         // will also accept admin (due to gate defaults)
                         .get("/deny", SecurityFeature.rolesAllowed("deny"))
@@ -110,7 +110,7 @@ class WebSecurityBuilderGateDefaultsTest {
                                 .skipAuthorization()
                                 .auditEventType("unit_test")
                                 .auditMessageFormat(WebSecurityTests.AUDIT_MESSAGE_FORMAT))
-                        .get("/{*}", (req, res) -> {
+                        .get("/*", (req, res) -> {
                             Optional<SecurityContext> securityContext = Contexts.context()
                                     .flatMap(it -> it.get(SecurityContext.class));
                             res.headers().contentType(HttpMediaTypes.PLAINTEXT_UTF_8);

--- a/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityProgrammaticTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/WebSecurityProgrammaticTest.java
@@ -73,7 +73,7 @@ public class WebSecurityProgrammaticTest extends WebSecurityTests {
                                     .build())
                 .routing(routing -> routing
                         .get("/noRoles", SecurityFeature.secure())
-                        .get("/user[/{*}]", SecurityFeature.rolesAllowed("user"))
+                        .get("/user/*", SecurityFeature.rolesAllowed("user"))
                         .get("/admin", SecurityFeature.rolesAllowed("admin"))
                         .get("/deny", SecurityFeature.rolesAllowed("deny"), (req, res) -> {
                             res.status(Status.INTERNAL_SERVER_ERROR_500);
@@ -84,7 +84,7 @@ public class WebSecurityProgrammaticTest extends WebSecurityTests {
                                 .auditEventType("unit_test")
                                 .auditMessageFormat(AUDIT_MESSAGE_FORMAT)
                         )
-                        .get("/{*}", (req, res) -> {
+                        .get("/*", (req, res) -> {
                             Optional<SecurityContext> securityContext = Contexts.context()
                                     .flatMap(it -> it.get(SecurityContext.class));
                             res.headers().contentType(HttpMediaTypes.PLAINTEXT_UTF_8);

--- a/webserver/security/src/test/resources/security-application.yaml
+++ b/webserver/security/src/test/resources/security-application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2016, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ server:
         - path: "/noRoles"
           methods: ["get"]
           authenticate: true
-        - path: "/user[/{*}]"
+        - path: "/user/*"
           methods: ["get"]
           # implies authentication and authorization
           roles-allowed: ["user"]


### PR DESCRIPTION
Backport #10162 to Helidon 4.2.3

Fix path pattern `{*}` to have the meaning we assigned to it in documentation.

Updated documentation and javadocs to use the correct patterns for "any path" using the 4.0 pattern of `/*` Added tests for the patterns.


#10159 for 4.x `main` branch

Resolves https://github.com/helidon-io/helidon/issues/10163