### PR TITLE
4.2.x: Remove deprecation of Config.global() getter

### DIFF
--- a/archetypes/archetypes/src/main/archetype/se/common/common-se.xml
+++ b/archetypes/archetypes/src/main/archetype/se/common/common-se.xml
@@ -113,9 +113,8 @@
         // load logging configuration
         LogConfig.configureRuntime();
 
-        // initialize global config from default configuration
-        Config config = Config.create();
-        Config.global(config);
+        // initialize config from default configuration
+        Config config = Config.global();
 
         {{#Main-main}}
         {{.}}

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -406,11 +406,8 @@ public interface Config extends io.helidon.common.config.Config {
      * global config registered in not an instance of this type.
      *
      * @return global config instance, creates one if not yet registered
-     * @deprecated either use {@link io.helidon.service.registry.Services#get(Class)} instead for static access,
-     *  inject an instance into your service when creating a service, or use your service registry instance
      */
     @SuppressWarnings("removal")
-    @Deprecated(forRemoval = true, since = "4.2.0")
     static Config global() {
         if (io.helidon.common.config.GlobalConfig.configured()) {
             io.helidon.common.config.Config global = io.helidon.common.config.GlobalConfig.config();

--- a/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/Main.java
+++ b/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/Main.java
@@ -91,7 +91,7 @@ public final class Main {
         LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
-        Config config = Config.create();
+        Config config = Config.global();
 
         HealthObserver health = HealthObserver.builder()
                 .useSystemServices(false)


### PR DESCRIPTION
### Description

This is for 4.2.x

* Removes deprecation of `Config.global()`  getter
* Updates archetype to not use deprecated `Config.global(config)` setter
* Updates bookstore test application to use `Config.global()` getter instead of creating config instance.

