### PR TITLE
4.x: Changed example request method in WebClient docs

### DIFF
--- a/docs/src/main/asciidoc/se/webclient.adoc
+++ b/docs/src/main/asciidoc/se/webclient.adoc
@@ -96,7 +96,7 @@ WebClient offers a set of request methods that are used to specify the type of a
 * `get()`
 * `post()`
 * `put()`
-* `method(String methodName)`
+* `method(Method method)`
 
 Check out link:{webclient-javadoc-base-url}.api/io/helidon/webclient/api/HttpClient.html[HttpClient] API to learn more about
 request methods. These methods will create a new instance of link:{webclient-javadoc-base-url}.api/io/helidon/webclient/api/HttpClientRequest.html[HttpClientRequest] which can then be configured to add optional settings that will customize the behavior of the request.


### PR DESCRIPTION
### Description
In the `WebClient` docs was mentioned method `method(String method)`, but this method doesn't exist any more. I replaced it on `method(Method method)`

<img width="968" height="969" alt="Screenshot 2025-08-17 at 18 25 16" src="https://github.com/user-attachments/assets/33cf7af5-5a62-49c1-bf61-091503fd08e5" />
