### PR TITLE
fix: return validators errors if token validation fails

### DIFF
--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -309,7 +309,7 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
                         if (validate.isValid()) {
                             return AuthenticationResponse.success(buildSubject(jwt, signedJwt));
                         } else {
-                            return AuthenticationResponse.failed(errors.toString());
+                            return AuthenticationResponse.failed(validate.toString());
                         }
                     } else {
                         return AuthenticationResponse.failed(errors.toString());


### PR DESCRIPTION
### Description

Fix for #10257. You can see that on L272 errors is also returned

### Documentation

If enhancement: provide description with example code/config snippet or pointer to issue with the description

If feature: summarize feature and provide pointer to doc issue

If no doc impact: None
