### PR TITLE
3.x: Upgrade OCI SDK to 3.68.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -130,7 +130,7 @@
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
         <version.lib.netty>4.1.124.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
-        <version.lib.oci>3.46.1</version.lib.oci>
+        <version.lib.oci>3.68.0</version.lib.oci>
         <version.lib.ojdbc8>21.15.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <!-- Manage okio version for dependency convergence -->


### PR DESCRIPTION
### Description

Upgrade OCI SDK to 3.68.0