### PR TITLE
4.2.3: Docs dependency fix for GraphQL server.

### DIFF
--- a/docs/src/main/asciidoc/se/graphql.adoc
+++ b/docs/src/main/asciidoc/se/graphql.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -46,8 +46,8 @@ include::{rootdir}/includes/dependencies.adoc[]
 [source,xml]
 ----
 <dependency>
-    <groupId>io.helidon.graphql</groupId>
-    <artifactId>helidon-graphql-server</artifactId>
+  <groupId>io.helidon.webserver</groupId>
+  <artifactId>helidon-webserver-graphql</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
Backport #10218 to Helidon 4.2.3

### Description
Resolves #10130 

Fix to correct dependency in docs
