### PR TITLE
4.x: Change occurrances of "${AES" to "${GCM"

### DIFF
--- a/config/config/src/test/resources/io/helidon/config/application.conf
+++ b/config/config/src/test/resources/io/helidon/config/application.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ app {
     name = "Demo"
     page-size = 20
     basic-range = [ -20, 20 ]
-    storagePassphrase = "${AES=thisIsEncriptedPassphrase}"
+    storagePassphrase = "${GCM=thisIsEncriptedPassphrase}"
 }
 
 logging {

--- a/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import io.helidon.config.spi.ConfigFilter;
  * <p>
  * Password in properties must be stored as follows:
  * <ul>
- * <li>${AES=base64} - encrypted password using a master password (must be provided to prime through configuration, system
+ * <li>${GCM=base64} - encrypted password using a master password (must be provided to prime through configuration, system
  * property or environment variable)</li>
  * <li>${RSA=base64} - encrypted password using a public key (private key must be available to Prime instance,
  * its location must be provided to prime through configuration, system property or environment variable)</li>
@@ -46,7 +46,7 @@ import io.helidon.config.spi.ConfigFilter;
  * </ul>
  * Example:
  * <pre>
- * google_client_secret=${AES=mYRkg+4Q4hua1kvpCCI2hg==}
+ * google_client_secret=${GCM=mYRkg+4Q4hua1kvpCCI2hg==}
  * service_password=${RSA=mYRkg+4Q4hua1kvpCCI2hg==}
  * another_password=${service_password}
  * cleartext_password=${CLEAR=known_password}
@@ -205,7 +205,7 @@ public final class EncryptionFilter implements ConfigFilter {
     }
 
     private String decryptAes(char[] masterPassword, String value) {
-        // google_client_secret=${AES=mYRkg+4Q4hua1kvpCCI2hg==}
+        // google_client_secret=${GCM=mYRkg+4Q4hua1kvpCCI2hg==}
 
         if (value.startsWith(PREFIX_GCM)) {
             String b64Value = value.substring(PREFIX_GCM.length(), value.length() - 1);

--- a/config/encryption/src/main/java/io/helidon/config/encryption/MpEncryptionFilter.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/MpEncryptionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.eclipse.microprofile.config.Config;
  * <p>
  * Password in properties must be stored as follows:
  * <ul>
- * <li>${AES=base64} - encrypted password using a master password (must be provided to prime through configuration, system
+ * <li>${GCM=base64} - encrypted password using a master password (must be provided to prime through configuration, system
  * property or environment variable)</li>
  * <li>${RSA=base64} - encrypted password using a public key (private key must be available to Prime instance,
  * its location must be provided to prime through configuration, system property or environment variable)</li>
@@ -173,7 +173,7 @@ public final class MpEncryptionFilter implements MpConfigFilter {
     }
 
     private String decryptAes(char[] masterPassword, String value) {
-        // google_client_secret=${AES=mYRkg+4Q4hua1kvpCCI2hg==}
+        // google_client_secret=${GCM=mYRkg+4Q4hua1kvpCCI2hg==}
 
         if (value.startsWith(PREFIX_GCM)) {
             String b64Value = value.substring(PREFIX_GCM.length(), value.length() - 1);

--- a/config/encryption/src/test/resources/application.yaml
+++ b/config/encryption/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,40 +40,6 @@ rsa-current:
 
   passwords: [
     "${RSA-P=fXoVMRlWzlj4fUPnLYFm2h0hSqnKgJqzJLiSslSfmf5MLXRYxNT0MKDZfmGN1If1E4/TR0jeVW/myPUaAJnO3tpadi6AyWsyz6pmEt2mzXZ+yQa1Em0/6ORiqnR2NedyrtVkn8lWL2YIkWfqbNwHODB3jehJ/BPfXru0WNDNRw3jVlPA33FsLBJFeZSRPs+fu1jNu/SeSjvS23a0+rGHUR/zeDP+jqHGEEjiUb73RMRBgvaBxU3RPM2dJ4hWOMKssjYJeu6SOidc3Ej9HpL1XNw5lGfQrqU2u7Lkga1uKd7eW1hSQZQEypcAa6ZtXrKZS4sIXwKqyYt3mdPJaUnzOA==}"
-  ]
-
-aes-legacy:
-  # Secret in clear text - for non-prod environments, this is enough. Intentionally wrapped as password to protect for prod.
-  pwd1: "${CLEAR=known_password}"
-  # A reference to another property (and maybe in the future to a key in a "wallet" service)
-  pwd2: "${ALIAS=aes-legacy.pwd1}"
- # "master" password encrypted password
-  pwd4: "${AES=YbaZGjQfwOv0htF2nmRYaOMYp0+qY/IRQUlWHfRKeTw6Q2uy33Rp8ZhTwv0oDywE}"
-
-  # empty string
-  pwd6: "${AES=D/UgMzsNb265HU1NDvdzm7tACHdsW6u1PjYEcRkV/OLiWcI+ET6Q4MKCz0zHyEh9}"
-  # encrypted alias
-  pwd7: "${ALIAS=aes-legacy.pwd4}"
-  # missing alias
-  pwd8: "${ALIAS=missing}"
-  # wrong encryption
-  pwd9: "${AES=not really encrypted}"
-
-  pwd11: "${ALIAS=aes-legacy.pwd2}"
-  pwd12: "${ALIAS=aes-legacy.pwd11}"
-
-  passwords: [
-    "${AES=LrbVVJOnn82fjl9ioV0pIDnYDhoNZp21KIEIjX8nTadlnlM8VQu2XXjJv8MFfHgm}",
-    "${AES=xAzTBAstoNzvq2qk7szFGreIEfdxNx4OkIuLZHMUO/+p2441Sd4DkdmqgFKv0zNx}"
-  ]
-
-  objects: [
-  {
-    pwd: "${AES=gMTQIU+zcu9UPkGY8IKpYoVV2sxPna4O6rtlgKXtkqspSyxbLJMiu+VgqZq7okMX}"
-  },
-  {
-    pwd: "${AES=DalgBVpVjvbqNgC+jCM5AmMG0rr4BlTf0XQbJVs85ukch/PsF8reJ1NqGHF1GqgN}"
-  }
   ]
 
   customEnc: "${URGH=argh}"

--- a/config/etcd/src/test/resources/application.conf
+++ b/config/etcd/src/test/resources/application.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ app {
   name = "Demo"
   page-size = 20
   basic-range = [ -20, 20 ]
-  storagePassphrase = "${AES=thisIsEncriptedPassphrase}"
+  storagePassphrase = "${GCM=thisIsEncriptedPassphrase}"
 }
 
 logging {

--- a/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -298,7 +298,7 @@ public class HoconConfigParserTest {
                 + "  name = \"" + NAME + "\"\n"
                 + "  page-size = " + PAGE_SIZE + "\n"
                 + "  basic-range = [ " + BASIC_RANGE.get(0) + ", " + BASIC_RANGE.get(1) + " ]\n"
-                + "  storagePassphrase = \"${AES=thisIsEncriptedPassphrase}\""
+                + "  storagePassphrase = \"${GCM=thisIsEncriptedPassphrase}\""
                 + "}";
 
         private final String greeting;

--- a/config/tests/integration-tests/src/test/java/io/helidon/config/tests/DemoTest.java
+++ b/config/tests/integration-tests/src/test/java/io/helidon/config/tests/DemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -242,7 +242,7 @@ public class DemoTest {
         assertThat(appConfig.getPageSize(), is(20));
         assertThat(appConfig.getBasicRange(), contains(-20, 20));
         assertThat(appConfig.isStorageEnabled(), is(false));
-        assertThat(appConfig.getStoragePassphrase(), is("${AES=thisIsEncriptedPassphrase}"));
+        assertThat(appConfig.getStoragePassphrase(), is("${GCM=thisIsEncriptedPassphrase}"));
     }
 
     @Test
@@ -263,7 +263,7 @@ public class DemoTest {
         assertThat(appConfig.getPageSize(), is(20));
         assertThat(appConfig.getBasicRange(), contains(-20, 20));
         assertThat(appConfig.isStorageEnabled(), is(false));
-        assertThat(appConfig.getStoragePassphrase(), is("${AES=thisIsEncriptedPassphrase}"));
+        assertThat(appConfig.getStoragePassphrase(), is("${GCM=thisIsEncriptedPassphrase}"));
     }
 
     @Test

--- a/config/tests/integration-tests/src/test/java/io/helidon/config/tests/SecurityConfigFilter.java
+++ b/config/tests/integration-tests/src/test/java/io/helidon/config/tests/SecurityConfigFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import io.helidon.config.spi.ConfigFilter;
 public class SecurityConfigFilter implements ConfigFilter {
     @Override
     public String apply(Config.Key key, String stringValue) {
-        if ("${AES=thisIsEncriptedPassphrase}".equals(stringValue)) {
+        if ("${GCM=thisIsEncriptedPassphrase}".equals(stringValue)) {
             return "Password1.";
         } else {
             return stringValue;

--- a/config/tests/integration-tests/src/test/resources/application.conf
+++ b/config/tests/integration-tests/src/test/resources/application.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ app {
     name = "Demo"
     page-size = 20
     basic-range = [ -20, 20 ]
-    storagePassphrase = "${AES=thisIsEncriptedPassphrase}"
+    storagePassphrase = "${GCM=thisIsEncriptedPassphrase}"
 }
 
 logging {

--- a/security/providers/http-auth/docs/full.yaml
+++ b/security/providers/http-auth/docs/full.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2016, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ security:
             roles: ["user", "admin"]
           - login: "jill"
             # master password is "jungle", password is "password"
-            password: "${AES=3XQ8A1RszE9JbXl+lUnnsX0gakuqjnTyp8YJWIAU1D3SiM2TaSnxd6U0/LjrdJYv}"
+            password: "${GCM=3XQ8A1RszE9JbXl+lUnnsX0gakuqjnTyp8YJWIAU1D3SiM2TaSnxd6U0/LjrdJYv}"
             roles: ["user"]
     - http-digest-auth:
         # If set to true, provider will abstain rather than fail if authentication fails
@@ -60,5 +60,5 @@ security:
             roles: ["user", "admin"]
           - login: "jill"
             # master password is "jungle", password is "password"
-            password: "${AES=3XQ8A1RszE9JbXl+lUnnsX0gakuqjnTyp8YJWIAU1D3SiM2TaSnxd6U0/LjrdJYv}"
+            password: "${GCM=3XQ8A1RszE9JbXl+lUnnsX0gakuqjnTyp8YJWIAU1D3SiM2TaSnxd6U0/LjrdJYv}"
             roles: ["user"]

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class ConfigUserStore implements SecureUserStore {
      * {
      *   login = "jill"
      *   # master password is "jungle", password is "password"
-     *   password = "${AES=3XQ8A1RszE9JbXl+lUnnsX0gakuqjnTyp8YJWIAU1D3SiM2TaSnxd6U0/LjrdJYv}"
+     *   password = "${GCM=3XQ8A1RszE9JbXl+lUnnsX0gakuqjnTyp8YJWIAU1D3SiM2TaSnxd6U0/LjrdJYv}"
      *   roles = ["user"]
      * }
      * ]


### PR DESCRIPTION
### Description

We had some leftover occurrences of "${AES" in the code. This changes thsoe to "${GCM"

Also removes `aes-legacy` test data that was not used.




