### PR TITLE
 4.3.3: 4.x fix owasp nvd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>12.1.8</version.plugin.dependency-check>
+        <version.plugin.dependency-check>12.1.9</version.plugin.dependency-check>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
@@ -663,8 +663,6 @@
                         <skipTestScope>true</skipTestScope>
                         <failBuildOnCVSS>0</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                        <!--suppress MavenModelInspection -->
-                        <nvdApiKey>${nvd-api-key}</nvdApiKey>
                         <excludes>
                             <!-- Exclude stuff we do not deploy -->
                             <exclude>io.helidon.tracing:helidon-tracing-tests</exclude>


### PR DESCRIPTION
Backport #10853 to Helidon 4.3.3

### Description

Fixes a regression that was introduced by #10702 concerning configuring of `nvdApiKey`.

We remove configuration of `nvdApiKey` from the plugin configuration in the pom and rely only on the `owasp-dependency-check.sh` script to set the configuration directly.

Upgrade dependency check plugin to 12.1.9
