### PR TITLE
4.x: Global config now works consistent with Testing.Test and global service registry

### DIFF
--- a/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
+++ b/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
@@ -47,7 +47,7 @@ public final class GlobalConfig {
     private static final System.Logger LOGGER = System.getLogger(GlobalConfig.class.getName());
     private static final AtomicBoolean LOGGED_REGISTERED = new AtomicBoolean(false);
     private static final Config EMPTY = Config.empty();
-    private static final AtomicReference<Boolean> GLOBAL_FROM_REGISTRY = new AtomicReference<>();
+    private static final AtomicBoolean GLOBAL_FROM_REGISTRY = new AtomicBoolean();
     private static final LazyValue<Config> DEFAULT_CONFIG = LazyValue.create(() -> {
         List<io.helidon.common.config.spi.ConfigProvider> providers =
                 HelidonServiceLoader.create(ServiceLoader.load(io.helidon.common.config.spi.ConfigProvider.class))
@@ -84,7 +84,7 @@ public final class GlobalConfig {
      */
     @Deprecated(forRemoval = true, since = "4.2.0")
     public static Config config() {
-        if (Boolean.TRUE.equals(GLOBAL_FROM_REGISTRY.get())) {
+        if (GLOBAL_FROM_REGISTRY.get()) {
             return Services.get(Config.class);
         }
 
@@ -115,7 +115,7 @@ public final class GlobalConfig {
     public static Config config(Supplier<Config> config, boolean overwrite) {
         Objects.requireNonNull(config);
 
-        if (Boolean.TRUE.equals(GLOBAL_FROM_REGISTRY.get())) {
+        if (GLOBAL_FROM_REGISTRY.get()) {
             return Services.get(Config.class);
         }
 

--- a/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
+++ b/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
@@ -47,6 +47,7 @@ public final class GlobalConfig {
     private static final System.Logger LOGGER = System.getLogger(GlobalConfig.class.getName());
     private static final AtomicBoolean LOGGED_REGISTERED = new AtomicBoolean(false);
     private static final Config EMPTY = Config.empty();
+    private static final AtomicReference<Boolean> GLOBAL_FROM_REGISTRY = new AtomicReference<>();
     private static final LazyValue<Config> DEFAULT_CONFIG = LazyValue.create(() -> {
         List<io.helidon.common.config.spi.ConfigProvider> providers =
                 HelidonServiceLoader.create(ServiceLoader.load(io.helidon.common.config.spi.ConfigProvider.class))
@@ -83,6 +84,10 @@ public final class GlobalConfig {
      */
     @Deprecated(forRemoval = true, since = "4.2.0")
     public static Config config() {
+        if (Boolean.TRUE.equals(GLOBAL_FROM_REGISTRY.get())) {
+            return Services.get(Config.class);
+        }
+
         return configured() ? CONFIG.get() : DEFAULT_CONFIG.get();
     }
 
@@ -110,11 +115,15 @@ public final class GlobalConfig {
     public static Config config(Supplier<Config> config, boolean overwrite) {
         Objects.requireNonNull(config);
 
+        if (Boolean.TRUE.equals(GLOBAL_FROM_REGISTRY.get())) {
+            return Services.get(Config.class);
+        }
+
         if (overwrite || !configured()) {
             // there is a certain risk we may do this twice, if two components try to set global config in parallel.
             // as the result was already unclear (as order matters), we do not need to be 100% thread safe here
             Config configInstance = config.get();
-            CONFIG.set(configInstance);
+            config(configInstance, false);
 
             try {
                 Services.set(Config.class, configInstance);
@@ -134,7 +143,20 @@ public final class GlobalConfig {
                 }
             }
         }
+
         return CONFIG.get();
+    }
+
+    /**
+     * This is a temporary method to allow backward compatibility. Please do not use this method.
+     *
+     * @param config config to set
+     * @param fromServiceRegistry whether the instance was explicitly configured by user, or obtained from service registry
+     */
+    @Deprecated(forRemoval = true, since = "4.3.0")
+    public static void config(Config config, boolean fromServiceRegistry) {
+        GLOBAL_FROM_REGISTRY.set(fromServiceRegistry);
+        CONFIG.set(config);
     }
 
     static Config create() {

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -422,7 +422,7 @@ public interface Config extends io.helidon.common.config.Config {
             return BuilderImpl.GlobalConfigHolder.get();
         }
         Config config = Services.get(Config.class);
-        io.helidon.common.config.GlobalConfig.config(() -> config, true);
+        io.helidon.common.config.GlobalConfig.config(config, true);
         return config;
     }
 
@@ -437,7 +437,7 @@ public interface Config extends io.helidon.common.config.Config {
     @SuppressWarnings("removal")
     @Deprecated(forRemoval = true, since = "4.2.0")
     static void global(Config config) {
-        io.helidon.common.config.GlobalConfig.config(() -> config, true);
+        io.helidon.common.config.GlobalConfig.config(config, false);
         BuilderImpl.GlobalConfigHolder.set(config);
     }
 

--- a/config/tests/service-registry/pom.xml
+++ b/config/tests/service-registry/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/TestGlobalConfig.java
+++ b/config/tests/service-registry/src/test/java/io/helidon/config/tests/service/registry/TestGlobalConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.tests.service.registry;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.config.MapConfigSource;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Testing.Test(perMethod = true)
+public class TestGlobalConfig {
+
+    @Test
+    void one() {
+        Services.set(Config.class, Config.just(MapConfigSource.create(Map.of("key", "one"))));
+        assertThat(Config.global().get("key").asString().get(), is("one"));
+    }
+
+    @Test
+    void two() {
+        Services.set(Config.class, Config.just(MapConfigSource.create(Map.of("key", "two"))));
+        assertThat(Config.global().get("key").asString().get(), is("two"));;
+    }
+
+    @Test
+    void three() {
+        Services.set(Config.class, Config.just(MapConfigSource.create(Map.of("key", "three"))));
+        assertThat(Config.global().get("key").asString().get(), is("three"));
+    }
+
+
+    @Test
+    void oneServices() {
+        Services.set(Config.class, Config.just(MapConfigSource.create(Map.of("key", "one"))));
+        assertThat(Services.get(Config.class).get("key").asString().get(), is("one"));
+    }
+
+    @Test
+    void twoServices() {
+        Services.set(Config.class, Config.just(MapConfigSource.create(Map.of("key", "two"))));
+        assertThat(Services.get(Config.class).get("key").asString().get(), is("two"));;
+    }
+
+    @Test
+    void threeServices() {
+        Services.set(Config.class, Config.just(MapConfigSource.create(Map.of("key", "three"))));
+        assertThat(Services.get(Config.class).get("key").asString().get(), is("three"));
+    }
+}

--- a/testing/junit5/src/main/java/io/helidon/testing/junit5/TestJunitExtension.java
+++ b/testing/junit5/src/main/java/io/helidon/testing/junit5/TestJunitExtension.java
@@ -427,10 +427,6 @@ public class TestJunitExtension implements Extension,
     }
 
     private interface TestContext extends CloseableResource {
-        default boolean isPerMethod() {
-            return false;
-        }
-
         default void close() {
         }
 
@@ -446,12 +442,10 @@ public class TestJunitExtension implements Extension,
     private static class PerClassTestContext implements TestContext {
         private final Context context;
         private final ServiceRegistryManager manager;
-        private final ServiceRegistry registry;
 
-        private PerClassTestContext(Context context, ServiceRegistryManager manager, ServiceRegistry registry) {
+        private PerClassTestContext(Context context, ServiceRegistryManager manager) {
             this.context = context;
             this.manager = manager;
-            this.registry = registry;
         }
 
         @Override
@@ -478,7 +472,7 @@ public class TestJunitExtension implements Extension,
             // supply registry
             context.register("helidon-registry", registry);
 
-            return new PerClassTestContext(context, manager, registry);
+            return new PerClassTestContext(context, manager);
         }
     }
 
@@ -489,7 +483,6 @@ public class TestJunitExtension implements Extension,
 
         private volatile Context context;
         private volatile ServiceRegistryManager manager;
-        private volatile ServiceRegistry registry;
 
         private PerMethodTestContext(Class<?> testClass, Context testClassContext) {
             this.testClass = testClass;
@@ -508,11 +501,6 @@ public class TestJunitExtension implements Extension,
         }
 
         @Override
-        public boolean isPerMethod() {
-            return true;
-        }
-
-        @Override
         public Context context() {
             if (context == null) {
                 return testClassContext;
@@ -526,7 +514,6 @@ public class TestJunitExtension implements Extension,
                 manager.shutdown();
                 context = null;
                 manager = null;
-                registry = null;
             }
         }
 
@@ -548,7 +535,6 @@ public class TestJunitExtension implements Extension,
             testClassContext.register("helidon-registry-static-context", context);
 
             this.manager = manager;
-            this.registry = registry;
             this.context = context;
         }
 

--- a/testing/junit5/src/main/java/io/helidon/testing/junit5/Testing.java
+++ b/testing/junit5/src/main/java/io/helidon/testing/junit5/Testing.java
@@ -39,5 +39,11 @@ public final class Testing {
     @Inherited
     @ExtendWith(TestJunitExtension.class)
     public @interface Test {
+        /**
+         * If set to {@code true}, service registry will be reset after each test method, instead after the whole test class.
+         *
+         * @return whether to reset registry after each test method
+         */
+        boolean perMethod() default false;
     }
 }

--- a/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassB.java
+++ b/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassB.java
@@ -16,8 +16,14 @@
 
 package io.helidon.testing.junit5;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import io.helidon.service.registry.GlobalServiceRegistry;
 import io.helidon.service.registry.Services;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -32,12 +38,35 @@ TestClassDefault - expecting default (injected) value
  */
 @Testing.Test
 public class TestClassB {
+    private static final Set<Integer> INSTANCES = new HashSet<>();
+
+    @BeforeAll
+    public static void beforeAll() {
+        Services.set(TestService.class, new TestService("testB"));
+        INSTANCES.add(System.identityHashCode(GlobalServiceRegistry.registry()));
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        INSTANCES.add(System.identityHashCode(GlobalServiceRegistry.registry()));
+        assertThat("We should only use a single registry instance when annotated with @Testing.Test", INSTANCES.size(), is(1));
+    }
+
     @Test
     public void testRegistry() {
-        Services.set(TestService.class, new TestService("testB"));
-
         TestService testService = Services.get(TestService.class);
 
         assertThat(testService.message(), is("testB"));
+
+        INSTANCES.add(System.identityHashCode(GlobalServiceRegistry.registry()));
+    }
+
+    @Test
+    public void testRegistry2() {
+        TestService testService = Services.get(TestService.class);
+
+        assertThat(testService.message(), is("testB"));
+
+        INSTANCES.add(System.identityHashCode(GlobalServiceRegistry.registry()));
     }
 }

--- a/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassPerMethod.java
+++ b/testing/junit5/src/test/java/io/helidon/testing/junit5/TestClassPerMethod.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.testing.junit5;
+
+import io.helidon.service.registry.Services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/*
+Tests that each test method has its own instance of global registry.
+ */
+@Testing.Test(perMethod = true)
+public class TestClassPerMethod {
+    @Test
+    public void testRegistryA() {
+        Services.set(TestService.class, new TestService("testA"));
+
+        TestService testService = Services.get(TestService.class);
+
+        assertThat(testService.message(), is("testA"));
+    }
+
+    @Test
+    public void testRegistryB() {
+        Services.set(TestService.class, new TestService("testB"));
+
+        TestService testService = Services.get(TestService.class);
+
+        assertThat(testService.message(), is("testB"));
+    }
+}


### PR DESCRIPTION
### Description
Resolves #10633 

This change makes sure that if global config is set using service registry, the service registry will be used for further lookups, to avoid setting a static global config when user did not intend to.

This is now aligned with `@Testing.Test` extension (and webserver and MP testing).