### PR TITLE
Fix injection scope is not active error (fixes #10311)

### DIFF
--- a/common/context/context/src/main/java/io/helidon/common/context/Context.java
+++ b/common/context/context/src/main/java/io/helidon/common/context/Context.java
@@ -163,6 +163,11 @@ public interface Context {
     String id();
 
     /**
+     * Removes all of the elements from this context.
+     */
+    void clear();
+
+    /**
      * Fluent API builder for {@link Context}.
      */
     class Builder implements io.helidon.common.Builder<Builder, Context> {

--- a/common/context/context/src/main/java/io/helidon/common/context/Contexts.java
+++ b/common/context/context/src/main/java/io/helidon/common/context/Contexts.java
@@ -49,6 +49,14 @@ public final class Contexts {
     }
 
     /**
+     * Removes all of the elements from the global context.
+     */
+    public static void clearGlobalContext() {
+        clear();
+        GLOBAL_CONTEXT.get().clear();
+    }
+
+    /**
      * Get context registry associated with current thread.
      *
      * @return context that is associated with current thread or empty if none is

--- a/common/context/context/src/main/java/io/helidon/common/context/ListContext.java
+++ b/common/context/context/src/main/java/io/helidon/common/context/ListContext.java
@@ -61,6 +61,11 @@ class ListContext implements Context {
     }
 
     @Override
+    public void clear() {
+        classifiers.clear();
+    }
+
+    @Override
     public <T> Optional<T> get(Class<T> type) {
         T result = registry.get(type);
         if (result == null) {

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistryManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistryManager.java
@@ -32,6 +32,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import io.helidon.common.context.Contexts;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
@@ -224,6 +225,7 @@ public final class ServiceRegistryManager {
             registry.shutdown();
             registry = null;
         } finally {
+            Contexts.clearGlobalContext();
             lock.unlock();
         }
     }


### PR DESCRIPTION
### Problem

We occasionally observe the following error:
```
io.helidon.service.registry.ScopeNotActiveException: Injection scope io.helidon.service.registry.Service.Singleton[7] is not active.
```

### Description of the change

 Here are the specific changes:
- A `clear()` method was added to the `Context` interface to allow for the removal of all registered elements.
- This `clear()` method was implemented in the `ListContext` class.
- A new `public static` method, `clearGlobalContext()`, was added to the `Contexts` utility class to expose this clearing functionality.
- The `ServiceRegistryManager.shutdown()` method was modified to call `Contexts.clearGlobalContext()`, ensuring that a shutdown always cleans up the global context, which prevents service leftovers from interfering with subsequent operations, especially in a testing environment.

This fixes https://github.com/helidon-io/helidon/issues/10311.

### Documentation

It shouldn't impact the documentation, because the existing behavior should remain the same.