### PR TITLE
feat: introduce GrpcDatagramReader

### DIFF
--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -235,8 +235,6 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
     }
 
     protected ResT toResponse(BufferData bufferData) {
-        bufferData.read();                  // compression
-        bufferData.readUnsignedInt32();     // length prefixed
         return responseMarshaller.parse(new InputStream() {
             @Override
             public int read() {

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcDatagramReader.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcDatagramReader.java
@@ -1,0 +1,169 @@
+package io.helidon.webclient.grpc;
+
+import io.helidon.common.buffers.BufferData;
+
+import java.nio.BufferOverflowException;
+
+/**
+ * An abstraction responsible for building complete GRPC datagrams out of individual data frames.
+ * <p>
+ * Each datagram has a prefix consisting of a compression flag
+ * and a size of the datagram. Note that this class doesn't support compression currently.
+ * However, due to the HTTP2 flow control, a single GRPC datagram may be split accross multiple
+ * individual data frames, and the GRPC client must use the size of the datagram in order to reconstruct
+ * the entire datagram so that its content can actually be parsed by a reply type marshaler.
+ * This is exactly what this class is doing, along with some required buffering because
+ * the last data frame may in fact contain a beginning of a new GRPC datagram which we'll
+ * need to fully receive and process as well in the future.
+ * <p>
+ * Typically, the client would call the GrpcDatagramReader.add(BufferData) method as it receives data
+ * from the network, and then call the GrpcDatagramReader.extractNextDatagram() to check if a complete
+ * datagram is available.
+ * <p>
+ * This class is not thread-safe. The client is responsible for synchronizing access to its APIs.
+ */
+class GrpcDatagramReader {
+
+    // These are arbitrary limits, but they seem sane and support the immediate use-case.
+    // It would be nice to make them configurable. However, note that this is a Helidon-internal class.
+    private static final int INITIAL_BUFFER_SIZE = 1024;
+    private static final int MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+
+    /**
+     * A buffer for incoming data. We copy the incoming BufferData objects into this buffer
+     * on purpose because existing BufferData implementations aren't immutable. Further, the code
+     * that creates the BufferData objects may reuse the underlying byte arrays now or in the future.
+     * So we cannot just maintain a list of BufferData objects added to the reader, although that would be nice.
+     * <p>
+     * The io.helidon.common.buffers.GrowingBufferData is nice, too. However, it seems to create interim
+     * byte arrays when adding data to the buffer. Also, it doesn't support a capacity limit which
+     * may be important to prevent OOM. For this reason, we use a low-level circular byte array here.
+     */
+    private byte[] buffer = new byte[INITIAL_BUFFER_SIZE];
+
+    /** Where we read data from. */
+    private int readPosition = 0;
+
+    /** Where we write new data to. */
+    private int writePosition = 0;
+
+    /** The length of the actual data added to the reader. Note that the buffer is circular. */
+    private int length = 0;
+
+    /**
+     * Add a new piece of data to this reader. It may be a complete GRPC datagram, or a piece of it,
+     * maybe even a piece containing a tail of one datagram and a head of another.
+     * The client should call the extractNextDatagram() method to see if there's a complete datagram yet.
+     * @param bufferData a piece of data to add to the reader
+     */
+    void add(final BufferData bufferData) {
+        ensureCapacity(bufferData.available());
+
+        // Avoid creating interim arrays. Fill up the tail of the buffer first...
+        final int firstPartMaxLengthForWriting = buffer.length - writePosition;
+        int read = bufferData.read(buffer, writePosition, Math.min(bufferData.available(), firstPartMaxLengthForWriting));
+
+        // ...and flip to the head if necessary
+        if (bufferData.available() > 0) {
+            read += bufferData.read(buffer, 0, bufferData.available());
+        }
+
+        // Adjust the length and the writePosition
+        length += read;
+        writePosition += read;
+        writePosition %= buffer.length;
+    }
+
+    /** Return the size of the next complete datagram, or -1 if it's incomplete yet. */
+    private int getNextSize() {
+        // Check if we have a complete datagram
+        if (length < 5) {
+            // We don't even have a complete GRPC header yet
+            return -1;
+        }
+
+        // We only remove complete datagrams from the buffer, so the readPosition is guaranteed to point
+        // to the beginning of a new datagram.
+
+        // Read big endian (unsigned, but oh well...) int32 size from the GRPC header first
+        // (ignoring the first byte which is a compression flag)
+        final int size = buffer[(readPosition + 1) % buffer.length] << 24
+                | (buffer[(readPosition + 2) % buffer.length] << 16)
+                | (buffer[(readPosition + 3) % buffer.length] << 8)
+                | (buffer[(readPosition + 4) % buffer.length]);
+
+        if (length < 5 + size) {
+            // We don't have enough data yet. More data needs to be added to the reader to complete this datagram.
+            return -1;
+        }
+
+        return size;
+    }
+
+    /**
+     * Read the next complete GRPC datagram and return a BufferData with its data payload,
+     * or return null if the datagram is incomplete yet and more data needs to be added to this reader.
+     * @return the GRPC datagram data payload, or null if not ready yet
+     */
+    BufferData extractNextDatagram() {
+        final int size = getNextSize();
+        if (size == -1) {
+            return null;
+        }
+
+        // We have a complete datagram (and perhaps also a start of the next datagram) in the buffer.
+        // Let's extract the complete one. Note that we only return the data bytes because higher level code
+        // shouldn't be concerned with the details of the GRPC header.
+        // So if we want to support compression in the future, it has to be implemented here somewhere.
+        final BufferData data = BufferData.create(size);
+
+        // Skip the header because we've already read the size, and we ignore the compression:
+        readPosition += 5;
+        readPosition %= buffer.length;
+
+        final int firstPartMaxLengthForReading = buffer.length - readPosition;
+        data.write(buffer, readPosition, Math.min(firstPartMaxLengthForReading, size));
+        // and read the head of the buffer if needed:
+        if (size > firstPartMaxLengthForReading) {
+            data.write(buffer, 0, size - firstPartMaxLengthForReading);
+        }
+
+        // Advance the readPosition
+        readPosition += size;
+        readPosition %= buffer.length;
+        // Adjust the length
+        length -= 5 + size;
+
+        return data;
+    }
+
+    /** Ensure there's enough capacity to write more data, or throw BufferOverflowException. */
+    private void ensureCapacity(final int minCapacity) {
+        final int currentCapacity = buffer.length - length;
+        if (currentCapacity >= minCapacity) {
+            return;
+        }
+
+        final int newLength = buffer.length + (minCapacity - currentCapacity);
+        if (newLength > MAX_BUFFER_SIZE) {
+            throw new BufferOverflowException();
+        }
+
+        // Prefer to double the size each time. But resort to the newLength if it's greater, and respect the max limit.
+        final int actualNewLength = Math.min(Math.max(buffer.length * 2, newLength), MAX_BUFFER_SIZE);
+        final byte[] newBuffer = new byte[actualNewLength];
+
+        if (length > 0) {
+            final int firstPartMaxLength = buffer.length - readPosition;
+            System.arraycopy(buffer, readPosition, newBuffer, 0, Math.min(length, firstPartMaxLength));
+            if (firstPartMaxLength < length) {
+                // The data has the second part in the head of our circular buffer:
+                System.arraycopy(buffer, 0, newBuffer, firstPartMaxLength, length - firstPartMaxLength);
+            }
+        }
+
+        buffer = newBuffer;
+        readPosition = 0;
+        writePosition = length;
+    }
+}

--- a/webclient/grpc/src/test/java/io/helidon/webclient/grpc/GrpcDatagramReaderTest.java
+++ b/webclient/grpc/src/test/java/io/helidon/webclient/grpc/GrpcDatagramReaderTest.java
@@ -1,0 +1,88 @@
+package io.helidon.webclient.grpc;
+
+import io.helidon.common.buffers.BufferData;
+import org.junit.jupiter.api.Test;
+
+import java.nio.BufferOverflowException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class GrpcDatagramReaderTest {
+    @Test
+    void checkBufferOverflow() {
+        GrpcDatagramReader reader = new GrpcDatagramReader();
+
+        // First, test the happy case, fill up the buffer to the current max limit (note that it's hard-coded here):
+        BufferData goodData = BufferData.create("a".repeat(10 * 1024 * 1024));
+        reader.add(goodData);
+
+        // Now try to add some more, 1 byte should be enough:
+        BufferData badData = BufferData.create("b");
+        assertThrows(BufferOverflowException.class, () -> reader.add(badData));
+    }
+
+    @Test
+    void testSingleCompleteDatagram() {
+        GrpcDatagramReader reader = new GrpcDatagramReader();
+
+        // Trivial case of a zero-size datagram
+        BufferData zeroData = BufferData.create(new byte[] {0, 0, 0, 0, 0});
+        reader.add(zeroData);
+        BufferData bufferData = reader.extractNextDatagram();
+        assertNotNull(bufferData);
+        assertEquals(0, bufferData.available());
+
+        // 1 byte long datagram
+        BufferData oneData = BufferData.create(new byte[] {0, 0, 0, 0, 1, 66});
+        reader.add(oneData);
+        bufferData = reader.extractNextDatagram();
+        assertNotNull(bufferData);
+        assertEquals(1, bufferData.available());
+        assertEquals(66, bufferData.read());
+
+        // Many bytes long datagram
+        String data = "Some test data here...";
+        BufferData manyData = BufferData.create(5 +  data.getBytes().length);
+        manyData.write(0);
+        manyData.writeInt32(data.getBytes().length);
+        manyData.write(data.getBytes());
+        reader.add(manyData);
+        bufferData = reader.extractNextDatagram();
+        assertNotNull(bufferData);
+        assertEquals(data.getBytes().length, bufferData.available());
+        assertEquals(data, bufferData.readString(data.getBytes().length));
+    }
+
+    @Test
+    void testSplitDatagram() {
+        GrpcDatagramReader reader = new GrpcDatagramReader();
+
+        // This is very similar to the many bytes long datagram test above, but we feed the reader
+        // little by little instead of adding the entire datagram at once:
+        String data = "Some test data here...";
+
+        reader.add(BufferData.create(new byte[] {0}));
+        assertNull(reader.extractNextDatagram());
+
+        BufferData someData = BufferData.create(4);
+        someData.writeInt32(data.getBytes().length);
+        reader.add(someData);
+        assertNull(reader.extractNextDatagram());
+
+        BufferData someMoreData = BufferData.create(Arrays.copyOf(data.getBytes(), 8));
+        reader.add(someMoreData);
+        assertNull(reader.extractNextDatagram());
+
+        BufferData finalData = BufferData.create(Arrays.copyOfRange(data.getBytes(), 8, data.getBytes().length));
+        reader.add(finalData);
+
+        BufferData bufferData = reader.extractNextDatagram();
+        assertNotNull(bufferData);
+        assertEquals(data.getBytes().length, bufferData.available());
+        assertEquals(data, bufferData.readString(data.getBytes().length));
+    }
+}


### PR DESCRIPTION
### Description
A fix for https://github.com/helidon-io/helidon/issues/10234 . Copying its description here for convenience:

Helidon Version: 4.x

## Enhancement Description
### Background
In GRPC protocol over HTTP2, a single GRPC datagram such as a request or a reply may not fit into the HTTP2 flow control window (which is 64KB by default.) In this case, the datagram is transmitted in multiple frames which the HTTP2 client feeds to the application one by one via the `clientStream().readOne()` method. The application must receive all the frames belonging to a single GRPC datagram before the datagram can be parsed correctly. Each GRPC datagram starts with a 5 bytes header containing a compression flag and a size of the datagram, so the application knows the expected size in bytes that it should receive before the datagram is complete.

### Problem statement
The current implementation of the GRPC client in Helidon, in both the `GrpcClientCall.java` and `GrpcUnaryClientCall.java`, assumes that a single HTTP2 frame represents a complete GRPC datagram and tries to pass it to the marshaller to parse it. However, when the actual datagram exceeds 64KB, or the client is running at a very high TPS such that the HTTP2 window of 64KB fills up very quickly and some datagrams start falling on the window boundary, the frames would contain only partial data, resulting in the marshaller to fail to parse the data.

### Solution
Implement a GRPC datagram reader. The GRPC client would feed the reader with individual HTTP2 data frames, and the reader would assemble complete GRPC datagrams once they're actually received completely, and only then return them to be inserted in the receiving queue or otherwise get processed.

## The PR is:
* Introducing the GrpcDatagramReader with a unit test
* Using the reader in `GrpcClientCall.java` and `GrpcUnaryClientCall.java`

