### PR TITLE
4.x: Update Jakarta EL implementation to org.glassfish.expressly:expressly:5.0.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -47,6 +47,8 @@
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.dropwizard.metrics>4.1.36</version.lib.dropwizard.metrics>
         <version.lib.eclipselink>4.0.7</version.lib.eclipselink>
+        <!-- el-impl has been replaced by expressly. But we still manage version to not break existing application poms -->
+        <version.lib.el-impl>4.0.2</version.lib.el-impl>
         <version.lib.expressly>5.0.0</version.lib.expressly>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>
@@ -333,6 +335,13 @@
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
                 <version>${version.lib.jaxb-runtime}</version>
+            </dependency>
+            <dependency>
+                <!-- contains the API as well -->
+                <!-- Has been replaced by expressly. We manage version to not break existing application poms -->
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.el</artifactId>
+                <version>${version.lib.el-impl}</version>
             </dependency>
             <dependency>
                 <!-- Jakarta EL implementation -->

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -47,7 +47,7 @@
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.dropwizard.metrics>4.1.36</version.lib.dropwizard.metrics>
         <version.lib.eclipselink>4.0.7</version.lib.eclipselink>
-        <version.lib.el-impl>4.0.2</version.lib.el-impl>
+        <version.lib.expressly>5.0.0</version.lib.expressly>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>
         <version.lib.google-api-client>2.7.2</version.lib.google-api-client>
@@ -335,10 +335,10 @@
                 <version>${version.lib.jaxb-runtime}</version>
             </dependency>
             <dependency>
-                <!-- contains the API as well -->
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>${version.lib.el-impl}</version>
+                <!-- Jakarta EL implementation -->
+                <groupId>org.glassfish.expressly</groupId>
+                <artifactId>expressly</artifactId>
+                <version>${version.lib.expressly}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.ws.rs</groupId>

--- a/microprofile/bean-validation/pom.xml
+++ b/microprofile/bean-validation/pom.xml
@@ -40,8 +40,8 @@
             <artifactId>hibernate-validator-cdi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>

--- a/microprofile/tests/tck/tck-cdi-lang-model/pom.xml
+++ b/microprofile/tests/tck/tck-cdi-lang-model/pom.xml
@@ -75,8 +75,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microprofile/tests/tck/tck-cdi/pom.xml
+++ b/microprofile/tests/tck/tck-cdi/pom.xml
@@ -60,8 +60,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security/abac/policy-el/pom.xml
+++ b/security/abac/policy-el/pom.xml
@@ -48,8 +48,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/integration/crac/pom.xml
+++ b/tests/integration/crac/pom.xml
@@ -131,8 +131,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/tests/integration/security/abac-policy/pom.xml
+++ b/tests/integration/security/abac-policy/pom.xml
@@ -40,8 +40,8 @@
             <artifactId>helidon-security-abac-policy-el</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/integration/security/gh1487/pom.xml
+++ b/tests/integration/security/gh1487/pom.xml
@@ -42,8 +42,8 @@
             <artifactId>helidon-security-abac-policy-el</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Description

Helidon 4 supports Jakarta EE 10 which has EL 5.  But to date the EL implementation used by Helidon has been `org.glassfish:jakarta.el:4.0.2` which is for EL 4.

This PR upgrades the EL implementation to  `org.glassfish.expressly:expressly:5.0.0` (Expressly is the Eclipse project producing the EL implementation).

Note that the old EL implementation included the EL API. The new implementation (Expressly) does not include the API, instead it has it as a dependency.

We continue to manage the version of `org.glassfish:jakarta.el` so that we do not break existing application poms (which might assume Helidon manages the version of this artifact).