### PR TITLE
Allow a JsonRpcResponse to obtain an SSE sink

### DIFF
--- a/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcResponseImpl.java
+++ b/webserver/jsonrpc/src/main/java/io/helidon/webserver/jsonrpc/JsonRpcResponseImpl.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 
+import io.helidon.common.GenericType;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.http.Header;
 import io.helidon.http.ServerResponseHeaders;
@@ -28,6 +29,7 @@ import io.helidon.http.Status;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.jsonrpc.core.JsonUtil;
 import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http.spi.Sink;
 
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
@@ -130,6 +132,10 @@ class JsonRpcResponseImpl implements JsonRpcResponse {
             builder.add("error", error.asJsonObject());
         }
         return builder.build();
+    }
+
+    public <T extends Sink<?>> T sink(GenericType<T> sinkType) {
+        return delegate.sink(sinkType);
     }
 
     @Override

--- a/webserver/tests/jsonrpc/pom.xml
+++ b/webserver/tests/jsonrpc/pom.xml
@@ -59,6 +59,16 @@
             <artifactId>yasson</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-sse</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-sse</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcBaseTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcBaseTest.java
@@ -18,7 +18,9 @@ package io.helidon.webserver.tests.jsonrpc;
 import java.time.Duration;
 import java.util.Optional;
 
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
+import io.helidon.http.sse.SseEvent;
 import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.jsonrpc.JsonRpcClient;
@@ -30,6 +32,7 @@ import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 import io.helidon.webserver.jsonrpc.JsonRpcRules;
 import io.helidon.webserver.jsonrpc.JsonRpcService;
+import io.helidon.webserver.sse.SseSink;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import jakarta.json.Json;
@@ -77,6 +80,7 @@ class JsonRpcBaseTest {
                 // register a service under "/machine"
                 .service(new JsonRpcService1())
                 .register("/notifier", "ping", JsonRpcBaseTest::ping)
+                .register("/sse", "sse", JsonRpcBaseTest::sse)
                 .build();
 
         builder.register("/rpc", jsonRpcRouting);
@@ -173,5 +177,21 @@ class JsonRpcBaseTest {
 
     static void ping(JsonRpcRequest req, JsonRpcResponse res) {
         // don't call send(), just HTTP status response returned
+    }
+
+    // -- SSE -----------------------------------------------------------------
+
+    static void sse(JsonRpcRequest req, JsonRpcResponse res) {
+        res.header(HeaderValues.CONTENT_TYPE_EVENT_STREAM);
+        try (SseSink sink = res.sink(SseSink.TYPE)) {
+            sink.emit(SseEvent.builder()
+                              .name("message")
+                              .data(MACHINE_START)
+                              .build());
+            sink.emit(SseEvent.builder()
+                              .name("message")
+                              .data(MACHINE_STOP)
+                              .build());
+        }
     }
 }

--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcSseTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcSseTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.tests.jsonrpc;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.sse.SseEvent;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.jsonrpc.JsonRpcClient;
+import io.helidon.webclient.sse.SseSource;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class JsonRpcSseTest extends JsonRpcBaseTest {
+
+    static final String SSE_METHOD = """
+            {"jsonrpc": "2.0",
+                "method": "sse",
+                "params": {},
+                "id": 1}
+            """;
+
+    JsonRpcSseTest(Http1Client client, JsonRpcClient jsonRpcClient) {
+        super(client, jsonRpcClient);
+    }
+
+    @Test
+    void testSse() throws ExecutionException, InterruptedException, TimeoutException {
+        CompletableFuture<List<String>> future = new CompletableFuture<>();
+
+        try (var res = client().post("/rpc/sse")
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .accept(MediaTypes.TEXT_EVENT_STREAM)
+                .submit(SSE_METHOD)) {
+            assertThat(res.status().code(), is(200));
+
+            res.source(SseSource.TYPE, new SseSource() {
+                private final List<String> methods = new ArrayList<>();
+
+                @Override
+                public void onEvent(SseEvent value) {
+                    String jsonRpc = value.data(String.class);
+                    JsonObject json = Json.createReader(new StringReader(jsonRpc)).readObject();
+                    methods.add(json.getString("method"));
+                }
+
+                @Override
+                public void onClose() {
+                    future.complete(methods);
+                }
+            });
+
+            List<String> methods = future.get(5, TimeUnit.SECONDS);
+            assertThat(methods.size(), is(2));
+            assertThat(methods.getFirst(), is("start"));
+            assertThat(methods.getLast(), is("stop"));
+        }
+    }
+}


### PR DESCRIPTION
### Description

`JsonRpcResponse` extends `ServerResponse` but its implementation was accidentally lacking support to obtain an SSE sink. This PR fixes that and adds a new test that shows how that works.

### Documentation

None