### PR TITLE
 4.2.3: Add support for `metrics.rest-request.enabled` (with dot instead of hyphen) in SE metrics config

### DIFF
--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -72,6 +72,11 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -198,9 +198,22 @@ interface MetricsConfigBlueprint {
      *
      * @return true/false
      */
-    @Option.Configured
+    @Option.Configured("rest-request.enabled")
     @Option.DefaultBoolean(false)
     boolean restRequestEnabled();
+
+    /**
+     * Whether automatic REST request metrics should be measured (as indicated by the deprecated config
+     * key {@code rest-request-enabled}, the config key using a hyphen instead of a dot separator).
+     *
+     * @return true/false
+     * @deprecated Use {@code rest-request.enabled} instead.
+     */
+    @Deprecated(since = "4.2.3", forRemoval = true)
+    @Option.Configured("rest-request-enabled")
+    @Option.Access("")
+    @Option.Decorator(MetricsConfigSupport.RestRequestEnabledDecorator.class)
+    Optional<Boolean> restRequestEnabledShadow();
 
     /**
      * Whether Helidon should expose meters related to virtual threads.

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigSupport.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,14 @@ class MetricsConfigSupport {
             if (builder.scoping().isEmpty()) {
                 builder.scoping(ScopingConfig.create());
             }
+        }
+    }
+
+    static class RestRequestEnabledDecorator implements Prototype.OptionDecorator<MetricsConfig.BuilderBase<?, ?>, Optional<Boolean>> {
+
+        @Override
+        public void decorate(MetricsConfig.BuilderBase<?, ?> builder, Optional<Boolean> optionValue) {
+            optionValue.ifPresent(builder::restRequestEnabled);
         }
     }
 }

--- a/metrics/api/src/test/java/io/helidon/metrics/api/TestRestRequestConfig.java
+++ b/metrics/api/src/test/java/io/helidon/metrics/api/TestRestRequestConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics.api;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class TestRestRequestConfig {
+
+    @Test
+    void testWithHyphenConfigKey() {
+
+        MetricsConfig metricsConfig = MetricsConfig.create(Config.just(
+                ConfigSources.create(Map.of("rest-request-enabled", "true")).build()));
+
+        assertThat("REST request enabled using hyphen", metricsConfig.restRequestEnabled(), is(true));
+    }
+
+    @Test
+    void testWithDotConfigKey() {
+
+        MetricsConfig metricsConfig = MetricsConfig.create(Config.just(
+                ConfigSources.create(Map.of("rest-request.enabled", "true")).build()));
+
+        assertThat("REST request enabled using dot", metricsConfig.restRequestEnabled(), is(true));
+    }
+
+    @Test
+    void testWithExplicitSetting() {
+        MetricsConfig.Builder builder = MetricsConfig.builder();
+        builder.restRequestEnabled(true);
+        MetricsConfig metricsConfig = builder.build();
+
+        assertThat("REST request enabled set explicitly", metricsConfig.restRequestEnabled(), is(true));
+    }
+
+    @Test
+    void testWithNoSetting() {
+        MetricsConfig.Builder builder = MetricsConfig.builder();
+        MetricsConfig metricsConfig = builder.build();
+
+        assertThat("REST request enabled unset", metricsConfig.restRequestEnabled(), is(false));
+    }
+}


### PR DESCRIPTION
Backport #10177 to Helidon 4.2.3

### Description
Resolves #10168 along with PR #10173.

## Release note
____
Helidon 4.x SE did not properly recognize the config key `metrics.rest-request.enabled` to turn on automatic REST request metrics. Instead the config key Helidon responded to was `metrics.rest-request-enabled` (using a hyphen instead of a dot separator). Helidon SE now honors both forms, although the `rest-request-enabled` form is deprecated and will likely be removed in a future major release.
____

## PR Notes
Helidon 4.x MP _does_ correctly recognize `metrics.rest-request.enabled` in `META-INF/microprofile-config.properties`. (The MP code has not used the generated `MetricConfig` class; rather its code directly accessed the MP config setting.)

Helidon 3.x SE and MP properly recognized the "dotted" key.

The PR:
* Explicitly sets the key for the `restRequestEnabled` blueprint method to `rest-request.enabled` (rather than letting it default).
* Adds a deprecated config setting with key `rest-request-enabled` to remain compatible with 4.x SE apps that might already be configured using the hyphen form of the key.

Any assignment of the deprecated setting--either via config using `rest-request-enabled` or via the new deprecated method on the builder--also assign the same value to the non-deprecated setting.

### Documentation
See #10173 for the related doc update.
