### PR TITLE
4.x: Remove /#/ from helidon.io docs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1337,11 +1337,11 @@ Thanks to @lilac for their contributions.
 
 We are pleased to announce the release of Helidon 4.0.0. The big news in Helidon 4.0.0 is the introduction of Helidon Níma -- a ground up webserver implementation based on JDK Project Loom virtual threads. With Helidon 4 you get the high throughput of a reactive server with the simplicity of thread-per-request style programming.
 
-The Helidon SE API in 4.0.0 has changed significantly from Helidon 3. The use of virtual threads have enabled these APIs to change from asynchronous to blocking. This results in much simpler code that is easier to write, maintain, debug and understand. Existing Helidon SE code will require modification to run on these new APIs. For more information see the [Helidon SE Upgrade Guide](https://helidon.io/docs/v4/#/se/guides/upgrade_4x).
+The Helidon SE API in 4.0.0 has changed significantly from Helidon 3. The use of virtual threads have enabled these APIs to change from asynchronous to blocking. This results in much simpler code that is easier to write, maintain, debug and understand. Existing Helidon SE code will require modification to run on these new APIs. For more information see the [Helidon SE Upgrade Guide](https://helidon.io/docs/v4/se/guides/upgrade_4x).
 
-Helidon 4 supports MicroProfile 6. This means your existing Helidon MP 3.x applications will run on Helidon 4 with only minor modifications. And since Helidon’s MicroProfile server is based on the new Níma WebServer you get all the benefits of running on virtual threads. For more information see the [Helidon MP Upgrade Guide](https://helidon.io/docs/v4/#/mp/guides/upgrade_4x).
+Helidon 4 supports MicroProfile 6. This means your existing Helidon MP 3.x applications will run on Helidon 4 with only minor modifications. And since Helidon’s MicroProfile server is based on the new Níma WebServer you get all the benefits of running on virtual threads. For more information see the [Helidon MP Upgrade Guide](https://helidon.io/docs/v4/mp/guides/upgrade_4x).
 
-New to Helidon? Then jump in and [get started](https://helidon.io/docs/v4/#/about/prerequisites).
+New to Helidon? Then jump in and [get started](https://helidon.io/docs/v4/about/prerequisites).
 
 Java 21 is required to use Helidon 4.0.0.
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ In either case your application is a Java SE program running on the
 new Helidon Níma WebServer that has been written from the ground up to
 use Java 21 Virtual Threads. With Helidon 4 you get the high throughput of a reactive server with the simplicity of thread-per-request style programming.
 
-The Helidon SE API in Helidon 4 has changed significantly from Helidon 3. The use of virtual threads has enabled these APIs to change from asynchronous to blocking. This results in much simpler code that is easier to write, maintain, debug and understand. Earlier Helidon SE code will require modification to run on these new APIs. For more information see the [Helidon SE Upgrade Guide](https://helidon.io/docs/v4/#/se/guides/upgrade_4x).
+The Helidon SE API in Helidon 4 has changed significantly from Helidon 3. The use of virtual threads has enabled these APIs to change from asynchronous to blocking. This results in much simpler code that is easier to write, maintain, debug and understand. Earlier Helidon SE code will require modification to run on these new APIs. For more information see the [Helidon SE Upgrade Guide](https://helidon.io/docs/v4/se/guides/upgrade_4x).
 
-Helidon 4 supports MicroProfile 6. This means your existing Helidon MP 3.x applications will run on Helidon 4 with only minor modifications. And since Helidon’s MicroProfile server is based on the new Níma WebServer you get all the benefits of running on virtual threads. For more information see the [Helidon MP Upgrade Guide](https://helidon.io/docs/v4/#/mp/guides/upgrade_4x).
+Helidon 4 supports MicroProfile 6. This means your existing Helidon MP 3.x applications will run on Helidon 4 with only minor modifications. And since Helidon’s MicroProfile server is based on the new Níma WebServer you get all the benefits of running on virtual threads. For more information see the [Helidon MP Upgrade Guide](https://helidon.io/docs/v4/mp/guides/upgrade_4x).
 
-New to Helidon? Then jump in and [get started](https://helidon.io/docs/v4/#/about/prerequisites).
+New to Helidon? Then jump in and [get started](https://helidon.io/docs/v4/about/prerequisites).
 
 Java 21 is required to use Helidon 4.
 

--- a/archetypes/archetypes/src/main/archetype/common/packaging.xml
+++ b/archetypes/archetypes/src/main/archetype/common/packaging.xml
@@ -40,7 +40,7 @@
                     <value order="50" template="mustache"><![CDATA[
 ## Run the application in Kubernetes
 
-If you don’t have access to a Kubernetes cluster, you can [install one](https://helidon.io/docs/latest/#/about/kubernetes) on your desktop.
+If you don’t have access to a Kubernetes cluster, you can [install one](https://helidon.io/docs/latest/about/kubernetes) on your desktop.
 
 ### Verify connectivity to cluster
 

--- a/archetypes/archetypes/src/main/archetype/mp/oci/files/client/README.md.mustache
+++ b/archetypes/archetypes/src/main/archetype/mp/oci/files/client/README.md.mustache
@@ -6,7 +6,7 @@ This module demonstrates how to generate a Helidon Microprofile restful microser
 of [api.yaml](../spec/api.yaml) as an input. The generated source code will be located in 
 target.generated-sources.client.src.main.java.{{package}}.client and will have the following components:
    * A microprofile rest client interface (that can be registered with CDI). Please check out
-     [Microprofile Rest Client](https://helidon.io/docs/v3/#/mp/restclient) for more
+     [Microprofile Rest Client](https://helidon.io/docs/v3/mp/restclient) for more
      information about this concept.
    * A Json-based request/response model.
 2. The generated Microprofile rest client interface called target.generated-sources.client.src.main.java.{{package}}.client.api.GreetApi

--- a/archetypes/archetypes/src/main/archetype/mp/oci/files/server/README.md.mustache
+++ b/archetypes/archetypes/src/main/archetype/mp/oci/files/server/README.md.mustache
@@ -155,7 +155,7 @@ dependency in the application's [pom.xml](pom.xml):
         </dependency>
 ```
 
-For more details about the Helidon metrics, please check out the [Helidon MP Metrics Guide](https://helidon.io/docs/v3/#/mp/guides/metrics)
+For more details about the Helidon metrics, please check out the [Helidon MP Metrics Guide](https://helidon.io/docs/v3/mp/guides/metrics)
 particularly the following relevant sections:
 1. `Controlling Metrics Behavior` - has various options to manage the behaviour of the helidon metrics
 2. `Application-Specific Metrics Data` - allows application-specific metrics to be created using CDI.
@@ -182,9 +182,9 @@ where annotated with Application-Specific metrics such as @Counted and @Timed as
 
 ## Health Checks
 Helidon supports built-in and custom liveness and readiness health checks. Refer to 
-[MicroProfile Health](https://helidon.io/docs/v3/#/mp/health) for an overview and how to set up this
+[MicroProfile Health](https://helidon.io/docs/v3/mp/health) for an overview and how to set up this
 feature. For more details on how to use it including creating custom health checks, check out 
-[Helidon MP Health Check Guide](https://helidon.io/docs/v3/#/mp/guides/health).
+[Helidon MP Health Check Guide](https://helidon.io/docs/v3/mp/guides/health).
 src.main.java.{{package}}.server.GreetLivenessCheck.java and src.main.java.{{package}}.server.GreetReadinessCheck.java had been added
 in the application to demonstrate custom liveness and readiness check, respectively. Liveness can be retrieved via
 `/health/live` and readiness via `/health/ready`. Check out [Run and exercise the application](#run-and-exercise-the-application)
@@ -197,7 +197,7 @@ and currently has the following parameters:
 1. `app.greeting` - The greeting word and currently set to `Hello`
 2. `server.host` - Host IP address of the server application and currently set to accept all at `0.0.0.0`
 3. `server.port` - Host port of the server application and currently set to `8080`
-4. `metrics.rest-request.enabled` - Enables rest request metrics and currently set `true`. Please see [Controlling REST.request Metrics](https://helidon.io/docs/v3/#/mp/guides/metrics#controlling-rest-request-metrics) for more information.
+4. `metrics.rest-request.enabled` - Enables rest request metrics and currently set `true`. Please see [Controlling REST.request Metrics](https://helidon.io/docs/v3/mp/guides/metrics#controlling-rest-request-metrics) for more information.
 5. `oci.monitoring.compartmentId` - Compartment Id used for the sending custom metrics. Please see [Publishing Custom Metrics](https://docs.oracle.com/en-us/iaas/Content/Monitoring/Tasks/publishingcustommetrics.htm#Publishing_Custom_Metrics) for more details.
 6. `oci.monitoring.namespace` - Monitoring namespace configured for sending metrics. Please see [Publishing Custom Metrics](https://docs.oracle.com/en-us/iaas/Content/Monitoring/Tasks/publishingcustommetrics.htm#Publishing_Custom_Metrics) for more information.
 7. `oci.logging.id` - Custom log id configured. Please see [Custom Logs Monitoring](#Custom-Logs-Monitoring) for more information.


### PR DESCRIPTION
### Description

Remove `/#/` from helidon.io documentation links.

E.g. replace `https://helidon.io/docs/v4/#/about/prerequisites` with `https://helidon.io/docs/v4/about/prerequisites`

### Documentation

None.
