### PR TITLE
In MP CORS do not add CORS headers if request is rejected

### DIFF
--- a/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
+++ b/cors/src/main/java/io/helidon/cors/CorsSupportHelper.java
@@ -315,7 +315,8 @@ public class CorsSupportHelper<Q, R> {
     }
 
     /**
-     * Prepares a response with CORS headers, if the supplied request is in fact a CORS request.
+     * Prepares a response with CORS headers, if the supplied request is in fact a CORS request and if upstream processing has
+     * not already determined the request should be refused.
      *
      * @param requestAdapter abstraction of a request
      * @param responseAdapter abstraction of a response
@@ -323,6 +324,12 @@ public class CorsSupportHelper<Q, R> {
     public void prepareResponse(CorsRequestAdapter<Q> requestAdapter, CorsResponseAdapter<R> responseAdapter) {
         if (!isActive()) {
             decisionLog(() -> String.format("CORS ignoring request %s; CORS processing is inactive", requestAdapter));
+            return;
+        }
+
+        if (responseAdapter.status() == Status.FORBIDDEN_403_CODE) {
+            decisionLog(() -> String.format("CORS bypassing addition of CORS headers for request %s; status is Forbidden",
+                                            requestAdapter));
             return;
         }
 

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CrossOriginTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CrossOriginTest.java
@@ -46,6 +46,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.isEmptyString;
 
 /**
@@ -55,9 +56,13 @@ import static org.hamcrest.Matchers.isEmptyString;
 @AddBean(CrossOriginTest.CorsResource1.class)
 @AddBean(CrossOriginTest.CorsResource2.class)
 @AddBean(CrossOriginTest.CorsResource3.class)
+@AddBean(CrossOriginTest.CorsResource4.class)
 @AddConfig(key = "cors.paths.0.path-pattern", value = "/cors3")
 @AddConfig(key = "cors.paths.0.allow-origins", value = "http://foo.bar, http://bar.foo")
 @AddConfig(key = "cors.paths.0.allow-methods", value = "DELETE, PUT")
+@AddConfig(key = "cors.paths.1.path-pattern", value = "/cors4")
+@AddConfig(key = "cors.paths.1.allow-origins", value = "http://foo.bar, http://bar.foo")
+@AddConfig(key = "cors.paths.1.allow-methods", value = "GET")
 class CrossOriginTest extends BaseCrossOriginTest {
     @Inject
     private WebTarget target;
@@ -145,6 +150,16 @@ class CrossOriginTest extends BaseCrossOriginTest {
         @OPTIONS
         @CrossOrigin()
         public void optionsForMainPath() {
+        }
+    }
+
+    @RequestScoped
+    @Path("/cors4")
+    static public class CorsResource4 {
+
+        @GET
+        public Response get() {
+            return Response.ok().build();
         }
     }
 
@@ -381,5 +396,18 @@ class CrossOriginTest extends BaseCrossOriginTest {
                 .put(Entity.entity("", MediaType.TEXT_PLAIN_TYPE));
         assertThat(res.getStatusInfo(), is(Response.Status.OK));
         assertThat(res.getHeaders().getFirst(ACCESS_CONTROL_ALLOW_ORIGIN.defaultCase()), is("http://foo.bar"));
+    }
+
+    @Test
+    void testEntityAndHeadersWhenForbidden() {
+        Response res = target.path("/cors4")
+                .request()
+                .header(ORIGIN.defaultCase(), "http://other.com")
+                .header(ACCESS_CONTROL_REQUEST_METHOD.defaultCase(), "GET")
+                .get();
+        assertThat("Status of rejection response", res.getStatusInfo(), is(Response.Status.FORBIDDEN));
+        assertThat("Entity of rejection response", res.hasEntity(), is(false));
+        assertThat("Headers of rejection response", res.getHeaders().get(ACCESS_CONTROL_ALLOW_ORIGIN.defaultCase()), nullValue());
+
     }
 }


### PR DESCRIPTION
### Description
Resolves #10630 

### Release note ###
____
Helidon MP no longer adds CORS headers if the request is rejected.
____

The MP CORS code path was still adding CORS headers even if the CORS processing was rejecting the request. This PR suppresses the addition of headers in that case. The status in the response adapter will have been set by CORS code to 403 Forbidden by the time `prepareResponse` is running, so the change in the PR simply returns immediately in that case rather than adding CORS headers to the response.

PR also adds a test.

### Documentation
No impact.