### PR TITLE
Add missing assignment of value from config to OTel class for Zipkin exporter

### DIFF
--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigSupport.java
@@ -78,6 +78,7 @@ class OtlpExporterConfigSupport {
             var zipkinConfig = ZipkinExporterConfig.create(config);
 
             zipkinConfig.compression().map(CompressionType::lowerCase).ifPresent(builder::setCompression);
+            zipkinConfig.encoder().ifPresent(builder::setEncoder);
             zipkinConfig.endpoint().map(URI::toASCIIString).ifPresent(builder::setEndpoint);
             zipkinConfig.timeout().ifPresent(builder::setReadTimeout);
             zipkinConfig.sender().ifPresent(builder::setSender);


### PR DESCRIPTION
### Description

The OpenTelemetry Zipkin span exporter can have an encoder.

The config blueprint for the Zipkin exporter has a setting for it but the setting value (if present) was not being copied from config to the OTel Zipkin exporter builder.

One-line fix.

### Documentation
Bug fix; no doc update.