### PR TITLE
Drop prefix in singular map methods generated from JsonRpcHandlersBlueprint

### DIFF
--- a/docs/src/main/java/io/helidon/docs/se/jsonrpc/ServerSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/jsonrpc/ServerSnippets.java
@@ -57,8 +57,8 @@ class ServerSnippets {
         public void routing(JsonRpcRules rules) {
             rules.register("/machine",
                            JsonRpcHandlers.builder()
-                                   .putMethod("start", this::start)
-                                   .putMethod("stop", this::stop)
+                                   .method("start", this::start)
+                                   .method("stop", this::stop)
                                    .build());
         }
 

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcHandlersBlueprint.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcHandlersBlueprint.java
@@ -33,7 +33,7 @@ interface JsonRpcHandlersBlueprint {
      *
      * @return a map of method names to handlers
      */
-    @Option.Singular("method")
+    @Option.Singular(value = "method", withPrefix = false)
     Map<String, JsonRpcHandler> handlersMap();
 
     /**

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRouting.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRouting.java
@@ -331,7 +331,7 @@ public class JsonRpcRouting implements HttpService {
          */
         public Builder register(String pathPattern, String method, JsonRpcHandler handler) {
             JsonRpcHandlers.Builder builder = JsonRpcHandlers.builder();
-            builder.putMethod(method, handler);
+            builder.method(method, handler);
             register(pathPattern, builder.build());
             return this;
         }

--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRulesImpl.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcRulesImpl.java
@@ -48,7 +48,7 @@ class JsonRpcRulesImpl implements JsonRpcRules, Iterable<JsonRpcRulesImpl.Rule> 
     @Override
     public JsonRpcRules register(String pathPattern, String method, JsonRpcHandler handler) {
         JsonRpcHandlers.Builder builder = JsonRpcHandlers.builder();
-        builder.putMethod(method, handler);
+        builder.method(method, handler);
         return register(pathPattern, builder.build());
     }
 

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcBaseTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcBaseTest.java
@@ -117,8 +117,8 @@ class JsonRpcBaseTest {
         public void routing(JsonRpcRules rules) {
             rules.register("/machine",
                            JsonRpcHandlers.builder()
-                                   .putMethod("start", this::start)
-                                   .putMethod("stop", this::stop)
+                                   .method("start", this::start)
+                                   .method("stop", this::stop)
                                    .errorHandler(this::error)
                                    .build());
         }


### PR DESCRIPTION
### Description

Drop prefix in singular map methods generated from JsonRpcHandlersBlueprint

### Documentation

Non-compatible change from 4.3.0-M1 to 4.3.0-M2. Justification: improves API readability.
