### PR TITLE
4.x: Deprecate Google Login Security Provider

### DIFF
--- a/docs/src/main/asciidoc/includes/security/providers/google-login.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/google-login.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,11 @@ ifndef::rootdir[:rootdir: {docdir}/../../..]
 :keywords: helidon, security, google
 :feature-name: Google Login Security Provider
 
-Authenticates a token from request against Google identity provider
+[.line-through]#Authenticates a token from request against Google identity provider#
+
+This provider is deprecated and will be removed in a future version of Helidon.
+Please use our OpenID Connect security provider instead.
+
 
 ==== Setup
 

--- a/docs/src/main/asciidoc/mp/security/providers.adoc
+++ b/docs/src/main/asciidoc/mp/security/providers.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ The following providers are no longer evolved:
 |===
 ^|Provider ^|Type ^|Outbound supported ^|Description
 
-|<<Google Login Provider,Google Login>> |Authentication |✅ |Authenticates a token from request against Google servers
+|<<Google Login Provider,Google Login>> |Authentication |✅ |*Deprecated!* Authenticates a token from request against Google servers
 |<<JWT Provider,JWT Provider>> |Authentication |✅ |JWT tokens passed from frontend
 |===
 

--- a/docs/src/main/asciidoc/se/security/providers.adoc
+++ b/docs/src/main/asciidoc/se/security/providers.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ The following providers are no longer evolved:
 |===
 ^|Provider ^|Type ^|Outbound supported ^|Description
 
-|<<Google Login Provider,Google Login>> |Authentication |✅ |Authenticates a token from request against Google servers
+|<<Google Login Provider,Google Login>> |Authentication |✅ |*Deprecated*! Authenticates a token from request against Google servers
 |<<JWT Provider,JWT Provider>> |Authentication |✅ |JWT tokens passed from frontend
 |===
 

--- a/security/providers/google-login/pom.xml
+++ b/security/providers/google-login/pom.xml
@@ -104,7 +104,7 @@
                         </path>
                         <path>
                             <groupId>io.helidon.common.features</groupId>
-                            <artifactId>helidon-common-features-processor</artifactId>
+                            <artifactId>helidon-common-features-codegen</artifactId>
                             <version>${helidon.version}</version>
                         </path>
                         <path>
@@ -122,7 +122,7 @@
                     </dependency>
                     <dependency>
                         <groupId>io.helidon.common.features</groupId>
-                        <artifactId>helidon-common-features-processor</artifactId>
+                        <artifactId>helidon-common-features-codegen</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                     <dependency>

--- a/security/providers/google-login/src/main/java/module-info.java
+++ b/security/providers/google-login/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-import io.helidon.common.features.api.Aot;
-import io.helidon.common.features.api.Feature;
+import io.helidon.common.features.api.Features;
 import io.helidon.common.features.api.HelidonFlavor;
 
 /**
  * Google login authentication provider.
+ *
+ * @deprecated use our OpenID Connect security provider instead
  */
-@Feature(value = "Google Login",
-        description = "Security provider for Google login button authentication and outbound",
-        in = {HelidonFlavor.SE, HelidonFlavor.MP},
-        path = {"Security", "Provider", "Google-Login"}
-)
-@Aot(false)
+@Features.Name("Google Login")
+@Features.Description("Security provider for Google login button authentication and outbound")
+@Features.Flavor({HelidonFlavor.SE, HelidonFlavor.MP})
+@Features.Path({"Security", "Provider", "Google-Login"})
+@Features.Aot(false)
+@Deprecated(forRemoval = true, since = "4.3.0")
 module io.helidon.security.providers.google.login {
 
     requires com.google.api.client.auth;


### PR DESCRIPTION
Updated documentation

Resolves #10044 
