### PR TITLE
4.2.3: Fix content type handling in server request headers.

### DIFF
--- a/http/http/src/main/java/io/helidon/http/ServerRequestHeadersImpl.java
+++ b/http/http/src/main/java/io/helidon/http/ServerRequestHeadersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,12 @@ class ServerRequestHeadersImpl implements ServerRequestHeaders {
     @Override
     public Optional<HttpMediaType> contentType() {
         if (cacheContentType == null) {
-            cacheContentType = ServerRequestHeaders.super.contentType();
+            try {
+                cacheContentType = ServerRequestHeaders.super.contentType();
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException("Invalid content type", e);
+            }
+
         }
         return cacheContentType;
     }

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/HeadersServerTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/HeadersServerTest.java
@@ -47,9 +47,9 @@ class HeadersServerTest {
     private static final String DATA = "Helidon!!!".repeat(10);
     private static final Header TEST_TRAILER_HEADER = HeaderValues.create("test-trailer", "trailer-value");
     private static final HeaderName CLIENT_PORT_HEADER_NAME = HeaderNames.create("client-port");
-    private static final Header BAD_CONTENT_TYPE = HeaderValues.create(HeaderNames.CONTENT_TYPE_NAME, "bullseye");
-    private static final Header GOOD_CONTENT_TYPE = HeaderValues.create(HeaderNames.CONTENT_TYPE_NAME,
-                                                                       MediaTypes.APPLICATION_XML_VALUE);
+    private static final Header BAD_CONTENT_TYPE = HeaderValues.create(HeaderNames.CONTENT_TYPE, "bullseye");
+    private static final Header GOOD_CONTENT_TYPE = HeaderValues.create(HeaderNames.CONTENT_TYPE,
+                                                                       MediaTypes.APPLICATION_XML.text());
 
     private int clientPort = -1;
 
@@ -118,7 +118,7 @@ class HeadersServerTest {
                 .request(String.class);
 
         assertThat(response.status(), is(Status.OK_200));
-        assertThat(response.entity(), is(MediaTypes.APPLICATION_XML_VALUE));
+        assertThat(response.entity(), is(MediaTypes.APPLICATION_XML.text()));
     }
 
     @Test


### PR DESCRIPTION
Backport #10191 to Helidon 4.2.3

Resolves #10190 

Adds a test as well.