### PR TITLE
4.x: Upgrade Netty to 4.1.130.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -137,7 +137,7 @@
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.0.0.Final</version.lib.narayana>
         <version.lib.neo4j>5.28.3</version.lib.neo4j>
-        <version.lib.netty>4.1.126.Final</version.lib.netty>
+        <version.lib.netty>4.1.130.Final</version.lib.netty>
         <version.lib.oci>3.77.0</version.lib.oci>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.9.0.25.07</version.lib.ojdbc>


### PR DESCRIPTION
### Description

Upgrade Netty to 4.1.130.Final.

Why does 4.x manage Netty version? See #9645