### PR TITLE
 4.2.3: update snapshot timeout

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -90,7 +90,7 @@ jobs:
   deploy:
     needs: [ get-version, stage ]
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     environment: release
     steps:
       - uses: actions/checkout@v4

--- a/etc/scripts/upload.sh
+++ b/etc/scripts/upload.sh
@@ -299,7 +299,7 @@ nexus_upload() {
   # Upload
   curl -s \
     --user "${CENTRAL_USER}:${CENTRAL_PASSWORD}" \
-    --write-out "%{stderr}%{http_code} %{url_effective}\n" \
+    --write-out "%{stderr}%{http_code} %{url_effective} t_pretrans=%{time_pretransfer}s t_tot=%{time_total}s %{speed_upload}B/s\n" \
     --config "${tmpfile}" \
     --parallel \
     --parallel-max 10 \


### PR DESCRIPTION

Backport #10197 to Helidon 4.2.3

### Description

Uploading artifacts to central publishing portal snapshot repository is slow. This PR:

- Increases timeout for snapshot deploy job
- Adds some timing information to curl output when uploading snapshot artifacts
