### PR TITLE
For MP CORS, suppress explanation of rejection in response; log it instead

### DIFF
--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ import jakarta.ws.rs.core.Response;
  * MP implementation of {@link CorsSupportBase}.
  */
 class CorsSupportMp extends CorsSupportBase<ContainerRequestContext, Response, CorsSupportMp, CorsSupportMp.Builder> {
+
+    private static final System.Logger LOGGER = System.getLogger(CorsSupportMp.class.getName());
 
     /**
      *
@@ -205,7 +207,8 @@ class CorsSupportMp extends CorsSupportBase<ContainerRequestContext, Response, C
 
         @Override
         public Response forbidden(String message) {
-            return Response.status(Response.Status.FORBIDDEN).entity(message).build();
+            LOGGER.log(System.Logger.Level.TRACE, "Rejecting CORS request: " + message);
+            return Response.status(Response.Status.FORBIDDEN).build();
         }
 
         @Override

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CrossOriginTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CrossOriginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.http.HeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS;
@@ -45,6 +46,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyString;
 
 /**
  * Class CrossOriginTest.
@@ -201,6 +203,7 @@ class CrossOriginTest extends BaseCrossOriginTest {
                 .header(ACCESS_CONTROL_REQUEST_METHOD.defaultCase(), "PUT")
                 .options();
         assertThat(res.getStatusInfo(), is(Response.Status.FORBIDDEN));
+        assertThat(res.readEntity(String.class), isEmptyString());
     }
 
     @Test
@@ -226,6 +229,7 @@ class CrossOriginTest extends BaseCrossOriginTest {
                 .header(ACCESS_CONTROL_REQUEST_METHOD.defaultCase(), "POST")
                 .options();
         assertThat(res.getStatusInfo(), is(Response.Status.FORBIDDEN));
+        assertThat(res.readEntity(String.class), isEmptyString());
     }
 
     @Test
@@ -237,6 +241,7 @@ class CrossOriginTest extends BaseCrossOriginTest {
                 .header(ACCESS_CONTROL_REQUEST_HEADERS.defaultCase(), "X-foo, X-bar, X-oops")
                 .options();
         assertThat(res.getStatusInfo(), is(Response.Status.FORBIDDEN));
+        assertThat(res.readEntity(String.class), isEmptyString());
     }
 
     @Test


### PR DESCRIPTION
### Description
Resolves #10630 

Identical in spirit to PR #10631 but for MP.

When we reject a CORS request, log the underlying reason instead of sending the reason back in the response.

### Documentation
Bug fix; no impact.