### PR TITLE
Fix gRPC ALPN negotiation by advertising h2 protocol

### DIFF
--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,11 +54,11 @@ import io.helidon.webclient.api.DnsAddressLookup;
 import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webclient.http2.Http2ClientConnection;
 import io.helidon.webclient.http2.Http2ClientImpl;
 import io.helidon.webclient.http2.Http2StreamConfig;
 import io.helidon.webclient.http2.StreamTimeoutException;
-import io.helidon.webclient.http2.Http2Client;
 
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
@@ -83,7 +82,6 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
     protected static final BufferData PING_FRAME = BufferData.create("PING");
     protected static final BufferData EMPTY_BUFFER_DATA = BufferData.empty();
     protected static final int DATA_PREFIX_LENGTH = 5;
-
     protected static final Tag OK_TAG = Tag.create("grpc.status", "OK");
     protected record MethodMetrics(Counter callStarted,
                                    Timer callDuration,


### PR DESCRIPTION
Fixes #10431 

gRPC client fails to connect to standards-compliant TLS servers (like Netty) because it doesn't advertise any ALPN protocols during TLS handshake.

Replace `Collections.emptyList()` with `List.of(Http2Client.PROTOCOL_ID)` in `GrpcBaseClientCall.java` to properly advertise HTTP/2 protocol.

Enables gRPC client to work with all standards-compliant gRPC servers that require ALPN negotiation.