### PR TITLE
4.x: Improve performance of Services.get(Class).

### DIFF
--- a/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/CoreServiceRegistry.java
@@ -44,7 +44,6 @@ import io.helidon.service.registry.ServiceSupplies.ServiceSupplyList;
 
 import static io.helidon.service.registry.LookupTrace.traceLookup;
 import static io.helidon.service.registry.ServiceRegistryManager.SERVICE_INFO_COMPARATOR;
-import static java.util.function.Predicate.not;
 
 /**
  * Basic implementation of the service registry with simple dependency support.
@@ -191,12 +190,12 @@ class CoreServiceRegistry implements ServiceRegistry, Scopes {
 
             List<ServiceManager<Object>> serviceManagers = lookupManagers(Lookup.create(contract));
             // all must be singletons, otherwise cannot cache
-            var hasNonSingleton = serviceManagers.stream()
+            var onlySingletons = serviceManagers.stream()
                     .map(ServiceManager::descriptor)
                     .map(ServiceInfo::scope)
-                    .anyMatch(not(Service.Singleton.TYPE::equals));
+                    .allMatch(Service.Singleton.TYPE::equals);
 
-            if (hasNonSingleton) {
+            if (onlySingletons) {
                 getCacheLock.writeLock().lock();
                 try {
                     // we do not care if we write it twice - it is a singleton, it will be the same instance


### PR DESCRIPTION
This changed improves perf a lot - from 66 seconds to 4 seconds on a use case that repeatedly calls Services.get(Mappers.class). As this may be on a hot path of applications, we need to optimize this specific lookup.

