### PR TITLE
4.2.7: Upgrade jgit to 7.3.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -93,7 +93,7 @@
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
         <version.lib.jaxb-runtime>4.0.5</version.lib.jaxb-runtime>
         <version.lib.jersey>3.1.10</version.lib.jersey>
-        <version.lib.jgit>7.2.1.202505142326-r</version.lib.jgit>
+        <version.lib.jgit>7.3.0.202506031305-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>
         <version.lib.junit-platform-testkit>1.11.3</version.lib.junit-platform-testkit>
         <version.lib.kafka>3.9.1</version.lib.kafka>


### PR DESCRIPTION
Backport #10602 to Helidon 4.2.7

### Description

Upgrade jgit to 7.3.0.202506031305-r

