### PR TITLE
4.x: uses the 17 variants of ojdbc and ucp artifacts

### DIFF
--- a/data/sql/datasource/ucp/pom.xml
+++ b/data/sql/datasource/ucp/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp11</artifactId>
+            <artifactId>ucp17</artifactId>
         </dependency>
     </dependencies>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -143,10 +143,6 @@
         <version.lib.netty>4.1.124.Final</version.lib.netty>
         <version.lib.oci>3.72.0</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
-        <!--
-            UCP versions 21.10.0.0 and up throw NPEs. There is a test to catch them.
-            Until this bug is fixed do not upgrade past version 21.9.0.0.
-        -->
         <version.lib.ojdbc>${version.lib.ojdbc.family}.9.0.25.07</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okhttp3 for dependency convergence -->

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp11</artifactId>
+            <artifactId>ucp17</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -41,12 +41,12 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc11-production</artifactId>
+            <artifactId>ojdbc17-production</artifactId>
             <type>pom</type>
             <exclusions>
                 <exclusion>
                     <groupId>com.oracle.database.jdbc</groupId>
-                    <artifactId>ucp11</artifactId>
+                    <artifactId>ucp17</artifactId>
                 </exclusion>
                 <exclusion>
                     <!-- Contains JAXP impl, so we exclude it to not interfere -->


### PR DESCRIPTION
This pull request uses the `17` variants of the `ojdbc*` and `ucp*` libraries.

Following https://github.com/helidon-io/helidon/issues/9351#issuecomment-2411990030, we want to make sure we're using the latest and greatest artifacts where possible.