### PR TITLE
 4.3.3: Improve Prometheus output performance

### DIFF
--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusPerf.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusPerf.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.providers.micrometer;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.Metrics;
+import io.helidon.metrics.api.Timer;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Retained for ad hoc simple performance testing of Prometheus formatting. To get a rough timing, uncomment the @Disabled
+ * annotation below, run the test, and look in the test's output file in target/surefire to see the timings.
+ * This test does not attempt to detect any failure condition; it simply runs the code to capture timing.
+ */
+class TestPrometheusPerf {
+
+    @Disabled
+    @Test
+    void testPerf() {
+        int loops = 40;
+
+        // Warmup
+        registerAndFormat(10);
+
+        // Timed test
+        double[] results = registerAndFormat(loops);
+
+        double totalElapsedMillis = 0.0;
+        for (double result : results) {
+            totalElapsedMillis += result;
+        }
+
+        System.err.println("Durations:" + Arrays.toString(results));
+        System.err.println("Mean: " + totalElapsedMillis / (double) loops);
+    }
+
+    private static double[] registerAndFormat(int loops) {
+
+        double[] result = new double[loops];
+
+        for (int loop = 0; loop < loops; loop++) {
+            MeterRegistry meterRegistry = Metrics.globalRegistry();
+            meterRegistry.close();
+
+            Random random = new Random();
+            for (int i = 0; i < 400; i++) {
+                Counter c = meterRegistry.getOrCreate(Counter.builder("ctr" + i));
+                c.increment();
+
+                Timer t = meterRegistry.getOrCreate(Timer.builder("tmr" + i));
+                t.record(123, TimeUnit.MILLISECONDS);
+
+                DistributionSummary ds = meterRegistry.getOrCreate(DistributionSummary.builder("dist" + i));
+                ds.record(random.nextDouble());
+            }
+
+            long start = System.nanoTime();
+            MicrometerPrometheusFormatter formatter = MicrometerPrometheusFormatter.builder(meterRegistry)
+                    .resultMediaType(MediaTypes.APPLICATION_OPENMETRICS_TEXT)
+                    .build();
+            Optional<Object> outputOpt = formatter.format();
+            result[loop] = (System.nanoTime() - start) / 1000.0 / 1000.0;
+            meterRegistry.close();
+            System.err.println(outputOpt.toString());
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
Backport #10850 to Helidon 4.3.3

### Description
This PR addresses slow performance in creating Prometheus format output with a large number of metrics as reported by users.

## Release Note
____
Helidon now more efficiently creates Prometheus output, especially for large numbers of registered metrics.
____

The Helidon code to create Prometheus format output relies mostly on the Micrometer Prometheus meter registry. To optimize performance when there _is_ a selection using meter names or scopes, the original code would:
1. Check all meters for ones matching the name and scope predicates.
2. Convert the matching meter names into Prometheus-format names (meter-name_units_submeter) (for example, the counter `mycounter` is converted to `mycounter_total` and a single distribution summary or timer actually appears inside a Prometheus meter registry as multiple sub-meters).
3. Pass the converted meter names to the Prometheus registry `scrape` method which requires the converted meter names (not the original name).

The PR introduces several optimizations:
* If there is no name or scope selection the code now skips converting meter names into the Prometheus name format entirely. It passes a `null` for the name `Set` which the Micrometer Prometheus registry treats as a wildcard that matches all meters.
* The name and scope selections are passed as `Iterable<String>`. But now, if the iterables happen to be `Set<String>` already then the code skips creating separate sets for use internally and just uses those sets directly. This logic was also moved from the `format` method to the formatter's constructor so it runs only once. The name and scope selections are set in the builder and therefore hold for the formatter regardless of how many times `format` might be invoked.
* If there is a name or scope selection but the combined selection yields no matching meters, the code now skips the scrape (which returned nothing anyway).

Informal performance testing on my local system showed that (after warmup) the mean time to format 1200 meters was about 90-100 ms. After the changes the mean time is about 30 ms.

### Documentation
No impact.

