### PR TITLE
 4.2.5: Handle single baggage header with multiple assignments; add test

### DIFF
--- a/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
+++ b/microprofile/telemetry/src/main/java/io/helidon/microprofile/telemetry/HelidonTelemetryContainerFilter.java
@@ -280,13 +280,16 @@ class HelidonTelemetryContainerFilter implements ContainerRequestFilter, Contain
         if (baggageProperties != null) {
             var baggageBuilder = Baggage.builder();
             for (String b : baggageProperties) {
-                String[] split = b.split("=");
-                if (split.length == 2) {
-                    String[] valueAndMetadata = split[1].split(";");
-                    String value = valueAndMetadata.length > 0 ? valueAndMetadata[0] : "";
-                    String metadata = valueAndMetadata.length > 1 ? valueAndMetadata[1] : "";
-                    baggageBuilder
-                            .put(split[0], value, BaggageEntryMetadata.create(metadata));
+                String[] assignments = b.split(",");
+                for (String assignment : assignments) {
+                    String[] split = assignment.split("=");
+                    if (split.length == 2) {
+                        String[] valueAndMetadata = split[1].split(";");
+                        String value = valueAndMetadata.length > 0 ? valueAndMetadata[0] : "";
+                        String metadata = valueAndMetadata.length > 1 ? valueAndMetadata[1] : "";
+                        baggageBuilder
+                                .put(split[0], value, BaggageEntryMetadata.create(metadata));
+                    }
                 }
             }
             baggageBuilder.build()

--- a/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestMultipleBaggageHeaders.java
+++ b/microprofile/telemetry/src/test/java/io/helidon/microprofile/telemetry/TestMultipleBaggageHeaders.java
@@ -67,4 +67,26 @@ class TestMultipleBaggageHeaders {
         }
     }
 
+    @Test
+    void testMultipleBaggageValuesInOneHeader() throws IOException, InterruptedException, URISyntaxException {
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            URI uri = new URI(webTarget.getUri().getScheme(),
+                              webTarget.getUri().getUserInfo(),
+                              webTarget.getUri().getHost(),
+                              webTarget.getUri().getPort(),
+                              BaggageCheckingResource.PATH,
+                              null,
+                              null);
+            var requestBuilder = HttpRequest.newBuilder(uri)
+                    .GET();
+            requestBuilder.header("Baggage", "k1=val1,k2=val2");
+            var request = requestBuilder.build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat("Baggage-checking endpoint status", response.statusCode(), is(200));
+            assertThat("Baggage-checking endpoint response", response.body(), allOf(containsString("k1=val1"),
+                                                                                    containsString("k2=val2")));
+        }
+    }
+
 }


### PR DESCRIPTION

Backport #10470 to Helidon 4.2.5

### Description

Resolves #10469 

## Release note
____
Helidon MP now correctly handles a single incoming `baggage` header with multiple assignments (`Baggage: k1=val1,k2=val2`).
____


### Documentation
No impact; bug fix.