### PR TITLE
4.x: Fix Jackson when charset is used for Accept header.

### DIFF
--- a/http/media/jackson/src/main/java/io/helidon/http/media/jackson/JacksonWriter.java
+++ b/http/media/jackson/src/main/java/io/helidon/http/media/jackson/JacksonWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,10 +77,16 @@ class JacksonWriter<T> implements EntityWriter<T> {
 
     private void write(GenericType<T> type, T object, Writer out) {
         try {
+            // even though the javadoc claims they do not close the writer, it is actually closed
             writer(type).writeValue(out, object);
-            out.flush();
         } catch (IOException e) {
             throw new JacksonRuntimeException("Failed to serialize to JSON: " + type, e);
+        }
+
+        try {
+            out.flush();
+        } catch (IOException ignored) {
+            // ignore failure, the stream is most likely closed, so it was flushed
         }
     }
 

--- a/http/media/jackson/src/test/java/io/helidon/http/media/jackson/JacksonMediaTest.java
+++ b/http/media/jackson/src/test/java/io/helidon/http/media/jackson/JacksonMediaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ import io.helidon.common.GenericType;
 import io.helidon.common.config.Config;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
+import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpMediaType;
+import io.helidon.http.HttpMediaTypes;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaSupport;
@@ -39,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /*
@@ -208,6 +211,26 @@ class JacksonMediaTest {
 
         assertThat(books, hasItems(new Book("čř"), new Book("šň")));
     }
+
+    @Test
+    void testReadServerUtf8() {
+        WritableHeaders<?> responseHeaders = WritableHeaders.create();
+        ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        headers.accept(HttpMediaTypes.JSON_UTF_8);
+
+        MediaSupport.WriterResponse<Book> res = support.writer(BOOK_TYPE, headers, responseHeaders);
+
+        assertThat(res.support(), is(MediaSupport.SupportLevel.COMPATIBLE));
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+        res.supplier()
+                .get()
+                .write(BOOK_TYPE, new Book("čr"), bos, headers, responseHeaders);
+
+        assertThat(bos.size(), not(0));
+    }
+
 
     public static class Book {
         private String title;

--- a/http/tests/media/jackson/pom.xml
+++ b/http/tests/media/jackson/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.http.tests.media</groupId>
+        <artifactId>helidon-http-tests-media-project</artifactId>
+        <version>4.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-http-tests-tegration-media-jackson</artifactId>
+    <name>Helidon HTTP Tests Media Jackson</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jackson</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/http/tests/media/jackson/src/test/java/io/helidon/http/tests/integration/media/jackson/JacksonTest.java
+++ b/http/tests/media/jackson/src/test/java/io/helidon/http/tests/integration/media/jackson/JacksonTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.tests.integration.media.jackson;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HttpMediaType;
+import io.helidon.http.HttpMediaTypes;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@ServerTest
+class JacksonTest {
+    // use utf-8 to validate everything works
+    private static final JacksonMessage MESSAGE = new JacksonMessage("český řízný text");
+
+    private final Http1Client client;
+
+    JacksonTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder router) {
+        router.get("/jackson", (req, res) -> res.send(MESSAGE))
+                .post("/jackson", (req, res) -> {
+                    JacksonMessage message = req.content().as(JacksonMessage.class);
+                    res.send(new JacksonMessage(message.message));
+                });
+    }
+
+    @Test
+    void testGet() {
+        var response = client.get("/jackson")
+                .request(JacksonMessage.class);
+
+        assertAll(
+                () -> assertThat(response.status(), is(Status.OK_200)),
+                () -> assertThat("Should contain content type application/json",
+                                 response.headers().contentType(),
+                                 is(Optional.of(HttpMediaType.create(MediaTypes.APPLICATION_JSON)))),
+                () -> assertThat(response.entity(), is(MESSAGE)));
+    }
+
+    @Test
+    void testGetWithAcceptUtf8() {
+        var response = client.get("/jackson")
+                .accept(HttpMediaTypes.JSON_UTF_8)
+                .request(JacksonMessage.class);
+
+        assertAll(
+                () -> assertThat(response.status(), is(Status.OK_200)),
+                () -> assertThat("Should contain content type application/json",
+                                 response.headers().contentType(),
+                                 is(Optional.of(HttpMediaType.create(MediaTypes.APPLICATION_JSON)))),
+                () -> assertThat(response.entity(), is(MESSAGE)));
+    }
+
+    @Test
+    void testPost() {
+        var response = client.method(Method.POST)
+                .uri("/jackson")
+                .submit(MESSAGE, JacksonMessage.class);
+
+        assertAll(
+                () -> assertThat(response.status(), is(Status.OK_200)),
+                () -> assertThat("Should contain content type application/json",
+                                 response.headers().contentType(),
+                                 is(Optional.of(HttpMediaType.create(MediaTypes.APPLICATION_JSON)))),
+                () -> assertThat(response.entity(), is(MESSAGE)));
+    }
+
+    public static class JacksonMessage {
+        private String message;
+
+        public JacksonMessage() {
+        }
+
+        public JacksonMessage(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(message);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof JacksonMessage)) {
+                return false;
+            }
+            JacksonMessage that = (JacksonMessage) o;
+            return message.equals(that.message);
+        }
+    }
+
+}

--- a/http/tests/media/jackson/src/test/resources/logging.properties
+++ b/http/tests/media/jackson/src/test/resources/logging.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+.level=INFO

--- a/http/tests/media/pom.xml
+++ b/http/tests/media/pom.xml
@@ -34,5 +34,6 @@
         <module>jsonb</module>
         <module>jsonp</module>
         <module>multipart</module>
+        <module>jackson</module>
     </modules>
 </project>


### PR DESCRIPTION
Added tests for this usecase


### Description
Resolves #10250 


### Documentation
Bugfix where if Accept header contained charset, the Jackson writer would fail (because a method closes the output stream, and when `.flush()` was called, we got an exception