### PR TITLE
4.x: Builder fix for not-configured providers

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/BuilderSupport.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/BuilderSupport.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.api;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.common.HelidonServiceLoader;
+
+/**
+ * Static methods used from generated prototypes and builders.
+ * <p>
+ * This only contains methods that can be used without additional dependencies (i.e. {@link java.util.ServiceLoader} based).
+ */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public final class BuilderSupport {
+    private BuilderSupport() {
+    }
+
+    /**
+     * Discover services from Java {@link java.util.ServiceLoader}.
+     * This method will only add instances of classes that are not already part of {@code existingInstances}.
+     *
+     * @param contract          service contract (or provider interface as used in {@link java.util.ServiceLoader})
+     * @param discoverServices  whether to discover services from service loader, if set to false, service loader is ignored
+     * @param existingInstances instances already configured on the builder
+     * @param <C>               type of the contract to use
+     * @return a list of new instances to add to the builder
+     */
+    public static <C> List<C> discoverServices(Class<C> contract,
+                                               boolean discoverServices,
+                                               List<C> existingInstances) {
+        if (!discoverServices) {
+            return List.of();
+        }
+        List<C> newInstances = new ArrayList<>();
+        Set<Class<?>> existingServiceTypes = new HashSet<>();
+        existingInstances.forEach(it -> existingServiceTypes.add(it.getClass()));
+        HelidonServiceLoader.create(contract).forEach(it -> {
+            if (!existingServiceTypes.contains(it.getClass())) {
+                newInstances.add(it);
+            }
+        });
+
+        return newInstances;
+    }
+
+    /**
+     * Discover a service from {@link java.util.ServiceLoader}.
+     * This method will only query the service loader if the {@code existingInstance} is empty.
+     *
+     * @param contract         service contract (or provider interface as used in {@link java.util.ServiceLoader})
+     * @param discoverServices whether to discover services from service loader, if set to false, service loader is ignored
+     * @param existingInstance an instance configured on the builder
+     * @param <C>              type of the contract
+     * @return value to be used by the builder (either the existing instance, an instance from {@link java.util.ServiceLoader},
+     *         or empty if none found
+     */
+    public static <C> Optional<C> discoverService(Class<C> contract,
+                                                  boolean discoverServices,
+                                                  Optional<C> existingInstance) {
+        if (existingInstance.isPresent() || !discoverServices) {
+            return existingInstance;
+        }
+
+        return HelidonServiceLoader.create(contract)
+                .stream()
+                .findFirst();
+    }
+}

