### PR TITLE
4.2.4: Shutdown services in reverse order (fixes issue #10239)

### DIFF
--- a/docs/src/main/asciidoc/se/injection.adoc
+++ b/docs/src/main/asciidoc/se/injection.adoc
@@ -877,18 +877,17 @@ is the annotation used for specifying the steps in which certain services should
 It always starts from the lowest number to the highest.
 It is possible to have one or more services in each run level.
 When more than one service is defined to a specific run level, the order of creation is defined by
-link:{common-javadoc-base-url}/io/helidon/common/Weight.html[`@Weight`].
+link:{common-javadoc-base-url}/io/helidon/common/Weight.html[`@Weight`] from highest weight to lowest.
 
-To start, add the
-link:{service-registry-base-url}/io/helidon/service/registry/Service.RunLevel.html[`@Service.RunLevel`]
-on the service.
 
+When the service manager shuts down it destroys services in the opposite order, from highest run-level value to lowest and, within a single run level, from lowest weight to highest.
+
+We can also add methods which are executed after service construction and before service destruction, respectively.
 [source,java]
 ----
 include::{sourcedir}/se/inject/RunLevelExample.java[tag=snippet_1, indent=0]
 ----
 
-For better understanding, we can also add helpful method, which get executed post service construction.
 
 The easiest way for us to use these annotations, is to use `start` method on the
 link:{service-registry-base-url}/io/helidon/service/registry/ServiceRegistryManager.html[`ServiceRegistryManager`].
@@ -903,4 +902,6 @@ Once executed, we get the following output:
 ----
 level1 created
 level2 created
+level2 destroyed
+level1 destroyed
 ----

--- a/docs/src/main/java/io/helidon/docs/se/inject/RunLevelExample.java
+++ b/docs/src/main/java/io/helidon/docs/se/inject/RunLevelExample.java
@@ -32,6 +32,10 @@ class RunLevelExample {
         void onCreate() {
             System.out.println("level1 created");
         }
+
+        @Service.PreDestroy
+        void onDestroy() {
+            System.out.println("level1 destroyed"); }
     }
 
     @Service.RunLevel(2)
@@ -42,6 +46,10 @@ class RunLevelExample {
         void onCreate() {
             System.out.println("level2 created");
         }
+
+        @Service.PreDestroy
+        void onDestroy() {
+            System.out.println("level2 destroyed"); }
     }
     // end::snippet_1[]
 

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -156,7 +156,8 @@ class ScopedRegistryImpl implements ScopedRegistry {
     private static Comparator<? super Activator<?>> shutdownComparator() {
         return Comparator
                 .<Activator<?>>comparingDouble(it -> it.descriptor().runLevel().orElse(Service.RunLevel.NORMAL))
-                .thenComparing(it -> it.descriptor().weight());
+                .thenComparing(it -> it.descriptor().weight())
+                .reversed();
     }
 
     private void checkActive() {

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/StartStopFixture.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/StartStopFixture.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.Service.PostConstruct;
+import io.helidon.service.registry.Service.PreDestroy;
+
+interface StartStopFixture {
+    Queue<String> startUpQueue = new ArrayBlockingQueue<>(3);
+    Queue<String> shutDownQueue = new ArrayBlockingQueue<>(3);
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP)
+    static class Service1 implements StartStopFixture {
+        @PostConstruct
+        void startUp() {
+            startUpQueue.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            shutDownQueue.add(getClass().getSimpleName());
+        }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP + 1)
+    static class Service2 implements StartStopFixture {
+        @PostConstruct
+        void startUp() {
+            startUpQueue.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            shutDownQueue.add(getClass().getSimpleName());
+        }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.STARTUP + 2)
+    static class Service3 implements StartStopFixture {
+        @PostConstruct
+        void startUp() {
+            startUpQueue.add(getClass().getSimpleName());
+        }
+
+        @PreDestroy
+        void shutDown() {
+            shutDownQueue.add(getClass().getSimpleName());
+        }
+    }
+
+}

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/StartStopTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/StartStopTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.test.registry.StartStopFixture;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+class StartStopTest {
+
+    @Test
+    void test() {
+        var config = ServiceRegistryConfig.create();
+        var manager = ServiceRegistryManager.start(config);
+        var services = manager.registry().all(StartStopFixture.class);
+        assertThat(services, hasSize(3));
+
+        manager.shutdown();
+
+        assertThat(StartStopFixture.startUpQueue, contains("Service1", "Service2", "Service3"));
+        assertThat(StartStopFixture.shutDownQueue, contains("Service3", "Service2", "Service1"));
+    }
+}


### PR DESCRIPTION

Backport #10240 to Helidon 4.2.4

### Problem Description

Due to a wrong shutdown order of Helidon services, we run into errors, because dependent services are already shut down (see a detailed explanation in https://github.com/helidon-io/helidon/issues/10239).

### Documentation

With this change, Helidon services will be shut down in reverse chronological order in which they were started. This fixes issue https://github.com/helidon-io/helidon/issues/10239.