### PR TITLE
4.x: Javadoc on blueprint can now contain simple references to other methods.

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -417,12 +417,21 @@ public final class Prototype {
     }
 
     /**
-     * Include default methods from the blueprint and its super types.
+     * Include default methods from the blueprint and its super types (interface methods declared as {@code default}).
      * <p>
      * If the value is specified, only methods with names matching the values are included, as long as they qualify as
      * blueprint methods (i.e. they have a non-void return type and zero parameters).
      * <p>
      * This can be used to define backward compatible changes.
+     * <p>
+     * Behavior for handling {@code default} methods on interfaces in blueprints:
+     * <ul>
+     *     <li>If this annotation is NOT present on a blueprint, methods declared as {@code default} are ignored</li>
+     *     <li>If this annotation is present on a blueprint and has empty value, all methods declared as {@code default} are
+     *          included as long as they are property getters (non-void, no parameters, not private)</li>
+     *     <li>If this annotation is present on a blueprint and has non-empty value, only methods with names matching a
+     *          value are included as long as they are property getters (non-void, no parameters, not private</li>
+     * </ul>
      */
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.CLASS)
@@ -432,6 +441,7 @@ public final class Prototype {
          * This can be used for backward compatibility.
          *
          * @return names of methods, if left blank, all default methods are included
+         * @see IncludeDefaultMethods
          */
         String[] value() default {};
     }

--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -415,5 +415,26 @@ public final class Prototype {
          */
         boolean value() default true;
     }
+
+    /**
+     * Include default methods from the blueprint and its super types.
+     * <p>
+     * If the value is specified, only methods with names matching the values are included, as long as they qualify as
+     * blueprint methods (i.e. they have a non-void return type and zero parameters).
+     * <p>
+     * This can be used to define backward compatible changes.
+     */
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.CLASS)
+    public @interface IncludeDefaultMethods {
+        /**
+         * Names of default methods from super types or this blueprint to include as prototype properties.
+         * This can be used for backward compatibility.
+         *
+         * @return names of methods, if left blank, all default methods are included
+         */
+        String[] value() default {};
+    }
+
 }
 

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/PrototypeProperty.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/PrototypeProperty.java
@@ -34,7 +34,8 @@ import io.helidon.common.types.TypedElementInfo;
 import static io.helidon.codegen.CodegenUtil.capitalize;
 
 // builder property
-record PrototypeProperty(MethodSignature signature,
+record PrototypeProperty(TypedElementInfo element,
+                         MethodSignature signature,
                          TypeHandler typeHandler,
                          AnnotationDataOption configuredOption,
                          FactoryMethods factoryMethods,
@@ -111,6 +112,7 @@ record PrototypeProperty(MethodSignature signature,
                 .toList();
 
         return new PrototypeProperty(
+                element,
                 MethodSignature.create(element),
                 typeHandler,
                 configuredOption,

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/Types.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/Types.java
@@ -57,6 +57,7 @@ final class Types {
     static final TypeName PROTOTYPE_BUILDER_DECORATOR = TypeName.create("io.helidon.builder.api.Prototype.BuilderDecorator");
     static final TypeName PROTOTYPE_CONSTANT = TypeName.create("io.helidon.builder.api.Prototype.Constant");
     static final TypeName PROTOTYPE_SERVICE_REGISTRY = TypeName.create("io.helidon.builder.api.Prototype.RegistrySupport");
+    static final TypeName PROTOTYPE_INCLUDE_DEFAULTS = TypeName.create("io.helidon.builder.api.Prototype.IncludeDefaultMethods");
     static final TypeName GENERATED_EQUALITY_UTIL = TypeName.create("io.helidon.builder.api.GeneratedBuilder.EqualityUtil");
 
     static final TypeName RUNTIME_PROTOTYPE = TypeName.create("io.helidon.builder.api.RuntimeType.PrototypedBy");

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ABlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/ABlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 
 package io.helidon.builder.test.testsubjects;
 
+import java.util.Optional;
+
 import io.helidon.builder.api.Prototype;
 
 /**
  * Example A.
  */
 @Prototype.Blueprint
+@Prototype.IncludeDefaultMethods
 interface ABlueprint {
     /**
      * Example A.
@@ -29,4 +32,14 @@ interface ABlueprint {
      * @return 'a' val
      */
     String a();
+
+    /**
+     * Example of a backward compatible method. The generated code will correctly return the configured value,
+     * but if somebody actually implements the prototype interface, their code would not break.
+     *
+     * @return some b value
+     */
+    default Optional<String> aNewProperty() {
+        return Optional.empty();
+    }
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/UsageTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/UsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package io.helidon.builder.test;
+
+import java.util.Optional;
 
 import io.helidon.builder.test.testsubjects.A;
 import io.helidon.builder.test.testsubjects.B;
@@ -66,4 +68,15 @@ class UsageTest {
         assertThat(t.t(), is("helloT"));
     }
 
+    @Test
+    void testDefaultMethod() {
+        A a = A.builder()
+                .a("hello")
+                .aNewProperty("value")
+                .build();
+
+        assertThat(a.a(), is("hello"));
+        assertThat(a.aNewProperty(), is(Optional.of("value")));
+
+    }
 }

--- a/builder/tests/codegen/src/test/java/io/helidon/builder/codegen/TypesTest.java
+++ b/builder/tests/codegen/src/test/java/io/helidon/builder/codegen/TypesTest.java
@@ -110,6 +110,7 @@ public class TypesTest {
         checkField(toCheck, checked, fields, "PROTOTYPE_BUILDER_DECORATOR", Prototype.BuilderDecorator.class);
         checkField(toCheck, checked, fields, "PROTOTYPE_CONSTANT", Prototype.Constant.class);
         checkField(toCheck, checked, fields, "PROTOTYPE_SERVICE_REGISTRY", Prototype.RegistrySupport.class);
+        checkField(toCheck, checked, fields, "PROTOTYPE_INCLUDE_DEFAULTS", Prototype.IncludeDefaultMethods.class);
         checkField(toCheck, checked, fields, "GENERATED_EQUALITY_UTIL", GeneratedBuilder.EqualityUtil.class);
         checkField(toCheck, checked, fields, "RUNTIME_PROTOTYPE", RuntimeType.PrototypedBy.class);
         checkField(toCheck, checked, fields, "RUNTIME_PROTOTYPED_BY", RuntimeType.PrototypedBy.class);


### PR DESCRIPTION
Generated prototypes now copy all methods from blueprint, including javadoc, so javadoc references work as expected.

A blueprint may now add default methods as prototype methods, to support backward compatibility of the generated prototype interface.

Resolves #10553 
