### PR TITLE
4.x commons lang 3.18.0

### DIFF
--- a/config/etcd/pom.xml
+++ b/config/etcd/pom.xml
@@ -57,6 +57,18 @@
         <dependency>
             <groupId>org.mousio</groupId>
             <artifactId>etcd4j</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- for dependency convergence with handlebars -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${version.lib.commons-text}</version>
         </dependency>
         <!-- etcd v3 -->
         <dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -63,7 +63,7 @@
         <version.lib.guava>32.0.1-jre</version.lib.guava>
         <version.lib.h2>2.2.220</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
-        <version.lib.handlebars>4.3.1</version.lib.handlebars>
+        <version.lib.handlebars>4.4.0</version.lib.handlebars>
         <version.lib.hibernate.family>6.3</version.lib.hibernate.family>
         <version.lib.hibernate>${version.lib.hibernate.family}.1.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,8 @@
         <version.lib.jmh>1.23</version.lib.jmh>
         <version.lib.vertx-core>4.3.8</version.lib.vertx-core>
         <version.lib.wiremock>2.26.3</version.lib.wiremock>
-        <version.lib.commons-lang3>3.10</version.lib.commons-lang3>
+        <version.lib.commons-lang3>3.18.0</version.lib.commons-lang3>
+        <version.lib.commons-text>1.11.0</version.lib.commons-text>
         <version.lib.classgraph>4.8.165</version.lib.classgraph>
         <version.lib.plexus.classworlds>2.7.0</version.lib.plexus.classworlds>
         <version.lib.plexus.utils>3.3.0</version.lib.plexus.utils>


### PR DESCRIPTION
### Description

* Upgrade apache commons-lang to 3.18.0
* Upgrade handlebars to 4.4.0 to remove use of shaded commons-lang
* Force upgrade commons-text by etcd4j to resolve dependency convergence with handlebars 