### PR TITLE
Shutdown services in reverse order when using `Weight` (fixes issue #10267)

### DIFF
--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -156,8 +156,8 @@ class ScopedRegistryImpl implements ScopedRegistry {
     private static Comparator<? super Activator<?>> shutdownComparator() {
         return Comparator
                 .<Activator<?>>comparingDouble(it -> it.descriptor().runLevel().orElse(Service.RunLevel.NORMAL))
-                .thenComparing(it -> it.descriptor().weight())
-                .reversed();
+                .reversed()
+                .thenComparing(it -> it.descriptor().weight());
     }
 
     private void checkActive() {

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/RunLevelAndWeightStartStopFixture.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/RunLevelAndWeightStartStopFixture.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import io.helidon.common.Weight;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.Service.PostConstruct;
+import io.helidon.service.registry.Service.PreDestroy;
+
+interface RunLevelAndWeightStartStopFixture {
+
+    @Service.Singleton
+    static class State {
+        final Queue<String> startUpSequence = new ArrayBlockingQueue<>(4);
+        final Queue<String> shutDownSequence = new ArrayBlockingQueue<>(4);
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP) // more significant
+    @Weight(1) // less significant
+    static class Service1 implements RunLevelAndWeightStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service1(State state) {
+            this.state = state;
+        }
+
+        @PostConstruct
+        void startUp() {
+            state.startUpSequence.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            state.shutDownSequence.add(getClass().getSimpleName());
+        }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP) // more significant
+    @Weight(2) // more significant
+    static class Service2 implements RunLevelAndWeightStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service2(State state) {
+            this.state = state;
+        }
+
+        @PostConstruct
+        void startUp() {
+            state.startUpSequence.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            state.shutDownSequence.add(getClass().getSimpleName());
+        }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP + 1) // less significant
+    @Weight(1) // less significant
+    static class Service3 implements RunLevelAndWeightStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service3(State state) {
+            this.state = state;
+        }
+
+        @PostConstruct
+        void startUp() {
+            state.startUpSequence.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            state.shutDownSequence.add(getClass().getSimpleName());
+        }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP + 1) // less significant
+    @Weight(2) // more significant
+    static class Service4 implements RunLevelAndWeightStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service4(State state) {
+            this.state = state;
+        }
+
+        @PostConstruct
+        void startUp() {
+            state.startUpSequence.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            state.shutDownSequence.add(getClass().getSimpleName());
+        }
+    }
+
+}

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/RunLevelStartStopFixture.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/RunLevelStartStopFixture.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.Service.PostConstruct;
+import io.helidon.service.registry.Service.PreDestroy;
+
+interface RunLevelStartStopFixture {
+
+    @Service.Singleton
+    static class State {
+        final Queue<String> startUpSequence = new ArrayBlockingQueue<>(3);
+        final Queue<String> shutDownSequence = new ArrayBlockingQueue<>(3);
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP)
+    static class Service1 implements RunLevelStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service1(State state) {
+            this.state = state;
+        }
+
+        @PostConstruct
+        void startUp() {
+            state.startUpSequence.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            state.shutDownSequence.add(getClass().getSimpleName());
+        }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP + 1)
+    static class Service2 implements RunLevelStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service2(State state) {
+            this.state = state;
+        }
+
+        @PostConstruct
+        void startUp() {
+            state.startUpSequence.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            state.shutDownSequence.add(getClass().getSimpleName());
+        }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP + 2)
+    static class Service3 implements RunLevelStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service3(State state) {
+            this.state = state;
+        }
+
+        @PostConstruct
+        void startUp() {
+            state.startUpSequence.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            state.shutDownSequence.add(getClass().getSimpleName());
+        }
+    }
+
+}

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/WeightStartStopFixture.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/WeightStartStopFixture.java
@@ -19,53 +19,79 @@ package io.helidon.service.test.registry;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 
+import io.helidon.common.Weight;
 import io.helidon.service.registry.Service;
 import io.helidon.service.registry.Service.PostConstruct;
 import io.helidon.service.registry.Service.PreDestroy;
 
