### PR TITLE
4.2.x:  Update owasp dep check to 12.1.5 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ For Helidon 2.x releases please see [Helidon 2.x CHANGELOG.md](https://github.co
 
 For Helidon 1.x releases please see [Helidon 1.x CHANGELOG.md](https://github.com/oracle/helidon/blob/helidon-1.x/CHANGELOG.md)
 
+# [4.2.7]
+
+This release contains important bugfixes and dependency upgrades and is recommended for all users of Helidon 4.
+
+A minimum of Java 21 is required to use Helidon 4.
+
+### CHANGES
+
+- For MP CORS, suppress explanation of rejection in response; log it instead [10671](https://github.com/helidon-io/helidon/pull/10671)
+- Reduce text in CORS response status [10670](https://github.com/helidon-io/helidon/pull/10670)
+- Set addClasspath to true so config encryption jar is runnable [10669](https://github.com/helidon-io/helidon/pull/10669)
+- Upgrade jgit to 7.3.0 [10653](https://github.com/helidon-io/helidon/pull/10653)
+- Upgrade netty to 4.1.126.Final [10652](https://github.com/helidon-io/helidon/pull/10652)
+- Upgrade oci sdk to 3.72.0 [10652](https://github.com/helidon-io/helidon/pull/10652)
+
+# [4.2.6]
+
+This release contains important bugfixes and is recommended for all users of Helidon 4.
+
+A minimum of Java 21 is required to use Helidon 4.
+
+### CHANGES
+
+- WebServer: Connection checks update [10539](https://github.com/helidon-io/helidon/pull/10539)
+- Dependencies: Upgrade jaxb-core, -impl, -runtime [10537](https://github.com/helidon-io/helidon/pull/10537)
+- Build: Ensure aggregated javadocs are built as part of release profile [10536](https://github.com/helidon-io/helidon/pull/10536)
+
 
 ## [4.2.5]
 
@@ -1861,6 +1888,8 @@ Helidon 4.0.0 is a major release that includes significant new features and fixe
 - MicroProfile: MP path based static content should use index.html (4.x) [4737](https://github.com/oracle/helidon/pull/4737)
 - Build: 4.0 version and poms [4655](https://github.com/oracle/helidon/pull/4655)
 
+[4.2.7]: https://github.com/oracle/helidon/compare/4.2.5...4.2.7
+[4.2.6]: https://github.com/oracle/helidon/compare/4.2.5...4.2.6
 [4.2.5]: https://github.com/oracle/helidon/compare/4.2.4...4.2.5
 [4.2.4]: https://github.com/oracle/helidon/compare/4.2.3...4.2.4
 [4.2.3]: https://github.com/oracle/helidon/compare/4.2.2...4.2.3

--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,13 +51,24 @@ if [ "${PIPELINE}" = "true" ] ; then
     mvn ${MAVEN_ARGS} -f "${WS_DIR}"/pom.xml clean install -DskipTests
 fi
 
+# The Sonatype OSS Index analyzer requires authentication
+# See https://ossindex.sonatype.org/doc/auth-required
+# Set OSS_INDEX_USERNAME and OSS_INDEX_PASSWORD to authenticate.
+# Otherwise OSS Index analyzer will be disabled
+# And yes, this option uses a lower case i while Username and Password has an upper case I
+OSS_INDEX_OPTIONS="-DossindexAnalyzerEnabled=false"
+if [ -n "${OSS_INDEX_PASSWORD}" ] && [ -n "${OSS_INDEX_USERNAME}" ]; then
+    OSS_INDEX_OPTIONS="-DossindexAnalyzerEnabled=true -DossIndexUsername=${OSS_INDEX_USERNAME} -DossIndexPassword=${OSS_INDEX_PASSWORD}"
+fi
+
 # Setting NVD_API_KEY is not required but improves behavior of NVD API throttling
 
 # shellcheck disable=SC2086
 mvn ${MAVEN_ARGS} -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN org.owasp:dependency-check-maven:aggregate \
         -f "${WS_DIR}"/pom.xml \
         -Dtop.parent.basedir="${WS_DIR}" \
-        -Dnvd-api-key="${NVD_API_KEY}" \
+        -DnvdApiKey="${NVD_API_KEY}" \
+        ${OSS_INDEX_OPTIONS} \
         > "${RESULT_FILE}" || die "Error running the Maven command"
 
 grep -i "One or more dependencies were identified with known vulnerabilities" "${RESULT_FILE}" \

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.1.3</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.1.5</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

* Update CHANGELOG with info from last couple of releases
* Upgrade owasp dependency checker to 12.1.5
* Update owasp-dependency-check script to handle ossindex.sonatype.org authentication
* Update `nvdApiKey` to proper syntax

To enable use of https://ossindex.sonatype.org/ you need to set the following environment variables:

```
OSS_INDEX_PASSWORD
OSS_INDEX_USERNAME
```

For reference see https://ossindex.sonatype.org/doc/auth-required