### PR TITLE
4.3.3: Fix "typo" in header name construction. Use the correct create method…

### DIFF
--- a/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHeadersUtil.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHeadersUtil.java
@@ -46,7 +46,7 @@ public class GrpcHeadersUtil {
             if (name.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
                 Metadata.Key<byte[]> key = Metadata.Key.of(name, Metadata.BINARY_BYTE_MARSHALLER);
                 byte[] binary = metadata.get(key);
-                headers.add(HeaderNames.create(name, new String(encoder.encode(binary), US_ASCII)));
+                headers.add(HeaderNames.create(name), new String(encoder.encode(binary), US_ASCII));
             } else {
                 Metadata.Key<String> key = Metadata.Key.of(name, Metadata.ASCII_STRING_MARSHALLER);
                 Iterable<String> ascii = metadata.getAll(key);

--- a/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHeadersUtilTest.java
+++ b/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHeadersUtilTest.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.grpc.core;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -46,6 +48,20 @@ class GrpcHeadersUtilTest {
         List<String> values = headers.get(HeaderNames.COOKIE).allValues();
         assertThat(values, hasItem("sugar"));
         assertThat(values, hasItem("almond"));
+    }
+
+    @Test
+    void testUpdateBinaryHeaders() {
+        Metadata metadata = new Metadata();
+        Metadata.Key<byte[]> key = Metadata.Key.of("secret-bin", Metadata.BINARY_BYTE_MARSHALLER);
+        byte[] mySecret = "my-secret".getBytes(StandardCharsets.UTF_8);
+        metadata.put(key, mySecret);
+        WritableHeaders<?> headers = WritableHeaders.create();
+        GrpcHeadersUtil.updateHeaders(headers, metadata);
+        assertThat(headers.size(), is(1));
+        List<String> values = headers.get(HeaderNames.create("secret-bin")).allValues();
+        byte[] value = Base64.getDecoder().decode(values.getFirst().getBytes(StandardCharsets.UTF_8));
+        assertThat(new String(value, StandardCharsets.UTF_8), is("my-secret"));
     }
 
     @Test


### PR DESCRIPTION

Backport #10987 to Helidon 4.3.3

### Description

Fix "typo" in header name construction. Use the correct create method and add a test to verify fix. See issue #10937.

### Documentation

None
