### PR TITLE
4.x: Upgrade netty to 4.1.126.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -140,7 +140,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.124.Final</version.lib.netty>
+        <version.lib.netty>4.1.126.Final</version.lib.netty>
         <version.lib.oci>3.72.0</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <!--


### PR DESCRIPTION
### Description

 Upgrade netty to 4.1.126.Final

Helidon 4 doesn't use Netty as its HTTP server. For why we still manage the Netty version see #9645

