### PR TITLE
 4.2.5: Decrease log level severity when a stream timeout is retried

### DIFF
--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -68,6 +68,7 @@ import io.grpc.MethodDescriptor;
 import static io.helidon.metrics.api.Meter.Scope.VENDOR;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
+import static java.lang.System.Logger.Level.TRACE;
 
 /**
  * Base class for gRPC client calls.
@@ -386,7 +387,7 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
             socket().log(LOGGER, ERROR, "[Reading thread] HTTP/2 stream timeout, aborting");
             throw e;
         }
-        socket().log(LOGGER, ERROR, "[Reading thread] HTTP/2 stream timeout, retrying");
+        socket().log(LOGGER, TRACE, "[Reading thread] HTTP/2 stream timeout, retrying");
     }
 
     protected void initMetrics() {


### PR DESCRIPTION
Backport #10445 to Helidon 4.2.5

### Description

Decrease log level severity when a stream timeout is retried. See issue #10432.

### Documentation

None