### PR TITLE
Support injection in guardrails #10714

### DIFF
--- a/integrations/langchain4j/langchain4j/src/main/java/io/helidon/integrations/langchain4j/ServiceRegistryClassInstanceFactory.java
+++ b/integrations/langchain4j/langchain4j/src/main/java/io/helidon/integrations/langchain4j/ServiceRegistryClassInstanceFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.langchain4j;
+
+import io.helidon.service.registry.Services;
+
+import dev.langchain4j.spi.classloading.ClassInstanceFactory;
+
+/**
+ * LangChain4j ClassInstanceFactory implementation
+ * that retrieves instances of classes from Helidon global
+ * {@link Services} registry.
+ *
+ * @see ClassInstanceFactory
+ * @see Services
+ */
+public class ServiceRegistryClassInstanceFactory implements ClassInstanceFactory {
+
+    /**
+     * Constructs a new {@code ServiceRegistryClassInstanceFactory}.
+     */
+    public ServiceRegistryClassInstanceFactory() {
+    }
+
+    /**
+     * Retrieves an instance of the given class from the Helidon {@link Services} registry.
+     *
+     * @param <T>   the type of the class
+     * @param clazz the class to retrieve an instance of
+     * @return an instance of the requested class, or {@code null} if not found
+     */
+    @Override
+    public <T> T getInstanceOfClass(Class<T> clazz) {
+        return Services.first(clazz).orElse(null);
+    }
+}

--- a/integrations/langchain4j/langchain4j/src/main/java/module-info.java
+++ b/integrations/langchain4j/langchain4j/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,4 +43,6 @@ module io.helidon.integrations.langchain4j {
 
     provides dev.langchain4j.spi.services.TokenStreamAdapter
             with io.helidon.integrations.langchain4j.TokenStreamToStreamAdapter;
+    provides dev.langchain4j.spi.classloading.ClassInstanceFactory
+            with io.helidon.integrations.langchain4j.ServiceRegistryClassInstanceFactory;
 }


### PR DESCRIPTION
Implement [ClassInstanceFactory](https://github.com/langchain4j/langchain4j/blob/release-1.10.0/langchain4j-core/src/main/java/dev/langchain4j/spi/classloading/ClassInstanceFactory.java) to be picked up by lc4j service loader and used for Guardrails instantiation.

Fixes #10714
