### PR TITLE
Changes for native image to work with GraalVM 25 for a simple application

### DIFF
--- a/service/registry/src/main/resources/META-INF/native-image/io.helidon.service/helidon-service-registry/native-image.properties
+++ b/service/registry/src/main/resources/META-INF/native-image/io.helidon.service/helidon-service-registry/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Tested with our declarative example in examples repository.

Does not impact GraalVM version 21, it still successfully builds a native image.

This PR does not enable support for v. 25 in general.