### PR TITLE
1.x: Upgrade netty, oci sdk, jgit and dependency check. Update test

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -48,7 +48,7 @@
         <version.lib.google-api-client>1.35.2</version.lib.google-api-client>
         <version.lib.google-protobuf>3.25.5</version.lib.google-protobuf>
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
-        <version.lib.gson>2.9.0</version.lib.gson>
+        <version.lib.gson>2.13.1</version.lib.gson>
         <version.lib.grpc>1.65.1</version.lib.grpc>
         <version.lib.guava>32.0.0-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>
@@ -87,8 +87,8 @@
         <version.lib.mockito>2.23.4</version.lib.mockito>
         <version.lib.mysql-connector-java>8.0.29</version.lib.mysql-connector-java>
         <version.lib.narayana>5.9.3.Final</version.lib.narayana>
-        <version.lib.netty>4.1.118.Final</version.lib.netty>
-        <version.lib.oci-java-sdk-objectstorage>2.73.0</version.lib.oci-java-sdk-objectstorage>
+        <version.lib.netty>4.1.126.Final</version.lib.netty>
+        <version.lib.oci-java-sdk-objectstorage>2.81.0</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>19.3.0.0</version.lib.ojdbc8>
         <version.lib.opentracing>0.32.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <version.lib.checkstyle>8.29</version.lib.checkstyle>
         <version.lib.classfilewriter>1.2.4.Final</version.lib.classfilewriter>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
-        <version.lib.jgit>6.7.0.202309050840-r</version.lib.jgit>
+        <version.lib.jgit>6.10.1.202505221210-r</version.lib.jgit>
         <version.lib.jsch>0.1.55</version.lib.jsch>
         <version.lib.netty.tcnative>2.0.54.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
@@ -112,7 +112,7 @@
         <version.plugin.spotbugs>3.1.12</version.plugin.spotbugs>
         <version.plugin.surefire.provider.junit>1.0.3</version.plugin.surefire.provider.junit>
         <version.plugin.surefire>2.19.1</version.plugin.surefire>
-        <version.plugin.dependency-check>12.1.0</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.1.3</version.plugin.dependency-check>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -16,11 +16,7 @@
 
 package io.helidon.webserver.utils;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
+import java.io.*;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketException;
@@ -254,17 +250,21 @@ public class SocketHttpClient implements AutoCloseable {
         pw.print(method.name());
         pw.print(" ");
         pw.print(path);
-        pw.println(" HTTP/1.1");
-        pw.println("Host: 127.0.0.1");
+        println(pw, " HTTP/1.1");
+        println(pw, "Host: 127.0.0.1");
 
         for (String header : headers) {
-            pw.println(header);
+            println(pw, header);
         }
 
         sendPayload(pw, payload);
 
-        pw.println("");
+        println(pw, "");
         pw.flush();
+    }
+
+    private void println(PrintWriter pw, String line) {
+        pw.print(line + "\r\n");
     }
 
     /**
@@ -275,9 +275,9 @@ public class SocketHttpClient implements AutoCloseable {
      */
     protected void sendPayload(PrintWriter pw, String payload) {
         if (payload != null) {
-            pw.println("Content-Length: " + payload.length());
-            pw.println("");
-            pw.println(payload);
+            println(pw, "Content-Length: " + payload.length());
+            println(pw, "");
+            println(pw, payload);
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -16,7 +16,11 @@
 
 package io.helidon.webserver.utils;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketException;
@@ -263,10 +267,6 @@ public class SocketHttpClient implements AutoCloseable {
         pw.flush();
     }
 
-    private void println(PrintWriter pw, String line) {
-        pw.print(line + "\r\n");
-    }
-
     /**
      * Override this to send a specific payload.
      *
@@ -285,4 +285,9 @@ public class SocketHttpClient implements AutoCloseable {
     public void close() throws Exception {
         socket.close();
     }
+
+    private void println(PrintWriter pw, String line) {
+        pw.print(line + "\r\n");
+    }
+
 }


### PR DESCRIPTION
### Description

* Upgrades Netty to 4.1.126.Final
* Upgrades gson to 2.13.1
* Upgrades oci-java-sdk to 2.81.0
* Upgrades jgit to 6.10.1.202505221210-r
* Upgrades dependency check plugin to 12.1.3

As part of the Netty upgrade it appeared to get stricter interpreting the HTTP protocol. Specifically it now requires that lines are terminated with "CR LF" and not just "LF".  

`SocketHttpClient` used by WebServer testing was not terminating lines correctly which resulted in test failures. This PR fixes that. 