--- a/builder/api/src/main/java/io/helidon/builder/api/Option.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Option.java
@@ -146,6 +146,8 @@ public final class Option {
          * When set to {@code true}, all services discovered by the service loader will be added (even if no configuration
          * node exists for them). When set to {@code false}, only services that have a configuration node will be added.
          * This can be overridden by {@code discover-services} configuration option under this option's key.
+         * In case the option is not {@link io.helidon.builder.api.Option.Configured}, this is always considered true,
+         * as otherwise this annotation would not make any sense (i.e. it would never provide a value).
          *
          * @return whether to discover services by default for a provider
          */

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/Types.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/Types.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ final class Types {
 
     static final TypeName CONFIG_CONFIGURED_BUILDER = TypeName.create(
             "io.helidon.common.config.ConfigBuilderSupport.ConfiguredBuilder");
+    static final TypeName BUILDER_SUPPORT = TypeName.create("io.helidon.builder.api.BuilderSupport");
     static final TypeName CONFIG_BUILDER_SUPPORT = TypeName.create("io.helidon.common.config.ConfigBuilderSupport");
 
     static final TypeName REGISTRY_BUILDER_SUPPORT = TypeName.create("io.helidon.service.registry.RegistryBuilderSupport");

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,13 @@ interface WithProviderBlueprint {
     @Option.Configured
     @Option.Provider(ProviderNoImpls.class)
     Optional<ProviderNoImpls.SomeService> optionalNoImplDiscover();
+
+    @Option.Access("")
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    List<ProviderNoImpls.SomeService> listNoImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();
 
     @Option.Configured
     @Option.Provider(value = ProviderNoImpls.class, discoverServices = false)

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderRegistryBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithProviderRegistryBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,13 @@ interface WithProviderRegistryBlueprint {
     @Option.Configured
     @Option.Provider(ProviderNoImpls.class)
     List<ProviderNoImpls.SomeService> listNoImplDiscover();
+
+    @Option.Access("")
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    List<ProviderNoImpls.SomeService> listNoImplDiscoverNoConfig();
+
+    @Option.Provider(ProviderNoImpls.SomeService.class)
+    Optional<ProviderNoImpls.SomeService> noImplDiscoverNoConfig();
 
     @Option.Configured
     @Option.Provider(value = ProviderNoImpls.class, discoverServices = false)

--- a/builder/tests/codegen/src/test/java/io/helidon/builder/codegen/TypesTest.java
+++ b/builder/tests/codegen/src/test/java/io/helidon/builder/codegen/TypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import io.helidon.builder.api.BuilderSupport;
 import io.helidon.builder.api.Description;
 import io.helidon.builder.api.GeneratedBuilder;
 import io.helidon.builder.api.Option;
@@ -133,6 +134,7 @@ public class TypesTest {
         checkField(toCheck, checked, fields, "OPTION_TYPE", Option.Type.class);
         checkField(toCheck, checked, fields, "OPTION_DECORATOR", Option.Decorator.class);
         checkField(toCheck, checked, fields, "OPTION_REGISTRY_SERVICE", Option.RegistryService.class);
+        checkField(toCheck, checked, fields, "BUILDER_SUPPORT", BuilderSupport.class);
 
         checkField(toCheck, checked, fields, "SERVICES", Services.class);
 

--- a/common/config/src/main/java/io/helidon/common/config/ConfigBuilderSupport.java
+++ b/common/config/src/main/java/io/helidon/common/config/ConfigBuilderSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.helidon.service.registry.ServiceRegistry;
  * Methods used from generated code in builders when
  * {@link io.helidon.builder.api.Prototype.Configured} is used.
  */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public final class ConfigBuilderSupport {
     private ConfigBuilderSupport() {
     }
@@ -115,7 +116,9 @@ public final class ConfigBuilderSupport {
      * @param <S>                  type of the expected service
      * @param <T>                  type of the configured service provider that creates instances of S
      * @return list of discovered services, ordered by {@link io.helidon.common.Weight} (highest weight is first in the list)
+     * @deprecated use {@link #discoverServices(Config, String, Class, Class, boolean, java.util.List)} instead
      */
+    @Deprecated(forRemoval = true, since = "4.3.0")
     public static <S extends NamedService, T extends ConfiguredProvider<S>> List<S>
     discoverServices(Config config,
                      String configKey,
@@ -132,6 +135,41 @@ public final class ConfigBuilderSupport {
                                              allFromServiceLoader,
                                              existingInstances);
     }
+
+    /**
+     * Discover services from configuration.
+     * If already configured instances contain a service of the same type and name that would be added from
+     * configuration, the configuration would be ignored (e.g. the user must make a choice whether to configure, or
+     * set using an API).
+     *
+     * @param config               configuration located at the parent node of the service providers
+     * @param configKey            configuration key of the provider list
+     *                             (either a list node, or object, where each child is one service)
+     * @param providerType         type of the service provider interface, used to lookup from {@link java.util.ServiceLoader}
+     * @param configType           type of the configured service
+     * @param allFromServiceLoader whether all services from service loader should be used, or only the ones with configured
+     *                             node
+     * @param existingInstances    already configured instances
+     * @param <S>                  type of the expected service
+     * @param <T>                  type of the configured service provider that creates instances of S
+     * @return list of discovered services, ordered by {@link io.helidon.common.Weight} (highest weight is first in the list)
+     */
+    public static <S extends NamedService, T extends ConfiguredProvider<S>> List<S>
+    discoverServices(Config config,
+                     String configKey,
+                     Class<T> providerType,
+                     Class<S> configType,
+                     boolean allFromServiceLoader,
+                     List<S> existingInstances) {
+        return ProvidedUtil.discoverServices(config,
+                                             configKey,
+                                             HelidonServiceLoader.create(providerType),
+                                             providerType,
+                                             configType,
+                                             allFromServiceLoader,
+                                             existingInstances);
+    }
+
 
     /**
      * Discover service from configuration. If an instance is already configured using a builder, it will not be
@@ -151,8 +189,9 @@ public final class ConfigBuilderSupport {
      * @param <T>                  type of the configured service provider that creates instances of S
      * @return the first service (ordered by {@link io.helidon.common.Weight} that is discovered, or empty optional if none
      *         is found
+     * @deprecated use {@link #discoverService(Config, String, Class, Class, boolean, java.util.Optional)}
      */
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @Deprecated(forRemoval = true, since = "4.3.0")
     public static <S extends NamedService, T extends ConfiguredProvider<S>> Optional<S>
     discoverService(Config config,
                     String configKey,
@@ -164,6 +203,40 @@ public final class ConfigBuilderSupport {
         return ProvidedUtil.discoverService(config,
                                             configKey,
                                             serviceLoader,
+                                            providerType,
+                                            configType,
+                                            allFromServiceLoader,
+                                            existingValue);
+    }
+
+    /**
+     * Discover service from configuration. If an instance is already configured using a builder, it will not be
+     * discovered from configuration (e.g. the user must make a choice whether to configure, or set using API).
+     *
+     * @param config               configuration located at the parent node of the service providers
+     * @param configKey            configuration key of the provider list
+     *                             (either a list node, or object, where each child is one service - this method requires
+     *                             *                             zero to one configured services)
+     * @param providerType         type of the service provider interface, used to lookup from {@link java.util.ServiceLoader}
+     * @param configType           type of the configured service
+     * @param allFromServiceLoader whether all services from service loader should be used, or only the ones with configured
+     *                             node
+     * @param existingValue        value already configured, if the name is same as discovered from configuration
+     * @param <S>                  type of the expected service
+     * @param <T>                  type of the configured service provider that creates instances of S
+     * @return the first service (ordered by {@link io.helidon.common.Weight} that is discovered, or empty optional if none
+     *         is found
+     */
+    public static <S extends NamedService, T extends ConfiguredProvider<S>> Optional<S>
+    discoverService(Config config,
+                    String configKey,
+                    Class<T> providerType,
+                    Class<S> configType,
+                    boolean allFromServiceLoader,
+                    Optional<S> existingValue) {
+        return ProvidedUtil.discoverService(config,
+                                            configKey,
+                                            HelidonServiceLoader.create(providerType),
                                             providerType,
                                             configType,
                                             allFromServiceLoader,

--- a/common/config/src/main/java/io/helidon/common/config/ProvidedUtil.java
+++ b/common/config/src/main/java/io/helidon/common/config/ProvidedUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.Services;
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 final class ProvidedUtil {
     private static final System.Logger PROVIDER_LOGGER = System.getLogger(Prototype.class.getName() + ".provider");
     /**

--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceDiscovery.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,13 +98,13 @@ class CoreServiceDiscovery implements ServiceDiscovery {
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
             cl = (cl == null) ? CoreServiceDiscovery.class.getClassLoader() : cl;
 
-            return (Class) cl.loadClass(className.fqName());
+            return (Class) cl.loadClass(className.declaredName());
         } catch (ClassNotFoundException e) {
             try {
                 // fall back to classloader of our class
-                return (Class) CoreServiceDiscovery.class.getClassLoader().loadClass(className.fqName());
+                return (Class) CoreServiceDiscovery.class.getClassLoader().loadClass(className.declaredName());
             } catch (ClassNotFoundException ex) {
-                var toThrow = new ServiceRegistryException("Resolution of type \"" + className.fqName()
+                var toThrow = new ServiceRegistryException("Resolution of type \"" + className.declaredName()
                                                            + "\" to class failed.",
                                                    ex);
                 toThrow.addSuppressed(e);


### PR DESCRIPTION
Builder - fixed a problem where providers that were not also configured failed to generate valid code.


Resolves #10285 

Added appropriate methods to test blueprints.
Small update to javadoc.