### PR TITLE
Use Services.get(Config.class) instead of global config

### DIFF
--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>helidon-builder-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.features</groupId>
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigSupport.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigSupport.java
@@ -19,7 +19,8 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 import io.helidon.builder.api.Prototype;
-import io.helidon.common.config.GlobalConfig;
+import io.helidon.common.config.Config;
+import io.helidon.service.registry.Services;
 
 class MetricsConfigSupport {
 
@@ -82,7 +83,7 @@ class MetricsConfigSupport {
         @Override
         public void decorate(MetricsConfig.BuilderBase<?, ?> builder) {
             if (builder.config().isEmpty()) {
-                builder.config(GlobalConfig.config().get(MetricsConfigBlueprint.METRICS_CONFIG_KEY));
+                builder.config(Services.get(Config.class).get(MetricsConfigBlueprint.METRICS_CONFIG_KEY));
             }
             if (builder.keyPerformanceIndicatorMetricsConfig().isEmpty()) {
                 builder.keyPerformanceIndicatorMetricsConfig(KeyPerformanceIndicatorMetricsConfig.create());

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public interface MetricsFactory {
     /**
      * Returns the most-recently created implementation or, if none, a new one from a highest-weight provider available at
      * runtime and using the {@value MetricsConfigBlueprint#METRICS_CONFIG_KEY} section from the
-     * {@link io.helidon.common.config.GlobalConfig}.
+     * current config.
      *
      * @return current or new metrics factory
      */
@@ -96,7 +96,7 @@ public interface MetricsFactory {
      * {@link #getInstance()}.{@link #createMeterRegistry(MetricsConfig)} with a
      * {@link MetricsConfig} instance derived from the root {@link io.helidon.common.config.Config} most recently passed to
      * {@link #getInstance(io.helidon.common.config.Config)}, or if none then the config from
-     * {@link io.helidon.common.config.GlobalConfig}.
+     * current {@link io.helidon.common.config.Config}.
      *
      * @return the global meter registry
      */

--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsFactoryManager.java
@@ -26,10 +26,10 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
 import io.helidon.common.Weighted;
 import io.helidon.common.config.Config;
-import io.helidon.common.config.GlobalConfig;
 import io.helidon.metrics.spi.MetersProvider;
 import io.helidon.metrics.spi.MetricsFactoryProvider;
 import io.helidon.metrics.spi.MetricsProgrammaticConfig;
+import io.helidon.service.registry.Services;
 
 /**
  * Provides {@link io.helidon.metrics.api.MetricsFactory} instances using a highest-weight implementation of
@@ -40,8 +40,8 @@ import io.helidon.metrics.spi.MetricsProgrammaticConfig;
  * resulting metrics factory as the most recent.
  * <p>
  * Invoking {@code getMetricsFactory()} (no argument) <em>before</em> invoking the variant with the
- * {@link io.helidon.common.config.Config} parameter creates and saves a metrics factory using the
- * {@link io.helidon.common.config.GlobalConfig}.
+ * {@link io.helidon.common.config.Config} parameter creates and saves a metrics factory using the current
+ * {@link io.helidon.common.config.Config}.
  * <p>
  * The {@link #create(Config)} method neither reads nor updates the most-recently used config and factory.
  */
@@ -156,9 +156,10 @@ class MetricsFactoryManager {
     }
 
     private static Config externalMetricsConfig() {
-        Config serverFeaturesMetricsConfig = GlobalConfig.config().get("server.features.observe.observers.metrics");
+        Config currentConfig = Services.get(Config.class);
+        Config serverFeaturesMetricsConfig = currentConfig.get("server.features.observe.observers.metrics");
         if (!serverFeaturesMetricsConfig.exists()) {
-            serverFeaturesMetricsConfig = GlobalConfig.config().get("metrics");
+            serverFeaturesMetricsConfig = currentConfig.get("metrics");
         }
         return serverFeaturesMetricsConfig;
     }

--- a/metrics/api/src/main/java/module-info.java
+++ b/metrics/api/src/main/java/module-info.java
@@ -32,6 +32,7 @@ import io.helidon.common.features.api.HelidonFlavor;
     requires transitive io.helidon.common.config;
 
     requires io.helidon.builder.api;
+    requires io.helidon.service.registry;
     requires static io.helidon.config.metadata;
 
     exports io.helidon.metrics.api;

--- a/metrics/providers/micrometer/pom.xml
+++ b/metrics/providers/micrometer/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactory.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import io.helidon.metrics.api.Timer;
 import io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider;
 import io.helidon.metrics.spi.MeterRegistryLifeCycleListener;
 import io.helidon.metrics.spi.MetersProvider;
+import io.helidon.service.registry.Services;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
@@ -160,7 +161,7 @@ class MicrometerMetricsFactory implements MetricsFactory {
     public MeterRegistry globalRegistry() {
         return globalMeterRegistry != null
                 ? globalMeterRegistry
-                : globalRegistry(MetricsConfig.create(Config.global().get(MetricsConfig.METRICS_CONFIG_KEY)));
+                : globalRegistry(MetricsConfig.create(Services.get(Config.class).get(MetricsConfig.METRICS_CONFIG_KEY)));
     }
 
     @Override

--- a/metrics/providers/micrometer/src/main/java/module-info.java
+++ b/metrics/providers/micrometer/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/providers/micrometer/src/main/java/module-info.java
+++ b/metrics/providers/micrometer/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module io.helidon.metrics.providers.micrometer {
     requires simpleclient.common;
     requires simpleclient.tracer.common;
     requires simpleclient;
+    requires io.helidon.service.registry;
 
     exports io.helidon.metrics.providers.micrometer.spi;
 


### PR DESCRIPTION
### Description
Resolves #10320 

Changes several lines to use `Services.get(Config.class)` instead of `GlobalConfig` or `Config.global()`.

### Documentation
No impact