### PR TITLE
Fix hidden edge-case bug in compareNotNullUnsigned (builds on previous PR #9379)

### DIFF
--- a/integrations/db/h2/src/main/java/io/helidon/integrations/db/h2/BitsSubstitution.java
+++ b/integrations/db/h2/src/main/java/io/helidon/integrations/db/h2/BitsSubstitution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/db/h2/src/test/java/io/helidon/integrations/db/h2/BitsSubstitutionTest.java
+++ b/integrations/db/h2/src/test/java/io/helidon/integrations/db/h2/BitsSubstitutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Summary
This PR fixes a hidden bug in `compareNotNullUnsigned(byte[] data1, byte[] data2)`.  

Although PR #9379 corrected similar issues in `compareNotNull(byte[] data1, byte[] data2) ...`,  
the unsigned byte array version still had subtle edge cases that returned incorrect results.

### Problem
- Arrays with different lengths but first differing element determining the order returned wrong result.

