### PR TITLE
Include the JSON-RPC ID in all error responses when available

### DIFF
--- a/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcExceptionTest.java
+++ b/webserver/tests/jsonrpc/src/test/java/io/helidon/webserver/tests/jsonrpc/JsonRpcExceptionTest.java
@@ -98,8 +98,11 @@ class JsonRpcExceptionTest {
     @Test
     void testPing1() throws InterruptedException {
         try (JsonRpcClientResponse res = client.rpcMethod("ping1")
+                .rpcId(1)
                 .path("/rpc")
                 .submit()) {
+            assertThat(res.rpcId().isPresent(), is(true));
+            assertThat(res.rpcId().get().toString(), is("1"));
             assertThat(res.error().isPresent(), is(true));
             assertThat(res.error().get().code(), is(-10001));
             assertThat(res.error().get().message(), is(MESSAGE1));
@@ -110,8 +113,11 @@ class JsonRpcExceptionTest {
     @Test
     void testPing2() throws InterruptedException {
         try (JsonRpcClientResponse res = client.rpcMethod("ping2")
+                .rpcId(1)
                 .path("/rpc")
                 .submit()) {
+            assertThat(res.rpcId().isPresent(), is(true));
+            assertThat(res.rpcId().get().toString(), is("1"));
             assertThat(res.error().isPresent(), is(true));
             assertThat(res.error().get().code(), is(-10002));
             assertThat(res.error().get().message(), is(MESSAGE2));
@@ -122,8 +128,11 @@ class JsonRpcExceptionTest {
     @Test
     void testPing3() throws InterruptedException {
         try (JsonRpcClientResponse res = client.rpcMethod("ping3")
+                .rpcId(1)
                 .path("/rpc")
                 .submit()) {
+            assertThat(res.rpcId().isPresent(), is(true));
+            assertThat(res.rpcId().get().toString(), is("1"));
             assertThat(res.error().isPresent(), is(true));
             assertThat(res.error().get().code(), is(JsonRpcError.INTERNAL_ERROR));
         }


### PR DESCRIPTION
### Description

Include the request ID in all error responses when available. This prevents any clients from getting stuck awaiting for a specific response. The ID will not be available if the request is somehow malformed. See issue #10738.

### Documentation

None