### PR TITLE
4.x: Remove direct dependency on commons-text

### DIFF
--- a/config/etcd/pom.xml
+++ b/config/etcd/pom.xml
@@ -57,18 +57,6 @@
         <dependency>
             <groupId>org.mousio</groupId>
             <artifactId>etcd4j</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-text</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <!-- for dependency convergence with handlebars -->
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>${version.lib.commons-text}</version>
         </dependency>
         <!-- etcd v3 -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1189,6 +1189,12 @@
                 <version>${version.lib.maven-wagon}</version>
             </dependency>
             <dependency>
+                <!-- for dependency convergence with handlebars -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${version.lib.commons-text}</version>
+            </dependency>
+            <dependency>
                 <!--
                 Required for dependency convergence
                 Used by both


### PR DESCRIPTION
### Description

We manage the version of org.apache.commons:commons-text to enforce dependency convergence. We previously did this by replacing the dependency brought in by etcd v2 -- but this adds a direct dependency on commons-text which we don't want.

This PR manages the version of commons-text without adding a direct dependency. Not sure why I didn't do this the first time.