### PR TITLE
Coordinate the OpenTelemetry tracing provider init with the new config-based init

### DIFF
--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/HelidonOpenTelemetryImpl.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/HelidonOpenTelemetryImpl.java
@@ -16,7 +16,10 @@
 
 package io.helidon.telemetry.otelconfig;
 
+import java.util.Map;
+
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.tracing.Tracer;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -35,6 +38,15 @@ class HelidonOpenTelemetryImpl implements HelidonOpenTelemetry, RuntimeType.Api<
             try {
                 OpenTelemetry openTelemetry = prototype().openTelemetry();
                 GlobalOpenTelemetry.set(openTelemetry);
+                /*
+                Initialize the Helidon global tracer with the newly-set-up OpenTelemetry instance.
+                 */
+                Tracer globalHelidonTracer = io.helidon.tracing.providers.opentelemetry.HelidonOpenTelemetry
+                        .create(openTelemetry,
+                                openTelemetry.getTracer(
+                                        prototype().service()),
+                                Map.of());
+                Tracer.global(globalHelidonTracer);
 
 
             } catch (Exception e) {

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/HelidonOpenTelemetryServiceFactory.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/HelidonOpenTelemetryServiceFactory.java
@@ -38,7 +38,6 @@ class HelidonOpenTelemetryServiceFactory implements Supplier<OpenTelemetry> {
     @Override
     public OpenTelemetry get() {
         OpenTelemetry result;
-        boolean wasOtelGlobalSet = false;
         var otelConfig = OpenTelemetryConfig.create(config.get(HelidonOpenTelemetry.CONFIG_KEY));
         try {
             result = HelidonOpenTelemetry.create(otelConfig)
@@ -51,7 +50,6 @@ class HelidonOpenTelemetryServiceFactory implements Supplier<OpenTelemetry> {
             that retrieves it from our registry will use the actual OTel global instance.
              */
             result = GlobalOpenTelemetry.get();
-            wasOtelGlobalSet = true;
         }
 
         return result;

--- a/tracing/providers/opentelemetry/src/main/java/module-info.java
+++ b/tracing/providers/opentelemetry/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ module io.helidon.tracing.providers.opentelemetry {
     requires io.helidon.common.context;
     requires io.helidon.common;
     requires io.helidon.config;
+    requires io.helidon.service.registry;
     requires io.opentelemetry.context;
     requires io.opentelemetry.extension.trace.propagation;
     requires io.opentelemetry.semconv;


### PR DESCRIPTION
### Description
Resolves #10623 

## Release Note ##
____
If an application uses the new OpenTelemetry configuration feature with `global` set to `true` (the default), Helidon not only assigns the global `OpenTelemetry` instance (as it did in 4.3.0-M2), but it now also initializes the global Helidon `Tracer` instance using the `OpenTelemetry` instance that was prepared using the configuration.

Further, for backward compatibility, in an app that includes the (pre-existing) Helidon OpenTelemetry tracing provider, if any code attempts to fetch the global Helidon `Tracer` before it has been assigned, `OpenTelemetryTracerProvider` now also tries to use the new OpenTelemetry configuration support to prepare OpenTelemetry and create the global tracer from it. For this to work, the `helidon-telemetry-opentelemetry-config` component must be on the class path. If that component is absent, the behavior is as in 4.2.x.
____

## PR Overview

### Added logic in `telemetry` config handling
Previously, the `HelidonOpenTelemetryImpl` class (which transforms configuration into the `OpenTelemetry` instance) would use the resulting `OpenTelemetry` instance to assign the OTel global instance (if the config's `global` setting was `true`).

Now, that same logic also (if `global` is `true`) uses the new `OpenTelemetry` instance to create a new OpenTelemetry `Tracer` instance, enclose that in our `OpenTelemetryTracer` wrapper, and make that wrapper the global Helidon `Tracer` using the existing `OpenTelemetryTracerProvider.global(Tracer)` method. 

This makes sure that any code that retrieves the Helidon global `Tracer` gets a tracer prepared according to the telemetry configuration (if, of course, the tracing provider is the OTel one). 

### Added logic in `OpenTelemetryTracerProvider` initialization
For some time, this class has allowed callers to set the "configured" tracer by invoking the static `global(Tracer)` method and to retrieve it using the `globa()` method. If the `global()` method found the configured tracer un-initialized, it would try to find one in the current Helidon context. Failing that, it would create a new `OpenTelemetry` instance and create a tracer from that.

Now, that code:
1. Checks to see if the configured tracer is set (as before). If so, return it as before.
2. If not, attempts to use the service registry to prepare an `OpenTelemetry` instance using the new OTel config support which now (see above) also sets the global tracer.
3. Failing that, as before creates a new global `OpenTelemetry` instance and uses it to prepare a Helidon `Tracer`. 
 
### Documentation
None
