### PR TITLE
 4.3.3: Fix problem handling server-side gRPC errors. Handles grpc-status headers

### DIFF
--- a/microprofile/grpc/client/src/test/proto/echo.proto
+++ b/microprofile/grpc/client/src/test/proto/echo.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ option java_package = "io.helidon.microprofile.grpc.client.test";
 
 service EchoService {
   rpc Echo (EchoRequest) returns (EchoResponse) {}
+  rpc EchoMany (EchoRequest) returns (stream EchoResponse) {}
 }
 
 message EchoRequest {

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -33,6 +33,7 @@ import io.helidon.common.buffers.CompositeBufferData;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.grpc.core.GrpcHeadersUtil;
 import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.WritableHeaders;
@@ -81,6 +82,7 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
     protected static final Metadata EMPTY_METADATA = new Metadata();
     protected static final Header GRPC_ACCEPT_ENCODING = HeaderValues.create(HeaderNames.ACCEPT_ENCODING, "gzip");
     protected static final Header GRPC_CONTENT_TYPE = HeaderValues.create(HeaderNames.CONTENT_TYPE, "application/grpc");
+    protected static final HeaderName STATUS_NAME = HeaderNames.createFromLowercase("grpc-status");
 
     protected static final BufferData PING_FRAME = BufferData.create("PING");
     protected static final BufferData EMPTY_BUFFER_DATA = BufferData.empty();


### PR DESCRIPTION

Backport #10890 to Helidon 4.3.3

### Description

Fix problem handling server-side gRPC errors. Handles grpc-status headers correctly on client side gRPC. New tests. See issue #10843.

### Documentation

None