### PR TITLE
 4.2.6: Upgrade jaxb-core, -impl, -runtime

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -87,11 +87,11 @@
         <!-- Check Hibernate when upgrading to ensure its supplied jaxb-runtime is compatible. -->
         <version.lib.jakarta.xml.bind-api>4.0.2</version.lib.jakarta.xml.bind-api>
         <version.lib.jandex>3.1.2</version.lib.jandex>
-        <version.lib.jaxb-core>4.0.3</version.lib.jaxb-core>
-        <version.lib.jaxb-impl>4.0.3</version.lib.jaxb-impl>
+        <version.lib.jaxb-core>4.0.5</version.lib.jaxb-core>
+        <version.lib.jaxb-impl>4.0.5</version.lib.jaxb-impl>
         <version.lib.jboss.classfilewriter>1.3.0.Final</version.lib.jboss.classfilewriter>
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
-        <version.lib.jaxb-runtime>4.0.3</version.lib.jaxb-runtime>
+        <version.lib.jaxb-runtime>4.0.5</version.lib.jaxb-runtime>
         <version.lib.jersey>3.1.10</version.lib.jersey>
         <version.lib.jgit>7.2.1.202505142326-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>


### PR DESCRIPTION
Backport #10513 to Helidon 4.2.6

### Description

Upgrade jaxb-core, -impl, -runtime to 4.0.5


