### PR TITLE
Correctly discover parent configured blueprints even when from a different module

### DIFF
--- a/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfigMetadataTypes.java
+++ b/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfigMetadataTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ final class ConfigMetadataTypes {
     /*
     Using builder API
      */
-    static final TypeName COMMON_CONFIG = TypeName.create("io.helidon.common.config.Config");
     static final TypeName CONFIG = TypeName.create("io.helidon.config.Config");
     static final TypeName PROTOTYPE_FACTORY = TypeName.create("io.helidon.builder.api.Prototype.Factory");
     static final TypeName BLUEPRINT = TypeName.create("io.helidon.builder.api.Prototype.Blueprint");

--- a/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfiguredType.java
+++ b/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/ConfiguredType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.config.metadata.codegen;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -38,7 +39,7 @@ final class ConfiguredType {
     The type we are processing that has @Configured annotation
      */
     private final TypeName annotatedClass;
-    private final List<TypeName> inherited = new LinkedList<>();
+    private final Set<TypeName> inherited = new LinkedHashSet<>();
     private final ConfiguredAnnotation configured;
 
     ConfiguredType(ConfiguredAnnotation configured, TypeName annotatedClass, TypeName targetClass, boolean typeDefinition) {


### PR DESCRIPTION
Make sure the generated `config-metadata.json` contains the `inherited` property.

Validated on `helidon-webclient-grpc` module, also validated there is just one `inherited` option there.
Validated generated config metadata documentation that it contains inherited options.

Resolves #10983 

