### PR TITLE
4.x: Upgrade okhttp3 to 4.12.0. Do a little cleanup.

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -149,10 +149,8 @@
         -->
         <version.lib.ojdbc>${version.lib.ojdbc.family}.6.0.24.10</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
-        <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
-        <version.lib.okio>3.4.0</version.lib.okio>
-        <!-- Force upgrade okhttp3 for CVE-2023-0833 -->
-        <version.lib.okhttp3>4.11.0</version.lib.okhttp3>
+        <!-- Force upgrade okhttp3 for dependency convergence -->
+        <version.lib.okhttp3>4.12.0</version.lib.okhttp3>
         <version.lib.opentelemetry.semconv>1.29.0-alpha</version.lib.opentelemetry.semconv>
         <version.lib.opentelemetry-sdk-extension-autoconfigure>1.29.0</version.lib.opentelemetry-sdk-extension-autoconfigure>
         <version.lib.opentelemetry.opentracing.shim>1.29.0</version.lib.opentelemetry.opentracing.shim>
@@ -1255,16 +1253,10 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <!-- Force upgrade okhttp3 for CVE-2023-0833 -->
+                <!-- Force upgrade okhttp3 for dependency convergence -->
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
                 <version>${version.lib.okhttp3}</version>
-            </dependency>
-            <dependency>
-                <!-- Force upgrade okio for CVE-2023-3635. When okhttp 4.12.0 is available we can remove this -->
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
-                <version>${version.lib.okio}</version>
             </dependency>
             <!-- END OF Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
 

--- a/tracing/providers/jaeger/pom.xml
+++ b/tracing/providers/jaeger/pom.xml
@@ -41,28 +41,9 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
         </dependency>
-        <!-- For dependency convergence of kotlin-stdlib
-             Once okhttp3 4.12.0 is released we can remove this since it upgrades okio
-             https://github.com/square/okhttp/pull/7947 -->
-        <dependency>
-            <groupId>com.squareup.okio</groupId>
-            <artifactId>okio</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-jaeger</artifactId>
-            <exclusions>
-                <!-- For dependency convergence. This excludes the transitive dep
-                     on kotlin from okhttp. We defer to the transitive dep from okio -->
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.tracing.providers</groupId>
@@ -88,6 +69,12 @@
             <!-- redirecting Jaeger slf4j logging to JUL logging -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
+        </dependency>
+        <!-- Needed for module-info -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.features</groupId>


### PR DESCRIPTION
### Description

* Upgrades okhttp3 to 4.12.0. This removed the need to manage the version of okio
* Cleanup some dependency convergence overrides

At this time it's the langchain4j cohere provider that has the dependency convergence issue with okhttp/kotlin. The other module that has an okhttp dependency is the opentelemetry jaeger provider.

The langchain4j integrations are moving away from requiring okhttp, and the opentelemetry jaeger provider will eventually go away.  So hopefully this gets resolved in the near future.

See also #10526
