### PR TITLE
3.x: Backport releasing to Central Publishing Portal

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,8 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.HELIDON_GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY: ${{ secrets.HELIDON_GPG_PRIVATE_KEY }}
           GPG_PUBLIC_KEY: ${{ secrets.HELIDON_GPG_PUBLIC_KEY }}
-          MAVEN_SETTINGS: ${{ secrets.MAVEN_SETTINGS }}
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           RELEASE_WORKFLOW: "true"
         run: |
           git config user.email "helidon-robot_ww@oracle.com"
@@ -62,5 +63,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: io-helidon-artifacts-${{ github.ref_name }}
-          path: parent/target/nexus-staging/
+          path: staging
           retention-days: 90

--- a/applications/parent/pom.xml
+++ b/applications/parent/pom.xml
@@ -292,11 +292,11 @@
     </profiles>
 
     <!-- Remove the Helidon specific info from the effective pom. -->
-    <url/>
+    <url>https://example.com</url>
     <scm>
         <connection/>
         <developerConnection/>
-        <url/>
+        <url>https://example.com</url>
     </scm>
     <inceptionYear/>
     <organization/>

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,12 +85,6 @@ if [ -z "${COMMAND}" ] ; then
     exit 1
 fi
 
-# Hooks for version substitution work
-readonly PREPARE_HOOKS=( )
-
-# Hooks for deployment work
-readonly PERFORM_HOOKS=( )
-
 # Resolve FULL_VERSION
 if [ -z "${VERSION+x}" ]; then
 
@@ -154,24 +148,11 @@ update_version(){
         cat ${dfile} | \
             sed -e s@':helidon-version-is-release: .*'@":helidon-version-is-release: ${IS_RELEASED}"@g \
             > ${dfile}.tmp
-        mv ${dfile}.tmp ${dfile}
+        mv "${dfile}.tmp" "${dfile}"
     done
-
-    # Invoke prepare hook
-    if [ -n "${PREPARE_HOOKS}" ]; then
-        for prepare_hook in ${PREPARE_HOOKS} ; do
-            bash "${prepare_hook}"
-        done
-    fi
 }
 
