### PR TITLE
4.x: Allow full customization of singular setter for collections and maps.

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Option.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Option.java
@@ -361,6 +361,18 @@ public final class Option {
          * @return The singular name to add
          */
         String value() default "";
+
+        /**
+         * When set to {@code true}, the prefix {@code add} or {@code put} will be added to generated methods
+         * (for collections and maps respectively).
+         * When set to {@code false}, the {@link #value()} will be used as a full method name for singular add/put methods.
+         * <p>
+         * In case you set this to {@code false}, you must make sure the method name does not conflict with other methods
+         * on the generated type
+         *
+         * @return whether to add prefix to the generated method, defaults to {@code true}
+         */
+        boolean withPrefix() default true;
     }
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/AnnotationDataOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/AnnotationDataOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ record AnnotationDataOption(Javadoc javadoc,
                             boolean providerDiscoverServices,
                             boolean singular,
                             String singularName,
+                            boolean singularAddPrefix,
                             boolean sameGeneric,
                             boolean equalityRedundant,
                             boolean toStringRedundant,
@@ -90,6 +91,7 @@ record AnnotationDataOption(Javadoc javadoc,
         List<AllowedValue> allowedValues = null;
         boolean singular;
         String singularName;
+        boolean singularAddPrefix;
         boolean equalityRedundant;
         boolean toStringRedundant;
 
@@ -123,14 +125,17 @@ record AnnotationDataOption(Javadoc javadoc,
                     .toList();
         }
         if (element.hasAnnotation(OPTION_SINGULAR)) {
+            var singularAnnot = element.annotation(OPTION_SINGULAR);
             singular = true;
-            singularName = element.annotation(OPTION_SINGULAR)
-                    .value()
+            singularName = singularAnnot.value()
                     .filter(Predicate.not(String::isBlank))
                     .orElseGet(() -> singularName(handler.name()));
+            singularAddPrefix = singularAnnot.booleanValue("withPrefix")
+                    .orElse(true);
         } else {
             singular = false;
             singularName = null;
+            singularAddPrefix = true;
         }
         if (element.hasAnnotation(OPTION_REDUNDANT)) {
             Annotation annotation = element.annotation(OPTION_REDUNDANT);
@@ -180,6 +185,7 @@ record AnnotationDataOption(Javadoc javadoc,
                                         discoverServices,
                                         singular,
                                         singularName,
+                                        singularAddPrefix,
                                         element.hasAnnotation(OPTION_SAME_GENERIC),
                                         equalityRedundant,
                                         toStringRedundant,

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -397,7 +397,12 @@ abstract class TypeHandlerCollection extends TypeHandler.OneTypeHandler {
                                 TypeName returnType,
                                 Javadoc blueprintJavadoc,
                                 String singularName) {
-        String methodName = "add" + capitalize(singularName);
+        String methodName;
+        if (configured.singularAddPrefix()) {
+            methodName = "add" + capitalize(singularName);
+        } else {
+            methodName = singularName;
+        }
 
         Method.Builder builder = Method.builder()
                 .name(methodName)

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerMap.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,7 +211,12 @@ class TypeHandlerMap extends TypeHandler {
         if (configured.singular()) {
             // Builder putValue(String key, String value)
             String singularName = configured.singularName();
-            String methodName = "put" + capitalize(singularName);
+            String methodName;
+            if (configured.singularAddPrefix()) {
+                methodName = "put" + capitalize(singularName);
+            } else {
+                methodName = singularName;
+            }
 
             Method.Builder method = Method.builder()
                     .name(methodName)

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ComplexCaseBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ComplexCaseBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ interface ComplexCaseBlueprint extends MyConfigBeanBlueprint {
      *
      * @return ignored, here for testing purposes only
      */
-    @Option.Singular("configBean")
+    @Option.Singular(value = "allowConfigBean", withPrefix = false)
     List<MyConfigBean> getListOfConfigBeans();
 
     /**

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/MapCaseBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/MapCaseBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,14 @@ interface MapCaseBlueprint {
      */
     @Option.Singular
     Map<String, List<String>> stringToStringList();
+
+    /**
+     * For Testing.
+     *
+     * @return return testing
+     */
+    @Option.Singular(value = "addToMap", withPrefix = false)
+    Map<String, String> customMethodName();
 
     /**
      * Test example only.

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ComplexCaseTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ComplexCaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,20 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ComplexCaseTest {
+    @Test
+    void testCustomAddName() {
+        var configBean = MyConfigBean.builder()
+                .setName("cfb")
+                .build();
+
+        var complexCase = ComplexCase.builder()
+                .setName("name")
+                .setClassType(Object.class)
+                .allowConfigBean(configBean)                .build();
+
+        assertThat(complexCase.getName(), is("name"));
+        assertThat(complexCase.getListOfConfigBeans(), hasItem(configBean));
+    }
 
     @Test
     void testIt() {

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ComplexCaseTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ComplexCaseTest.java
@@ -46,7 +46,8 @@ class ComplexCaseTest {
         var complexCase = ComplexCase.builder()
                 .setName("name")
                 .setClassType(Object.class)
-                .allowConfigBean(configBean)                .build();
+                .allowConfigBean(configBean)
+                .build();
 
         assertThat(complexCase.getName(), is("name"));
         assertThat(complexCase.getListOfConfigBeans(), hasItem(configBean));

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/MapCaseTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/MapCaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,22 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasKey;
 
 class MapCaseTest {
+    @Test
+    void testCustomPutMethodName() {
+        var mapCase = MapCase.builder()
+                .addToMap("key", "value")
+                .build();
+
+
+        assertThat(mapCase.customMethodName(), is(Map.of("key", "value")));
+    }
 
     @Test
     void testIt() {


### PR DESCRIPTION
### Description
Resolves #10302 

Simply set `io.helidon.builder.api.Option.Singular#withPrefix` to false, and the name  in value of the same annotation will be used as the full name of the "add" or "put" method.

This is to enable nicer names when adding a value to a map, that is more aligned with its behavior (as `put` may not always be the best solution here).

