### PR TITLE
4.3.3: Upgrade apache commons-text to 1.15.0 (#10976)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <version.lib.vertx-core>4.3.8</version.lib.vertx-core>
         <version.lib.wiremock>2.26.3</version.lib.wiremock>
         <version.lib.commons-lang3>3.18.0</version.lib.commons-lang3>
-        <version.lib.commons-text>1.11.0</version.lib.commons-text>
+        <version.lib.commons-text>1.15.0</version.lib.commons-text>
         <version.lib.classgraph>4.8.165</version.lib.classgraph>
         <version.lib.plexus.classworlds>2.7.0</version.lib.plexus.classworlds>
         <version.lib.plexus.utils>3.3.0</version.lib.plexus.utils>
@@ -1187,7 +1187,7 @@
                 <version>${version.lib.maven-wagon}</version>
             </dependency>
             <dependency>
-                <!-- for dependency convergence with handlebars -->
+                <!-- for dependency convergence with handlebars and force upgrade -->
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>${version.lib.commons-text}</version>


### PR DESCRIPTION
Backport #10976 to Helidon 4.3.3

### Description


