### PR TITLE
4.x: Update Jackson to 2.20.0. Update owasp dependency check

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -74,7 +74,7 @@
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.18.1</version.lib.jackson>
+        <version.lib.jackson>2.20.0</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.1.3</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.1.1</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>4.0.1</version.lib.jakarta.cdi-api>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.1.5</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.1.8</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
### Description

 Update Jackson to 2.20.0. Update owasp dependency check


