### PR TITLE
Fix issues with trailers in HTTP/2

### DIFF
--- a/http/http/src/main/java/io/helidon/http/Header.java
+++ b/http/http/src/main/java/io/helidon/http/Header.java
@@ -57,12 +57,12 @@ public interface Header extends Value<String> {
     HeaderName headerName();
 
     /**
-     * All values concatenated using a comma.
+     * All values concatenated using a comma and a space.
      *
      * @return all values joined by a comma
      */
     default String values() {
-        return String.join(",", allValues());
+        return String.join(", ", allValues());
     }
 
     /**

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -445,7 +445,8 @@ public class Http2Headers {
         }
 
         for (Header header : headers) {
-            String value = header.get();
+            // send all values of the header
+            String value = header.values();
             boolean shouldIndex = !header.changing();
             boolean neverIndex = header.sensitive();
 

--- a/webserver/tests/http2/src/test/resources/logging-test.properties
+++ b/webserver/tests/http2/src/test/resources/logging-test.properties
@@ -13,16 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level=FINEST
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %5$s%6$s%n
-# Global logging level. Can be overridden by specific loggers
-.level=INFO
-io.helidon.webserver.level=INFO
 
-#io.helidon.http.http2.level=FINEST
-#io.helidon.http.http2.FlowControl.ifc.level=FINEST
-#io.helidon.http.http2.FlowControl.ofc.level=FINEST
+.level=INFO
+
 # This must be set to FINEST, as otherwise `CutConnectionTest` stops working - it checks log output
 io.helidon.webserver.ConnectionHandler.level=FINEST

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -58,6 +58,11 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      */
     protected static final HeaderName STREAM_RESULT_NAME = HeaderNames.create("stream-result");
     /**
+     * Stream result OK.
+     */
+    protected static final Header STREAM_RESULT_OK = HeaderValues.create(STREAM_RESULT_NAME, "OK");
+
+    /**
      * Stream status trailers.
      */
     protected static final Header STREAM_TRAILERS =


### PR DESCRIPTION
- Header now uses the same separator for creating and parsing a single value (comma and a space)
- Http2Headers now send all values, not just he first one 
- Trailers are considered available only if they are set in the "trailer" response header, otherwise stream ends with data 
- Updated tests to ensure we get the trailers as expected, and all trailer names as well
- Sending stream result OK when using streaming, as we announced the trailer in trailer header


Resolves #10996 


The original issue was caused by our implementation not sending trailers when we had a single pass-through in the output stream.
Additional issues discovered when troubleshooting the issue and adding tests.
