### PR TITLE
3.x Express Prometheus timer sum in untruncated (decimal) seconds

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -375,7 +375,7 @@ abstract class MetricImpl extends AbstractMetric implements HelidonMetric {
                                            boolean withHelpType, long count, long sum, DisplayableLabeledSnapshot snap,
                                            boolean isStrictExemplars) {
         PrometheusName name = PrometheusName.create(this, metricID);
-        appendPrometheusHistogramElements(sb, name, getUnits(), withHelpType, count, sum, snap, isStrictExemplars);
+        appendPrometheusHistogramElements(sb, name, getUnits(), withHelpType, count, Long.toString(sum), snap, isStrictExemplars);
     }
 
     void appendPrometheusHistogramElements(StringBuilder sb,
@@ -390,19 +390,19 @@ abstract class MetricImpl extends AbstractMetric implements HelidonMetric {
                                           TimeUnits.PROMETHEUS_TIMER_CONVERSION_TIME_UNITS,
                                           withHelpType,
                                           count,
-                                          elapsedTime.toSeconds(),
+                                          Double.toString(elapsedTime.toNanos() / 1_000_000_000d),
                                           snap,
                                           isStrictExemplars);
     }
 
-    void appendPrometheusHistogramElements(StringBuilder sb,
-                                           PrometheusName name,
-                                           Units units,
-                                           boolean withHelpType,
-                                           long count,
-                                           long sum,
-                                           DisplayableLabeledSnapshot snap,
-                                           boolean isStrictExemplars) {
+    private void appendPrometheusHistogramElements(StringBuilder sb,
+                                                   PrometheusName name,
+                                                   Units units,
+                                                   boolean withHelpType,
+                                                   long count,
+                                                   String sum,
+                                                   DisplayableLabeledSnapshot snap,
+                                                   boolean isStrictExemplars) {
 
         // # TYPE application:file_sizes_mean_bytes gauge
         // application:file_sizes_mean_bytes 4738.231

--- a/metrics/metrics/src/test/java/io/helidon/metrics/HelidonTimerTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/HelidonTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -234,7 +234,7 @@ class HelidonTimerTest {
                 # TYPE application_response_time_seconds summary
                 # HELP application_response_time_seconds Server response time for /index.html
                 application_response_time_seconds_count 200
-                application_response_time_seconds_sum 0"""));
+                application_response_time_seconds_sum""")); // After bug fix, no telling what the value starts with in E notation.
     }
 
     @Test


### PR DESCRIPTION
### Description
Resolves #10337 

## Release note

____
Helidon 3.x formerly expressed the timer `sum` value (total elapsed time) in Prometheus output  in _truncated_ seconds, so sums less than 1 would be reported as 0. Now the value is in seconds but not truncated.
____

## PR overview
The timer exposes the total elapsed time as a `Duration`. The code to produce Prometheus output would use `duration.toSeconds()` which converted _and truncated_ the time to seconds.

The code now extracts the value in nanoseconds and divides it to convert to decimal (non-truncated) seconds.

### Documentation
No impact; bug fix.