### PR TITLE
4.x: Update to ServiceRegistry API to add helper methods for qualified instances

### DIFF
--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistry.java
@@ -17,7 +17,9 @@
 package io.helidon.service.registry;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import io.helidon.common.types.TypeName;
@@ -49,6 +51,43 @@ public interface ServiceRegistry {
     }
 
     /**
+     * Get the first named service instance matching the contract with the expectation that there is a match available.
+     *
+     * @param contract contract to look-up
+     * @param name     name qualifier of the instance to get
+     * @param <T>      type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    default <T> T getNamed(Class<T> contract, String name) {
+        Objects.requireNonNull(contract);
+        Objects.requireNonNull(name);
+
+        return get(contract, Qualifier.createNamed(name));
+    }
+
+    /**
+     * Get the first service instance matching the contract and qualifiers with the expectation that there is a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    default <T> T get(Class<T> contract, Qualifier... qualifiers) {
+        Objects.requireNonNull(contract);
+        Objects.requireNonNull(qualifiers);
+
+        return get(Lookup.builder()
+                           .addContract(contract)
+                           .qualifiers(Set.of(qualifiers))
+                           .build());
+    }
+
+    /**
      * Get the first service instance matching the contract with the expectation that there is a match available.
      *
      * @param contract contract to look-up
@@ -59,6 +98,39 @@ public interface ServiceRegistry {
      *                                                              resolution to instance failed
      */
     <T> T get(TypeName contract);
+
+    /**
+     * Get the first named service instance matching the contract with the expectation that there is a match available.
+     *
+     * @param contract contract to look-up
+     * @param name     name qualifier of the instance to get
+     * @param <T>      type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    default <T> T getNamed(TypeName contract, String name) {
+        return get(contract, Qualifier.createNamed(name));
+    }
+
+    /**
+     * Get the first service instance matching the contract and qualifiers with the expectation that there is a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract (we will "blindly" cast the result to the expected type, make sure you use the right
+     *                   one)
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    default <T> T get(TypeName contract, Qualifier... qualifiers) {
+        return get(Lookup.builder()
+                           .addContract(contract)
+                           .qualifiers(Set.of(qualifiers))
+                           .build());
+    }
+
 
     /**
      * Get the first service instance matching the contract with the expectation that there may not be a match available.
@@ -74,6 +146,37 @@ public interface ServiceRegistry {
     }
 
     /**
+     * Get the first named service instance matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract contract to look-up
+     * @param name     name qualifier of the instance to get
+     * @param <T>      type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    default <T> Optional<T> firstNamed(Class<T> contract, String name) {
+        return first(contract, Qualifier.createNamed(name));
+    }
+
+    /**
+     * Get the first service instance matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best service instance matching the contract, or an empty {@link java.util.Optional} if none match
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    default <T> Optional<T> first(Class<T> contract, Qualifier... qualifiers) {
+        return first(Lookup.builder()
+                             .addContract(contract)
+                             .qualifiers(Set.of(qualifiers))
+                             .build());
+    }
+
+    /**
      * Get the first service instance matching the contract with the expectation that there may not be a match available.
      *
      * @param contract contract to look-up
@@ -83,6 +186,37 @@ public interface ServiceRegistry {
      *                                                              resolution to instance failed
      */
     <T> Optional<T> first(TypeName contract);
+
+    /**
+     * Get the first named service instance matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract contract to look-up
+     * @param name     name qualifier of the instance to get
+     * @param <T>      type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    default <T> Optional<T> firstNamed(TypeName contract, String name) {
+        return first(contract, Qualifier.createNamed(name));
+    }
+
+    /**
+     * Get the first service instance matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best service instance matching the contract, or an empty {@link java.util.Optional} if none match
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    default <T> Optional<T> first(TypeName contract, Qualifier... qualifiers) {
+        return first(Lookup.builder()
+                             .addContract(contract)
+                             .qualifiers(Set.of(qualifiers))
+                             .build());
+    }
 
     /**
      * Get all service instances matching the contract with the expectation that there may not be a match available.
@@ -98,11 +232,41 @@ public interface ServiceRegistry {
     /**
      * Get all service instances matching the contract with the expectation that there may not be a match available.
      *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return list of services matching the criteria, may be empty if none matched, or no instances were provided
+     */
+    default <T> List<T> all(Class<T> contract, Qualifier... qualifiers) {
+        return all(Lookup.builder()
+                           .addContract(contract)
+                           .qualifiers(Set.of(qualifiers))
+                           .build());
+    }
+
+    /**
+     * Get all service instances matching the contract with the expectation that there may not be a match available.
+     *
      * @param contract contract to look-up
      * @param <T>      type of the contract
      * @return list of services matching the criteria, may be empty if none matched, or no instances were provided
      */
     <T> List<T> all(TypeName contract);