-release_site(){
-    if [ -n "${STAGING_REPO_ID}" ] ; then
-        readonly MAVEN_REPO_URL="https://oss.sonatype.org/service/local/staging/deployByRepositoryId/${STAGING_REPO_ID}/"
-    else
-        readonly MAVEN_REPO_URL="https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-    fi
-
+stage_site(){
     # Generate site
     mvn ${MAVEN_ARGS} site
 
@@ -189,9 +170,7 @@ release_site(){
         -DgroupId="io.helidon" \
         -DartifactId="helidon-project" \
         -Dversion="${FULL_VERSION}" \
-        -Durl="${MAVEN_REPO_URL}" \
-        -DrepositoryId="ossrh" \
-        -DretryFailedDeploymentCount="10"
+        -Durl="file://${PWD}/staging"
 }
 
 release_build(){
@@ -216,70 +195,37 @@ release_build(){
     # Commit version changes
     git commit -a -m "Release ${FULL_VERSION} [ci skip]"
 
-    # Create the nexus staging repository
-    local STAGING_DESC="Helidon v${FULL_VERSION}"
-    mvn ${MAVEN_ARGS} nexus-staging:rc-open \
-        -DstagingProfileId="6026dab46eed94" \
-        -DstagingDescription="${STAGING_DESC}"
-
-    export STAGING_REPO_ID=$(mvn ${MAVEN_ARGS} nexus-staging:rc-list | \
-        egrep "^[0-9:,]*[ ]?\[INFO\] iohelidon\-[0-9]+[ ]+OPEN[ ]+${STAGING_DESC}" | \
-        awk '{print $2" "$3}' | \
-        sed -e s@'\[INFO\] '@@g -e s@'OPEN'@@g | \
-        head -1)
-    echo "Nexus staging repository ID: ${STAGING_REPO_ID}"
-
-    # Perform deployment
+    # Perform deployment to local file system
     mvn ${MAVEN_ARGS} clean deploy \
-       -Prelease,archetypes \
+      -Prelease,archetypes \
       -DskipTests \
-      -DstagingRepositoryId="${STAGING_REPO_ID}" \
-      -DretryFailedDeploymentCount="10"
+      -DaltDeploymentRepository=":::file://${PWD}/staging"
 
-    # Invoke perform hooks
-    if [ -n "${PERFORM_HOOKS}" ]; then
-      for perform_hook in ${PERFORM_HOOKS} ; do
-        bash "${perform_hook}"
-      done
-    fi
-
-    # Release site (documentation, javadocs)
-    release_site
-
-    # Close the nexus staging repository
-    mvn ${MAVEN_ARGS} nexus-staging:rc-close \
-      -DstagingRepositoryId="${STAGING_REPO_ID}" \
-      -DstagingDescription="${STAGING_DESC}"
+    # Stage site (documentation, javadocs) to local filesystem
+    stage_site
 
     git tag -f "${FULL_VERSION}"
     git push --force origin refs/tags/"${FULL_VERSION}":refs/tags/"${FULL_VERSION}"
+
+    "${WS_DIR}/etc/scripts/upload.sh" upload_release \
+                --dir="staging" \
+                --description="Helidon v%{FULL_VERSION}"
 }
 
 deploy_snapshot(){
-
     # Make sure version ends in -SNAPSHOT
     if [[ ${MVN_VERSION} != *-SNAPSHOT ]]; then
         echo "Helidon version ${MVN_VERSION} is not a SNAPSHOT version. Failing snapshot release."
         exit 1
     fi
 
-    readonly NEXUS_SNAPSHOT_URL="https://oss.sonatype.org/content/repositories/snapshots/"
-    echo "Deploying snapshot build ${MVN_VERSION} to ${NEXUS_SNAPSHOT_URL}"
-
-    # The nexus-staging-maven-plugin had issues deploying the module
-    # helidon-applications because the distributionManagement section is empty.
-    # So we deploy using the apache maven-deploy-plugin and altDeploymentRepository
-    # property. The deployAtEnd option requires version 3.0.0 of maven-deploy-plugin
-    # or newer to work correctly on multi-module systems
-    set -x
     mvn ${MAVEN_ARGS} -e clean deploy \
       -Parchetypes \
       -DskipTests \
-      -DaltDeploymentRepository="ossrh::${NEXUS_SNAPSHOT_URL}" \
-      -DdeployAtEnd=true \
-      -DretryFailedDeploymentCount="10"
+      -DaltDeploymentRepository=":::file://${PWD}/staging"
 
-    echo "Done. ${MVN_VERSION} deployed to ${NEXUS_SNAPSHOT_URL}"
+    "${WS_DIR}/etc/scripts/upload.sh" upload_snapshots \
+            --dir="staging"
 }
 
 # Invoke command

--- a/etc/scripts/upload.sh
+++ b/etc/scripts/upload.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o pipefail || true  # trace ERR through pipes
+set -o errtrace || true # trace ERR through commands and functions
+set -o errexit || true  # exit the script if any statement returns a non-true return value
+
+on_error(){
+  CODE="${?}" && \
+  set +x && \
+  printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+      "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}" >&2
+}
+trap on_error ERR
+
+usage(){
+    cat <<EOF
+
+DESCRIPTION: Upload staged artifacts to the Central Portal
+
+USAGE:
+
+$(basename "${0}") [OPTIONS] --directory=DIR CMD
+
+  --dir=DIR
+      Set the staging directory to use.
+
+  --description=DESCRIPTION
+        Set the staging repository description to use.
+        %{version} can be used to subsitute the release version.
+
+  --help
+        Prints the usage and exits.
+
+  CMD:
+
+    upload_release
+        Upload staging directory to a release repository
+
+    upload_snapshot
+        Uploading staging directory to a snapshots repository
+EOF
+}
+
+# parse command line args
+ARGS=( )
+while (( ${#} > 0 )); do
+  case ${1} in
+  "--dir="*)
+    STAGING_DIR=${1#*=}
+    shift
+    ;;
+  "--description="*)
+    DESCRIPTION=${1#*=}
+    shift
+    ;;
+  "--help")
+    usage
+    exit 0
+    ;;
+  "upload_release"|"upload_snapshot")
+    COMMAND="${1}"
+    shift
+    ;;
+  *)
+    ARGS+=( "${1}" )
+    shift
+    ;;
+  esac
+done
+readonly ARGS
+readonly COMMAND
+
+# copy stdout as fd 6 and redirect stdout to stderr
+# this allows us to use fd 6 for returning data
+exec 6>&1 1>&2
+
+case ${COMMAND} in
+"upload_release")
+  if [ -z "${DESCRIPTION}" ] ; then
+    echo "ERROR: description required" >&2
+    usage
+    exit 1
+  fi
+  ;;
+"upload_snapshot")
+  ;;
+"")
+  echo "ERROR: no command provided" >&2
+  usage
+  exit 1
+  ;;
+*)
+  echo "ERROR: unknown command ${COMMAND}" >&2
+  usage
+  exit 1
+  ;;
+esac
+
+if [ -z "${STAGING_DIR}" ] ; then
+  echo "ERROR: --staging-dir is required" >&2
+  usage
+  exit 1
+fi
+
+if [ -z "${CENTRAL_USER}" ] ; then
+  echo "ERROR: CENTRAL_USER environment is not set" >&2
+  usage
+  exit 1
+fi
+if [ -z "${CENTRAL_PASSWORD}" ] ; then
+  echo "ERROR: CENTRAL_PASSWORD environment is not set" >&2
+  usage
+  exit 1
+fi
+
+if [ ! -d "${STAGING_DIR}" ] ; then
+  echo "ERROR: Invalid staging directory: ${STAGING_DIR}" >&2
+  exit 1
+fi
+
+# Central Portal URL for releases
+readonly CENTRAL_URL="https://central.sonatype.com/api/v1"
+# Central SNAPSHOT URL
+readonly SNAPSHOT_URL="https://central.sonatype.com/repository/maven-snapshots"
+
+BEARER=$(printf "%s:%s" "${CENTRAL_USER}" "${CENTRAL_PASSWORD}" | base64)
+
+find_version() {
+  local versions version
+
+  # List the "version" directories
+  versions=$(while read -r v ; do
+   dirname "${v}" | xargs basename
+  done < <(find "${STAGING_DIR}" -type f -name "*.pom" -print) | sort | uniq)
+
+  # Enforce one version per staging directory
+  for v in ${versions} ; do
+    if [ -n "${version}" ] ; then
+      echo "ERROR: staging directory contains more than one version: ${versions}" >&2
+      return 1
+    fi
+    version="${v}"
+  done
+
+  if [ -z "${version}" ] ; then
+    echo "ERROR: version not found" >&2
+    return 1
+  fi
+  echo "${version}"
+}
+
+upload_snapshot() {
+  echo "Uploading SNAPSHOT..." >&2
+  local version
+  version=$(find_version)
+
+  # Make sure version ends in -SNAPSHOT
+  if [[ "${version}" != *-SNAPSHOT ]]; then
+    echo "ERROR: Version ${version} is NOT a SNAPSHOT version" >&2
+    exit 1
+  fi
+
+  nexus_upload "${SNAPSHOT_URL}" "${STAGING_DIR}"
+}
+
+upload_release() {
+  echo "Uploading release..." >&2
+  local version
+  version=$(find_version)
+
+  # Make sure version does NOT end in -SNAPSHOT
+  if [[ "${v}" = *-SNAPSHOT ]]; then
+    echo "ERROR: Version ${version} is a SNAPSHOT version" >&2
+    exit 1
+  fi
+
+  deployment_id="$(central_upload "${CENTRAL_URL}" "${STAGING_DIR}")"
+  central_finish "${deployment_id}"
+}
+
+# Upload contents of the staging directory to central portal
+# arg1: base URL of upload portal
+# arg2: staging directory
+# prints deployment ID
+central_upload() {
+  local version
+  version=$(find_version)
+
+  printf "Uploading artifacts...\n" >&2
+  readonly UPLOAD_BUNDLE=io-helidon-artifacts-${version}.zip
+  rm -f "${UPLOAD_BUNDLE}"
+  printf "Creating artifact bundle %s...\n" "${UPLOAD_BUNDLE}" >&2
+  (cd "${2}"; zip -ryq "../${UPLOAD_BUNDLE}" .)
+
+  local responseFile statusFile
+  responseFile=$(mktemp)
+  statusFile=$(mktemp)
+
+  printf "Uploading %s to %s...\n" "${UPLOAD_BUNDLE}" "${1}" >&2
+  # Upload bundle in one shot
+  # publishingType of USER_MANAGED acts like "staging". Artifacts are uploaded and verified but not published.
+  curl --request POST \
+    --retry 2 \
+    --header "Authorization: Bearer ${BEARER}" \
+    --write-out "%{stderr}%{http_code} %{url_effective}\n%{stdout}%{http_code}" \
+    --form bundle=@"${UPLOAD_BUNDLE}" \
+    -o  "${responseFile}" \
+    "${1}/publisher/upload?name=io-helidon-${version}&publishingType=USER_MANAGED" > "${statusFile}"
+
+  # handle errors
+  if [ "$(cat "${statusFile}")" != "201" ] ; then
+    printf "[ERROR] %s\n" "$(cat "${responseFile}")" >&2
+    exit 1
+  fi
+
+  # If success then output deployment ID
+  cat "${responseFile}"
+}
+
+# Poll deployment status until operation is complete.
+# arg1: deployment ID
+central_finish() {
+  printf "\n\nVerifying upload status of %s...\n\n" "$1" >&2
+
+  while true; do
+    local deploymentState
+    deploymentState=$(central_get_deployment_state "$1")
+    printf "%s...\n" "${deploymentState}" >&2
+    case ${deploymentState} in
+    "PENDING")
+      ;;
+    "VALIDATING")
+      ;;
+    "VALIDATED")
+      printf "Done. Bits are uploaded." >&2
+      exit
+      ;;
+    "PUBLISHING")
+      ;;
+    "PUBLISHED")
+      printf "!!!! Oh No! Artifacts have been published!!!! That should not have happened." >&2
+      exit
+      ;;
+    "FAILED")
+      exit
+      ;;
+    esac
+    sleep 10
+  done
+}
+
+# Gets the status of a deployment from central portal
+# arg1: deployment ID
+# Prints deployment state for the given ID:
+# PENDING, VALIDATING, VALIDATED, PUBLISHING, PUBLISHED, FAILED
+# Should never be PUBLISHING or PUBLISHED since our publishingType is USER_MANAGED
+central_get_deployment_state() {
+  curl --request POST \
+    -s \
+    --retry 3 \
+    --header "Authorization: Bearer ${BEARER}" \
+    "${CENTRAL_URL}/publisher/status?id=${1}" \
+    | jq -r ".deploymentState"
+}
+
+# Upload to a nexus repository. This is used to support SNAPSHOT releases
+# arg1: base URL
+# arg2: staging directory
+nexus_upload() {
+  printf "\nUploading artifacts...\n" >&2
+
+  local tmpfile
+  tmpfile=$(mktemp)
+
+  # Generate a curl config file for all files to deploy
+  # Use -T <file> --url <url> for each file
+  while read -r i ; do
+      echo "-T ${2}/${i}" >> "${tmpfile}"
+      echo "--url ${1}/${i}" >> "${tmpfile}"
+  done < <(find "${2}" -type f | cut -c $((${#2} + 2))-)
+
+  # Upload
+  curl -s \
+    --user "${CENTRAL_USER}:${CENTRAL_PASSWORD}" \
+    --write-out "%{stderr}%{http_code} %{url_effective} t_tot=%{time_total}s %{speed_upload}B/s\n" \
+    --config "${tmpfile}" \
+    --parallel \
+    --parallel-max 10 \
+    --retry 3
+}
+
+${COMMAND}

--- a/microprofile/weld/weld-core-impl/pom.xml
+++ b/microprofile/weld/weld-core-impl/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>weld-core-impl</artifactId>
+    <name>Helidon Weld SE Core</name>
 
     <properties>
         <spotbugs.skip>true</spotbugs.skip>

--- a/microprofile/weld/weld-se-core/pom.xml
+++ b/microprofile/weld/weld-se-core/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>weld-se-core</artifactId>
+    <name>Helidon Weld SE Core</name>
 
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -51,19 +51,6 @@
         <url>https://github.com/oracle/helidon</url>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <name>Helidon Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <name>Helidon Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <developers>
         <developer>
             <name>Tomas Langer</name>
@@ -198,18 +185,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>${version.plugin.nexus-staging}</version>
-                    <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                        <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                        <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${version.plugin.versions}</version>
@@ -228,11 +203,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <extensions>true</extensions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
@@ -247,48 +217,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>staging</id>
-            <repositories>
-                <repository>
-                    <id>ossrh-staging</id>
-                    <url>https://oss.sonatype.org/content/repositories/staging/</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>ossrh-staging</id>
-                    <url>https://oss.sonatype.org/content/repositories/staging/</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
-        <profile>
-            <id>snapshot</id>
-            <repositories>
-                <repository>
-                    <id>ossrh-snapshot</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>ossrh-snapshot</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
         </profile>
     </profiles>
 </project>

--- a/service-common/rest-cdi/pom.xml
+++ b/service-common/rest-cdi/pom.xml
@@ -25,6 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>helidon-service-common-rest-cdi</artifactId>
+    <name>Helidon Service Common Rest CDI</name>
 
     <properties>
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>

--- a/service-common/rest/pom.xml
+++ b/service-common/rest/pom.xml
@@ -25,6 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>helidon-service-common-rest</artifactId>
+    <name>Helidon Service Common Rest</name>
 
     <build>
         <plugins>


### PR DESCRIPTION
### Description

Backport support for releasing to the central publishing portal:

1. Add upload.sh script
2. Fix pom.xml metadata to pass central validation
3. Update release.sh to use upload.sh
4. Remove references to legacy oss

This has been tested by doing a test release.

See #10219
