### PR TITLE
Fix a problem where we kept bad candidates for builder methods.

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
@@ -221,7 +221,7 @@ final class FactoryOption {
         // we must validate - any candidate that is void, or has parameters is a bad candidate
         var collector = Errors.collector();
         for (TypedElementInfo candidate : candidates) {
-            if (candidate.typeName().equals(TypeNames.PRIMITIVE_VOID)) {
+            if (candidate.typeName().unboxed().equals(TypeNames.PRIMITIVE_VOID)) {
                 collector.warn("Builder definition methods cannot have void return type "
                                        + "(must be getters): "
                                        + typeInfo.typeName().fqName() + "." + candidate.elementName());
@@ -243,6 +243,12 @@ final class FactoryOption {
                     };
                     logger.log(level, errorMessage.getMessage());
                 });
+
+        // now filter out the candidates that are not valid (void or with parameters) - user must take care of them
+        candidates = candidates.stream()
+                .filter(it -> !it.typeName().unboxed().equals(TypeNames.PRIMITIVE_VOID))
+                .filter(it -> it.parameterArguments().isEmpty())
+                .toList();
 
         return candidates;
     }

--- a/builder/tests/custom-void-method/pom.xml
+++ b/builder/tests/custom-void-method/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.builder.tests</groupId>
+        <artifactId>helidon-builder-tests-project</artifactId>
+        <version>4.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-builder-tests-custom-void-method</artifactId>
+    <name>Helidon Builder Tests Custom Void Method</name>
+    <description>Tests a void method on interface implemented using a custom method</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.builder</groupId>
+            <artifactId>helidon-builder-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/builder/tests/custom-void-method/src/main/java/io/helidon/builder/tests/custom/voidmethod/SomeTypeBlueprint.java
+++ b/builder/tests/custom-void-method/src/main/java/io/helidon/builder/tests/custom/voidmethod/SomeTypeBlueprint.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.tests.custom.voidmethod;
+
+import java.util.List;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.CustomMethods(SomeTypeSupport.class)
+interface SomeTypeBlueprint {
+    @Option.Default("default")
+    String name();
+
+    /**
+     * This method is implemented using a custom method in SomeTypeSupport class.
+     *
+     * @param first first parameter
+     * @param second second parameter
+     */
+    void doSomething(List<String> first, List<String> second);
+}

--- a/builder/tests/custom-void-method/src/main/java/io/helidon/builder/tests/custom/voidmethod/SomeTypeSupport.java
+++ b/builder/tests/custom-void-method/src/main/java/io/helidon/builder/tests/custom/voidmethod/SomeTypeSupport.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.tests.custom.voidmethod;
+
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+
+class SomeTypeSupport {
+    @Prototype.PrototypeMethod
+    @Prototype.Annotated("java.lang.Override")
+    static void doSomething(SomeType prototype, List<String> first, List<String> second) {
+        second.addAll(first);
+    }
+}

--- a/builder/tests/custom-void-method/src/main/java/module-info.java
+++ b/builder/tests/custom-void-method/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module io.helidon.builder.tests.custom.voidmethod {
+    requires io.helidon.builder.api;
+    requires io.helidon.common;
+
+    exports io.helidon.builder.tests.custom.voidmethod;
+}

--- a/builder/tests/custom-void-method/src/test/java/io/helidon/builder/tests/custom/voidmethod/TestCustomVoidMethod.java
+++ b/builder/tests/custom-void-method/src/test/java/io/helidon/builder/tests/custom/voidmethod/TestCustomVoidMethod.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.tests.custom.voidmethod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestCustomVoidMethod {
+    @Test
+    void testCustomVoidMethod() {
+        var prototype = SomeType.builder()
+                .build();
+        List<String> first = List.of("one");
+        List<String> second = new ArrayList<>(List.of("two"));
+
+        prototype.doSomething(first, second);
+
+        assertThat(second, hasItems("one", "two"));
+    }
+}

--- a/builder/tests/pom.xml
+++ b/builder/tests/pom.xml
@@ -51,6 +51,7 @@
         <module>inheritance</module>
         <module>jackson</module>
         <module>builder-codegen</module>
+        <module>custom-void-method</module>
     </modules>
 
 </project>


### PR DESCRIPTION
### Description
Resolves  #10896

non-default `void` method on blueprint is now accepted - warned.
It can be implemented using a custom method.

This is not a recommended pattern, though it can be useful when implementing third party interfaces that we consider prototypes.

Recommended solution for our own prototypes - only add the custom method to prototype, do not have it on blueprint.
