### PR TITLE
4.x: Use helidon-common-features-codegen processor in helidon-scheduling

### DIFF
--- a/scheduling/pom.xml
+++ b/scheduling/pom.xml
@@ -100,7 +100,7 @@
                         </path>
                         <path>
                             <groupId>io.helidon.common.features</groupId>
-                            <artifactId>helidon-common-features-processor</artifactId>
+                            <artifactId>helidon-common-features-codegen</artifactId>
                             <version>${helidon.version}</version>
                         </path>
                         <path>


### PR DESCRIPTION
### Description

Use helidon-common-features-codegen processor in helidon-scheduling.

The scheduling module is using ` io.helidon.common.features.api.Features` annotations, but had wrong annotation processor.

Fixes #10499
