### PR TITLE
 4.2.4:  Full debugging possible for HTTP client requests

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientImpl.java
@@ -72,6 +72,7 @@ class Http1ClientImpl implements Http1Client, HttpClientSpi {
         // this method is called from the "generic" HTTP client, that can support any version (that is on classpath).
         // usually HTTP/1.1 is either the only available, or a fallback if other versions cannot be used
         Http1ClientRequest request = new Http1ClientRequestImpl(this,
+                                                                clientRequest,
                                                                 clientRequest.method(),
                                                                 clientUri,
                                                                 clientRequest.sendExpectContinue().orElse(null),

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
+import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
@@ -31,6 +32,7 @@ import io.helidon.http.media.InstanceWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.FullClientRequest;
 import io.helidon.webclient.api.Proxy.ProxyType;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
@@ -38,27 +40,30 @@ import io.helidon.webclient.api.WebClientServiceResponse;
 class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1ClientResponse> implements Http1ClientRequest {
     private static final System.Logger LOGGER = System.getLogger(Http1ClientRequestImpl.class.getName());
     private final Http1ClientImpl http1Client;
+    private final FullClientRequest<?> delegate;
 
     Http1ClientRequestImpl(Http1ClientImpl http1Client,
                            Method method,
                            ClientUri clientUri,
                            Map<String, String> properties) {
-        this(http1Client, method, clientUri, null, properties);
+        this(http1Client, null, method, clientUri, null, properties);
     }
 
     Http1ClientRequestImpl(Http1ClientImpl http1Client,
-                               Method method,
-                               ClientUri clientUri,
-                               Boolean sendExpectContinue,
-                               Map<String, String> properties) {
+                           FullClientRequest<?> delegate,
+                           Method method,
+                           ClientUri clientUri,
+                           Boolean sendExpectContinue,
+                           Map<String, String> properties) {
         super(http1Client.clientConfig(),
-                http1Client.webClient().cookieManager(),
-                Http1Client.PROTOCOL_ID,
-                method,
-                clientUri,
-                sendExpectContinue,
-                properties);
+              http1Client.webClient().cookieManager(),
+              Http1Client.PROTOCOL_ID,
+              method,
+              clientUri,
+              sendExpectContinue,
+              properties);
         this.http1Client = http1Client;
+        this.delegate = delegate;
     }
 
     //Copy constructor for redirection purposes
@@ -67,10 +72,11 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
                            ClientUri clientUri,
                            Map<String, String> properties) {
         this(request.http1Client,
-                method,
-                clientUri,
-                null,
-                properties);
+             null,
+             method,
+             clientUri,
+             null,
+             properties);
 
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
@@ -231,6 +237,10 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
                     return null;
                 });
 
+        if (delegate != null) {
+            ClientRequestHeaders delegateHeaders = delegate.headers();
+            this.headers().forEach(delegateHeaders::set);
+        }
         return new Http1ClientResponseImpl(clientConfig(),
                                            http1Client().protocolConfig(),
                                            serviceResponse.status(),

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
         UriQueryWriteable query = UriQueryWriteable.create();
         clientConfig.baseQuery().ifPresent(query::from);
 
-        return new Http2ClientRequestImpl(this, method, clientUri, clientConfig.properties());
+        return new Http2ClientRequestImpl(this, null, method, clientUri, clientConfig.properties());
     }
 
     @Override
@@ -87,6 +87,7 @@ public class Http2ClientImpl implements Http2Client, HttpClientSpi {
     @Override
     public ClientRequest<?> clientRequest(FullClientRequest<?> clientRequest, ClientUri clientUri) {
         Http2ClientRequest request = new Http2ClientRequestImpl(this,
+                                                                clientRequest,
                                                                 clientRequest.method(),
                                                                 clientUri,
                                                                 clientRequest.properties());

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.GenericType;
@@ -100,6 +101,22 @@ class Http1ClientTest {
         rules.put("/afterRedirect", Http1ClientTest::afterRedirectPut);
         rules.put("/chunkresponse", Http1ClientTest::chunkResponseHandler);
         rules.put("/delayedEndpoint", Http1ClientTest::delayedHandler);
+    }
+
+    @Test
+    void testRequestHeadersUpdated() {
+        var client = WebClient.builder()
+                .baseUri(baseURI)
+                .build();
+
+        HttpClientRequest request = client.get("/test");
+
+        request.request(String.class);
+
+        // this header is computed by Helidon, and would not be present unless the bug 10175 was fixed
+        assertThat(request.headers().contentLength(), is(OptionalLong.of(0)));
+
+        client.closeResource();
     }
 
     @Test


### PR DESCRIPTION
Backport #10231 to Helidon 4.2.4

... and responses with dedicated loggers

Client request contains headers used when sending the request after the request was sent (even when using the general `WebClient`)


### Description
Resolves #10175 
