### PR TITLE
4.2.6: Upgrade Netty to 4.1.124.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -131,7 +131,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.118.Final</version.lib.netty>
+        <version.lib.netty>4.1.124.Final</version.lib.netty>
         <version.lib.oci>3.68.0</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <!--


### PR DESCRIPTION
### Description

Upgrade Netty to 4.1.124.Final

Netty is not used directly by any Helidon 4 code, so why does Helidon 4 still manage the version of Netty? See #9645

