### PR TITLE
4.x: Removed unnecessary modifier protected of utility methods in SchemaGeneratorHelper

### DIFF
--- a/microprofile/graphql/server/src/main/java/io/helidon/microprofile/graphql/server/SchemaGeneratorHelper.java
+++ b/microprofile/graphql/server/src/main/java/io/helidon/microprofile/graphql/server/SchemaGeneratorHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,107 +82,107 @@ final class SchemaGeneratorHelper {
     /**
      * {@link OffsetTime} class name.
      */
-    protected static final String OFFSET_TIME_CLASS = OffsetTime.class.getName();
+    static final String OFFSET_TIME_CLASS = OffsetTime.class.getName();
 
     /**
      * {@link LocalTime} class name.
      */
-    protected static final String LOCAL_TIME_CLASS = LocalTime.class.getName();
+    static final String LOCAL_TIME_CLASS = LocalTime.class.getName();
 
     /**
      * {@link OffsetDateTime} class name.
      */
-    protected static final String OFFSET_DATE_TIME_CLASS = OffsetDateTime.class.getName();
+    static final String OFFSET_DATE_TIME_CLASS = OffsetDateTime.class.getName();
 
     /**
      * {@link ZonedDateTime} class name.
      */
-    protected static final String ZONED_DATE_TIME_CLASS = ZonedDateTime.class.getName();
+    static final String ZONED_DATE_TIME_CLASS = ZonedDateTime.class.getName();
 
     /**
      * {@link LocalDateTime} class name.
      */
-    protected static final String LOCAL_DATE_TIME_CLASS = LocalDateTime.class.getName();
+    static final String LOCAL_DATE_TIME_CLASS = LocalDateTime.class.getName();
 
     /**
      * {@link LocalDate} class name.
      */
-    protected static final String LOCAL_DATE_CLASS = LocalDate.class.getName();
+    static final String LOCAL_DATE_CLASS = LocalDate.class.getName();
 
     /**
      * {@link LocalDate} class name.
      */
-    protected static final String LEGACY_DATE_CLASS = Date.class.getName();
+    static final String LEGACY_DATE_CLASS = Date.class.getName();
 
     /**
      * {@link BigDecimal} class name.
      */
-    protected static final String BIG_DECIMAL_CLASS = BigDecimal.class.getName();
+    static final String BIG_DECIMAL_CLASS = BigDecimal.class.getName();
 
     /**
      * {@link Long} class name.
      */
-    protected static final String LONG_CLASS = Long.class.getName();
+    static final String LONG_CLASS = Long.class.getName();
 
     /**
      * Class name for long primitive.
      */
-    protected static final String LONG_PRIMITIVE_CLASS = long.class.getName();
+    static final String LONG_PRIMITIVE_CLASS = long.class.getName();
 
     /**
      * {@link Float} class name.
      */
-    protected static final String FLOAT_CLASS = Float.class.getName();
+    static final String FLOAT_CLASS = Float.class.getName();
 
     /**
      * Class name for float primitive.
      */
-    protected static final String FLOAT_PRIMITIVE_CLASS = float.class.getName();
+    static final String FLOAT_PRIMITIVE_CLASS = float.class.getName();
 
     /**
      * {@link Double} class name.
      */
-    protected static final String DOUBLE_CLASS = Double.class.getName();
+    static final String DOUBLE_CLASS = Double.class.getName();
 
     /**
      * Class name for double primitive.
      */
-    protected static final String DOUBLE_PRIMITIVE_CLASS = double.class.getName();
+    static final String DOUBLE_PRIMITIVE_CLASS = double.class.getName();
 
     /**
      * Class name for {@link BigInteger}.
      */
-    protected static final String BIG_INTEGER_CLASS = BigInteger.class.getName();
+    static final String BIG_INTEGER_CLASS = BigInteger.class.getName();
 
     /**
      * Class name for {@link Integer}.
      */
-    protected static final String INTEGER_CLASS = Integer.class.getName();
+    static final String INTEGER_CLASS = Integer.class.getName();
 
     /**
      * Class name for int.
      */
-    protected static final String INTEGER_PRIMITIVE_CLASS = int.class.getName();
+    static final String INTEGER_PRIMITIVE_CLASS = int.class.getName();
 
     /**
      * Class name for {@link Byte}.
      */
-    protected static final String BYTE_CLASS = Byte.class.getName();
+    static final String BYTE_CLASS = Byte.class.getName();
 
     /**
      * Class name for byte.
      */
-    protected static final String BYTE_PRIMITIVE_CLASS = byte.class.getName();
+    static final String BYTE_PRIMITIVE_CLASS = byte.class.getName();
 
     /**
      * Class name for {@link Short}.
      */
-    protected static final String SHORT_CLASS = Short.class.getName();
+    static final String SHORT_CLASS = Short.class.getName();
 
     /**
      * Class name for short.
      */
-    protected static final String SHORT_PRIMITIVE_CLASS = short.class.getName();
+    private static final String SHORT_PRIMITIVE_CLASS = short.class.getName();
 
     /**
      * Formatted Date scalar.
@@ -208,10 +208,6 @@ final class SchemaGeneratorHelper {
      * Formatted Time Scalar.
      */
     public static final String FORMATTED_TIME_SCALAR = "FormattedTime";
-
-    /**
-     * Formatted Int.
-     */
 
     /**
      * Date scalar (with default formatting).
@@ -392,7 +388,7 @@ final class SchemaGeneratorHelper {
      * @return the simple class name
      * @throws ClassNotFoundException if invalid class name
      */
-    protected static String getSimpleName(String className)
+    static String getSimpleName(String className)
             throws ClassNotFoundException {
         return getSimpleName(className, false);
     }
@@ -403,7 +399,7 @@ final class SchemaGeneratorHelper {
      * @param clazz {@link Class} to check
      * @return true of the {@link Class} is a primitive or array of primitives.
      */
-    protected static boolean isPrimitive(Class<?> clazz) {
+    static boolean isPrimitive(Class<?> clazz) {
         return isPrimitive(clazz.getName());
     }
 
@@ -413,7 +409,7 @@ final class SchemaGeneratorHelper {
      * @param clazz class name to check
      * @return true if the class name is a primitive or array of primitives.
      */
-    protected static boolean isPrimitive(String clazz) {
+    static boolean isPrimitive(String clazz) {
         return JAVA_PRIMITIVE_TYPES.contains(clazz) || PRIMITIVE_ARRAY_MAP.containsValue(clazz);
     }
 
@@ -421,9 +417,9 @@ final class SchemaGeneratorHelper {
      * Return true of the class name is an array of primitives.
      *
      * @param clazz class name to check
-     * @return true true of the class name is an array of primitives.
+     * @return true of the class name is an array of primitives.
      */
-    protected static boolean isPrimitiveArray(String clazz) {
+    static boolean isPrimitiveArray(String clazz) {
         return PRIMITIVE_ARRAY_MAP.containsValue(clazz);
     }
 
@@ -431,9 +427,9 @@ final class SchemaGeneratorHelper {
      * Return true of the class name is an array of primitives.
      *
      * @param clazz {@link Class} to check
-     * @return true true of the class name is an array of primitives.
+     * @return true of the class name is an array of primitives.
      */
-    protected static boolean isPrimitiveArray(Class<?> clazz) {
+    static boolean isPrimitiveArray(Class<?> clazz) {
         String className = clazz.getName();
         for (String key : PRIMITIVE_ARRAY_MAP.keySet()) {
             if (className.contains(key)) {
@@ -452,7 +448,7 @@ final class SchemaGeneratorHelper {
      * @return the simple class name
      * @throws ClassNotFoundException if invalid class name
      */
-    protected static String getSimpleName(String className, boolean ignoreInputNameAnnotation)
+    static String getSimpleName(String className, boolean ignoreInputNameAnnotation)
             throws ClassNotFoundException {
         if (ID.equals(className)
                 || STRING.equals(className) || BOOLEAN.equalsIgnoreCase(className)
@@ -470,7 +466,7 @@ final class SchemaGeneratorHelper {
      * @param clazzName class name to check for
      * @return a {@link SchemaScalar} if one matches the known list of scalars or null if none found
      */
-    protected static SchemaScalar getScalar(String clazzName) {
+    static SchemaScalar getScalar(String clazzName) {
         return SUPPORTED_SCALARS.get(clazzName);
     }
 
@@ -480,7 +476,7 @@ final class SchemaGeneratorHelper {
      * @param scalarName the scalae name to check
      * @return true if the give name is a scalar with that name
      */
-    protected static boolean isScalar(String scalarName) {
+    private static boolean isScalar(String scalarName) {
         return SUPPORTED_SCALARS.values().stream().anyMatch((s -> s.name().equals(scalarName)));
     }
 
@@ -490,7 +486,7 @@ final class SchemaGeneratorHelper {
      * @param className fully qualified class name
      * @return the GraphQL type
      */
-    protected static String getGraphQLType(String className) {
+    static String getGraphQLType(String className) {
         if (BOOLEAN_LIST.contains(className)) {
             return BOOLEAN;
         } else if (STRING_LIST.contains(className)) {
@@ -508,7 +504,7 @@ final class SchemaGeneratorHelper {
      * @param scalarName scalar name
      * @return true of the name is a Date, DateTime, or Time scalar
      */
-    protected static boolean isDateTimeScalar(String scalarName) {
+    static boolean isDateTimeScalar(String scalarName) {
         return FORMATTED_DATE_SCALAR.equals(scalarName)
                 || FORMATTED_TIME_SCALAR.equals(scalarName)
                 || FORMATTED_OFFSET_DATETIME_SCALAR.equals(scalarName)
@@ -517,12 +513,12 @@ final class SchemaGeneratorHelper {
     }
 
     /**
-     * Return true if the type type is a native GraphQLType.
+     * Return true if the type is a native GraphQLType.
      *
      * @param type the type to check
-     * @return true if the type type is a GraphQLType
+     * @return true if the type is a GraphQLType
      */
-    protected static boolean isGraphQLType(String type) {
+    static boolean isGraphQLType(String type) {
         return BOOLEAN.equals(type) || STRING.equals(type) || ID.equals(type);
     }
 
@@ -534,7 +530,7 @@ final class SchemaGeneratorHelper {
      * @param fieldName field name to check
      * @return the field name or null if none exist
      */
-    protected static String getFieldName(Class<?> clazz, String fieldName) {
+    static String getFieldName(Class<?> clazz, String fieldName) {
         try {
             Field field = clazz.getDeclaredField(fieldName);
             Name nameAnnotation = field.getAnnotation(Name.class);
@@ -560,7 +556,7 @@ final class SchemaGeneratorHelper {
      * @param method {@link Method} to check
      * @return the field name or null if non exist
      */
-    protected static String getMethodName(Method method) {
+    static String getMethodName(Method method) {
         if (method != null) {
             Query queryAnnotation = method.getAnnotation(Query.class);
             Mutation mutationAnnotation = method.getAnnotation(Mutation.class);
@@ -589,7 +585,7 @@ final class SchemaGeneratorHelper {
      * @param clazzName the class name as a String
      * @return a Class name
      */
-    protected static Class<?> getSafeClass(String clazzName) {
+    static Class<?> getSafeClass(String clazzName) {
         try {
             return Class.forName(clazzName);
         } catch (ClassNotFoundException e) {
@@ -603,7 +599,7 @@ final class SchemaGeneratorHelper {
      * @param clazz the {@link Class} to check
      * @return true if the class is a date, time or date/time
      */
-    protected static boolean isDateTimeClass(Class<?> clazz) {
+    static boolean isDateTimeClass(Class<?> clazz) {
         return clazz != null && (
                 clazz.equals(LocalDate.class)
                         || clazz.equals(Date.class)
@@ -620,7 +616,7 @@ final class SchemaGeneratorHelper {
      * @param clazz {@link Class} to check
      * @return true if the {@link Class} is a valid {@link Class} to apply the {@link Id} annotation
      */
-    protected static boolean isValidIDType(Class<?> clazz) {
+    private static boolean isValidIDType(Class<?> clazz) {
         return clazz.equals(Long.class) || clazz.equals(Integer.class)
                 || clazz.equals(java.util.UUID.class) || clazz.equals(int.class)
                 || clazz.equals(String.class) || clazz.equals(long.class);
@@ -632,7 +628,7 @@ final class SchemaGeneratorHelper {
      * @param clazz class to check
      * @return true if the fully qualified class is an enum.
      */
-    protected static boolean isEnumClass(String clazz) {
+    static boolean isEnumClass(String clazz) {
         try {
             return (Class.forName(clazz)).isEnum();
         } catch (ClassNotFoundException e) {
@@ -646,7 +642,7 @@ final class SchemaGeneratorHelper {
      * @param clazz {@link Class} to check
      * @return the {@link Name} annotation value if it exists or null
      */
-    protected static String getNameAnnotationValue(Class<?> clazz) {
+    private static String getNameAnnotationValue(Class<?> clazz) {
         Name nameAnnotation = clazz.getAnnotation(Name.class);
         if (nameAnnotation != null && !"".equals(nameAnnotation.value())) {
             return nameAnnotation.value();
@@ -660,7 +656,7 @@ final class SchemaGeneratorHelper {
      * @param annotatedElement {@link AnnotatedElement} to check
      * @return the {@link DefaultValue} annotation value if it exists or null
      */
-    protected static String getDefaultValueAnnotationValue(AnnotatedElement annotatedElement) {
+    static String getDefaultValueAnnotationValue(AnnotatedElement annotatedElement) {
         DefaultValue defaultValueAnnotation = annotatedElement.getAnnotation(DefaultValue.class);
         if (defaultValueAnnotation != null && !"".equals(defaultValueAnnotation.value())) {
             return defaultValueAnnotation.value();
@@ -675,7 +671,7 @@ final class SchemaGeneratorHelper {
      * @param description description
      * @return the default description
      */
-    protected static String getDefaultDescription(String[] format, String description) {
+    static String getDefaultDescription(String[] format, String description) {
         String fmt = format == null || format.length != 2 || (format[0] == null || format[1] == null)
                 ? null : format[0] + (DEFAULT_LOCALE.equals(format[1]) ? "" : " " + format[1]);
         if (description == null && fmt == null) {
@@ -698,7 +694,7 @@ final class SchemaGeneratorHelper {
      * @param isStrictTest indicates if a strict test for setters and getters should be carried out.
      * @return the method name
      */
-    protected static String stripMethodName(Method method, boolean isStrictTest) {
+    static String stripMethodName(Method method, boolean isStrictTest) {
         String name = method.getName();
         boolean isPublic = Modifier.isPublic(method.getModifiers());
         boolean isSetterName = name.matches("^set[A-Z].*");
@@ -755,7 +751,7 @@ final class SchemaGeneratorHelper {
      * @param clazz {@link Class} to introspect.
      * @return the correct name
      */
-    protected static String getTypeName(Class<?> clazz) {
+    static String getTypeName(Class<?> clazz) {
         return getTypeName(clazz, false);
     }
 
@@ -766,7 +762,7 @@ final class SchemaGeneratorHelper {
      * @param index index of type generic type. 0 = List/Collection 1 = Map
      * @return the array of {@link Annotation}s on a {@link Parameter}
      */
-    protected static Annotation[] getFieldAnnotations(Field field, int index) {
+    static Annotation[] getFieldAnnotations(Field field, int index) {
         if (field.getAnnotatedType() instanceof AnnotatedParameterizedType) {
             return getAnnotationsFromType((AnnotatedParameterizedType) field.getAnnotatedType(), index);
         }
@@ -781,7 +777,7 @@ final class SchemaGeneratorHelper {
      * @param index  index of type generic type. 0 = List/Collection 1 = Map
      * @return the array of {@link Annotation}s on a {@link Parameter}
      */
-    protected static Annotation[] getMethodAnnotations(Method method, int index) {
+    static Annotation[] getMethodAnnotations(Method method, int index) {
         if (method.getAnnotatedReturnType() instanceof AnnotatedParameterizedType) {
             return getAnnotationsFromType((AnnotatedParameterizedType) method.getAnnotatedReturnType(), index);
         }
@@ -796,7 +792,7 @@ final class SchemaGeneratorHelper {
      * @param index     index of type generic type. 0 = List/Collection 1 = Map
      * @return the array of {@link Annotation}s on a {@link Parameter}
      */
-    protected static Annotation[] getParameterAnnotations(Parameter parameter, int index) {
+    static Annotation[] getParameterAnnotations(Parameter parameter, int index) {
 
         if (parameter.getAnnotatedType() instanceof AnnotatedParameterizedType) {
             return getAnnotationsFromType((AnnotatedParameterizedType) parameter.getAnnotatedType(), index);
@@ -836,7 +832,7 @@ final class SchemaGeneratorHelper {
      * @param type        the {@link Type} to find
      * @return the annotation that matches the type
      */
-    protected static Annotation getAnnotationValue(Annotation[] annotations, java.lang.reflect.Type type) {
+    static Annotation getAnnotationValue(Annotation[] annotations, java.lang.reflect.Type type) {
         if (annotations != null) {
             for (Annotation annotation : annotations) {
                 if (annotation.annotationType().equals(type)) {
@@ -855,7 +851,7 @@ final class SchemaGeneratorHelper {
      *                                  change the name of a type if it as and {@link Input} annotation
      * @return the correct name
      */
-    protected static String getTypeName(Class<?> clazz, boolean ignoreInputNameAnnotation) {
+    static String getTypeName(Class<?> clazz, boolean ignoreInputNameAnnotation) {
         Type typeAnnotation = clazz.getAnnotation(Type.class);
         Interface interfaceAnnotation = clazz.getAnnotation(Interface.class);
         Input inputAnnotation = ignoreInputNameAnnotation ? null : clazz.getAnnotation(Input.class);
@@ -893,7 +889,7 @@ final class SchemaGeneratorHelper {
      * @param logger {@link System.Logger} to log to
      * @param name   to validate
      */
-    protected static void ensureValidName(System.Logger logger, String name) {
+    static void ensureValidName(System.Logger logger, String name) {
         if (name != null && !isValidGraphQLName(name)) {
             ensureConfigurationException(LOGGER, "The name '" + name + "' is not a valid "
                     + "GraphQL name and cannot be used.");
@@ -907,7 +903,7 @@ final class SchemaGeneratorHelper {
      * @param schema {@link Schema} to check scalars for.
      * @param type   {@link SchemaType} to check
      */
-    protected static void checkScalars(Schema schema, SchemaType type) {
+    static void checkScalars(Schema schema, SchemaType type) {
         type.fieldDefinitions().forEach(fd -> {
             SchemaScalar scalar = getScalar(fd.returnType());
             if (scalar != null) {
@@ -927,7 +923,7 @@ final class SchemaGeneratorHelper {
      * @param existingFormat the existing format
      * @return current format or if none exists, then the default if it exists for the scalar
      */
-    protected static String[] ensureFormat(String scalarName, String clazzName, String[] existingFormat) {
+    static String[] ensureFormat(String scalarName, String clazzName, String[] existingFormat) {
         if (existingFormat == null || (existingFormat[0] == null && existingFormat[1] == null && isScalar(scalarName))) {
             String[] defaultFormat = getDefaultDateTimeFormat(scalarName, clazzName);
             if (defaultFormat != null) {
@@ -943,7 +939,7 @@ final class SchemaGeneratorHelper {
      * @param clazz the class name retrieved via Class.getName()
      * @return the number of array levels in the class
      */
-    protected static int getArrayLevels(String clazz) {
+    static int getArrayLevels(String clazz) {
         int c = 0;
         for (int i = 0; i < clazz.length(); i++) {
             if (clazz.charAt(i) == '[') {
@@ -959,7 +955,7 @@ final class SchemaGeneratorHelper {
      * @param clazz the class name retrieved via Class.getName()
      * @return true if the class is an array type
      */
-    protected static boolean isArrayType(String clazz) {
+    static boolean isArrayType(String clazz) {
         return clazz.startsWith(OPEN_SQUARE);
     }
 
@@ -969,7 +965,7 @@ final class SchemaGeneratorHelper {
      * @param clazz the class name retrieved via Class.getName()
      * @return the root class name
      */
-    protected static String getRootArrayClass(String clazz) {
+    static String getRootArrayClass(String clazz) {
         if (clazz == null || "".equals(clazz.trim()) || clazz.length() < 2) {
             throw new IllegalArgumentException("Class must be not null");
         }
@@ -989,7 +985,7 @@ final class SchemaGeneratorHelper {
      * @param isInputType indicates if this is an input type
      * @return true if the method should be ignored
      */
-    protected static boolean shouldIgnoreMethod(Method method, boolean isInputType) {
+    static boolean shouldIgnoreMethod(Method method, boolean isInputType) {
         Ignore ignore = method.getAnnotation(Ignore.class);
         JsonbTransient jsonbTransient = method.getAnnotation(JsonbTransient.class);
 
@@ -1021,7 +1017,7 @@ final class SchemaGeneratorHelper {
      * @param fieldName field name to check
      * @return true if the {@link Field} should be ignored
      */
-    protected static boolean shouldIgnoreField(Class<?> clazz, String fieldName) {
+    static boolean shouldIgnoreField(Class<?> clazz, String fieldName) {
         Field field = null;
         try {
             field = clazz.getDeclaredField(fieldName);
@@ -1038,7 +1034,7 @@ final class SchemaGeneratorHelper {
      * @param description {@link Description} annotation
      * @return the description or null
      */
-    protected static String getDescription(Description description) {
+    static String getDescription(Description description) {
         return description == null || "".equals(description.value())
                 ? null
                 : description.value();
@@ -1050,7 +1046,7 @@ final class SchemaGeneratorHelper {
      * @param name name to validate
      * @return true if the name is valid
      */
-    protected static boolean isValidGraphQLName(String name) {
+    static boolean isValidGraphQLName(String name) {
         return name != null && name.matches("[_A-Za-z][_0-9A-Za-z]*") && !name.startsWith("__");
     }
 
@@ -1060,7 +1056,7 @@ final class SchemaGeneratorHelper {
      * @param message message to throw
      * @param logger  the {@link System.Logger} to use
      */
-    protected static void ensureRuntimeException(System.Logger logger, String message) {
+    static void ensureRuntimeException(System.Logger logger, String message) {
         ensureRuntimeException(logger, message, null);
     }
 
@@ -1068,10 +1064,10 @@ final class SchemaGeneratorHelper {
      * Ensures a {@link RuntimeException} with the message supplied is thrown and logged.
      *
      * @param message message to throw
-     * @param cause   cause of the erro
+     * @param cause   cause of the error
      * @param logger  the {@link System.Logger} to use
      */
-    protected static void ensureRuntimeException(System.Logger logger, String message, Throwable cause) {
+    static void ensureRuntimeException(System.Logger logger, String message, Throwable cause) {
         logger.log(Level.WARNING, message);
         if (cause != null) {
             logger.log(Level.WARNING, getStackTrace(cause));
@@ -1085,7 +1081,7 @@ final class SchemaGeneratorHelper {
      * @param message message to throw
      * @param logger  the {@link System.Logger} to use
      */
-    protected static void ensureConfigurationException(System.Logger logger, String message) {
+    static void ensureConfigurationException(System.Logger logger, String message) {
         ensureConfigurationException(logger, message, null);
     }
 
@@ -1093,10 +1089,10 @@ final class SchemaGeneratorHelper {
      * Ensures a {@link GraphQlConfigurationException} with the message supplied is thrown and logged.
      *
      * @param message message to throw
-     * @param cause   cause of the erro
+     * @param cause   cause of the error
      * @param logger  the {@link System.Logger} to use
      */
-    protected static void ensureConfigurationException(System.Logger logger, String message, Throwable cause) {
+    static void ensureConfigurationException(System.Logger logger, String message, Throwable cause) {
         logger.log(Level.WARNING, message);
         if (cause != null) {
             logger.log(Level.WARNING, getStackTrace(cause));
@@ -1110,7 +1106,7 @@ final class SchemaGeneratorHelper {
      * @param throwable {@link Throwable} to get stack tracek for
      * @return the stacktrace of the given {@link Throwable}
      */
-    protected static String getStackTrace(Throwable throwable) {
+    private static String getStackTrace(Throwable throwable) {
         StringWriter stack = new StringWriter();
         throwable.printStackTrace(new PrintWriter(stack));
         return stack.toString();
@@ -1121,7 +1117,7 @@ final class SchemaGeneratorHelper {
      *
      * @param returnClazz {@link Class} to check
      */
-    protected static void validateIDClass(Class<?> returnClazz) {
+    static void validateIDClass(Class<?> returnClazz) {
         if (!isValidIDType(returnClazz)) {
             ensureConfigurationException(LOGGER, "A class of type " + returnClazz + " is not allowed to be an @Id");
         }
@@ -1132,7 +1128,7 @@ final class SchemaGeneratorHelper {
      *
      * @param returnClazz class to check
      */
-    protected static void validateIDClass(String returnClazz) {
+    static void validateIDClass(String returnClazz) {
         try {
             validateIDClass(Class.forName(returnClazz));
         } catch (ClassNotFoundException e) {


### PR DESCRIPTION
### Description
Modifier `protected` is useless for methods in final class. I replaced it on package-private.

 `SchemaGeneratorHelper` [was final initially](https://github.com/helidon-io/helidon/pull/2504).