### PR TITLE
Check consistency of x-forwarded- headers; fix incorrect port assignment in compatibility helper

### DIFF
--- a/http/http/src/main/java/io/helidon/http/RequestedUriDiscoveryContext.java
+++ b/http/http/src/main/java/io/helidon/http/RequestedUriDiscoveryContext.java
@@ -73,7 +73,7 @@ public interface RequestedUriDiscoveryContext {
      * @param isSecure      whether the request is secure
      * @return {@code UriInfo} which reconstructs, as well as possible, the requested URI from the originating client
      * @deprecated Use
-     *         {@link RequestedUriDiscoveryContext#uriInfo(java.net.InetSocketAddress, java.net.InetSocketAddress, String,
+     *         {@link RequestedUriDiscoveryContext#uriInfo(java.net.SocketAddress, java.net.SocketAddress, String,
      *         ServerRequestHeaders, io.helidon.common.uri.UriQuery, boolean)}
      */
     @Deprecated(forRemoval = true, since = "4.2.1")
@@ -449,7 +449,7 @@ public interface RequestedUriDiscoveryContext {
                 String path = null;
 
                 List<String> xForwardedFors = headers.values(HeaderNames.X_FORWARDED_FOR);
-                boolean areProxiesTrusted = true;
+                boolean areProxiesTrusted = !xForwardedFors.isEmpty();
                 if (!xForwardedFors.isEmpty()) {
                     // Intentionally skip the first X-Forwarded-For value. That is the originating client, and as such it
                     // is not a proxy and we do not need to check its trustworthiness.

--- a/http/http/src/main/java/io/helidon/http/UriInfoCompatibilityHelper.java
+++ b/http/http/src/main/java/io/helidon/http/UriInfoCompatibilityHelper.java
@@ -54,7 +54,7 @@ final class UriInfoCompatibilityHelper {
             return ctx.uriInfo(InetSocketAddress.createUnresolved(remoteMatcher.group(1),
                                                                   remotePort.isEmpty() ? 0 : Integer.parseInt(remotePort)),
                                InetSocketAddress.createUnresolved(localMatcher.group(1),
-                                                                  localPort.isEmpty() ? 0 : Integer.parseInt(remotePort)),
+                                                                  localPort.isEmpty() ? 0 : Integer.parseInt(localPort)),
                                requestPath, headers, query, isSecure);
         }
 


### PR DESCRIPTION
### Description
Resolves #10335 

## Release note
Helidon's requested URI support now better checks consistency of the `X-Forwarded-*` family of headers before applying them.


## PR overview
1. If the `X-Forwarded-For` header is absent, the code ignores the other `X-Forwarded-*` headers.
2. The `UriInfoCompatibilityHelper#uriInfo` method incorrectly used the _remote_ port in creating the `InetSocketAddress` for the _local_ address.
3. Added tests for # 1 above.

### Documentation
Bug fix; no impact.