### PR TITLE
Fix assignment of `http.route`; do it during end-of-span processing because `matchingPattern` is not available earlier

### DIFF
--- a/webserver/observe/telemetry/tracing/src/main/java/io/helidon/observe/telemetry/tracing/OpenTelemetryTracingSemanticConventionsProvider.java
+++ b/webserver/observe/telemetry/tracing/src/main/java/io/helidon/observe/telemetry/tracing/OpenTelemetryTracingSemanticConventionsProvider.java
@@ -75,9 +75,8 @@ class OpenTelemetryTracingSemanticConventionsProvider implements TracingSemantic
 
         @Override
         public String spanName() {
-            // Ideally, we would use {method-name} {matching-pattern} for the span name, but the matching pattern is not
-            // available here in a pre-matching filter.
-            return request.prologue().method().text();
+            methodText = request.prologue().method().text();
+            return methodText;
         }
 
         @Override


### PR DESCRIPTION
### Description
Resolves #10614 

The `matchingPattern` in `ServerRequest` is not available in a filter before the request is processed because that code runs before the webserver has matched the request to the correct route. 

Previously, the code in the SE OTel semantic conventions implementation retrieved `matchingPattern` in the filter _before_ the request was processed and, therefore, before the matching occurred, so the `Optional` was never present.

The fix is to assign the `http.route` tag using the matching pattern later in the filter, _after_ the request has been processed.

### Documentation
Bug fix; no doc impact.