### PR TITLE
4.x: CDI Bridge update, OCI extension update

### DIFF
--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -66,7 +66,8 @@ public class OciMetricsBean extends OciMetricsSupportFactory {
 
     // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
     void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object ignore,
-                            Config rootConfig, BeanManager beanManager) {
+                            Config rootConfig,
+                            BeanManager beanManager) {
 
         var instance = beanManager.createInstance().select(Monitoring.class);
         if (instance.isUnsatisfied()) {

--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Singleton;
 
 import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
@@ -65,8 +66,13 @@ public class OciMetricsBean extends OciMetricsSupportFactory {
 
     // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
     void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object ignore,
-                            Config rootConfig, Monitoring monitoringClient) {
-        registerOciMetrics(rootConfig, monitoringClient);
+                            Config rootConfig, BeanManager beanManager) {
+
+        var instance = beanManager.createInstance().select(Monitoring.class);
+        if (instance.isUnsatisfied()) {
+            return;
+        }
+        registerOciMetrics(rootConfig, instance.get());
     }
 
     // For testing

--- a/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/TestObserverPriorities.java
+++ b/integrations/oci/metrics/cdi/src/test/java/io/helidon/integrations/oci/metrics/cdi/TestObserverPriorities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import io.helidon.config.Config;
 import io.helidon.microprofile.server.ServerCdiExtension;
 
-import com.oracle.bmc.monitoring.Monitoring;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.BeanManager;
@@ -39,7 +38,7 @@ class TestObserverPriorities {
         Method ourObserverMethod = OciMetricsBean.class.getDeclaredMethod("registerOciMetrics",
                                                                           Object.class,
                                                                           Config.class,
-                                                                          Monitoring.class);
+                                                                          BeanManager.class);
         Class<?> metricsCdiExtension = Class.forName("io.helidon.microprofile.metrics.MetricsCdiExtension");
         Method metricsCdiExtensionRegisteringMethod = metricsCdiExtension.getDeclaredMethod("registerService",
                                                                                                   Object.class,

--- a/integrations/oci/sdk/cdi/pom.xml
+++ b/integrations/oci/sdk/cdi/pom.xml
@@ -52,7 +52,10 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
         </dependency>
 
         <!-- Provided-scoped dependencies. -->

--- a/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/OciExtension.java
+++ b/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/OciExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/OciExtension.java
+++ b/integrations/oci/sdk/cdi/src/main/java/io/helidon/integrations/oci/sdk/cdi/OciExtension.java
@@ -38,6 +38,8 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.helidon.service.registry.GlobalServiceRegistry;
+
 import com.oracle.bmc.ConfigFileReader.ConfigFile;
 import com.oracle.bmc.Service;
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
@@ -901,6 +903,12 @@ public final class OciExtension implements Extension {
     private static void installConfigFile(AfterBeanDiscovery event, BeanManager bm, Annotation[] qualifiers) {
         // Supplier<ConfigFile>
         if (isUnsatisfied(bm, SUPPLIER_CONFIGFILE_TYPE, qualifiers)) {
+            var existing = GlobalServiceRegistry.registry()
+                    .lookupServices(io.helidon.service.registry.Lookup.create(ConfigFile.class));
+            if (!existing.isEmpty()) {
+                // the config file will be available through CDI bridge, no need to install it
+                return;
+            }
             event.addBean()
                 .types(SUPPLIER_CONFIGFILE_TYPE)
                 .qualifiers(qualifiers)
@@ -1166,6 +1174,12 @@ public final class OciExtension implements Extension {
     private static void installBasicAdp(AfterBeanDiscovery event, BeanManager bm, Annotation[] qualifiers) {
         // AbstractAuthenticationDetailsProvider, BasicAuthenticationDetailsProvider
         if (isUnsatisfied(bm, BasicAuthenticationDetailsProvider.class, qualifiers)) {
+            var existing = GlobalServiceRegistry.registry()
+                    .lookupServices(io.helidon.service.registry.Lookup.create(BasicAuthenticationDetailsProvider.class));
+            if (!existing.isEmpty()) {
+                // the provider will be available through CDI bridge, no need to install it
+                return;
+            }
             event.addBean()
                 .types(AbstractAuthenticationDetailsProvider.class, BasicAuthenticationDetailsProvider.class)
                 .qualifiers(qualifiers)

--- a/integrations/oci/sdk/cdi/src/main/java/module-info.java
+++ b/integrations/oci/sdk/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/oci/sdk/cdi/src/main/java/module-info.java
+++ b/integrations/oci/sdk/cdi/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module io.helidon.integrations.oci.sdk.cdi {
     requires microprofile.config.api;
     requires oci.java.sdk.common;
     requires oci.java.sdk.addons.oke.workload.identity;
+    requires io.helidon.service.registry;
 
     exports io.helidon.integrations.oci.sdk.cdi;
 

--- a/microprofile/tests/service-registry/pom.xml
+++ b/microprofile/tests/service-registry/pom.xml
@@ -37,6 +37,27 @@
             <artifactId>helidon-microprofile-metrics</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.integrations.oci.metrics</groupId>
+            <artifactId>helidon-integrations-oci-metrics-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.oci.sdk</groupId>
+            <artifactId>helidon-integrations-oci-sdk-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-monitoring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.oci</groupId>
+            <artifactId>helidon-integrations-oci</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.logging</groupId>
             <artifactId>helidon-logging-jul</artifactId>
             <scope>test</scope>

--- a/microprofile/tests/service-registry/pom.xml
+++ b/microprofile/tests/service-registry/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>helidon-microprofile-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Description
Resolves #10096 

### Documentation
Instead of trying to rely on the CDI bridge being the last extension with full knowledge of all other synthetic and declared beans, I modified the integration modules of OCI to check if registry contains the values needed for the OCI CDI extension to work. If so, registration of beans is skipped.

