### PR TITLE
Do not set an initial value for SO_RCVBUF

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerConfigSupport.java
@@ -151,9 +151,6 @@ class WebServerConfigSupport {
             if (!socketOptions.containsKey(StandardSocketOptions.SO_REUSEADDR)) {
                 target.putListenerSocketOption(StandardSocketOptions.SO_REUSEADDR, true);
             }
-            if (!socketOptions.containsKey(StandardSocketOptions.SO_RCVBUF)) {
-                target.putListenerSocketOption(StandardSocketOptions.SO_RCVBUF, 4096);
-            }
             if (target.requestedUriDiscoveryContext().isEmpty()) {
                 target.requestedUriDiscoveryContext(RequestedUriDiscoveryContext.builder()
                                                             .socketId(target.name())


### PR DESCRIPTION
### Description
Do not set an initial value for SO_RCVBUF as this will disable TCP auto-tuning (Linux).

### Documentation

None.