### PR TITLE
4.x: Fix bad links in generated documentation.

### DIFF
--- a/config/metadata/docs/src/main/java/io/helidon/config/metadata/docs/CmType.java
+++ b/config/metadata/docs/src/main/java/io/helidon/config/metadata/docs/CmType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ public class CmType {
     private List<String> producers;
     private List<String> provides;
     private String typeReference;
+    private String module;
 
     /**
      * Required constructor.
@@ -250,5 +251,13 @@ public class CmType {
     @Override
     public String toString() {
         return getType();
+    }
+
+    void module(String module) {
+        this.module = module;
+    }
+
+    String module() {
+        return module;
     }
 }

--- a/docs/src/main/asciidoc/mp/scheduling.adoc
+++ b/docs/src/main/asciidoc/mp/scheduling.adoc
@@ -159,4 +159,4 @@ include::{sourcedir}/mp/SchedulingSnippets.java[tag=snippet_8, indent=0]
 == Reference
 
 * https://github.com/jmrozanec/cron-utils[Cron-utils GitHub page]
-* link:{scheduling-javadoc-base-url}/io/helidon/scheduling/package-summary.html[Helidon Scheduling JavaDoc]
+* link:{scheduling-javadoc-base-url}/io/helidon/microprofile/scheduling/package-summary.html[Helidon Scheduling JavaDoc]

--- a/docs/src/main/asciidoc/se/integrations/eureka/eureka-registration.adoc
+++ b/docs/src/main/asciidoc/se/integrations/eureka/eureka-registration.adoc
@@ -83,7 +83,7 @@ server:
 <3> The `base-uri` needs to identify an available Netflix Eureka Server of at least version
     {version-lib-eureka}. Netflix Eureka Server is commonly made available on port `8761`.
 <4> Configuration under the `client` node is wholly defined by the
-    link:{webclient-javadoc-base-url}/io/helidon/webclient/api/HttpClientConfig.html[`HttpClientConfig`] interface.
+    link:{webclient-api-javadoc-base-url}/io/helidon/webclient/api/HttpClientConfig.html[`HttpClientConfig`] interface.
 
 All other configuration values can be (and ordinarily are) defaulted, but some are best set explicitly:
 

--- a/docs/src/main/asciidoc/se/webserver/webserver.adoc
+++ b/docs/src/main/asciidoc/se/webserver/webserver.adoc
@@ -506,7 +506,7 @@ link:{javadoc-base-url}/io.helidon.http/io/helidon/http/DirectHandler.EventType.
 
 Direct handlers can be configured independently for each port exposed by the Webserver;
 similar to other config, if configured directly on the Webserver they will only apply to the default port. For more information see
-link:{webserver-javadoc-base-url}/ListenerConfig.BuilderBase.html#directHandlers(io.helidon.webserver.http.DirectHandlers)[directHandlers] method in `ListenerConfig`.
+link:{webserver-javadoc-base-url}/io/helidon/webserver/ListenerConfig.BuilderBase.html#directHandlers(io.helidon.webserver.http.DirectHandlers)[directHandlers] method in `ListenerConfig`.
 
 The following example shows how to register a custom handler for a request that
 is deemed invalid before the routing phase stars. The custom handler in

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
@@ -72,12 +72,22 @@ public class ConfigUserStore implements SecureUserStore {
         return Optional.ofNullable(users.get(login));
     }
 
+    /**
+     * A user that is loaded from configuration.
+     */
     @Configured
-    static class ConfigUser implements User {
+    public static class ConfigUser implements User {
         private final Set<String> roles = new LinkedHashSet<>();
         private String login;
         private char[] password;
 
+        /**
+         * Create a new user from configuration.
+         * The configuration must be located on the user's node.
+         *
+         * @param config configuration instance
+         * @return a new config user with the configured login, password, and roles
+         */
         @ConfiguredOption(key = "login", type = String.class, description = "User's login")
         @ConfiguredOption(key = "password", type = String.class, description = "User's password")
         @ConfiguredOption(key = "roles",

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
@@ -36,9 +36,12 @@ import jakarta.json.JsonReaderFactory;
 
 /**
  * Base builder of the OIDC config components.
+ *
+ * @param <B> type of the builder
+ * @param <T> type of the object built by this builder
  */
-@Configured
-abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B, T> {
+@Configured // as this class is configured, we reference it in the config metadata documentation, so it must be public
+public abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B, T> {
 
     static final String DEFAULT_SERVER_TYPE = "@default";
     static final String DEFAULT_BASE_SCOPES = "openid";
@@ -468,7 +471,7 @@ abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Builder<B,
         return oidcMetadata;
     }
 
-    public boolean useWellKnown() {
+    boolean useWellKnown() {
         return useWellKnown;
     }
 


### PR DESCRIPTION
Required fixes in the config metadata documentation module, as well as in some asciidoc documents. A few classes had to have updated visibility (as these are documented as configured, and as such must be referenced via javadoc)


Resolves #9088  
