### PR TITLE
2.x: Upgrade macos runners to 14

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -168,7 +168,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-14-large ]
+        os: [ ubuntu-22.04, macos-15-intel ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -168,7 +168,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-14 ]
+        os: [ ubuntu-22.04, macos-14-large ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -168,7 +168,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13 ]
+        os: [ ubuntu-22.04, macos-14 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


The macOS 13 runner image will be retired by December 4th, 2025. Brownouts will start in Nov.

