### PR TITLE
3.x: Upgrade apache commons-text to 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <version.lib.jmh>1.23</version.lib.jmh>
         <version.lib.wiremock>2.26.3</version.lib.wiremock>
         <version.lib.commons-lang3>3.18.0</version.lib.commons-lang3>
+        <version.lib.commons-text>1.15.0</version.lib.commons-text>
         <version.lib.classgraph>4.8.165</version.lib.classgraph>
         <!--
         !Version statement! - end
@@ -990,6 +991,12 @@
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-provider-api</artifactId>
                 <version>${version.lib.maven-wagon}</version>
+            </dependency>
+            <dependency>
+                <!-- force upgrade for etcd4j -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${version.lib.commons-text}</version>
             </dependency>
             <dependency>
                 <!--


### PR DESCRIPTION
### Description

Upgrade commons-text to 1.15.0. Used by etcd4j

