### PR TITLE
2.x dependency upgrades

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -87,7 +87,7 @@
         <version.lib.jaxb-runtime>2.3.3</version.lib.jaxb-runtime>
         <version.lib.jedis>3.6.3</version.lib.jedis>
         <version.lib.jersey>2.45</version.lib.jersey>
-        <version.lib.jgit>7.2.1.202505142326-r</version.lib.jgit>
+        <version.lib.jgit>6.10.1.202505221210-r</version.lib.jgit>
         <version.lib.jms-api>2.0</version.lib.jms-api>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -62,7 +62,7 @@
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
         <version.lib.graphql-java>22.1</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>22.0</version.lib.graphql-java.extended.scalars>
-        <version.lib.gson>2.9.0</version.lib.gson>
+        <version.lib.gson>2.13.1</version.lib.gson>
         <version.lib.grpc>1.65.1</version.lib.grpc>
         <version.lib.guava>32.0.1-jre</version.lib.guava>
         <version.lib.h2>1.4.200</version.lib.h2>
@@ -87,13 +87,13 @@
         <version.lib.jaxb-runtime>2.3.3</version.lib.jaxb-runtime>
         <version.lib.jedis>3.6.3</version.lib.jedis>
         <version.lib.jersey>2.45</version.lib.jersey>
-        <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
+        <version.lib.jgit>7.2.1.202505142326-r</version.lib.jgit>
         <version.lib.jms-api>2.0</version.lib.jms-api>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>
         <version.lib.jsonp-impl>1.1.6</version.lib.jsonp-impl>
         <version.lib.junit>5.7.0</version.lib.junit>
-        <version.lib.kafka>3.8.1</version.lib.kafka>
+        <version.lib.kafka>3.9.1</version.lib.kafka>
         <version.lib.log4j>2.21.1</version.lib.log4j>
         <version.lib.logback>1.4.14</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
@@ -124,7 +124,7 @@
         <version.lib.narayana>5.12.0.Final</version.lib.narayana>
         <version.lib.netty>4.1.124.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
-        <version.lib.oci>3.46.1</version.lib.oci>
+        <version.lib.oci>3.68.0</version.lib.oci>
         <version.lib.oci-java-sdk-objectstorage>${version.lib.oci}</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>21.15.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -238,6 +238,17 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
 </suppress>
 
 
+<!-- False Positive.
+     jgit-6.10.1 has the fix for CVE-2025-4949. See
+     https://projects.eclipse.org/projects/technology.jgit/releases/6.10.1
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: org.eclipse.jgit-6.10.1.202505221210-r.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.eclipse\.jgit/org\.eclipse\.jgit@.*$</packageUrl>
+   <cve>CVE-2025-4949</cve>
+</suppress>
 
 
 

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -214,6 +214,31 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <cve>CVE-2025-30694</cve>
 </suppress>
 
+<!-- False Positive.
+     This CVE is against grpc/grpc C++ not gRPC Java
+     https://github.com/grpc/grpc/issues/36245
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-core-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*@.*$</packageUrl>
+   <cve>CVE-2024-7246</cve>
+</suppress>
+<!-- False Positive.
+     This CVE is against gRPC-C++ - gRPC-C++ servers not gRPC Java
+     https://github.com/grpc/grpc/issues/36245
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: grpc-core-1.65.1.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*@.*$</packageUrl>
+   <cve>CVE-2024-11407</cve>
+</suppress>
+
+
+
 
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <version.lib.weld-junit>2.0.0.Final</version.lib.weld-junit>
         <version.lib.jmh>1.23</version.lib.jmh>
         <version.lib.wiremock>2.26.3</version.lib.wiremock>
-        <version.lib.commons-lang3>3.10</version.lib.commons-lang3>
+        <version.lib.commons-lang3>3.18.0</version.lib.commons-lang3>
         <version.lib.classgraph>4.8.165</version.lib.classgraph>
         <!--
         !Version statement! - end

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.1.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.1.3</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0-M5</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

* Upgrades gson to 2.13.1
* Upgrades jgit to 6.10.1
* Upgrades kafka client to 3.9.1
* Upgrades OCI sdk to 3.68.0
* Upgrades apache commons lang to 3.18.0
* Upgrades dependency check plugin to 12.1.3
* Suppresses jgit and C++ grpc false positives