### PR TITLE
4.x: Tests fail when upgrading to Hibernate 6.6.23.Final #10441

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -66,8 +66,8 @@
         <version.lib.h2>2.4.240</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.handlebars>4.4.0</version.lib.handlebars>
-        <version.lib.hibernate.family>6.3</version.lib.hibernate.family>
-        <version.lib.hibernate>${version.lib.hibernate.family}.1.Final</version.lib.hibernate>
+        <version.lib.hibernate.family>6.6</version.lib.hibernate.family>
+        <version.lib.hibernate>${version.lib.hibernate.family}.29.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>

--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -79,6 +79,11 @@
             <artifactId>svm</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Compile-scoped dependencies. -->
         <dependency>

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/ByteBuddyEnhancementContext.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/ByteBuddyEnhancementContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.cdi.hibernate;
+
+import java.util.Optional;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@TargetClass(className = "org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext")
+@SuppressWarnings("checkstyle:StaticVariableName")
+final class ByteBuddyEnhancementContext {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias)
+    private static ElementMatcher.Junction<MethodDescription> IS_GETTER;
+
+    @Substitute
+    Optional<MethodDescription> resolveGetter(FieldDescription fieldDescription) {
+        return Optional.empty();
+    }
+}

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/ByteBuddyProxyHelper.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/ByteBuddyProxyHelper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.cdi.hibernate;
+
+import java.util.Collection;
+import java.util.function.BiFunction;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.NamingStrategy;
+import net.bytebuddy.description.type.TypeDefinition;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+
+
+@TargetClass(className = "org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper")
+@SuppressWarnings("checkstyle:StaticVariableName")
+final class ByteBuddyProxyHelper {
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias)
+    private static TypeDescription OBJECT;
+
+    @Substitute
+    private BiFunction<ByteBuddy, NamingStrategy, DynamicType.Builder<?>> proxyBuilder(TypeDefinition persistentClass,
+            Collection<? extends TypeDefinition> interfaces) {
+        return null;
+    }
+}

--- a/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
@@ -39,6 +39,7 @@ module io.helidon.integrations.cdi.hibernate {
     requires transitive jakarta.inject;
     requires jakarta.persistence;
     requires transitive jakarta.transaction;
+    requires transitive net.bytebuddy;
     requires org.graalvm.nativeimage;
     requires transitive org.hibernate.orm.core;
 

--- a/integrations/cdi/hibernate-cdi/src/main/resources/META-INF/native-image/io.helidon.integrations.cdi/helidon-integrations-cdi-hibernate/native-image.properties
+++ b/integrations/cdi/hibernate-cdi/src/main/resources/META-INF/native-image/io.helidon.integrations.cdi/helidon-integrations-cdi-hibernate/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,4 +14,6 @@
 # limitations under the License.
 #
 
-Args=-H:ReflectionConfigurationResources=${.}/reflect-config-additional.json
+Args=-H:ReflectionConfigurationResources=${.}/reflect-config-additional.json \
+     -H:ClassInitialization=org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext:run_time \
+     -H:ClassInitialization=org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper:run_time

--- a/integrations/cdi/hibernate-cdi/src/main/resources/META-INF/native-image/io.helidon.integrations.cdi/helidon-integrations-cdi-hibernate/reflect-config.json
+++ b/integrations/cdi/hibernate-cdi/src/main/resources/META-INF/native-image/io.helidon.integrations.cdi/helidon-integrations-cdi-hibernate/reflect-config.json
@@ -2147,5 +2147,13 @@
         ]
       }
     ]
+  },
+  {
+    "name": "org.hibernate.event.spi.PostUpsertEventListener[]",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "unsafeAllocated": true
   }
 ]

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedSynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedSynchronizedEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -292,9 +292,9 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
         assertThat(transactionScopedContext.isActive(), is(true));
 
         // Remove the Author we successfully committed before.  We
-        // have to merge because author1 became detached a few lines
-        // above.
-        author1 = em.merge(author1);
+        // have to find because author1 became detached a few lines
+        // above and it is not allowed to attach it again with merge.
+        author1 = em.find(Author.class, Integer.valueOf(1));
         assertThat(author1, notNullValue());
         assertThat(em.contains(author1), is(true));
         em.remove(author1);
@@ -313,13 +313,15 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
         // tables.
         assertTableRowCount(dataSource, "AUTHOR", 0);
 
-        // Start a new transaction, merge our detached author1, and
+        // Start a new transaction, persist our detached author1, and
         // commit.  This will bump the author's ID and put a row in
         // the database.
         tm.begin();
         assertThat(em.isJoinedToTransaction(), is(true));
         assertThat(transactionScopedContext.isActive(), is(true));
-        author1 = em.merge(author1);
+        author1 = new Author("Abraham Lincoln");
+        em.persist(author1);
+        em.merge(author1);
         tm.commit();
         assertThat(em.isJoinedToTransaction(), is(false));
         assertThat(em.contains(author1), is(false));

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestRollbackScenarios.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestRollbackScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -276,6 +276,8 @@ class TestRollbackScenarios {
         assertThat(tm.getStatus(), is(Status.STATUS_ACTIVE));
         assertThat(em.isJoinedToTransaction(), is(true));
         assertThat(em.contains(author), is(false));
+        author = new Author("John Kennedy");
+        em.persist(author);
         author = em.merge(author);
         em.remove(author);
         tm.commit();


### PR DESCRIPTION
### Description
Resolves https://github.com/helidon-io/helidon/issues/10441 and https://github.com/helidon-io/helidon/issues/10688

Hibernate 6.6 cannot attach a removed entity:
https://docs.jboss.org/hibernate/orm/6.6/migration-guide/migration-guide.html#merge-versioned-deleted
