### PR TITLE
4.x: Set addClasspath to true so config encryption jar is runnable

### DIFF
--- a/config/encryption/pom.xml
+++ b/config/encryption/pom.xml
@@ -94,6 +94,7 @@
                 <configuration>
                     <archive>
                         <manifest>
+                            <addClasspath>true</addClasspath>
                             <mainClass>io.helidon.config.encryption.Main</mainClass>
                         </manifest>
                     </archive>


### PR DESCRIPTION
### Description

Set addClasspath to true so config encryption jar is runnable.

Fixes #10654

