### PR TITLE
4.2.5: Upgrade protobuf to 3.25.8

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -338,7 +338,7 @@ jobs:
               verify
   _native-image:
     needs: build
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         os: [ ubuntu-22.04, macos-14, windows-2022 ]

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -53,7 +53,7 @@
         <version.lib.google-api-client>1.34.1</version.lib.google-api-client>
         <version.lib.google-oauth-client>1.33.3</version.lib.google-oauth-client>
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
-        <version.lib.google-protobuf>3.25.5</version.lib.google-protobuf>
+        <version.lib.google-protobuf>3.25.8</version.lib.google-protobuf>
         <version.lib.graalvm>23.1.0</version.lib.graalvm>
         <version.lib.graphql-java>22.1</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>22.0</version.lib.graphql-java.extended.scalars>


### PR DESCRIPTION
### Description

4.2.5: Upgrade protobuf to 3.25.8

Also increases native-image job timeout because native-image-mp-2-macos was timing out.