### PR TITLE
Do not replace `#` sign for "href" links in `@see`

### DIFF
--- a/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/Javadoc.java
+++ b/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/Javadoc.java
@@ -143,10 +143,10 @@ final class Javadoc {
         // <a href="https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO_8601 Durations</a>
         int index = 0;
         StringBuilder result = new StringBuilder();
-        while(true) {
+        while (true) {
             int indexOfHref = originalValue.indexOf("href=\"", index);
             if (indexOfHref == -1) {
-                result.append(removeHash(originalValue.substring(index)));;
+                result.append(removeHash(originalValue.substring(index)));
                 break;
             }
             int endOfHref = originalValue.indexOf('\"', indexOfHref + 6);


### PR DESCRIPTION
Resolves #9084

Makes sure that when `<a href="link#anchor">..</a>` is not replaced with `link.anchor`.