### PR TITLE
Upgrade antlr to 4.13.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -37,7 +37,7 @@
         Changing these versions requires approval for a new third party dependency!
         -->
         <version.lib.activemq>5.16.0</version.lib.activemq>
-        <version.lib.antlr>4.13.1</version.lib.antlr>
+        <version.lib.antlr>4.13.2</version.lib.antlr>
         <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
         <version.lib.bytebuddy>1.17.5</version.lib.bytebuddy>
         <version.lib.coherence>25.03.1</version.lib.coherence>


### PR DESCRIPTION
### Description

Upgrade antlr runtime to 4.13.2

Used by helidon-data-codegen-parser
