### PR TITLE
Fixes problems converting HTTP/2 headers to Metadata

### DIFF
--- a/webserver/grpc/pom.xml
+++ b/webserver/grpc/pom.xml
@@ -87,8 +87,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.codegen</groupId>
-            <artifactId>helidon-codegen</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcHeadersUtilTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcHeadersUtilTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.grpc;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2Headers;
+
+import io.grpc.Metadata;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GrpcHeadersUtilTest {
+
+    @Test
+    void testUpdateHeaders() {
+        Metadata metadata = new Metadata();
+        Metadata.Key<String> key = Metadata.Key.of("cookie", Metadata.ASCII_STRING_MARSHALLER);
+        metadata.put(key, "sugar");
+        metadata.put(key, "almond");
+        WritableHeaders<?> headers = WritableHeaders.create();
+        GrpcHeadersUtil.updateHeaders(headers, metadata);
+        assertThat(headers.size(), is(2));
+        List<String> values = headers.get(HeaderNames.COOKIE).allValues();
+        assertThat(values, hasItem("sugar"));
+        assertThat(values, hasItem("almond"));
+    }
+
+    @Test
+    void testToMetadata() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.COOKIE, "sugar", "almond");
+        Http2Headers http2Headers = mock(Http2Headers.class);
+        when(http2Headers.httpHeaders()).thenReturn(headers);
+        Metadata metadata = GrpcHeadersUtil.toMetadata(http2Headers);
+        Metadata.Key<String> key = Metadata.Key.of("cookie", Metadata.ASCII_STRING_MARSHALLER);
+        assertThat(metadata.containsKey(key), is(true));
+        Set<String> values = new HashSet<>();
+        metadata.getAll(key).forEach(values::add);
+        assertThat(values, hasItem("sugar"));
+        assertThat(values, hasItem("almond"));
+    }
+}


### PR DESCRIPTION
### Description

Fixes problems converting HTTP/2 headers to Metadata and vice versa. Adds new test. See issue #10295.

### Documentation

None.
