### PR TITLE
4.3.3: Fix concurrent update problem in test log handler

### DIFF
--- a/telemetry/testing/tracing/pom.xml
+++ b/telemetry/testing/tracing/pom.xml
@@ -51,6 +51,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>
+        <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+    </dependency>
+
     </dependencies>
 
     <build>

--- a/telemetry/testing/tracing/src/main/java/io/helidon/telemetry/testing/tracing/JsonLogConverterImpl.java
+++ b/telemetry/testing/tracing/src/main/java/io/helidon/telemetry/testing/tracing/JsonLogConverterImpl.java
@@ -292,7 +292,13 @@ class JsonLogConverterImpl implements JsonLogConverter {
                    Map<String, Object> attributes) implements JsonLogConverter.LogSpan {
     }
 
-    private static class TestLogHandler extends Handler {
+    static class TestLogHandler extends Handler {
+
+        // For testing.
+        static TestLogHandler create() {
+            return new TestLogHandler();
+        }
+
 
         private final List<String> resourceSpans = Collections.synchronizedList(new ArrayList<>());
 
@@ -312,7 +318,7 @@ class JsonLogConverterImpl implements JsonLogConverter {
         }
 
         List<String> resourceSpans() {
-            return resourceSpans;
+            return List.copyOf(resourceSpans);
         }
 
     }

--- a/telemetry/testing/tracing/src/test/java/io/helidon/telemetry/testing/tracing/JsonLogConverterTest.java
+++ b/telemetry/testing/tracing/src/test/java/io/helidon/telemetry/testing/tracing/JsonLogConverterTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.telemetry.testing.tracing;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+class JsonLogConverterTest {
+
+    @Test
+    void testJsonLogConverterWithConcurrentUpdates() throws Exception {
+
+        Logger logger = Logger.getLogger(JsonLogConverterTest.class.getName());
+        JsonLogConverterImpl.TestLogHandler testLogHandler = JsonLogConverterImpl.TestLogHandler.create();
+        logger.addHandler(testLogHandler);
+
+        // Trigger a concurrent update exception if the code is not handling multithreading properly
+        // by starting a stream and then adding a new message.
+        logger.log(Level.INFO, "First msg");
+        testLogHandler.resourceSpans()
+                .forEach(span -> logger.log(Level.INFO, "Second msg"));
+        assertThat("Fetch of spans during update", testLogHandler.resourceSpans(), hasSize(2));
+
+    }
+}


### PR DESCRIPTION
Backport #10823 to Helidon 4.3.3

### Description

Resolves https://github.com/helidon-io/helidon-examples/issues/213

## Release Note
____
The test `JsonLogConverterImpl` class is no longer susceptible to concurrent update race conditions. 
____

The OpenTelemetry support includes a test log handler to make sure that our code set up the JSON log span output correctly.

The OTel mechanism can take a little time to record the log records, so typically tests will retry looking for the expected number of spans to be present, and the retry code must retrieve the reported log records each time. 

The code that returns the reported log records (`JsonLogConverterImpl.TestLogHandler#resourceSpans`) was returning a reference to the `List` of log records that could be updated concurrently when OTel sent span log records

The fix changes `resourceSpans` to record a copy of that list. This avoids the possible concurrent update problem.

The PR includes a test which predictably forces an error before the fix and shows that the fix repairs the problem.

### Documentation

If enhancement: provide description with example code/config snippet or pointer to issue with the description

If feature: summarize feature and provide pointer to doc issue

If no doc impact: None