### PR TITLE
4.x: removes jaxb-impl from jpa-cdi/pom.xml

### DIFF
--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -148,11 +148,6 @@
             <scope>runtime</scope> <!-- really should be test -->
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
             <artifactId>helidon-microprofile-config</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
This PR fixes #10794 by removing the `jaxb-impl` artifact from `integrations/cdi/jpa-cdi/pom.xml`.