### PR TITLE
4.x: Upgrade Jersey to 3.1.11

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -96,7 +96,7 @@
         <version.lib.jboss.classfilewriter>1.3.1.Final</version.lib.jboss.classfilewriter>
         <version.lib.jboss.logging>3.5.3.Final</version.lib.jboss.logging>
         <version.lib.jaxb-runtime>4.0.5</version.lib.jaxb-runtime>
-        <version.lib.jersey>3.1.10</version.lib.jersey>
+        <version.lib.jersey>3.1.11</version.lib.jersey>
         <!-- Jetbrains annotations: dependency convergence requirement, we never use this directly -->
         <version.lib.jetbrains.annotations>17.0.0</version.lib.jetbrains.annotations>
         <version.lib.jgit>7.3.0.202506031305-r</version.lib.jgit>


### PR DESCRIPTION
### Description

Upgrade Jersey to [3.1.11](https://github.com/eclipse-ee4j/jersey/releases/tag/3.1.11)

