### PR TITLE
3.x: Removed default header when abstain (#10255)

### DIFF
--- a/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/SecurityHandler.java
+++ b/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/SecurityHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -513,8 +513,7 @@ public final class SecurityHandler implements Handler {
         abortRequest(res,
                      response,
                      Http.Status.UNAUTHORIZED_401.code(),
-                     Map.of(Http.Header.WWW_AUTHENTICATE,
-                                             List.of("Basic realm=\"Security Realm\"")));
+                     Map.of());
         future.complete(AtxResult.STOP);
         return true;
     }


### PR DESCRIPTION
### Description
Fixes #10255 

The same [was done for 4.x](https://github.com/helidon-io/helidon/pull/10145). 

Changes between versions 3.x and 4.x should be consistent.