### PR TITLE
4.3.3: Export package from OpenAPI UI integration module; with integration test

### DIFF
--- a/integrations/openapi-ui/pom.xml
+++ b/integrations/openapi-ui/pom.xml
@@ -135,6 +135,23 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <!--
+                The following tests a bug fix, without which an added line to the project's module-info.java file triggers a
+                compiler error.
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/integrations/openapi-ui/src/it/projects/test1/pom.xml
+++ b/integrations/openapi-ui/src/it/projects/test1/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.helidon.integrations.openapi-ui.it</groupId>
+    <artifactId>test-1</artifactId>
+    <version>@project.version@</version>
+    <name>Test Project for OpenAPI UI module export</name>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <surefire.argLine>-Xmx1024m -Dfile.encoding=UTF-8</surefire.argLine>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.integrations.openapi-ui</groupId>
+            <artifactId>helidon-integrations-openapi-ui</artifactId>
+            <version>@project.version@</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.12.4</version>
+                    <configuration>
+                        <argLine>${surefire.argLine}</argLine>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/integrations/openapi-ui/src/it/projects/test1/src/main/java/io/helidon/integrations/openapi/ui/it/Main.java
+++ b/integrations/openapi-ui/src/it/projects/test1/src/main/java/io/helidon/integrations/openapi/ui/it/Main.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.openapi.ui.it;
+
+import io.helidon.integrations.openapi.ui.OpenApiUi;
+public class Main {
+
+    public static void main(String[] args) {
+        var ui = OpenApiUi.builder()
+                .webContext("/my-ui")
+                .build();
+    }
+}

--- a/integrations/openapi-ui/src/it/projects/test1/src/main/java/module-info.java
+++ b/integrations/openapi-ui/src/it/projects/test1/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test module.
+ */
+module it {
+
+    requires io.helidon.integrations.openapi.ui;
+}

--- a/integrations/openapi-ui/src/it/settings.xml
+++ b/integrations/openapi-ui/src/it/settings.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <checksumPolicy>ignore</checksumPolicy>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <checksumPolicy>ignore</checksumPolicy>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
+</settings>

--- a/integrations/openapi-ui/src/main/java/module-info.java
+++ b/integrations/openapi-ui/src/main/java/module-info.java
@@ -29,6 +29,8 @@ module io.helidon.integrations.openapi.ui {
 
     requires smallrye.open.api.ui;
 
+    exports io.helidon.integrations.openapi.ui;
+
     provides io.helidon.openapi.spi.OpenApiServiceProvider with
             OpenApiUiProvider;
 }


### PR DESCRIPTION

Backport #10902 to Helidon 4.3.3

### Description
Resolves #10889 

### Release Note
____
The Helidon OpenAPI UI integration component now exports its package so applications can set up the UI behavior programmatically and not only using config files.
____

The PR adds an `exports` line to the OpenAPI UI `module-info.java` and adds an integration test.

### Documentation
No impact.