### PR TITLE
 4.2.5: Add ability to exclude health checks by name; clarify doc

### DIFF
--- a/docs/src/main/asciidoc/includes/health.adoc
+++ b/docs/src/main/asciidoc/includes/health.adoc
@@ -1,0 +1,64 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+// tag::built-in-health-checks-section[]
+[[built-in-health-checks-table]]
+=== Built-In Health Checks
+
+You can use Helidon-provided health checks to report various
+common health check statuses:
+
+// Had to move the anchor to the heading above because the rendered page did not define the ID
+// correctly on the table so the link did not work. The link itself looks OK; just no ID generated on the page.
+//[[built-in-health-checks-table]]
+[cols="1,1,3,15,3"]
+|=======
+|Built-in health check |Health check name |JavaDoc |Config properties (within `server.features.observe.observers.health`) |Default config value
+
+|deadlock detection &dagger;
+|`deadlock`
+| link:{health-javadoc-base-url}/io/helidon/health/checks/DeadlockHealthCheck.html[`DeadlockHealthCheck`]
+| n/a
+| n/a
+
+.2+.^|available disk space &dagger;
+.2+.^|`diskSpace`
+.2+.^| link:{health-javadoc-base-url}/io/helidon/health/checks/DiskSpaceHealthCheck.html[`DiskSpaceHealthCheck`]
+|`helidon.health.diskSpace.thresholdPercent`
+| `99.999`
+|`helidon.health.diskSpace.path`
+|`/`
+|available heap memory
+| `heapMemory`
+| link:{health-javadoc-base-url}/io/helidon/health/checks/HeapMemoryHealthCheck.html[`HeapMemoryHealthCheck`]
+|`helidon.health.heapMemory.thresholdPercent`
+|`98`
+|=======
+&dagger; Helidon cannot support the indicated health checks in the GraalVM native image environment, so with native image those health checks do not appear in the health output.
+
+Simply adding the built-in health check dependency is sufficient to register all the built-in health checks automatically.
+If you want to use only some of the built-in checks in your application, you can disable automatic discovery of the built-in health checks and register only the ones you want.
+
+// end::built-in-health-checks-section[]
+
+// tag::configuring-built-in-health-checks[]
+
+Further, you can suppress one or more
+health checks by setting the configuration item
+`server.features.observe.observers.health.exclude` to a comma-separated list of the health check names you want to exclude.
+// end::configuring-built-in-health-checks[]

--- a/docs/src/main/asciidoc/mp/health.adoc
+++ b/docs/src/main/asciidoc/mp/health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -167,6 +167,13 @@ The example below will change the root path.
 health.endpoint=/myhealth  #<1>
 ----
 <1> The `endpoint` setting specifies the root path for the health endpoint.
+
+include::{rootdir}/includes/health.adoc[tag=built-in-health-checks-section]
+
+By setting the config properties listed in the table you can influence the behavior of the health checks.
+
+include::{rootdir}/includes/health.adoc[tag=configuring-built-in-health-checks]
+The table above lists the names for the built-in health checks.
 
 == Examples
 

--- a/docs/src/main/asciidoc/se/health.adoc
+++ b/docs/src/main/asciidoc/se/health.adoc
@@ -263,44 +263,7 @@ The following table provides a summary of the Health Check API classes.
 checks
 |=======
 
-[[built-in-health-checks-table]]
-=== Built-In Health Checks
-
-You can use Helidon-provided health checks to report various
-common health check statuses:
-
-// Had to move the anchor to the heading above because the rendered page did not define the ID
-// correctly on the table so the link did not work. The link itself looks OK; just no ID generated on the page.
-//[[built-in-health-checks-table]]
-[cols="1,1,3,15,3"]
-|=======
-|Built-in health check |Health check name |JavaDoc |Config properties (within `server.features.observe.observers.health`) |Default config value
-
-|deadlock detection &dagger;
-|`deadlock`
-| link:{health-javadoc-base-url}/io/helidon/health/checks/DeadlockHealthCheck.html[`DeadlockHealthCheck`]
-| n/a
-| n/a
-
-|available disk space &dagger;
-|`diskSpace`
-| link:{health-javadoc-base-url}/io/helidon/health/checks/DiskSpaceHealthCheck.html[`DiskSpaceHealthCheck`]
-|`helidon.health.diskSpace.thresholdPercent` +
-+
-`helidon.health.diskSpace.path`
-| `99.999` +
-+
-`/`
-|available heap memory
-| `heapMemory`
-| link:{health-javadoc-base-url}/io/helidon/health/checks/HeapMemoryHealthCheck.html[`HeapMemoryHealthCheck`]
-|`helidon.health.heapMemory.thresholdPercent`
-|`98`
-|=======
-&dagger; Helidon cannot support the indicated health checks in the GraalVM native image environment, so with native image those health checks do not appear in the health output.
-
-Simply adding the built-in health check dependency is sufficient to register all the built-in health checks automatically.
-If you want to use only some of the built-in checks in your application, you can disable automatic discovery of the built-in health checks and register only the ones you want.
+include::{rootdir}/includes/health.adoc[tag=built-in-health-checks-section]
 
 The following code adds only selected built-in health checks to your application:
 