+
+    /**
+     * Get all service instances matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return list of services matching the criteria, may be empty if none matched, or no instances were provided
+     */
+    default <T> List<T> all(TypeName contract, Qualifier... qualifiers) {
+        return all(Lookup.builder()
+                           .addContract(contract)
+                           .qualifiers(Set.of(qualifiers))
+                           .build());
+    }
 
     /**
      * Get the first service supplier matching the contract with the expectation that there is a match available.
@@ -125,12 +289,50 @@ public interface ServiceRegistry {
      * {@link io.helidon.service.registry.ServiceRegistryException} in case the matching service cannot provide a value (either
      * because of scope mismatch, or because an instance was not provided by the service provider.
      *
+     * @param contract   contract to find
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best service supplier matching the lookup
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup
+     */
+    default <T> Supplier<T> supply(Class<T> contract, Qualifier... qualifiers) {
+        return supply(Lookup.builder()
+                              .addContract(contract)
+                              .qualifiers(Set.of(qualifiers))
+                              .build());
+    }
+
+    /**
+     * Get the first service supplier matching the contract with the expectation that there is a match available.
+     * The provided {@link java.util.function.Supplier#get()} may throw an
+     * {@link io.helidon.service.registry.ServiceRegistryException} in case the matching service cannot provide a value (either
+     * because of scope mismatch, or because an instance was not provided by the service provider.
+     *
      * @param contract contract to find
      * @param <T>      type of the contract
      * @return the best service supplier matching the lookup
      * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup
      */
     <T> Supplier<T> supply(TypeName contract);
+
+    /**
+     * Get the first service supplier matching the contract with the expectation that there is a match available.
+     * The provided {@link java.util.function.Supplier#get()} may throw an
+     * {@link io.helidon.service.registry.ServiceRegistryException} in case the matching service cannot provide a value (either
+     * because of scope mismatch, or because an instance was not provided by the service provider.
+     *
+     * @param contract   contract to find
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best service supplier matching the lookup
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup
+     */
+    default <T> Supplier<T> supply(TypeName contract, Qualifier... qualifiers) {
+        return supply(Lookup.builder()
+                              .addContract(contract)
+                              .qualifiers(Set.of(qualifiers))
+                              .build());
+    }
 
     /**
      * Get the first service supplier matching the contract with the expectation that there may not be a match available.
@@ -146,11 +348,41 @@ public interface ServiceRegistry {
     /**
      * Get the first service supplier matching the contract with the expectation that there may not be a match available.
      *
+     * @param contract   contract we look for
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return supplier of an optional instance
+     */
+    default <T> Supplier<Optional<T>> supplyFirst(Class<T> contract, Qualifier... qualifiers) {
+        return supplyFirst(Lookup.builder()
+                                   .addContract(contract)
+                                   .qualifiers(Set.of(qualifiers))
+                                   .build());
+    }
+
+    /**
+     * Get the first service supplier matching the contract with the expectation that there may not be a match available.
+     *
      * @param contract contract we look for
      * @param <T>      type of the contract
      * @return supplier of an optional instance
      */
     <T> Supplier<Optional<T>> supplyFirst(TypeName contract);
+
+    /**
+     * Get the first service supplier matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract   contract we look for
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return supplier of an optional instance
+     */
+    default <T> Supplier<Optional<T>> supplyFirst(TypeName contract, Qualifier... qualifiers) {
+        return supplyFirst(Lookup.builder()
+                                   .addContract(contract)
+                                   .qualifiers(Set.of(qualifiers))
+                                   .build());
+    }
 
     /**
      * Lookup a supplier of a list of instances of the requested contract, with the expectation that there may not be a
@@ -168,11 +400,43 @@ public interface ServiceRegistry {
      * Lookup a supplier of a list of instances of the requested contract, with the expectation that there may not be a
      * match available.
      *
+     * @param contract   contract we look for
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return a supplier of list of instances
+     */
+    default <T> Supplier<List<T>> supplyAll(Class<T> contract, Qualifier... qualifiers) {
+        return supplyAll(Lookup.builder()
+                                 .addContract(contract)
+                                 .qualifiers(Set.of(qualifiers))
+                                 .build());
+    }
+
+    /**
+     * Lookup a supplier of a list of instances of the requested contract, with the expectation that there may not be a
+     * match available.
+     *
      * @param contract contract we look for
      * @param <T>      type of the contract
      * @return a supplier of list of instances
      */
     <T> Supplier<List<T>> supplyAll(TypeName contract);
