### PR TITLE
JwtProvider expected audience is no longer mandatory

### DIFF
--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -24,7 +24,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import io.helidon.common.Errors;
 import io.helidon.common.config.Config;


### PR DESCRIPTION
### Description
Fixes incorrect requirement for expected audience to be configured in the JwtProvider.

Fixes #10769

### Documentation

None
