### PR TITLE
4.x: Remove unused plugin declaration for helidon-service-maven-plugin

### DIFF
--- a/transaction/narayana/pom.xml
+++ b/transaction/narayana/pom.xml
@@ -90,10 +90,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.helidon.service</groupId>
-                <artifactId>helidon-service-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
### Description

Fix the following Maven warning:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.helidon.transaction:helidon-transaction-narayana:jar:4.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for io.helidon.service:helidon-service-maven-plugin is missing. @ line 92, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

The plugin declaration is unused and can be removed.

### Documentation

None