@@ -430,10 +393,10 @@ TIP: Create log messages in your health check implementation when setting a
 
 Built-in health checks can be configured using the config property keys
 described in this
-<<built-in-health-checks-table,table>>. Further, you can suppress one or more of the built-in
-health checks by setting the configuration item
-`helidon.health.exclude` to a comma-separated list of the health check names
-(from this <<built-in-health-checks-table,table>>) you want to exclude.
+<<built-in-health-checks-table,table>>.
+
+include::{rootdir}/includes/health.adoc[tag=configuring-built-in-health-checks]
+The same table lists the name names for the built-in health checks.
 
 == Examples
 

--- a/webserver/observe/health/pom.xml
+++ b/webserver/observe/health/pom.xml
@@ -63,6 +63,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.health</groupId>
+            <artifactId>helidon-health-checks</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver.testing.junit5</groupId>
             <artifactId>helidon-webserver-testing-junit5</artifactId>
             <scope>test</scope>

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserverConfigBlueprint.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthObserverConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,4 +84,14 @@ interface HealthObserverConfigBlueprint extends ObserverConfigBase, Prototype.Fa
      * @return configuration
      */
     Optional<Config> config();
+
+    /**
+     * Health check names to exclude in computing the overall health of the server.
+     *
+     * @return health check names to exclude
+     */
+    @Option.Configured
+    @Option.Singular("excluded")
+    List<String> exclude();
+
 }

--- a/webserver/observe/health/src/test/java/io/helidon/webserver/observe/health/TestExclude.java
+++ b/webserver/observe/health/src/test/java/io/helidon/webserver/observe/health/TestExclude.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe.health;
+
+import java.util.Map;
+
+import io.helidon.common.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.health.HealthCheck;
+import io.helidon.health.HealthCheckResponse;
+import io.helidon.health.HealthCheckType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+class TestExclude {
+
+    private static final HealthCheck CUSTOM_CHECK_1 = new HealthCheck() {
+        @Override
+        public HealthCheckType type() {
+            return HealthCheckType.READINESS;
+        }
+
+        @Override
+        public String name() {
+            return "custom-1";
+        }
+
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.builder().status(HealthCheckResponse.Status.DOWN).build();
+        }
+    };
+
+    @Test
+    void testExcluded() {
+        HealthObserver observerWithCustomCheck = HealthObserverConfig.builder()
+                .useSystemServices(true)
+                .addCheck(CUSTOM_CHECK_1)
+                .build();
+
+        assertThat("Without exclude",
+                   observerWithCustomCheck.all().stream().map(HealthCheck::name).toList(),
+                   allOf(hasItem("custom-1"),
+                         hasItem("diskSpace"),
+                         hasItem("heapMemory")));
+
+        HealthObserver observerWithoutCustomCheck = HealthObserverConfig.builder()
+                .useSystemServices(true)
+                .addCheck(CUSTOM_CHECK_1)
+                .addExcluded("custom-1")
+                .build();
+
+        assertThat("With programmatic exclude",
+                   observerWithoutCustomCheck.all().stream().map(HealthCheck::name).toList(),
+                   allOf(not(hasItem("custom-1")),
+                         hasItem("diskSpace"),
+                         hasItem("heapMemory")));
+
+    }
+
+    @Test
+    void testExcludeUsingConfig() {
+        HealthObserver observerWithCustomCheck = HealthObserverConfig.builder()
+                .addCheck(CUSTOM_CHECK_1)
+                .useSystemServices(true)
+                .build();
+
+        assertThat("Without exclude",
+                   observerWithCustomCheck.all().stream().map(HealthCheck::name).toList(),
+                   allOf(hasItem("custom-1"),
+                         hasItem("heapMemory"),
+                         hasItem("diskSpace"),
+                         hasItem("deadlock")));
+
+        Config config = io.helidon.config.Config.just(ConfigSources.create(
+                Map.of("server.features.observe.observers.health.exclude", "deadlock,custom-1",
+                       "server.features.observe.observers.health.use-system-services", "true")));
+
+        HealthObserver observerWithoutCustomCheck = HealthObserverConfig.builder()
+                .config(config.get("server.features.observe.observers.health"))
+                .addCheck(CUSTOM_CHECK_1)
+                .build();
+
+        assertThat("With exclude using config",
+                   observerWithoutCustomCheck.all().stream().map(HealthCheck::name).toList(),
+                   allOf(not(hasItem("custom-1")),
+                         not(hasItem("deadlock")),
+                         hasItem("diskSpace"),
+                         hasItem("heapMemory")));
+    }
+}


### PR DESCRIPTION

Backport #10379 to Helidon 4.2.5

### Description
Resolves #8698 

#### Release Note
____
You can now disable health checks by name using configuration. Set the config property `server.features.observe.observer.health.exclude` to a comma-separated list of the health check names you want to exclude.
____

#### PR summary

Most of the changes are in doc files. 

In the code, the `HealthObserverConfigBlueprint` now has `List<String> exclude()` and the observer constructor uses it to discard excluded health checks during initialization.

There are also new tests for the exclude feature.

### Documentation
Includes doc updates.
