### PR TITLE
4.2.4: 4.x: Do not warn about setting a config to registry when using Config.global

### DIFF
--- a/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
+++ b/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION

Backport #10367 to Helidon 4.2.4

Resolves #10361 
