### PR TITLE
Rename TestFilterService to FilterServiceTest so it is run

### DIFF
--- a/config/encryption/src/test/java/io/helidon/config/encryption/FilterServiceTest.java
+++ b/config/encryption/src/test/java/io/helidon/config/encryption/FilterServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/encryption/src/test/java/io/helidon/config/encryption/FilterServiceTest.java
+++ b/config/encryption/src/test/java/io/helidon/config/encryption/FilterServiceTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Test for automatic filter loading.
  */
-class TestFilterService {
+class FilterServiceTest {
     @Test
     void testFiltering() {
         Config config = Config.create().get("aes-current");


### PR DESCRIPTION
### Description

`TestFilterService` in `config/encryption` was not being run in the default reactor.  This is because in `config/pom.xml` the surefire plugin is configured with ` <include>**/*Test.java</include>`.

This PR updates the name of the test class to match this pattern.

