### PR TITLE
4.x: Support for varargs in common types

### DIFF
--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/VarargConfigBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/VarargConfigBlueprint.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.List;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.CustomMethods(VarargSupport.class)
+interface VarargConfigBlueprint {
+    @Option.Singular
+    List<String> options();
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/VarargSupport.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/VarargSupport.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+
+final class VarargSupport {
+    private VarargSupport() {
+    }
+
+    /**
+     * Create with defined options.
+     *
+     * @param options option values
+     * @return a new vararg config
+     */
+    @Prototype.FactoryMethod
+    static VarargConfig create(String... options) {
+        return VarargConfig.builder()
+                .options(List.of(options))
+                .build();
+    }
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/VarargTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/VarargTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test;
+
+import io.helidon.builder.test.testsubjects.VarargConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+class VarargTest {
+    @Test
+    void testNone() {
+        VarargConfig config = VarargConfig.create();
+        assertThat(config.options(), empty());
+    }
+
+    @Test
+    void testOne() {
+        VarargConfig config = VarargConfig.create("option1");
+        assertThat(config.options(), hasItem("option1"));
+    }
+
+    @Test
+    void testMore() {
+        VarargConfig config = VarargConfig.create("option1", "option2");
+        assertThat(config.options(), hasItems("option1", "option2"));
+    }
+
+}

--- a/builder/tests/common-types/src/main/java/io/helidon/common/types/TypeNameBlueprint.java
+++ b/builder/tests/common-types/src/main/java/io/helidon/common/types/TypeNameBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,17 @@ interface TypeNameBlueprint {
      */
     @Option.DefaultBoolean(false)
     boolean array();
+
+    /**
+     * If this is a representation of {@link io.helidon.common.types.TypeName#array()}, this method can identify that it
+     * was declared as a vararg.
+     * This may be used for method/constructor parameters (which is the only place this is supported in Java).
+     *
+     * @return whether an array is declared as a vararg
+     */
+    @Option.DefaultBoolean(false)
+    @Option.Redundant
+    boolean vararg();
 
     /**
      * Indicates whether this type is using generics.

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Parameter.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,15 @@ public final class Parameter extends AnnotatedComponent {
 
         @Override
         public Builder type(TypeName type) {
-            return super.type(type);
+            if (type.vararg()) {
+                vararg(true);
+                return super.type(TypeName.builder(type)
+                                          .array(false)
+                                          .vararg(false)
+                                          .build());
+            } else {
+                return super.type(type);
+            }
         }
 
         @Override

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/TypeArgument.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/TypeArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -265,6 +265,11 @@ public final class TypeArgument extends Type implements TypeName {
     @Override
     TypeName typeName() {
         return this;
+    }
+
+    @Override
+    public boolean vararg() {
+        return false;
     }
 
     /**

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/ClassModelTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/ClassModelTest.java
@@ -19,6 +19,7 @@ package io.helidon.codegen.classmodel;
 import java.io.IOException;
 import java.io.StringWriter;
 
+import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,17 @@ class ClassModelTest {
             
               public void create() {
                 service(List.of("@default"), Optional.class)
+              }
+
+            }
+            """;
+
+    private static final String EXPECTED_VARARG = """
+            package io.helidon.codegen.classmodel;
+
+            public class Vararg {
+            
+              public void create(String... name) {
               }
 
             }
@@ -63,5 +75,47 @@ class ClassModelTest {
                 .write(sw, "  ");
 
         assertThat(sw.toString(), is(EXPECTED_AT_SIGN_IN_TEXT));
+    }
+
+    @Test
+    void testVarargExplicit() throws IOException {
+        var m = Method.builder()
+                .name("create")
+                .addParameter(p -> p.name("name")
+                        .type(String.class)
+                        .vararg(true))
+                .build();
+
+        var sw = new StringWriter();
+        ClassModel.builder()
+                .packageName("io.helidon.codegen.classmodel")
+                .name("Vararg")
+                .addMethod(m)
+                .build()
+                .write(sw, "  ");
+
+        assertThat(sw.toString(), is(EXPECTED_VARARG));
+    }
+
+    @Test
+    void testVarargTypeName() throws IOException {
+        var m = Method.builder()
+                .name("create")
+                .addParameter(p -> p.name("name")
+                        .type(TypeName.builder()
+                                      .type(String[].class)
+                                      .vararg(true)
+                                      .build()))
+                .build();
+
+        var sw = new StringWriter();
+        ClassModel.builder()
+                .packageName("io.helidon.codegen.classmodel")
+                .name("Vararg")
+                .addMethod(m)
+                .build()
+                .write(sw, "  ");
+
+        assertThat(sw.toString(), is(EXPECTED_VARARG));
     }
 }

--- a/common/processor/class-model/src/main/java/io/helidon/common/processor/classmodel/TypeArgument.java
+++ b/common/processor/class-model/src/main/java/io/helidon/common/processor/classmodel/TypeArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -219,6 +219,11 @@ public final class TypeArgument extends Type implements TypeName {
     @Override
     public int compareTo(TypeName o) {
         return token.compareTo(o);
+    }
+
+    @Override
+    public boolean vararg() {
+        return false;
     }
 
     /**

--- a/common/types/src/main/java/io/helidon/common/types/TypeName.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,6 +138,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         private boolean isTypeParametersMutated;
         private boolean isUpperBoundsMutated;
         private boolean primitive = false;
+        private boolean vararg = false;
         private boolean wildcard = false;
         private String className;
         private String packageName = "";
@@ -163,6 +164,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
             addEnclosingNames(prototype.enclosingNames());
             primitive(prototype.primitive());
             array(prototype.array());
+            vararg(prototype.vararg());
             generic(prototype.generic());
             wildcard(prototype.wildcard());
             if (!isTypeArgumentsMutated) {
@@ -203,6 +205,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
             }
             primitive(builder.primitive());
             array(builder.array());
+            vararg(builder.vararg());
             generic(builder.generic());
             wildcard(builder.wildcard());
             if (isTypeArgumentsMutated) {
@@ -287,7 +290,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          * @return updated builder instance
          * @see #enclosingNames()
          */
-        public BUILDER enclosingNames(List<? extends String> enclosingNames) {
+        public BUILDER enclosingNames(List<String> enclosingNames) {
             Objects.requireNonNull(enclosingNames);
             isEnclosingNamesMutated = true;
             this.enclosingNames.clear();
@@ -304,7 +307,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          * @return updated builder instance
          * @see #enclosingNames()
          */
-        public BUILDER addEnclosingNames(List<? extends String> enclosingNames) {
+        public BUILDER addEnclosingNames(List<String> enclosingNames) {
             Objects.requireNonNull(enclosingNames);
             isEnclosingNamesMutated = true;
             this.enclosingNames.addAll(enclosingNames);
@@ -348,6 +351,19 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          */
         public BUILDER array(boolean array) {
             this.array = array;
+            return self();
+        }
+
+        /**
+         * If this is a representation of {@link #array()}, this method can identify that it was declared as a vararg.
+         * This may be used for method/constructor parameters (which is the only place this is supported in Java).
+         *
+         * @param vararg whether an array is declared as a vararg
+         * @return updated builder instance
+         * @see #vararg()
+         */
+        public BUILDER vararg(boolean vararg) {
+            this.vararg = vararg;
             return self();
         }
 
@@ -444,7 +460,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          * @return updated builder instance
          * @see #typeParameters()
          */
-        public BUILDER typeParameters(List<? extends String> typeParameters) {
+        public BUILDER typeParameters(List<String> typeParameters) {
             Objects.requireNonNull(typeParameters);
             isTypeParametersMutated = true;
             this.typeParameters.clear();
@@ -461,7 +477,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
          * @return updated builder instance
          * @see #typeParameters()
          */
-        public BUILDER addTypeParameters(List<? extends String> typeParameters) {
+        public BUILDER addTypeParameters(List<String> typeParameters) {
             Objects.requireNonNull(typeParameters);
             isTypeParametersMutated = true;
             this.typeParameters.addAll(typeParameters);
@@ -680,6 +696,16 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
         }
 
         /**
+         * If this is a representation of {@link #array()}, this method can identify that it was declared as a vararg.
+         * This may be used for method/constructor parameters (which is the only place this is supported in Java).
+         *
+         * @return the vararg
+         */
+        public boolean vararg() {
+            return vararg;
+        }
+
+        /**
          * Indicates whether this type is using generics.
          *
          * @return the generic
@@ -777,6 +803,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
             private final boolean array;
             private final boolean generic;
             private final boolean primitive;
+            private final boolean vararg;
             private final boolean wildcard;
             private final List<TypeName> lowerBounds;
             private final List<TypeName> typeArguments;
@@ -797,6 +824,7 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
                 this.enclosingNames = List.copyOf(builder.enclosingNames());
                 this.primitive = builder.primitive();
                 this.array = builder.array();
+                this.vararg = builder.vararg();
                 this.generic = builder.generic();
                 this.wildcard = builder.wildcard();
                 this.typeArguments = List.copyOf(builder.typeArguments());
@@ -863,6 +891,11 @@ public interface TypeName extends TypeNameBlueprint, Prototype.Api, Comparable<T
             @Override
             public boolean array() {
                 return array;
+            }
+
+            @Override
+            public boolean vararg() {
+                return vararg;
             }
 
             @Override

--- a/common/types/src/main/java/io/helidon/common/types/TypeNameBlueprint.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeNameBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,17 @@ interface TypeNameBlueprint {
      */
     @Option.DefaultBoolean(false)
     boolean array();
+
+    /**
+     * If this is a representation of {@link io.helidon.common.types.TypeName#array()}, this method can identify that it
+     * was declared as a vararg.
+     * This may be used for method/constructor parameters (which is the only place this is supported in Java).
+     *
+     * @return whether an array is declared as a vararg
+     */
+    @Option.DefaultBoolean(false)
+    @Option.Redundant
+    boolean vararg();
 
     /**
      * Indicates whether this type is using generics.

--- a/common/types/src/main/java/io/helidon/common/types/TypeNameSupport.java
+++ b/common/types/src/main/java/io/helidon/common/types/TypeNameSupport.java
@@ -361,7 +361,7 @@ final class TypeNameSupport {
         var builder = TypeName.builder()
                 .generic(true)
                 .className(typeNames.substring(0, index));
-        String theOtherPart = typeNames.substring(index + 9);
+        String theOtherPart = typeNames.substring(index + 7);
         if (theOtherPart.contains(".")) {
             builder.addLowerBound(TypeName.create(theOtherPart));
         } else {
@@ -413,7 +413,11 @@ final class TypeNameSupport {
         }
 
         if (instance.array()) {
-            nameBuilder.append("[]");
+            if (instance.vararg()) {
+                nameBuilder.append("...");
+            } else {
+                nameBuilder.append("[]");
+            }
         }
 
         return nameBuilder.toString();

--- a/common/types/src/test/java/io/helidon/common/types/TypeNameTest.java
+++ b/common/types/src/test/java/io/helidon/common/types/TypeNameTest.java
@@ -38,8 +38,64 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 class TypeNameTest {
+    @Test
+    void testBoxed() {
+        var boxed = TypeNameSupport.boxed(TypeNames.PRIMITIVE_BOOLEAN);
+
+        assertThat(boxed, is(TypeNames.BOXED_BOOLEAN));
+    }
+
+    @Test
+    void testFqName() {
+        var fqName = TypeNameSupport.fqName(TypeName.create(String[].class));
+        assertThat(fqName, is("java.lang.String[]"));
+    }
+
+    @Test
+    void testCreatePrimitive() {
+        var name = TypeNameSupport.create("boolean");
+
+        assertThat(name, is(TypeNames.PRIMITIVE_BOOLEAN));
+        assertThat(name.primitive(), is(true));
+    }
+
+    @Test
+    void testCreateSuper() {
+        var name = TypeNameSupport.create("java.util.List<? super java.lang.String>");
+
+        assertThat(name.genericTypeName(), is(TypeNames.LIST));
+
+        var list = name.typeArguments();
+        assertThat(list, not(empty()));
+        var typeArgument = list.getFirst();
+        assertThat("Type argument must be generic", typeArgument.generic(), is(true));
+        assertThat("Lower bounds should not be empty", typeArgument.lowerBounds(), not(empty()));
+        assertThat("Upper bounds should be empty", typeArgument.upperBounds(), empty());
+        assertThat("Type should be a question mark (? super java.lang.String)", typeArgument.className(), is("?"));
+        var lowerBound = typeArgument.lowerBounds().getFirst();
+        assertThat("Lower bound should be string", lowerBound, is(TypeNames.STRING));
+    }
+
+    @Test
+    void testCreateExtends() {
+        var name = TypeNameSupport.create("java.util.List<? extends java.lang.String>");
+
+        assertThat(name.genericTypeName(), is(TypeNames.LIST));
+
+        var list = name.typeArguments();
+        assertThat(list, not(empty()));
+        var typeArgument = list.getFirst();
+        assertThat("Type argument must be generic", typeArgument.generic(), is(true));
+        assertThat("Lower bounds should be empty", typeArgument.lowerBounds(), empty());
+        assertThat("Upper bounds should not be empty", typeArgument.upperBounds(), not(empty()));
+        assertThat("Type should be a question mark (? super java.lang.String)", typeArgument.className(), is("?"));
+        var upperBound = typeArgument.upperBounds().getFirst();
+        assertThat("Upper bound should be string", upperBound, is(TypeNames.STRING));
+    }
+
     @Test
     void testNested() {
         Class<?> type = TestType.class;


### PR DESCRIPTION
### Description
Resolves #10194 

### Documentation
Support for varargs in analyzed types and in builder codegen.

Java has `vararg` as a property of a method (i.e. the method is vararg, not the parameter).
We already had support for `vararg` in class model, where it was added as a property of the parameter. And this is much easier to carry over through our code (i.e. if I know a parameter was declared as vararg, I can easily ask for it to be generated as such).

So I have kept this concept, and added support also in `TypeName` - of course the user should make sure that if the parameter is no longer the last one, it should not be declared as vararg (whereas if we kept it as a method property, it would not matter).

One reason to not have it as a method property - we would have to update `TypedElementInfo`, which is used for methods, fields, parameters, and constructors (where it would be a bit strange to have a `vararg` property)