### PR TITLE
4.2.5 openai4j and grpc fp

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -230,5 +230,27 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <cve>CVE-2025-30694</cve>
 </suppress>
 
+<!-- False Positive.
+     This CVE is against ChatGPT rendering of SVG images  not the openai4j API
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: openai4j-0.23.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/dev\.ai4j/openai4j@.*$</packageUrl>
+   <cve>CVE-2025-43714</cve>
+</suppress>
+
+<!-- False Positive.
+     This CVE is against grpc/grpc C++ not gRPC Java
+     https://github.com/grpc/grpc/issues/36245
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-core-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*@.*$</packageUrl>
+   <cve>CVE-2024-7246</cve>
+</suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.1.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.1.3</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

* Upgrade dependency check plugin to 12.1.3
* Suppress openai4j and grpc false positives