+
+    /**
+     * Lookup a supplier of a list of instances of the requested contract, with the expectation that there may not be a
+     * match available.
+     *
+     * @param contract   contract we look for
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return a supplier of list of instances
+     */
+    default <T> Supplier<List<T>> supplyAll(TypeName contract, Qualifier... qualifiers) {
+        return supplyAll(Lookup.builder()
+                                 .addContract(contract)
+                                 .qualifiers(Set.of(qualifiers))
+                                 .build());
+    }
 
     /**
      * Provide a value for a specific service info instance.

--- a/service/registry/src/main/java/io/helidon/service/registry/Services.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Services.java
@@ -96,6 +96,53 @@ public final class Services {
     }
 
     /**
+     * Set a qualified instance.
+     * <p>
+     * Rules are the same as for {@link #set(Class, Object[])}.
+     *
+     * @param contract   contract to set
+     * @param instance   instance to use
+     * @param qualifiers qualifier(s) to qualify the instance
+     * @param <T>        type of the service
+     */
+    public static <T> void setQualified(Class<T> contract, T instance, Qualifier... qualifiers) {
+        Objects.requireNonNull(contract);
+        Objects.requireNonNull(instance);
+        Objects.requireNonNull(qualifiers);
+
+        if (qualifiers.length == 0) {
+            Services.set(contract, instance);
+            return;
+        }
+
+        for (Qualifier qualifier : qualifiers) {
+            Objects.requireNonNull(qualifier, "All qualifiers must be non-null");
+        }
+        ServiceRegistry registry = GlobalServiceRegistry.registry();
+        if (registry instanceof CoreServiceRegistry csr) {
+            csr.setQualified(contract, instance, Set.of(qualifiers));
+        }
+    }
+
+    /**
+     * Set a named instance.
+     * <p>
+     * Rules are the same as for {@link #set(Class, Object[])}.
+     *
+     * @param contract contract to set
+     * @param instance instance to use
+     * @param name     name qualifier to qualify the instance
+     * @param <T>      type of the service
+     */
+    public static <T> void setNamed(Class<T> contract, T instance, String name) {
+        Objects.requireNonNull(contract);
+        Objects.requireNonNull(instance);
+        Objects.requireNonNull(name);
+
+        setQualified(contract, instance, Qualifier.createNamed(name));
+    }
+
+    /**
      * Add an explicit instance for the specified service contract.
      * <p>
      * This method has similar contract to {@link #set(Class, Object[])} except it adds the implementation,

--- a/service/registry/src/main/java/io/helidon/service/registry/Services.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Services.java
@@ -19,6 +19,7 @@ package io.helidon.service.registry;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import io.helidon.common.types.TypeName;
 
@@ -100,10 +101,10 @@ public final class Services {
      * This method has similar contract to {@link #set(Class, Object[])} except it adds the implementation,
      * where the {@code set} method replaces all implementations.
      *
-     * @param contract  contract to bind the instance under
-     * @param weight weight of the instance (use {@link io.helidon.common.Weighted#DEFAULT_WEIGHT} for default)
+     * @param contract contract to bind the instance under
+     * @param weight   weight of the instance (use {@link io.helidon.common.Weighted#DEFAULT_WEIGHT} for default)
      * @param instance instance to add
-     * @param <T>       type of the contract
+     * @param <T>      type of the contract
      * @throws io.helidon.service.registry.ServiceRegistryException in case the service contract was already used and cannot be
      *                                                              re-bound
      * @throws java.lang.NullPointerException                       if either of the parameters is null
@@ -140,7 +141,6 @@ public final class Services {
         }
     }
 
-
     /**
      * Get the first instance of the contract, expecting the contract is available.
      *
@@ -154,6 +154,44 @@ public final class Services {
     public static <T> T get(Class<T> contract) {
         Objects.requireNonNull(contract);
         return GlobalServiceRegistry.registry().get(contract);
+    }
+
+    /**
+     * Get the first named service instance matching the contract with the expectation that there is a match available.
+     *
+     * @param contract contract to look-up
+     * @param name     name qualifier of the instance to get
+     * @param <T>      type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    public static <T> T getNamed(Class<T> contract, String name) {
+        Objects.requireNonNull(contract);
+        Objects.requireNonNull(name);
+
+        return get(contract, Qualifier.createNamed(name));
+    }
+
+    /**
+     * Get the first service instance matching the contract and qualifiers with the expectation that there is a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    public static <T> T get(Class<T> contract, Qualifier... qualifiers) {
+        Objects.requireNonNull(contract);
+        Objects.requireNonNull(qualifiers);
+
+        return GlobalServiceRegistry.registry()
+                .get(Lookup.builder()
+                             .addContract(contract)
+                             .qualifiers(Set.of(qualifiers))
+                             .build());
     }
 
     /**
@@ -171,6 +209,54 @@ public final class Services {
         return GlobalServiceRegistry.registry().get(contract);
     }
 
+    /**
+     * Get the first named service instance matching the contract with the expectation that there is a match available.
+     *
+     * @param contract contract to look-up
+     * @param name     name qualifier of the instance to get
+     * @param <T>      type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    public static <T> T getNamed(TypeName contract, String name) {
+        return get(contract, Qualifier.createNamed(name));
+    }
+
+    /**
+     * Get the first service instance matching the contract and qualifiers with the expectation that there is a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract (we will "blindly" cast the result to the expected type, make sure you use the right
+     *                   one)
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    public static <T> T get(TypeName contract, Qualifier... qualifiers) {
+        return GlobalServiceRegistry.registry()
+                .get(Lookup.builder()
+                             .addContract(contract)
+                             .qualifiers(Set.of(qualifiers))
+                             .build());
+    }
+
+    /**
+     * Get all service instances matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return list of services matching the criteria, may be empty if none matched, or no instances were provided
+     */
+    public static <T> List<T> all(Class<T> contract, Qualifier... qualifiers) {
+        return GlobalServiceRegistry.registry()
+                .all(Lookup.builder()
+                             .addContract(contract)
+                             .qualifiers(Set.of(qualifiers))
+                             .build());
+    }
 
     /**
      * Get all instances of the contract.
@@ -183,6 +269,22 @@ public final class Services {
     public static <T> List<T> all(Class<T> contract) {
         Objects.requireNonNull(contract);
         return GlobalServiceRegistry.registry().all(contract);
+    }
+
+    /**
+     * Get all service instances matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return list of services matching the criteria, may be empty if none matched, or no instances were provided
+     */
+    public static <T> List<T> all(TypeName contract, Qualifier... qualifiers) {
+        return GlobalServiceRegistry.registry()
+                .all(Lookup.builder()
+                             .addContract(contract)
+                             .qualifiers(Set.of(qualifiers))
+                             .build());
     }
 
     /**
@@ -212,6 +314,38 @@ public final class Services {
     }
 
     /**
+     * Get the first named service instance matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract contract to look-up
+     * @param name     name qualifier of the instance to get
+     * @param <T>      type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    public static <T> Optional<T> firstNamed(Class<T> contract, String name) {
+        return first(contract, Qualifier.createNamed(name));
+    }
+
+    /**
+     * Get the first service instance matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best service instance matching the contract, or an empty {@link java.util.Optional} if none match
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    public static <T> Optional<T> first(Class<T> contract, Qualifier... qualifiers) {
+        return GlobalServiceRegistry.registry()
+                .first(Lookup.builder()
+                               .addContract(contract)
+                               .qualifiers(Set.of(qualifiers))
+                               .build());
+    }
+
+    /**
      * Get first instance of the contract from the registry, all an empty optional if none exist.
      *
      * @param contract contract to find
@@ -223,4 +357,37 @@ public final class Services {
         Objects.requireNonNull(contract);
         return GlobalServiceRegistry.registry().first(contract);
     }
+
+    /**
+     * Get the first named service instance matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract contract to look-up
+     * @param name     name qualifier of the instance to get
+     * @param <T>      type of the contract
+     * @return the best service instance matching the contract
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    public static <T> Optional<T> firstNamed(TypeName contract, String name) {
+        return first(contract, Qualifier.createNamed(name));
+    }
+
+    /**
+     * Get the first service instance matching the contract with the expectation that there may not be a match available.
+     *
+     * @param contract   contract to look-up
+     * @param qualifiers qualifiers to find
+     * @param <T>        type of the contract
+     * @return the best service instance matching the contract, or an empty {@link java.util.Optional} if none match
+     * @throws io.helidon.service.registry.ServiceRegistryException if there is no service that could satisfy the lookup, or the
+     *                                                              resolution to instance failed
+     */
+    public static <T> Optional<T> first(TypeName contract, Qualifier... qualifiers) {
+        return GlobalServiceRegistry.registry()
+                .first(Lookup.builder()
+                               .addContract(contract)
+                               .qualifiers(Set.of(qualifiers))
+                               .build());
+    }
+
 }

