### PR TITLE
4.x grpc changes for proper event notification and tracing span propagation

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1481,6 +1481,11 @@
             </dependency>
             <dependency>
                 <groupId>io.helidon.webclient</groupId>
+                <artifactId>helidon-webclient-grpc-tracing</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.webclient</groupId>
                 <artifactId>helidon-webclient-sse</artifactId>
                 <version>${helidon.version}</version>
             </dependency>

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcTracingInterceptor.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcTracingInterceptor.java
@@ -264,13 +264,17 @@ public class GrpcTracingInterceptor implements ServerInterceptor {
 
         private void finishSpan(boolean ok) {
             spanLock.lock();
-            if (scope != null) {
-                scope.close();
-                scope = null;
-                if (!ok) {
-                    span.status(Span.Status.ERROR);
+            try {
+                if (scope != null) {
+                    scope.close();
+                    scope = null;
+                    if (!ok) {
+                        span.status(Span.Status.ERROR);
+                    }
+                    span.end();
                 }
-                span.end();
+            } finally {
+                spanLock.unlock();
             }
         }
     }


### PR DESCRIPTION
### Description
Resolves #10399 

Changes (thanks to Santiago for many of these):

* The new `helidon-webclient-grpc-tracing` component was added in an earlier PR but was not added to the bom.
* In the gRPC client tracing interceptor a new tracing span for the outgoing call was created but never made the current span; it is now made the current span (activated) prior to the outbound call and closed (stops being the current span) after the call is canceled or is fully sent.  
* In both the client and server tracing interceptor, because the gRPC processing can be asynchronous access to the created span is now via an `AtomicReference`. (Access to the scope is implicitly governed by the same `AtomicReference`.)
* In `GrpcUnaryClientCall`:
   * A field is renamed to more clearly convey its use. 
   * Requests without entities did not previously set `responseReceived`. It does now.
* `GrpcProtocolHandler` did not notify listeners when the message exchange was complete. It does now.

### Documentation
Bug fixes; no doc impact.