### PR TITLE
4.x: Upgrades ojdbc* and ucp* artifacts to 23.9.0.25.07

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -147,7 +147,7 @@
             UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.
             Until this bug is fixed do not upgrade past version 21.9.0.0.
         -->
-        <version.lib.ojdbc>${version.lib.ojdbc.family}.6.0.24.10</version.lib.ojdbc>
+        <version.lib.ojdbc>${version.lib.ojdbc.family}.9.0.25.07</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okhttp3 for dependency convergence -->
         <version.lib.okhttp3>4.12.0</version.lib.okhttp3>


### PR DESCRIPTION
This pull request updates the `version.lib.ojdbc` property in `dependencies/pom.xml` to be, effectively, `23.9.0.25.07`.

This release of the `ojdbc*` and `ucp*` artifacts apparently removes a GraalVM native image `Feature` implementation that was erroneously calling non-existing native-image-related classes. It appears that this release has solved a family of problems that has prevented Helidon from uptaking recent versions of the `ojdbc*` and `ucp*` artifacts.

A subsequent pull request may follow to replace usages of `ojdbc11` with `ojdbc17` instead. This pull request deliberately does not make this change.