-interface StartStopFixture {
-    Queue<String> startUpQueue = new ArrayBlockingQueue<>(3);
-    Queue<String> shutDownQueue = new ArrayBlockingQueue<>(3);
+interface WeightStartStopFixture {
 
     @Service.Singleton
-    @Service.RunLevel(Service.RunLevel.STARTUP)
-    static class Service1 implements StartStopFixture {
+    static class State {
+        final Queue<String> startUpSequence = new ArrayBlockingQueue<>(3);
+        final Queue<String> shutDownSequence = new ArrayBlockingQueue<>(3);
+    }
+
+    @Service.Singleton
+    @Weight(3)
+    static class Service1 implements WeightStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service1(State state) {
+            this.state = state;
+        }
+
         @PostConstruct
         void startUp() {
-            startUpQueue.add(getClass().getSimpleName());
+            state.startUpSequence.add(getClass().getSimpleName());
         }
 
         @PreDestroy
         void shutDown() {
-            shutDownQueue.add(getClass().getSimpleName());
+            state.shutDownSequence.add(getClass().getSimpleName());
         }
     }
 
     @Service.Singleton
-    @Service.RunLevel(Service.RunLevel.STARTUP + 1)
-    static class Service2 implements StartStopFixture {
+    @Weight(2)
+    static class Service2 implements WeightStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service2(State state) {
+            this.state = state;
+        }
+
         @PostConstruct
         void startUp() {
-            startUpQueue.add(getClass().getSimpleName());
+            state.startUpSequence.add(getClass().getSimpleName());
         }
 
         @PreDestroy
         void shutDown() {
-            shutDownQueue.add(getClass().getSimpleName());
+            state.shutDownSequence.add(getClass().getSimpleName());
         }
     }
 
     @Service.Singleton
-    @Service.RunLevel(Service.RunLevel.STARTUP + 2)
-    static class Service3 implements StartStopFixture {
+    @Weight(1)
+    static class Service3 implements WeightStartStopFixture {
+        final State state;
+
+        @Service.Inject
+        Service3(State state) {
+            this.state = state;
+        }
+
         @PostConstruct
         void startUp() {
-            startUpQueue.add(getClass().getSimpleName());
+            state.startUpSequence.add(getClass().getSimpleName());
         }
 
         @PreDestroy
         void shutDown() {
-            shutDownQueue.add(getClass().getSimpleName());
+            state.shutDownSequence.add(getClass().getSimpleName());
         }
     }
 

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RunLevelAndWeightStartStopTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RunLevelAndWeightStartStopTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import org.junit.jupiter.api.Test;
+
+class RunLevelAndWeightStartStopTest {
+
+    @Test
+    void test() {
+        var config = ServiceRegistryConfig.create();
+        var manager = ServiceRegistryManager.start(config);
+        var services = manager.registry().all(RunLevelAndWeightStartStopFixture.class);
+        assertThat(services, hasSize(4));
+        var state = manager.registry().get(RunLevelAndWeightStartStopFixture.State.class);
+        assertThat(state.startUpSequence, contains("Service2", "Service1", "Service4", "Service3"));
+        assertThat(state.shutDownSequence, hasSize(0));
+
+        manager.shutdown();
+
+        assertThat(state.shutDownSequence, contains("Service3", "Service4", "Service1", "Service2"));
+    }
+}

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/RunLevelStartStopTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/RunLevelStartStopTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import org.junit.jupiter.api.Test;
+
+class RunLevelStartStopTest {
+
+    @Test
+    void test() {
+        var config = ServiceRegistryConfig.create();
+        var manager = ServiceRegistryManager.start(config);
+        var services = manager.registry().all(RunLevelStartStopFixture.class);
+        assertThat(services, hasSize(3));
+        var state = manager.registry().get(RunLevelStartStopFixture.State.class);
+        assertThat(state.startUpSequence, contains("Service1", "Service2", "Service3"));
+        assertThat(state.shutDownSequence, hasSize(0));
+
+        manager.shutdown();
+
+        assertThat(state.shutDownSequence, contains("Service3", "Service2", "Service1"));
+    }
+}

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/WeightStartStopTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/WeightStartStopTest.java
@@ -16,27 +16,27 @@
 
 package io.helidon.service.test.registry;
 
-import io.helidon.service.registry.ServiceRegistryConfig;
-import io.helidon.service.registry.ServiceRegistryManager;
-import io.helidon.service.test.registry.StartStopFixture;
-
-import org.junit.jupiter.api.Test;
-
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
-class StartStopTest {
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import org.junit.jupiter.api.Test;
+
+class WeightStartStopTest {
 
     @Test
     void test() {
         var config = ServiceRegistryConfig.create();
         var manager = ServiceRegistryManager.start(config);
-        var services = manager.registry().all(StartStopFixture.class);
+        var services = manager.registry().all(WeightStartStopFixture.class);
         assertThat(services, hasSize(3));
+        var state = manager.registry().get(WeightStartStopFixture.State.class);
+        assertThat(state.startUpSequence, contains("Service1", "Service2", "Service3"));
+        assertThat(state.shutDownSequence, hasSize(0));
 
         manager.shutdown();
 
-        assertThat(StartStopFixture.startUpQueue, contains("Service1", "Service2", "Service3"));
-        assertThat(StartStopFixture.shutDownQueue, contains("Service3", "Service2", "Service1"));
+        assertThat(state.shutDownSequence, contains("Service3", "Service2", "Service1"));
     }
 }


### PR DESCRIPTION
### Problem Description

With the [bug fix](https://github.com/helidon-io/helidon/pull/10240) of https://github.com/helidon-io/helidon/issues/10239 we fixed the `RunLevel` interpretation when shutting down services but we accidentally reversed the `Weight` interpretation, which violates the `Weighted` contract (see a detailed explanation in https://github.com/helidon-io/helidon/issues/10267).

It is important to mention, that the `RunLevel` definition works reversed compared to the `Weighted` definition, e.g. `RunLevel 1` is more significant than `RunLevel 2`, but `Weight 1` is less significant than `Weight 2`.

### Documentation

With this change, Helidon services will be shut down in reverse chronological order in which they were started by respecting both `RunLevel` and `Weight`. This fixes issue https://github.com/helidon-io/helidon/issues/10267.