### PR TITLE
Fix inconsistent return type in JwtProvider.Builder.expectedAudience

### DIFF
--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -835,10 +835,12 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
          * Audience expected in inbound JWTs.
          *
          * @param audience audience string
+         * @return updated builder instance
          */
         @ConfiguredOption(key = "atn-token.jwt-audience")
-        public void expectedAudience(String audience) {
+        public Builder expectedAudience(String audience) {
             this.expectedAudience = audience;
+            return this;
         }
 
         /**


### PR DESCRIPTION
**Fixes #11037**

## Summary
This PR changes the return type of the `JwtProvider.Builder.expectedAudience(String)` method from `void` to `Builder`.

## Details
In `JwtProvider.java`, the `expectedAudience` method in the `Builder` class was inconsistently defined with a `void` return type, while all other builder methods in the same class return the `Builder` instance. This inconsistency broke the fluent API pattern and prevented method chaining when configuring the `expectedAudience`.

This change aligns `expectedAudience` with the rest of the `JwtProvider.Builder` API and follows Helidon's standard builder pattern.

## Changes
- Updated `io.helidon.security.providers.jwt.JwtProvider.Builder#expectedAudience(String)` return type to `Builder`.
- Updated the method implementation to return `this`.
- Added `@return` Javadoc tag to the method.

