### PR TITLE
io.helidon.messaging.connectors.jms.AckMpTest randomly fails #7011

### DIFF
--- a/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AckMpTest.java
+++ b/tests/integration/jms/src/test/java/io/helidon/messaging/connectors/jms/AckMpTest.java
@@ -24,13 +24,13 @@ import io.helidon.messaging.connectors.mock.MockConnector;
 import io.helidon.messaging.connectors.mock.TestConnector;
 import io.helidon.microprofile.config.ConfigCdiExtension;
 import io.helidon.microprofile.messaging.MessagingCdiExtension;
-import io.helidon.microprofile.testing.junit5.AddBean;
-import io.helidon.microprofile.testing.junit5.AddBeans;
-import io.helidon.microprofile.testing.junit5.AddConfig;
-import io.helidon.microprofile.testing.junit5.AddConfigs;
-import io.helidon.microprofile.testing.junit5.AddExtension;
-import io.helidon.microprofile.testing.junit5.AddExtensions;
-import io.helidon.microprofile.testing.junit5.DisableDiscovery;
+import io.helidon.microprofile.testing.AddBean;
+import io.helidon.microprofile.testing.AddBeans;
+import io.helidon.microprofile.testing.AddConfig;
+import io.helidon.microprofile.testing.AddConfigs;
+import io.helidon.microprofile.testing.AddExtension;
+import io.helidon.microprofile.testing.AddExtensions;
+import io.helidon.microprofile.testing.DisableDiscovery;
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 
 import jakarta.enterprise.inject.se.SeContainer;
@@ -100,10 +100,14 @@ public class AckMpTest extends AbstractMPTest {
     void resendAckTestPart1(SeContainer cdi) {
         MockConnector mockConnector = cdi.select(MockConnector.class, TEST_CONNECTOR_ANNOTATION).get();
         //Messages starting with NO_ACK is not acked by ChannelAck bean
-        List<String> testData = List.of("0", "1", "2", "NO_ACK-1", "NO_ACK-2", "NO_ACK-3");
-        produce(TEST_QUEUE_ACK, testData, m -> {});
+        List<String> testDataAcked = List.of("0", "1", "2");
+        produce(TEST_QUEUE_ACK, testDataAcked, m -> {});
         mockConnector.outgoing("mock-conn-channel", String.class)
-                        .awaitPayloads(Duration.ofSeconds(5), testData.toArray(String[]::new));
+            .awaitPayloads(Duration.ofSeconds(5), new String[] {"0", "1", "2"});
+        List<String> testDataNoAcked = List.of("NO_ACK-1", "NO_ACK-2", "NO_ACK-3");
+        produce(TEST_QUEUE_ACK, testDataNoAcked, m -> {});
+        mockConnector.outgoing("mock-conn-channel", String.class)
+            .awaitPayloads(Duration.ofSeconds(5), new String[] {"0", "1", "2", "NO_ACK-1", "NO_ACK-2", "NO_ACK-3"});
     }
 
     @Test


### PR DESCRIPTION
### Description
https://github.com/helidon-io/helidon/issues/7011

I think with `ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE` it should work too:
https://activemq.apache.org/components/artemis/documentation/latest/pre-acknowledge.html#individual-acknowledge

The issue seems to be in how complex it works internally, when `"NO_ACK-1"` is processed before `"2"`, it looks that `"NO_ACK-1"` is acked.

I tried to update ActiveMQ version and it didn't help.

With this change test will not fail.