### PR TITLE
4.x: Upgrades version.lib.ojdbc to 23.26.0.0.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -140,7 +140,7 @@
         <version.lib.netty>4.1.130.Final</version.lib.netty>
         <version.lib.oci>3.77.0</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
-        <version.lib.ojdbc>${version.lib.ojdbc.family}.9.0.25.07</version.lib.ojdbc>
+        <version.lib.ojdbc>${version.lib.ojdbc.family}.26.0.0.0</version.lib.ojdbc>
         <version.lib.ojdbc8>${version.lib.ojdbc}</version.lib.ojdbc8>
         <!-- Force upgrade okhttp3 for dependency convergence -->
         <version.lib.okhttp3>4.12.0</version.lib.okhttp3>


### PR DESCRIPTION
This PR updates the `version.lib.ojdbc` property such that [version 23.26.0.0.0 of the `ojdbc-bom`](https://central.sonatype.com/artifact/com.oracle.database.jdbc/ojdbc-bom/23.26.0.0.0) is used. See #10871.
