### PR TITLE
Upgrade jaxb-core, -impl, -runtime

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -92,11 +92,11 @@
         <version.lib.jakarta.xml.bind-api>4.0.2</version.lib.jakarta.xml.bind-api>
         <version.lib.jandex>3.3.0</version.lib.jandex>
         <version.lib.javassist>3.30.2-GA</version.lib.javassist>
-        <version.lib.jaxb-core>4.0.3</version.lib.jaxb-core>
-        <version.lib.jaxb-impl>4.0.3</version.lib.jaxb-impl>
+        <version.lib.jaxb-core>4.0.5</version.lib.jaxb-core>
+        <version.lib.jaxb-impl>4.0.5</version.lib.jaxb-impl>
         <version.lib.jboss.classfilewriter>1.3.1.Final</version.lib.jboss.classfilewriter>
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
-        <version.lib.jaxb-runtime>4.0.3</version.lib.jaxb-runtime>
+        <version.lib.jaxb-runtime>4.0.5</version.lib.jaxb-runtime>
         <version.lib.jersey>3.1.10</version.lib.jersey>
         <version.lib.jgit>7.2.1.202505142326-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -241,16 +241,4 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <cve>CVE-2025-43714</cve>
 </suppress>
 
-<!-- False Positive.
-     This CVE is in angus mail, not angus activation.
-     https://gitlab.eclipse.org/security/cve-assignement/-/issues/67
--->
-<suppress>
-   <notes><![CDATA[
-   file name: angus-activation-2.0.1.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus-activation@.*$</packageUrl>
-   <cve>CVE-2025-7962</cve>
-</suppress>
-
 </suppressions>


### PR DESCRIPTION
### Description

Upgrade jaxb-core, -impl, -runtime to 4.0.5

Remove suppression of angus-mail false positive as the jaxb-* upgrade results in upgrade of angus-activation which avoids the false positive.

