### PR TITLE
4.x snakeyaml 2.5

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -161,7 +161,7 @@
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <version.lib.slf4j>2.0.16</version.lib.slf4j>
         <version.lib.smallrye-openapi>3.3.4</version.lib.smallrye-openapi>
-        <version.lib.snakeyaml>2.4</version.lib.snakeyaml>
+        <version.lib.snakeyaml>2.5</version.lib.snakeyaml>
         <version.lib.testcontainers>1.19.8</version.lib.testcontainers>
         <version.lib.typesafe-config>1.4.4</version.lib.typesafe-config>
         <version.lib.tyrus>2.1.5</version.lib.tyrus>

--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -310,6 +310,29 @@
                         <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
                     </systemPropertyVariables>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/TestLogWarningFix.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>log-warning-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <!-- Run this separately so it uses a distinct OpenApiHelper with SnakeYAML warning logging on. -->
+                            <includes>
+                                <include>**/TestLogWarningFix.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/ExpandedTypeDescription.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/ExpandedTypeDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.introspector.MethodProperty;
 import org.yaml.snakeyaml.introspector.Property;
-import org.yaml.snakeyaml.introspector.PropertySubstitute;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.Node;
@@ -78,7 +77,7 @@ import org.yaml.snakeyaml.nodes.Tag;
  */
 public class ExpandedTypeDescription extends TypeDescription {
 
-    static final PropertyUtils PROPERTY_UTILS = new PropertyUtils();
+    static final PropertyUtils PROPERTY_UTILS = new ExtendedPropertyUtils();
 
     private static final String EXTENSION_PROPERTY_PREFIX = "x-";
 
@@ -87,6 +86,7 @@ public class ExpandedTypeDescription extends TypeDescription {
     private ExpandedTypeDescription(Class<?> clazz, Class<?> impl) {
         super(clazz, null, impl);
         this.impl = impl;
+        setPropertyUtils(PROPERTY_UTILS);
     }
 
     /**
@@ -110,7 +110,6 @@ public class ExpandedTypeDescription extends TypeDescription {
         } else {
             result = new ExpandedTypeDescription(clazz, impl);
         }
-        result.setPropertyUtils(PROPERTY_UTILS);
         return result;
     }
 
@@ -118,11 +117,10 @@ public class ExpandedTypeDescription extends TypeDescription {
      * Adds property handling for a {@code $ref} reference.
      *
      * @return this type description
+     * @deprecated No need to invoke addRef any longer; refs are handled by the custom property utils implementation.
      */
+    @Deprecated(since = "4.3.2", forRemoval = true)
     public ExpandedTypeDescription addRef() {
-        PropertySubstitute sub = new PropertySubstitute("ref", String.class, "getRef", "setRef");
-        sub.setTargetType(impl);
-        substituteProperty(sub);
         return this;
     }
 
@@ -130,19 +128,15 @@ public class ExpandedTypeDescription extends TypeDescription {
      * Adds property handling for extensions.
      *
      * @return this type description
+     * @deprecated No need to invoke addExtensions any longer; extensions are handled by the custom property utils implementation.
      */
+    @Deprecated(since = "4.3.2", forRemoval = true)
     public ExpandedTypeDescription addExtensions() {
-        PropertySubstitute sub = new PropertySubstitute("extensions", Map.class, "getExtensions", "setExtensions");
-        sub.setTargetType(impl);
-        substituteProperty(sub);
         return this;
     }
 
     @Override
     public Property getProperty(String name) {
-        if (isExtension(name)) {
-            return new ExtensionProperty(name);
-        }
         if (isRef(name)) {
             return new RenamedProperty(this.getType(), "ref");
         }

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/ExtendedPropertyUtils.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/ExtendedPropertyUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.openapi;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.openapi.models.Extensible;
+import org.eclipse.microprofile.openapi.models.Reference;
+import org.yaml.snakeyaml.introspector.BeanAccess;
+import org.yaml.snakeyaml.introspector.MethodProperty;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.introspector.PropertyUtils;
+
+/**
+ * Specialized SnakeYAML implementation of {@link org.yaml.snakeyaml.introspector.PropertyUtils} that essentially adds ad hoc
+ * properties to the SnakeYAML type if the underlying type meets certain criteria.
+ */
+class ExtendedPropertyUtils extends PropertyUtils {
+
+    private static final Map<Class<?>, InferredProperty> TYPE_INFO = Map.of(
+            Extensible.class, InferredProperty.create("extensions"),
+            Reference.class, InferredProperty.create("ref"));
+
+    @Override
+    public Set<Property> getProperties(Class<?> type, BeanAccess bAccess) {
+        var result = super.getProperties(type, bAccess);
+        TYPE_INFO.forEach((t, info) -> {
+            if (t.isAssignableFrom(type)) {
+                result.add(info.property(type));
+            }
+        });
+        return result;
+    }
+
+    @Override
+    protected Map<String, Property> getPropertiesMap(Class<?> type, BeanAccess bAccess) {
+        var result = super.getPropertiesMap(type, bAccess);
+        TYPE_INFO.forEach((t, info) -> {
+            if (t.isAssignableFrom(type)) {
+                result.put(info.propertyName, info.property(type));
+            }
+        });
+        return result;
+    }
+
+    private record InferredProperty(String propertyName) {
+
+        static InferredProperty create(String propertyName) {
+            return new InferredProperty(propertyName);
+        }
+
+        Property property(Class<?> type) {
+            String capitalizedPropertyName = propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+            try {
+                return new MethodProperty(new PropertyDescriptor(propertyName,
+                                                                 type,
+                                                                 "get" + capitalizedPropertyName,
+                                                                 "set" + capitalizedPropertyName));
+            } catch (IntrospectionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiSerializer.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,7 @@ final class OpenApiSerializer {
 
         CustomRepresenter(Map<Class<?>, ExpandedTypeDescription> types, DumperOptions dumperOptions, ScalarStyle stringStyle) {
             super(dumperOptions);
+            setPropertyUtils(ExpandedTypeDescription.PROPERTY_UTILS);
             this.stringStyle = stringStyle;
             types.values().stream()
                     .map(ImplTypeDescription::new)
@@ -147,6 +148,15 @@ final class OpenApiSerializer {
                                                                  represent(v));
                         tuples.add(extensionTuple);
                     });
+                }
+            }
+            if (mapping instanceof Reference<?> reference) {
+                List<NodeTuple> tuples = ((MappingNode) result).getValue();
+                String ref = reference.getRef();
+                if (ref != null) {
+                    NodeTuple refTuple = new NodeTuple(new ScalarNode(Tag.STR, "$ref", null, null, stringStyle),
+                                                       represent(ref));
+                    tuples.add(refTuple);
                 }
             }
             return result;

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestLogWarningFix.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestLogWarningFix.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.openapi;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.microprofile.openapi.TestUtil.resource;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TestLogWarningFix {
+
+    private static final java.util.logging.Logger SNAKE_YAML_INTROSPECTOR_LOGGER =
+            java.util.logging.Logger.getLogger(org.yaml.snakeyaml.introspector.PropertySubstitute.class.getPackage().getName());
+
+    @Test
+    void testLogWarningAbsent() {
+        var testHandler = new MonitoringHandler();
+        SNAKE_YAML_INTROSPECTOR_LOGGER.addHandler(testHandler);
+        String originalSetting = System.setProperty("openapi.parsing.warnings.enabled", "true");
+        try {
+
+            OpenAPI openAPI = parse("/openapi-greeting.yml");
+            assertThat("Warning messages", testHandler.messages(), is(Collections.emptyList()));
+
+        } finally {
+            if  (originalSetting != null) {
+                System.setProperty("openapi.parsing.warnings.enabled", "false");
+            }
+            SNAKE_YAML_INTROSPECTOR_LOGGER.removeHandler(testHandler);
+        }
+    }
+
+    private static OpenAPI parse(String path) {
+        String document = resource(path);
+        return OpenApiParser.parse(OpenApiHelper.types(), OpenAPI.class, new StringReader(document));
+    }
+
+    private static class MonitoringHandler extends Handler {
+
+        private final List<String> messages = Collections.synchronizedList(new ArrayList<>());
+
+
+        @Override
+        public void publish(LogRecord record) {
+            messages.add(record.getMessage());
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        List<String> messages() {
+            return messages;
+        }
+    }
+}

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestLogWarningFix.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestLogWarningFix.java
@@ -39,16 +39,12 @@ class TestLogWarningFix {
     void testLogWarningAbsent() {
         var testHandler = new MonitoringHandler();
         SNAKE_YAML_INTROSPECTOR_LOGGER.addHandler(testHandler);
-        String originalSetting = System.setProperty("openapi.parsing.warnings.enabled", "true");
         try {
 
             OpenAPI openAPI = parse("/openapi-greeting.yml");
             assertThat("Warning messages", testHandler.messages(), is(Collections.emptyList()));
 
         } finally {
-            if  (originalSetting != null) {
-                System.setProperty("openapi.parsing.warnings.enabled", "false");
-            }
             SNAKE_YAML_INTROSPECTOR_LOGGER.removeHandler(testHandler);
         }
     }


### PR DESCRIPTION
### Description
Resolves #9805

### Release Note

____
Helidon MP no longer triggers warning log messages from SnakeYAML while processing certain OpenAPI documents.
____

###  PR Background

SnakeYAML does a pretty good job matching YAML tags to Java field or method names to map values back and forth. And, it provides ways for "substituting" one property for another. For example, the MP OpenAPI model types support default values but the YAML tag is `default` and the MP types use `defaultValue` and we use a SnakeYAML property substitute for that.

Two other similar but not identical cases in OpenAPI concern the `$ref` YAML property and extension properties which, in YAML, start with `x-`. The MP OpenAPI types represent these using 
```
String getRef()
void setRef(String)

Map<String, Object> getExtensions()
void setExtensions(Map<String, Object>)
```
and related `addExtension` and `removeExtension` methods.

Originally, we received advice from the SnakeYAML team that property substitution was the easiest way to deal with the later two cases as well, so we did. But these are not true property "substitutions" as the "original" property in these cases does not exist in the SnakeYAML-derived property lists. As a result, SnakeYAML would log warnings when we tried to "substitute" for non-existent properties. The "new" properties were added correctly so the mapping between YAML and Java types worked correctly. 

So Helidon would, by default, set the logging level for the SnakeYAML class which did this logging to `SEVERE` using the JUL API so the innocuous but alarming warnings would not appear. (A system property allowed users to choose to preserve the warnings.)

The issue related to this PR resulted from a user using a non-JUL logging implementation in which the warnings were not suppressed.

### Changes overview

Adopts SnakeYAML 2.5 (was 2.4 previously).

The changes in the PR abandon the use of property substitution for these two cases. Instead, Helidon now includes  custom SnakeYAML implementation of a `PropertyUtils` class which knows how to deal with extensions and refs. 

The serialization code also is changed to explicitly deal with the mapping between "$ref" in YAML and "ref" in the Java types.

Two methods on `ExpandedTypeDescription` that used to have to be invoked explicitly are no longer needed and have no bodies, but they are public methods on a public class so we need to keep them in the very unlikely case a user has extended or used `ExpandedTypeDescription` themselves.

The PR also revises some other non-public methods to remove some special processing for ref or extensions now that we are handling those a bit differently.

The code no longer by default suppresses warnings from the SnakeYAML logger although it still respects the user's setting for that property.

The PR includes a new test to make sure that there are no logging messages from SnakeYAML (with the previous suppression turned off).

### Documentation
No impact.