### PR TITLE
Add config support for retry policy on OTLP exporters

### DIFF
--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
@@ -101,10 +101,11 @@ interface OpenTelemetryConfigBlueprint extends Prototype.Factory<HelidonOpenTele
     io.opentelemetry.api.OpenTelemetry openTelemetry();
 
     /**
-     * @hidden internal use only
-     * <p>
+     * Share the prepared OpenTelemetry SDK.
+      * <p>
      * The {@link io.opentelemetry.sdk.OpenTelemetrySdk} to use (restricted visibility).
      *
+     * @hidden internal use only
      * @return the SDK
      */
     @Option.Access("")

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryTracingConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryTracingConfigBlueprint.java
@@ -122,8 +122,9 @@ interface OpenTelemetryTracingConfigBlueprint {
     Map<String, Double> doubleAttributes();
 
     /**
-     * @hidden Internal use only to share information with the parent prototype.
+     * Share information with the parent prototype.
      *
+     * @hidden internal use only
      * @return shared tracer builder information
      */
     @Option.Access("")

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/RetryPolicyConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/RetryPolicyConfigBlueprint.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.otelconfig;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Retry policy settings.
+ */
+@Prototype.Configured
+@Prototype.Blueprint
+interface RetryPolicyConfigBlueprint {
+
+    /**
+     * Maximum number of retry attempts.
+     *
+     * @return max retry attempts
+     */
+    @Option.Configured
+    Optional<Integer> maxAttempts();
+
+    /**
+     * Initial backoff time.
+     *
+     * @return initial backoff time
+     */
+    @Option.Configured
+    Optional<Duration> initialBackoff();
+
+    /**
+     * Maximum backoff time.
+     *
+     * @return max backoff time
+     */
+    @Option.Configured
+    Optional<Duration> maxBackoff();
+
+    /**
+     * Maximum backoff multiplier.
+     *
+     * @return max backoff multiplier
+     */
+    @Option.Configured
+    Optional<Double> maxBackoffMultiplier();
+
+
+}


### PR DESCRIPTION
### Description

1. Add missing config support for OpenTelemetry `RetryPolicy`. Add test.
2. Correct Javadoc on two `@hidden` items.

### Documentation
No impact.