### PR TITLE
 4.2.4: Fix test problems with REST client metrics; also fix lack of support for on-demand registration of REST client metrics

### DIFF
--- a/microprofile/rest-client-metrics/src/main/java/io/helidon/microprofile/restclientmetrics/RestClientMetricsClientListener.java
+++ b/microprofile/rest-client-metrics/src/main/java/io/helidon/microprofile/restclientmetrics/RestClientMetricsClientListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,10 @@ public class RestClientMetricsClientListener implements RestClientListener {
 
     /*
     The listener can be instantiated multiple times, so we delegate the real work to a singleton.
+    The listener is an instance field instead of static so tests that create multiple containers in the
+    same JVM do not incorrectly all refer to only the first REST client metrics CDI extension.
      */
-    private static final LazyValue<Listener> LISTENER = LazyValue.create(Listener::new);
+    private final LazyValue<Listener> listener = LazyValue.create(Listener::new);
 
     /**
      * For service discovery.
@@ -44,7 +46,7 @@ public class RestClientMetricsClientListener implements RestClientListener {
 
     @Override
     public void onNewClient(Class<?> serviceInterface, RestClientBuilder builder) {
-        LISTENER.get().onNewClient(serviceInterface, builder);
+        listener.get().onNewClient(serviceInterface, builder);
     }
 
     private static class Listener {
@@ -62,6 +64,13 @@ public class RestClientMetricsClientListener implements RestClientListener {
                             .build();
                 });
 
+        /*
+        In some cases, the system will invoke REST client listeners before CDI has completed its startup. The REST client metrics
+        CDI extension registers the meters to be updated for each REST client method, so this listener has nothing to do if
+        it runs before CDI has initialized the extension. That said, it needs to keep retrying to locate the CDI extension
+        because the extension might (should) become available later. The code below uses a utility method to access this
+        lazy value to allow that retry behavior.
+         */
         private final LazyValue<RestClientMetricsCdiExtension> ext =
                 LazyValue.create(() -> CDI.current().getBeanManager().getExtension(RestClientMetricsCdiExtension.class));
 
@@ -77,7 +86,7 @@ public class RestClientMetricsClientListener implements RestClientListener {
                 // register metrics (and create metric-related work for the filter to do) only upon first
                 // discovering a given service interface.
                 if (restClientsDiscovered.add(serviceInterface)) {
-                    ext.get().registerMetricsForRestClient(serviceInterface);
+                    Utils.optOf(ext).ifPresent(ext -> ext.registerMetricsForRestClient(serviceInterface));
                 }
                 builder.register(restClientMetricsFilter, Priorities.USER - 100);
             }

--- a/microprofile/rest-client-metrics/src/main/java/io/helidon/microprofile/restclientmetrics/Utils.java
+++ b/microprofile/rest-client-metrics/src/main/java/io/helidon/microprofile/restclientmetrics/Utils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.restclientmetrics;
+
+import java.util.Optional;
+
+import io.helidon.common.LazyValue;
+
+class Utils {
+
+    private Utils() {
+    }
+
+    /**
+     * Wraps an {@link java.util.Optional} around the {@code lazyValue.get()} result, returning an
+     * {@code Optional.of(lazyValue.get())} if the lazy value successfully returns its value and an empty
+     * {@code Optional} if the lazy value cannot be loaded.
+     *
+     * @param lazyValue the {@link io.helidon.common.LazyValue} to wrap
+     * @return an {@code Optional} as described above
+     */
+    static <T> Optional<T> optOf(LazyValue<T> lazyValue) {
+        try {
+            return Optional.of(lazyValue.get());
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/microprofile/rest-client-metrics/src/test/java/io/helidon/microprofile/restclientmetrics/TestWithBeanNotAddedButInvoked.java
+++ b/microprofile/rest-client-metrics/src/test/java/io/helidon/microprofile/restclientmetrics/TestWithBeanNotAddedButInvoked.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.restclientmetrics;
+
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.WebTarget;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+
+@HelidonTest
+class TestWithBeanNotAddedButInvoked {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void testServiceClientWhenNotAdded() {
+        // Following should not fail, even though the CDI extension was not notified of the type
+        // because we did not add it as a bean. This simulates some tests in the MP REST client TCK.
+        RestClientBuilder.newBuilder()
+                .baseUri(webTarget.getUri())
+                .build(TestScanning.ServiceClient.class);
+    }
+
+    @Path("/")
+    interface ServiceClient {
+    }
+}

--- a/microprofile/tests/tck/tck-rest-client/pom.xml
+++ b/microprofile/tests/tck/tck-rest-client/pom.xml
@@ -39,6 +39,15 @@
             <artifactId>helidon-microprofile-rest-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+            Adding the REST client metrics support is not required for the REST client TCK to work,
+            but it exercises the metrics support in a very broad set of use cases.
+        -->
+        <dependency>
+            <groupId>io.helidon.microprofile.rest-client-metrics</groupId>
+            <artifactId>helidon-microprofile-rest-client-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>


### PR DESCRIPTION
Backport #10274 to Helidon 4.2.4

### Description
Resolves #10264 

## Release note
----
* Helidon's support for MicroProfile REST Client allows applications to use an interface that is _not_ discovered or injected by CDI for a REST client. (See [this section](https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html#_sample_builder_usage) in the MP REST Client spec.) Helidon's metrics support for REST clients did not correctly support such usage but this PR fixes that.
* Helidon's REST client metrics support now works properly in test scenarios where the Helidon container starts more than once in a JVM.
----

## PR overview 

1. Tests that run multiple REST clients in a reused JVM could fail.
 
 The code uses a CDI extension to register meters to be updated when user code invokes REST client methods, and a REST client filter updates those meters at call-time. The filter relies on data structures built by and stored in the extension.
 
 The code had a _static_ field holding a reference to the extension. This has worked correctly in production situations with one Helidon container per JVM, but in test suites that run the Helidon container multiple times the listener would always use the _first_ extension because of the static field. This PR changes that to an _instance_ field which is functionally the same in production runs but solves the testing problem.
2. The code now correctly supports when user code registers a REST client interface that is not known ahead of time to CDI. (REST clients can be activated programmatically before CDI is fully initialized.) 
 
 The Helidon REST client metrics support did not handle this case, throwing an NPE. Now this scenario works correctly. 
3. To test the REST client metrics code more, this PR updates the _REST client_ TCK, adding a test dependency on REST client metrics. Even though the code in the REST client TCK does not have any metrics annotations, adding the dependency revealed a timing issue which this PR also resolves, described next.
4. Recall that the extension registers the meters to update, the listener learns when new REST clients are activated, and it registers a REST client filter with each activated REST client. The filter uses the CDI extension's data structures to update the appropriate timers and counters when the user code invokes uses the REST client.
 
 As mentioned above, in some cases, the REST client mechanism can initialize and use listeners and filters _before_ CDI has completed its startup so the extension might not be ready. The listener and filter in this component have a `LazyValue` for the extension and they also tolerate if loading the `LazyValue` fails because CDI is not available yet. As with any `LazyValue` on each usage the filter and listener invoke `lazyValue.get()` which tries to load the `LazyValue` again. Eventually--once CDI is up--they obtain a valid reference to the extension. Until then no REST client metrics are supported on those early-activated REST clients.

### Documentation
No change. These are bug fixes.