### PR TITLE
4.2.4: Bump com.oracle.oci.sdk:oci-java-sdk-bom from 3.67.0 to 3.68.0 in /dependencies

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -132,7 +132,7 @@
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
         <version.lib.netty>4.1.118.Final</version.lib.netty>
-        <version.lib.oci>3.62.1</version.lib.oci>
+        <version.lib.oci>3.68.0</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <!--
             UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.


### PR DESCRIPTION
Backport #10325 to Helidon 4.2.4

Bumps [com.oracle.oci.sdk:oci-java-sdk-bom](https://github.com/oracle/oci-java-sdk) from 3.67.0 to 3.68.0.



