### PR TITLE
4.x: JUnit5 testing module is now marked as `open`, so we can run test on module path

### DIFF
--- a/service/tests/codegen/pom.xml
+++ b/service/tests/codegen/pom.xml
@@ -60,5 +60,23 @@
             <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.plugin.surefire}</version>
+                <configuration>
+                    <useModulePath>true</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
+++ b/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
@@ -56,6 +56,7 @@ import io.helidon.service.registry.ServiceLoader__ServiceDescriptor;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.testing.junit5.Testing;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.collection.IsEmptyCollection;
@@ -67,6 +68,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("deprecation")
+@Testing.Test
 class ServiceCodegenTypesTest {
     @SuppressWarnings("removal")
     @Test

--- a/service/tests/codegen/src/test/java/module-info.java
+++ b/service/tests/codegen/src/test/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ module io.helidon.service.tests.codegen.test {
     requires hamcrest.all;
     requires org.junit.jupiter.api;
     requires io.helidon.service.metadata;
+    requires io.helidon.testing.junit5;
 
     opens io.helidon.service.tests.codegen to org.junit.platform.commons;
 }

--- a/testing/junit5/src/main/java/module-info.java
+++ b/testing/junit5/src/main/java/module-info.java
@@ -17,7 +17,7 @@
 /**
  * See {@link io.helidon.testing.junit5}.
  */
-module io.helidon.testing.junit5 {
+open module io.helidon.testing.junit5 {
     requires org.junit.jupiter.api;
     requires io.helidon.service.registry;
     requires io.helidon.logging.common;


### PR DESCRIPTION
Resolves #10632 

Updated the one test we have with `module-info.java` in test sources to use the extension, to validate the fix.
The test failed before the fix.