### PR TITLE
3.x: Fixes typo in REST.request configuration option (#10259)

### DIFF
--- a/docs/includes/metrics/metrics-config.adoc
+++ b/docs/includes/metrics/metrics-config.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ ifdef::mp-flavor[]
 .Controlling REST request metrics
 [source,properties]
 ----
-metrics.rest-request-enabled=true
+metrics.rest-request.enabled=true
 ----
 Helidon automatically registers and updates `SimpleTimer` metrics for every REST endpoint in your service.
 endif::[]


### PR DESCRIPTION
### Description
Fixes #10259 

The same was [done for 4.x](https://github.com/helidon-io/helidon/pull/10173). Changes should be consistent between versions.

3.x honored the dot form. Details are [here](https://github.com/helidon-io/helidon/issues/10168#issuecomment-2920529482).