### PR TITLE
Use common config instead of config with `Services.get`

### DIFF
--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactory.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactory.java
@@ -27,7 +27,7 @@ import java.util.function.ToDoubleFunction;
 
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
-import io.helidon.config.Config;
+import io.helidon.common.config.Config;
 import io.helidon.metrics.api.Clock;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.DistributionStatisticsConfig;


### PR DESCRIPTION
### Description
Resolves #10320 

One part of metrics attempted to find a registered service for `io.helidon.config.Config` when it should have looked for `io.helidon.common.config.Config`.

### Documentation
No impact.