### PR TITLE
3.x owasp dep check 12.1.5

### DIFF
--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,31 +15,61 @@
 # limitations under the License.
 #
 
+set -o pipefail || true  # trace ERR through pipes
+set -o errtrace || true # trace ERR through commands and functions
+set -o errexit || true  # exit the script if any statement returns a non-true return value
+
 # Path to this script
-[ -h "${0}" ] && readonly SCRIPT_PATH="$(readlink "${0}")" || readonly SCRIPT_PATH="${0}"
+if [ -h "${0}" ] ; then
+    SCRIPT_PATH="$(readlink "${0}")"
+else
+    # shellcheck disable=SC155
+    SCRIPT_PATH="${0}"
+fi
+readonly SCRIPT_PATH
 
-# Load pipeline environment setup and define WS_DIR
-. $(dirname -- "${SCRIPT_PATH}")/includes/pipeline-env.sh "${SCRIPT_PATH}" '../..'
+# Path to the root of the workspace
+# shellcheck disable=SC2046
+WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 
-# Setup error handling using default settings (defined in includes/error_handlers.sh)
-error_trap_setup
+on_error(){
+    CODE="${?}" && \
+    set +x && \
+    printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+        "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
+}
+trap on_error ERR
 
-readonly RESULT_FILE=$(mktemp -t XXXdependency-check-result)
+RESULT_FILE=$(mktemp -t XXXdependency-check-result)
+readonly  RESULT_FILE
 
-die() { cat ${RESULT_FILE} ; echo "Dependency report in ${WS_DIR}/target" ; echo "${1}" ; exit 1 ;}
+die() { cat "${RESULT_FILE}" ; echo "Dependency report in ${WS_DIR}/target" ; echo "${1}" ; exit 1 ;}
 
-if [ -n "${JENKINS_HOME}"  ] || [ "${GITHUB_ACTIONS}" = "true" ]; then
+if [ "${PIPELINE}" = "true" ] ; then
     # If in pipeline do a priming build before scan
-    mvn ${MAVEN_ARGS} -f ${WS_DIR}/pom.xml clean install -DskipTests
+    # shellcheck disable=SC2086
+    mvn ${MAVEN_ARGS} -f "${WS_DIR}"/pom.xml clean install -DskipTests
+fi
+
+# The Sonatype OSS Index analyzer requires authentication
+# See https://ossindex.sonatype.org/doc/auth-required
+# Set OSS_INDEX_USERNAME and OSS_INDEX_PASSWORD to authenticate.
+# Otherwise OSS Index analyzer will be disabled
+# And yes, this option uses a lower case i while Username and Password has an upper case I
+OSS_INDEX_OPTIONS="-DossindexAnalyzerEnabled=false"
+if [ -n "${OSS_INDEX_PASSWORD}" ] && [ -n "${OSS_INDEX_USERNAME}" ]; then
+    OSS_INDEX_OPTIONS="-DossindexAnalyzerEnabled=true -DossIndexUsername=${OSS_INDEX_USERNAME} -DossIndexPassword=${OSS_INDEX_PASSWORD}"
 fi
 
 # Setting NVD_API_KEY is not required but improves behavior of NVD API throttling
 
+# shellcheck disable=SC2086
 mvn ${MAVEN_ARGS} -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN org.owasp:dependency-check-maven:aggregate \
-        -f ${WS_DIR}/pom.xml \
+        -f "${WS_DIR}"/pom.xml \
         -Dtop.parent.basedir="${WS_DIR}" \
-        -Dnvd-api-key=${NVD_API_KEY} \
-        > ${RESULT_FILE} || die "Error running the Maven command"
+        -DnvdApiKey="${NVD_API_KEY}" \
+        ${OSS_INDEX_OPTIONS} \
+        > "${RESULT_FILE}" || die "Error running the Maven command"
 
-grep -i "One or more dependencies were identified with known vulnerabilities" ${RESULT_FILE} \
+grep -i "One or more dependencies were identified with known vulnerabilities" "${RESULT_FILE}" \
     && die "CVE SCAN ERROR" || echo "CVE SCAN OK"

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.plugin.source>3.3.0</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.1.3</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.1.5</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

Backport of #10702 to 3.x.  This aligns owasp-dependency-check.sh with what is in 4.x

* Upgrade owasp dependency checker to 12.1.5
* Update owasp-dependency-check script to handle ossindex.sonatype.org authentication
* Update `nvdApiKey` to proper syntax

To enable use of https://ossindex.sonatype.org/ you need to set the following environment variables:

```
OSS_INDEX_PASSWORD
OSS_INDEX_USERNAME
```

For reference see https://ossindex.sonatype.org/doc/auth-required
