### PR TITLE
Use rawQuery() instead of query() in Tyrus integration code

### DIFF
--- a/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusUpgrader.java
+++ b/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusUpgrader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,7 +166,7 @@ public class TyrusUpgrader extends WsUpgrader {
         }
         RequestContext requestContext = RequestContext.Builder.create()
                 .requestURI(URI.create(path))      // excludes context path
-                .queryString(uriQuery.value())
+                .queryString(uriQuery.rawValue())
                 .parameterMap(paramsMap)
                 .build();
         headers.forEach(e -> requestContext.getHeaders().put(e.name(), List.of(e.values())));

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketEndpointAppTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketEndpointAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,15 @@ class WebSocketEndpointAppTest extends WebSocketBaseTest {
     @Test
     public void testEchoAnnot() throws Exception {
         URI echoUri = URI.create("ws://localhost:" + port() + "/web/echoAnnot");
+        EchoClient echoClient = new EchoClient(echoUri);
+        echoClient.echo("hi", "how are you?");
+        echoClient.shutdown();
+    }
+
+    @Test
+    public void testEchoAnnotWithQuery() throws Exception {
+        // Tyrus JDK client decodes %20 so we escape % here
+        URI echoUri = URI.create("ws://localhost:" + port() + "/web/echoAnnot?foo=bar%2520baz");
         EchoClient echoClient = new EchoClient(echoUri);
         echoClient.echo("hi", "how are you?");
         echoClient.shutdown();


### PR DESCRIPTION
### Description

Use rawQuery() instead of query() in the integration code to avoid decoding escaped chars such as %20 before passing the URI to Tyrus. See issue #10486.

### Documentation

None