--- a/service/registry/src/main/java/io/helidon/service/registry/VirtualDescriptor.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/VirtualDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ public class VirtualDescriptor implements ServiceDescriptor<Object> {
     private final TypeName descriptorType;
     private final double weight;
     private final Object instance;
+    private final Set<Qualifier> qualifiers;
 
     VirtualDescriptor(TypeName contract) {
         // explicit instances configured through config have a very high weight, to be used first
@@ -47,6 +48,18 @@ public class VirtualDescriptor implements ServiceDescriptor<Object> {
                 .build();
         this.weight = weight;
         this.instance = instance;
+        this.qualifiers = Set.of();
+    }
+
+    VirtualDescriptor(TypeName contract, double weight, Object instance, Set<Qualifier> qualifiers) {
+        this.contracts = Set.of(ResolvedType.create(contract));
+        this.serviceType = contract;
+        this.descriptorType = TypeName.builder(TYPE)
+                .className(TYPE.className() + "_" + contract.className() + "__VirtualDescriptor")
+                .build();
+        this.weight = weight;
+        this.instance = instance;
+        this.qualifiers = qualifiers;
     }
 
     @Override
@@ -67,6 +80,11 @@ public class VirtualDescriptor implements ServiceDescriptor<Object> {
     @Override
     public double weight() {
         return weight;
+    }
+
+    @Override
+    public Set<Qualifier> qualifiers() {
+        return qualifiers;
     }
 
     @Override

--- a/service/tests/inject/src/test/java/io/helidon/service/tests/inject/LateBindingTest.java
+++ b/service/tests/inject/src/test/java/io/helidon/service/tests/inject/LateBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.List;
 
 import io.helidon.common.Weighted;
 import io.helidon.service.registry.GlobalServiceRegistry;
+import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryException;
 import io.helidon.service.registry.ServiceRegistryManager;
@@ -189,6 +190,39 @@ public class LateBindingTest {
                                                       () -> Services.add(LateBindingTypes.ServiceProvider.class,
                                                                          Weighted.DEFAULT_WEIGHT,
                                                                          new LateBindingTypes.ServiceProvider("custom")));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void testLateBindingContractNamed() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry registry = manager.registry();
+        GlobalServiceRegistry.registry(registry);
+        try {
+            Services.setNamed(LateBindingTypes.Contract.class, new LateBindingTypes.ServiceProvider("named"), "named");
+
+            LateBindingTypes.Contract contract = registry.getNamed(LateBindingTypes.Contract.class, "named");
+            assertThat(contract.message(), is("named"));
+            contract = Services.getNamed(LateBindingTypes.Contract.class, "named");
+            assertThat(contract.message(), is("named"));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void testLateBindingContractQualified() {
+        ServiceRegistryManager manager = ServiceRegistryManager.create();
+        ServiceRegistry registry = manager.registry();
+        GlobalServiceRegistry.registry(registry);
+        try {
+            Services.setQualified(LateBindingTypes.Contract.class, new LateBindingTypes.ServiceProvider("named"),
+                                  Qualifier.createNamed("named"));
+
+            LateBindingTypes.Contract contract = registry.getNamed(LateBindingTypes.Contract.class, "named");
+            assertThat(contract.message(), is("named"));
         } finally {
             manager.shutdown();
         }


### PR DESCRIPTION
- get, first, all for qualified instances
- get, first, all methods for named instances (i.e. the only qualifier is a `@Service.Named`)
- late binding method for setting qualified instance
- late binding method for setting named instance


Resolves #10292 
