### PR TITLE
4.x: Fix wrong method generated for factory methods in builder

### DIFF
--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/OtelTracingBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/OtelTracingBlueprint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.List;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Configured
+@Prototype.Blueprint
+@Prototype.CustomMethods(OtelTracingSupport.class)
+interface OtelTracingBlueprint {
+    @Option.Configured
+    List<SpanProcessorConfig> processors();
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/OtelTracingSupport.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/OtelTracingSupport.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.common.config.Config;
+
+final class OtelTracingSupport {
+    private OtelTracingSupport() {
+    }
+
+    @Prototype.FactoryMethod
+    static List<SpanProcessorConfig> createProcessors(Config config) {
+        return List.of(SpanProcessorConfig.builder()
+                               .configured("some-value")
+                               .build());
+    }
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SpanProcessorConfigBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/SpanProcessorConfigBlueprint.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.Configured
+interface SpanProcessorConfigBlueprint {
+    @Option.Configured
+    String configured();
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/TestFactoryMethod.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/TestFactoryMethod.java
@@ -16,8 +16,11 @@
 
 package io.helidon.builder.test;
 
+import java.util.Map;
+
 import io.helidon.builder.test.testsubjects.OtelTracing;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +31,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 class TestFactoryMethod {
      @Test
     void testConfigFactory() {
-        var config = Config.empty();
+        var config = Config.just(ConfigSources.create(Map.of("processors", "")));
 
         var otelConfig = OtelTracing.create(config);
         var processors = otelConfig.processors();

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/TestFactoryMethod.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/TestFactoryMethod.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test;
+
+import io.helidon.builder.test.testsubjects.OtelTracing;
+import io.helidon.config.Config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+class TestFactoryMethod {
+     @Test
+    void testConfigFactory() {
+        var config = Config.empty();
+
+        var otelConfig = OtelTracing.create(config);
+        var processors = otelConfig.processors();
+
+        assertThat(processors, hasSize(1));
+        // returned from here: io.helidon.builder.test.testsubjects.OtelTracingSupport.createProcessors
+        assertThat(processors.getFirst().configured(), is("some-value"));
+    }
+}


### PR DESCRIPTION
Config factory methods for types that are also configured blueprints no longer generate an invalid method if the return type is a list.

Added tests

Resolves #10516 
