### PR TITLE
Backward compatible fix for common config in SecurityProviderService

### DIFF
--- a/integrations/vault/secrets/cubbyhole/src/main/java/io/helidon/integrations/vault/secrets/cubbyhole/CubbyholeSecurityService.java
+++ b/integrations/vault/secrets/cubbyhole/src/main/java/io/helidon/integrations/vault/secrets/cubbyhole/CubbyholeSecurityService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.integrations.vault.secrets.cubbyhole;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.integrations.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
@@ -43,7 +43,7 @@ public class CubbyholeSecurityService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return new CubbyholeSecurityProvider(Vault.create(config));
     }
 }

--- a/integrations/vault/secrets/kv1/src/main/java/io/helidon/integrations/vault/secrets/kv1/Kv1SecurityService.java
+++ b/integrations/vault/secrets/kv1/src/main/java/io/helidon/integrations/vault/secrets/kv1/Kv1SecurityService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.integrations.vault.secrets.kv1;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.integrations.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
@@ -43,7 +43,7 @@ public class Kv1SecurityService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return new Kv1SecurityProvider(Vault.create(config));
     }
 }

--- a/integrations/vault/secrets/kv2/src/main/java/io/helidon/integrations/vault/secrets/kv2/Kv2SecurityService.java
+++ b/integrations/vault/secrets/kv2/src/main/java/io/helidon/integrations/vault/secrets/kv2/Kv2SecurityService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.integrations.vault.secrets.kv2;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.integrations.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
@@ -43,7 +43,7 @@ public class Kv2SecurityService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return new Kv2SecurityProvider(Vault.create(config));
     }
 }

--- a/integrations/vault/secrets/transit/src/main/java/io/helidon/integrations/vault/secrets/transit/TransitSecurityService.java
+++ b/integrations/vault/secrets/transit/src/main/java/io/helidon/integrations/vault/secrets/transit/TransitSecurityService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.integrations.vault.secrets.transit;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.integrations.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
@@ -36,7 +36,7 @@ public class TransitSecurityService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return new TransitSecurityProvider(Vault.create(config));
     }
 }

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProviderService.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.helidon.microprofile.jwt.auth;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -35,7 +35,7 @@ public class JwtAuthProviderService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return JwtAuthProvider.create(config);
     }
 }

--- a/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProviderService.java
+++ b/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.security.providers.abac;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -38,7 +38,7 @@ public class AbacProviderService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return AbacProvider.create(config);
     }
 }

--- a/security/providers/config-vault/src/main/java/io/helidon/security/providers/config/vault/ConfigVaultProviderService.java
+++ b/security/providers/config-vault/src/main/java/io/helidon/security/providers/config/vault/ConfigVaultProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.helidon.security.providers.config.vault;
 
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -47,7 +47,7 @@ public class ConfigVaultProviderService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return ConfigVaultProvider.create(config);
     }
 }

--- a/security/providers/google-login/src/main/java/io/helidon/security/providers/google/login/GoogleTokenService.java
+++ b/security/providers/google-login/src/main/java/io/helidon/security/providers/google/login/GoogleTokenService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.security.providers.google.login;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -38,7 +38,7 @@ public class GoogleTokenService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return GoogleTokenProvider.create(config);
     }
 }

--- a/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnService.java
+++ b/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.security.providers.header;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -39,7 +39,7 @@ public class HeaderAtnService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return HeaderAtnProvider.create(config);
     }
 }

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthService.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.security.providers.httpauth;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -36,7 +36,7 @@ public class HttpBasicAuthService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return HttpBasicAuthProvider.create(config);
     }
 }

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthService.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.security.providers.httpauth;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -37,7 +37,7 @@ public class HttpDigestAuthService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return HttpDigestAuthProvider.create(config);
     }
 }

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignService.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.security.providers.httpsign;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -39,7 +39,7 @@ public class HttpSignService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return HttpSignProvider.create(config);
     }
 }

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderService.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package io.helidon.security.providers.idcs.mapper;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -38,7 +38,7 @@ public class IdcsRoleMapperProviderService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         if (config.get("multitenant").asBoolean().orElse(true)) {
             return IdcsMtRoleMapperProvider.create(config);
         }

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProviderService.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.security.providers.jwt;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -39,7 +39,7 @@ public class JwtProviderService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return JwtProvider.create(config);
     }
 }

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProviderService.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package io.helidon.security.providers.oidc;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 import io.helidon.security.spi.SecurityProvider;
 import io.helidon.security.spi.SecurityProviderService;
 
@@ -41,7 +41,7 @@ public class OidcProviderService implements SecurityProviderService {
     }
 
     @Override
-    public SecurityProvider providerInstance(Config config) {
+    public SecurityProvider create(Config config) {
         return OidcProvider.create(config);
     }
 }

--- a/security/security/src/main/java/io/helidon/security/spi/SecurityProviderService.java
+++ b/security/security/src/main/java/io/helidon/security/spi/SecurityProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
 
 package io.helidon.security.spi;
 
-import io.helidon.common.config.Config;
+import io.helidon.config.Config;
 
 /**
  * Service to use with ServiceLoader to map configuration to
  * provider.
+ * <p>
+ * Method {@link #create(io.helidon.config.Config)} must be implemented even though it is marked as default (this is for
+ * backward compatibility within Helidon 4); this method will not be default in a future version of Helidon
  */
 public interface SecurityProviderService {
     /**
@@ -55,7 +58,27 @@ public interface SecurityProviderService {
      * provided. The config is located at the config key of this provider.
      *
      * @param config Config with provider configuration
-     * @return provider instance created from the {@link Config} provided
+     * @return provider instance created from the {@link io.helidon.common.config.Config} provided
+     * @deprecated implement {@link #create(io.helidon.config.Config)} instead,
+     * IMPORTANT NOTE: if you are calling this method, and
+     * you want the update your code, you should call {@link #create(io.helidon.config.Config)}, catch
+     * {@link java.lang.UnsupportedOperationException}, and call this method as a fallback
      */
-    SecurityProvider providerInstance(Config config);
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true, since = "4.4.0")
+    default SecurityProvider providerInstance(io.helidon.common.config.Config config) {
+        return create(Config.config(config));
+    }
+
+    /**
+     * Create a new instance of the provider based on the configuration
+     * provided. The config is located at the config key of this provider.
+     *
+     * @param config Config with provider configuration
+     * @return provider instance created from the {@link io.helidon.config.Config} provided
+     */
+    default SecurityProvider create(Config config) {
+        throw new UnsupportedOperationException("A " + SecurityProviderService.class.getName() + " implementation must "
+                                                        + "implement the create(io.helidon.config.Config) method");
+    }
 }

--- a/tests/integration/security/security-response-mapper/src/main/java/io/helidon/tests/integration/security/mapper/RestrictedProviderService.java
+++ b/tests/integration/security/security-response-mapper/src/main/java/io/helidon/tests/integration/security/mapper/RestrictedProviderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,9 @@ public class RestrictedProviderService implements SecurityProviderService {
         return RestrictedProvider.class;
     }
 
+    /*
+    This method is intentionally kept as deprecated implementation, to make sure it works fine
+     */
     @Override
     public SecurityProvider providerInstance(Config config) {
         return new RestrictedProvider();


### PR DESCRIPTION
Update `SecurityProviderService` to include a create method with config that is not deprecated, and update implementations and usage to support this.

Resolves #10968 