### PR TITLE
Fix error in checking for out-of-order values in configured customizations

### DIFF
--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDistributionCustomizations.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDistributionCustomizations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.microprofile.metrics;
 
+import io.helidon.common.testing.junit5.OptionalMatcher;
 import io.helidon.microprofile.testing.junit5.AddConfig;
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 
@@ -71,5 +72,27 @@ class TestDistributionCustomizations {
         assertThat("beta.anything",
                    timer.getSnapshot().bucketValues(),
                    arrayWithSize(0));
+    }
+
+    @Test
+    void checkOrderEnforcementOk() {
+        var inOrderResult = DistributionCustomizations.MultiValuedCustomization.values("0.1,0.2,0.5",
+                                                                                Double.class,
+                                                                                Double::parseDouble,
+                                                                                value -> {},
+                                                                                () -> "pfx",
+                                                                                () -> false);
+
+        assertThat("In order", inOrderResult.collector(), OptionalMatcher.optionalEmpty());
+
+        var outOfOrderResult = DistributionCustomizations.MultiValuedCustomization.values("0.3,0.1,0.5",
+                                                                                          Double.class,
+                                                                                          Double::parseDouble,
+                                                                                          value -> {},
+                                                                                          () -> "pfx",
+                                                                                          () -> false);
+
+        assertThat("Out of order", outOfOrderResult.collector(), OptionalMatcher.optionalPresent());
+
     }
 }


### PR DESCRIPTION
### Description
Resolves #10572 

The check for out-of-order values had some bad logic. Fixed it and added a couple of tests. Had to refactor some code to make it accessible to the test.

### Documentation
Bug fix; no impact.