### PR TITLE
4.x: Fix issue with invalid registry if global registry is shutdown

### DIFF
--- a/common/context/context/src/main/java/io/helidon/common/context/Context.java
+++ b/common/context/context/src/main/java/io/helidon/common/context/Context.java
@@ -90,6 +90,16 @@ public interface Context {
     <T> void register(T instance);
 
     /**
+     * Remove an instance registration from the context.
+     *
+     * @param instance an instance to remove from context
+     * @param <T> type of the instance
+     */
+    default <T> void unregister(T instance) {
+        // do nothing by default for backward compatibility
+    }
+
+    /**
      * Register a new instance using a provided supplier. The supplier is guaranteed to be called at most once when it's
      * requested by the {@link #get(Class)} method. The returned value is then registered and the supplier is never used again.
      *
@@ -124,6 +134,17 @@ public interface Context {
      * @throws NullPointerException if {@code classifier} or registered object is {@code null}
      */
     <T> void register(Object classifier, T instance);
+
+    /**
+     * Remove an instance registration from the context.
+     *
+     * @param classifier an additional registered instance classifier
+     * @param instance an instance to remove from context
+     * @param <T> type of the instance
+     */
+    default <T> void unregister(Object classifier, T instance) {
+        // do nothing by default for backward compatibility
+    }
 
     /**
      * Registers a new instance using a provided supplier. The supplier is guarantied to be called at most once when it's

--- a/common/context/context/src/test/java/io/helidon/common/context/ContextsTest.java
+++ b/common/context/context/src/test/java/io/helidon/common/context/ContextsTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  * Unit test for {@link Contexts}.
@@ -225,5 +226,27 @@ class ContextsTest {
         Contexts.clear();
 
         assertThat(Contexts.context(), is(Optional.empty()));
+    }
+
+    @Test
+    void testUnregister() {
+        Context topLevel = Contexts.globalContext();
+        Context mine = Context.builder()
+                .parent(topLevel)
+                .id("unit-test-testUnregister")
+                .build();
+
+        MyType registered = new MyType();
+        mine.register(registered);
+        MyType actual = mine.get(MyType.class).get();
+
+        assertThat(actual, sameInstance(registered));
+
+        mine.unregister(registered);
+
+        assertThat(mine.get(MyType.class), is(Optional.empty()));
+    }
+
+    private static class MyType {
     }
 }

--- a/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistryManager.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ServiceRegistryManager.java
@@ -221,6 +221,11 @@ public final class ServiceRegistryManager {
                 return;
             }
 
+            ServiceRegistry global = GlobalServiceRegistry.registry();
+            if (global == registry) {
+                // this is the same instance, if we shut it down, global would stop working
+                GlobalServiceRegistry.unset(registry);
+            }
             registry.shutdown();
             registry = null;
         } finally {


### PR DESCRIPTION
Added support for unregistering an object from the registry.
Service registry manager now removes the global service registry if it is the same instance it manages, to make sure we do not have a stale registry configured.


Resolves #10311 