### PR TITLE
4.x: Updated TLS implementation to handle endpoint identification algorithm for server

### DIFF
--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -180,7 +180,8 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
 
             // create a copy of SSLParameters, as otherwise we may use wrong endpoint identification algorithm for server
             SSLParameters parameters = copySslParameters();
-            parameters.setApplicationProtocols(parameters.getApplicationProtocols());
+            parameters.setApplicationProtocols(this.sslParameters.getApplicationProtocols());
+            parameters.setEndpointIdentificationAlgorithm("");
 
             socket.setSSLParameters(parameters);
             return socket;

--- a/common/tls/src/main/java/io/helidon/common/tls/Tls.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/Tls.java
@@ -264,7 +264,7 @@ public class Tls implements RuntimeType.Api<TlsConfig> {
     }
 
     private SSLParameters copySslParameters() {
-        // this copy does not set application protocols (each client request may have different
+        // this copy does not set application protocols (each client request may have different ones)
         // this copy does not set endpoint identification algorithm, server must not set it
         SSLParameters parameters = new SSLParameters();
         parameters.setServerNames(this.sslParameters.getServerNames());

--- a/webserver/tests/mtls/src/test/java/io/helidon/webserver/tests/mtls/MtlsConfigTest.java
+++ b/webserver/tests/mtls/src/test/java/io/helidon/webserver/tests/mtls/MtlsConfigTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.mtls;
+
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.Keys;
+import io.helidon.common.tls.Tls;
+import io.helidon.common.tls.TlsClientAuth;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class MtlsConfigTest {
+    private final WebServer server;
+    private final int port;
+
+    MtlsConfigTest(WebServer server) {
+        this.server = server;
+        this.port = server.port();
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder routing) {
+        routing.get("/name", (req, res) -> {
+                    String name = req.remotePeer().tlsPrincipal().map(Principal::getName).orElse(null);
+                    if (name == null) {
+                        res.status(Status.BAD_REQUEST_400).send("Expected client principal");
+                    } else {
+                        res.send(name);
+                    }
+                })
+                .get("/certs", (req, res) -> {
+                    Certificate[] certs = req.remotePeer().tlsCertificates().orElse(null);
+                    sendCertificateString(certs, res);
+                })
+                .get("/serverCert", (req, res) -> {
+                    Certificate[] certs = req.localPeer().tlsCertificates().orElse(null);
+                    sendCertificateString(certs, res);
+                });
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder builder) {
+        Config config = Config.just(ConfigSources.classpath("mtls-config-test.yaml"));
+        builder.config(config.get("server"));
+    }
+
+    @Test
+    void testMutualTlsPrincipal() {
+        WebClient client = client();
+        ClientResponseTyped<String> response = client.method(Method.GET)
+                .uri("/name")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("CN=Helidon-Test-Client"));
+    }
+
+    @Test
+    void testMutualTlsCertificates() {
+        WebClient client = client();
+        ClientResponseTyped<String> response = client.method(Method.GET)
+                .uri("/certs")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("X.509:CN=Helidon-Test-Client|X.509:CN=Helidon-Test-CA"));
+    }
+
+    private static void sendCertificateString(Certificate[] certs, ServerResponse res) {
+        if (certs == null) {
+            res.status(Status.BAD_REQUEST_400).send("Expected client certificate");
+        } else {
+            List<String> certDefs = new LinkedList<>();
+            for (Certificate cert : certs) {
+                if (cert instanceof X509Certificate x509) {
+                    certDefs.add("X.509:" + x509.getSubjectX500Principal().getName());
+                } else {
+                    certDefs.add(cert.getType());
+                }
+            }
+
+            res.send(String.join("|", certDefs));
+        }
+    }
+
+    private WebClient client() {
+        Keys privateKeyConfig = Keys.builder()
+                .keystore(keystore -> keystore
+                        .keystore(Resource.create("client.p12"))
+                        .passphrase("password"))
+                .build();
+
+        Tls tls = Tls.builder()
+                .clientAuth(TlsClientAuth.REQUIRED)
+                .endpointIdentificationAlgorithm(Tls.ENDPOINT_IDENTIFICATION_HTTPS)
+                .privateKey(privateKeyConfig.privateKey().get())
+                .privateKeyCertChain(privateKeyConfig.certChain())
+                .trust(trust -> trust
+                        .keystore(store -> store
+                                .passphrase("password")
+                                .trustStore(true)
+                                .keystore(Resource.create("client.p12"))))
+                .build();
+
+        WebClient client = WebClient.builder()
+                .baseUri("https://localhost:" + port)
+                .tls(tls)
+                .connectTimeout(Duration.ZERO)
+                .readTimeout(Duration.ZERO)
+                .build();
+
+        return client;
+    }
+}

--- a/webserver/tests/mtls/src/test/resources/mtls-config-test.yaml
+++ b/webserver/tests/mtls/src/test/resources/mtls-config-test.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  tls:
+    client-auth: "REQUIRED"
+    trust:
+      keystore:
+        passphrase: "password"
+        trust-store: true
+        resource:
+          resource-path: "server.p12"
+    private-key:
+      keystore:
+        passphrase: "password"
+        resource:
+          resource-path: "server.p12"


### PR DESCRIPTION
The algorithm is now ignored for server sockets, as is mentioned in:  https://bugs.openjdk.org/browse/JDK-8229972?focusedId=14659802&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14659802
 
Added test, and verified on our example.

### Description
Resolves #10429 
