### PR TITLE
Helidon SE Scheduling: Add ZoneId support in cron builder

### DIFF
--- a/docs/src/main/asciidoc/se/scheduling.adoc
+++ b/docs/src/main/asciidoc/se/scheduling.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -85,6 +85,21 @@ For more complicated interval definition, Cron expression can be leveraged with
 ----
 include::{sourcedir}/se/SchedulingSnippets.java[tag=snippet_3, indent=0]
 ----
+
+==== Timezone Configuration
+
+By default, Cron expressions are evaluated using the system's default timezone. You can specify a custom timezone
+to control when the cron expression triggers, regardless of the system's timezone.
+
+[source,java]
+.Scheduling with custom timezone
+----
+include::{sourcedir}/se/SchedulingSnippets.java[tag=snippet_7, indent=0]
+----
+
+The timezone determines when the cron expression triggers. For example, a cron expression `0 0 9 * * ?`
+(every day at 9:00 AM) with zone `America/New_York` will trigger at 9:00 AM Eastern Time,
+regardless of the server's timezone setting.
 
 include::{rootdir}/config/io_helidon_scheduling_Cron.adoc[tag=config,leveloffset=+2]
 

--- a/docs/src/main/java/io/helidon/docs/se/SchedulingSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/se/SchedulingSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.docs.se;
 
+import java.time.ZoneId;
 import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.media.type.MediaTypes;
@@ -89,5 +90,15 @@ class SchedulingSnippets {
                 .task(inv -> System.out.println("Method invoked " + inv.description()))
                 .build();
         // end::snippet_6[]
+    }
+
+    void snippet_7() {
+        // tag::snippet_7[]
+        Cron.builder()
+                .expression("0 0 9 * * ?")
+                .zone(ZoneId.of("America/New_York"))
+                .task(inv -> System.out.println("Executes every day at 9:00 AM Eastern Time"))
+                .build();
+        // end::snippet_7[]
     }
 }

--- a/scheduling/src/main/java/io/helidon/scheduling/CronConfigBlueprint.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/CronConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package io.helidon.scheduling;
+
+import java.time.ZoneId;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
@@ -38,6 +40,21 @@ interface CronConfigBlueprint extends TaskConfigBlueprint, Prototype.Factory<Cro
     @Option.Configured
     @Option.Required
     String expression();
+
+    /**
+     * Time zone to use for cron expression evaluation.
+     * Defaults to {@link java.time.ZoneId#systemDefault()}.
+     * <p>
+     * The time zone determines when the cron expression triggers. For example,
+     * a cron expression {@code 0 0 9 * * ?} (every day at 9:00 AM) with zone
+     * {@code America/New_York} will trigger at 9:00 AM Eastern Time, regardless
+     * of the system's default time zone.
+     *
+     * @return time zone for cron expression evaluation
+     */
+    @Option.Configured
+    @Option.DefaultCode("@java.time.ZoneId@.systemDefault()")
+    ZoneId zone();
 
     /**
      * Allow concurrent execution if previous task didn't finish before next execution.

--- a/scheduling/src/main/java/io/helidon/scheduling/CronTask.java
+++ b/scheduling/src/main/java/io/helidon/scheduling/CronTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ class CronTask implements Cron {
                 return;
             }
 
-            ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now(config.zone());
             Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(now);
             if (nextExecution.isEmpty()) {
                 return;


### PR DESCRIPTION
**Fixes #10984**

**Summary**
This PR adds the ability to configure a specific `ZoneId` for Cron tasks in Helidon SE. Previously, Cron expressions were always evaluated against the system's default timezone (usually UTC), making it difficult to schedule tasks for specific "wall clock" times in regions observing Daylight Saving Time.

**Changes**
*   **API:** Added `zone(ZoneId zone)` to the `Cron` builder and configuration blueprint.
*   **Implementation:** Updated `CronTask` to calculate `ZonedDateTime.now(zone)` using the configured timezone instead of the system default.
*   **Default Behavior:** The default value is `ZoneId.systemDefault()`, ensuring full backward compatibility for existing applications.
*   **Documentation:** Added a "Timezone Configuration" section to `scheduling.adoc`.
*   **Tests:** Added `cronWithCustomZone` test to verify execution respects the configured zone when it differs from the system zone.

**Example Usage**
```java
Cron.builder()
    .expression("0 0 9 * * ?")
    .zone(ZoneId.of("America/New_York")) // Now supported
    .task(task)
    .build();
```