### PR TITLE
3.x: Upgrade Jersey, Jackson, Snakeyaml, oci sdk, h2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -63,14 +63,14 @@
         <version.lib.gson>2.13.1</version.lib.gson>
         <version.lib.grpc>1.65.1</version.lib.grpc>
         <version.lib.guava>32.0.1-jre</version.lib.guava>
-        <version.lib.h2>2.1.212</version.lib.h2>
+        <version.lib.h2>2.4.240</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.hibernate.family>6.1</version.lib.hibernate.family>
         <version.lib.hibernate>${version.lib.hibernate.family}.7.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>7.0.5.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.18.1</version.lib.jackson>
+        <version.lib.jackson>2.20.0</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.0.1</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.0.0</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>3.0.0</version.lib.jakarta.cdi-api>
@@ -96,7 +96,7 @@
         <!-- Force upgrade version used by maven-jaxb2-plugin. Needed to support Java 16 -->
         <version.lib.jaxb-runtime>3.0.2</version.lib.jaxb-runtime>
         <version.lib.jedis>3.6.3</version.lib.jedis>
-        <version.lib.jersey>3.0.14</version.lib.jersey>
+        <version.lib.jersey>3.0.18</version.lib.jersey>
         <version.lib.jgit>7.3.0.202506031305-r</version.lib.jgit>
         <version.lib.jsonp-impl>2.0.1</version.lib.jsonp-impl>
         <version.lib.junit>5.9.3</version.lib.junit>
@@ -130,7 +130,7 @@
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
         <version.lib.netty>4.1.126.Final</version.lib.netty>
         <version.lib.netty-io_uring>0.0.19.Final</version.lib.netty-io_uring>
-        <version.lib.oci>3.68.0</version.lib.oci>
+        <version.lib.oci>3.76.0</version.lib.oci>
         <version.lib.ojdbc8>21.15.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <!-- Manage okio version for dependency convergence -->
@@ -150,7 +150,7 @@
         <version.lib.slf4j>2.0.17</version.lib.slf4j>
         <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>
         <version.lib.smallrye-openapi-ui>3.13.0</version.lib.smallrye-openapi-ui>
-        <version.lib.snakeyaml>2.4</version.lib.snakeyaml>
+        <version.lib.snakeyaml>2.5</version.lib.snakeyaml>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>
         <version.lib.tyrus>2.1.5</version.lib.tyrus>
         <version.lib.weld-api>4.0.SP1</version.lib.weld-api>


### PR DESCRIPTION
### Description

Upgrades:

* Jersey to 3.0.18
* Jackson to 2.20.0
* H2 to 2.4.240
* OCI SDK to 3.76.0
* Snakeyaml to 2.5
