### PR TITLE
4.x: Use Maven 3.9.9

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -54,6 +54,9 @@ inputs:
   setup-latest-java:
     description: Whether to setup latest stable java version
     default: 'false'
+  setup-maven:
+    description: Wheter to setup Maven
+    default: 'true'
 runs:
   using: "composite"
   steps:
@@ -81,6 +84,25 @@ runs:
         echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
         git config --global core.autocrlf false
         git config --global core.eol lf
+    - if: ${{ inputs.setup-maven == 'true' }}
+      name: Cache Maven Installation
+      uses: actions/cache@v4.2.0
+      with:
+        path: .tools/apache-maven-*/**
+        enableCrossOsArchive: true
+        key: tools-maven-${{ hashFiles('.tools/apache-maven-*/**') }}
+        restore-keys: |
+          tools-maven-
+    - if: ${{ inputs.setup-maven == 'true' && runner.os != 'Windows' }}
+      name: Set up Maven
+      shell: bash
+      run: |
+        if [ -z "${MVN_VERSION}" ] ; then echo "MVN_VERSION not set"; exit 1 ; fi
+        if [ ! -d .tools/apache-maven-${MVN_VERSION}/bin ] ; then
+          curl -O https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.zip
+          unzip apache-maven-${MVN_VERSION}-bin.zip -d .tools
+        fi
+        echo ${PWD}/.tools/apache-maven-${MVN_VERSION}/bin >> "${GITHUB_PATH}"
     - name: Set up GraalVM
       if: ${{ inputs.native-image == 'true' }}
       uses: graalvm/setup-graalvm@v1.2.4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,6 +20,7 @@ on:
     - cron: '0 10 * * 0-6'
 
 env:
+  MVN_VERSION: 3.9.9
   MVN_ARGS: |
     -B -fae -e
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,8 +20,9 @@ on:
     branches: [ 'release-*' ]
 
 env:
-  JAVA_VERSION: '21'
-  JAVA_DISTRO: 'oracle'
+  MVN_VERSION: 3.9.9
+  JAVA_VERSION: 21
+  JAVA_DISTRO: oracle
   MVN_ARGS: |
     -B -e
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -23,8 +23,9 @@ on:
       - 'helidon-*.x'
 
 env:
-  JAVA_VERSION: '21'
-  JAVA_DISTRO: 'oracle'
+  MVN_VERSION: 3.9.9
+  JAVA_VERSION: 21
+  JAVA_DISTRO: oracle
   MVN_ARGS: |
     -B -e
     -Dmaven.wagon.httpconnectionManager.ttlSeconds=60

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,6 +29,7 @@ on:
         default: ''
 
 env:
+  MVN_VERSION: 3.9.9
   JAVA_VERSION: 21
   GRAALVM_VERSION: 21.0.3
   JAVA_DISTRO: oracle
@@ -88,6 +89,7 @@ jobs:
           build-cache: read-write
           maven-cache: read-write
           run: |
+            mvn --version
             mvn ${MVN_ARGS} build-cache:go-offline
             mvn ${MVN_ARGS} -T8 \
               -Dorg.slf4j.simpleLogger.showThreadName=true \


### PR DESCRIPTION
### Description

Use a Maven 3.9.9 explicitly.
The current version available in the runners (3.9.10) causes issues, see https://github.com/apache/maven/issues/2487

### Documentation

None