### PR TITLE
4.x Docs: remove use of Config.global(config) setter

### DIFF
--- a/docs/src/main/asciidoc/se/config/introduction.adoc
+++ b/docs/src/main/asciidoc/se/config/introduction.adoc
@@ -98,34 +98,37 @@ See the xref:advanced-configuration.adoc#_advanced_config_parsers[advanced topic
 
 == Configuration
 
-Helidon has an internal configuration, so you are not required to provide any configuration data for your application, though in practice you most likely would.
+=== Global Configuration
 
-In your application code, when you create a default `Config` object, Helidon uses the default configuration .
+Global configuration is a singleton instance of `Config` that is implicitly used by some components of Helidon, plus it provides a convenient mechanism for your application to retrieve configuration from anywhere in your code.
+By default, global configuration is initialized to the default `Config` object (as returned by `Config.create()`) and it is registered in the Helidon Service Registry.
+
+To retrieve the global configuration, you fetch it directly from the service registry:
 
 [source,java]
 ----
 include::{sourcedir}/se/config/IntroductionSnippets.java[tag=snippet_1, indent=0]
 ----
-<1> The `Config` object is created with default settings.
 
-=== Global Configuration
-
-Global configuration is a singleton instance of `Config` that is implicitly used by some components of Helidon, plus it provides a convenient mechanism for your application to retrieve configuration from anywhere in your code.
-By default, global configuration is initialized to the default `Config` object (as returned by `Config.create()`). But it is recommended that you initialize it explicitly. This is especially important if you define custom config sources.
+Or you can use the global configuration convenience method to retrieve it:
 
 [source,java]
 ----
 include::{sourcedir}/se/config/IntroductionSnippets.java[tag=snippet_2, indent=0]
 ----
-<1> Create configuration. This shows creating the default config, but it could be created from custom config sources.
-<2> Assign it to the application's global configuration
 
-You can use global configuration to conveniently retrieve the application's configuration:
+If your application builds a custom configuration (from custom config sources for example) and you would like this
+configuration to be discovered and used by Helidon components then you should set this custom configuration instance as the global configuration.
+You do this by setting the configuration instance directly into the service registry (the old way of doing this via `Config.global(config)` is deprecated).
 
 [source,java]
 ----
 include::{sourcedir}/se/config/IntroductionSnippets.java[tag=snippet_3, indent=0]
 ----
+
+Note that if you want to explicitly set the global configuration then you *must* do it before any code in your application
+(or any Helidon component) retrieves global configuration. That means it should be done early in your application
+initialization before you create any other Helidon component.
 
 === Custom Config Sources
 

--- a/docs/src/main/asciidoc/se/guides/upgrade_4x.adoc
+++ b/docs/src/main/asciidoc/se/guides/upgrade_4x.adoc
@@ -308,15 +308,6 @@ Metrics has changed significantly in Helidon 4. See xref:../metrics/metrics.adoc
 
 The global configuration represents a single instance of the `Config` class, which is implicitly employed by certain Helidon components. Furthermore, it offers a handy approach for your application to access configuration information from any part of your code.
 
-It is recommended that you explicitly initialize global configuration before using any Helidon components:
-
-[source,java]
-----
-include::{sourcedir}/se/guides/Upgrade4xSnippets.java[tag=snippet_7, indent=0]
-----
-
-You can then utilize the global configuration for easy retrieval of your application's configuration:
-
 [source,java]
 ----
 include::{sourcedir}/se/guides/Upgrade4xSnippets.java[tag=snippet_8, indent=0]

--- a/docs/src/main/java/io/helidon/docs/se/config/IntroductionSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/config/IntroductionSnippets.java
@@ -16,26 +16,27 @@
 package io.helidon.docs.se.config;
 
 import io.helidon.config.Config;
+import io.helidon.service.registry.Services;
 
 @SuppressWarnings("ALL")
 class IntroductionSnippets {
 
     void snippet_1() {
         // tag::snippet_1[]
-        Config config = Config.create(); // <1>
+        Config config = Services.get(Config.class);
         // end::snippet_1[]
     }
 
     void snippet_2() {
         // tag::snippet_2[]
-        Config config = Config.create(); // <1>
-        Config.global(config); // <2>
+        Config config = Config.global();
         // end::snippet_2[]
     }
 
     void snippet_3() {
+        Config config = Config.create();
         // tag::snippet_3[]
-        Config config = Config.global();
+        Services.set(Config.class, config);
         // end::snippet_3[]
     }
 

--- a/docs/src/main/java/io/helidon/docs/se/guides/DbclientSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/guides/DbclientSnippets.java
@@ -58,9 +58,7 @@ class DbclientSnippets {
             // load logging configuration
             LogConfig.configureRuntime();
 
-            // initialize global config from default configuration
-            Config config = Config.create();
-            Config.global(config);
+            Config config = Config.global();
 
             DbClient dbClient = DbClient.create(config.get("db")); // <1>
             Contexts.globalContext().register(dbClient); // <2>

--- a/docs/src/main/java/io/helidon/docs/se/guides/Upgrade4xSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/guides/Upgrade4xSnippets.java
@@ -63,8 +63,7 @@ class Upgrade4xSnippets {
         // tag::snippet_2[]
         public static void main(String[] args) {
 
-            Config config = Config.create();
-            Config.global(config);
+            Config config = Config.global();
 
             WebServer server = WebServer.builder() // <1>
                     .config(config.get("server"))
@@ -162,13 +161,6 @@ class Upgrade4xSnippets {
     }
 
     static void sendResponse(ServerResponse response, String str) {
-    }
-
-    void snippet_7() {
-        // tag::snippet_7[]
-        Config config = Config.create();  // Uses default config sources
-        Config.global(config);
-        // end::snippet_7[]
     }
 
     void snippet_8() {


### PR DESCRIPTION
### Description

This removes use of `Config.global(config)` setter from our documentation. It also documents use of `Services.get(Config.class)` as a mechanism to fetch the global configuration.

This PR does NOT replace all instances of `Config.global()` with `Services.get(Config.class)`. That will come in a subsequent PR.  I want to get this PR in quickly so I can backport to 4.2.x.

See #10322

