### PR TITLE
4.x: Fix dependency:analyze-only for http-media-json

### DIFF
--- a/http/media/json/pom.xml
+++ b/http/media/json/pom.xml
@@ -37,10 +37,6 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-buffers</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.json</groupId>
             <artifactId>helidon-json-binding</artifactId>
         </dependency>
@@ -63,18 +59,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-media-type</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.json</groupId>
-            <artifactId>helidon-json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-types</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.service</groupId>
-            <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.features</groupId>
@@ -186,24 +170,24 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>check-dependencies</id>
                         <phase>verify</phase>
                         <configuration>
-                            <ignoredNonTestScopedDependencies>
+                            <ignoredDependencies combine.children="append">
                                 <!-- Used from generated code, the plugin does not see this -->
                                 <dependency>io.helidon.common:helidon-common-types::</dependency>
                                 <dependency>io.helidon.service:helidon-service-registry::</dependency>
                                 <dependency>io.helidon.json:helidon-json::</dependency>
                                 <dependency>io.helidon.common:helidon-common-buffers::</dependency>
-                            </ignoredNonTestScopedDependencies>
+                            </ignoredDependencies>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
### Description

Code used only by tests should be allowed to compile against transitive dependencies:
- If declared as direct dependencies, and tests aren't compiled, they are flagged as "unused declared dependencies"
- If marked as test scoped, the compilation fails

The helidon-examples repository does a prime build of the helidon repository using `-Dmaven.test.skip=true` which skips compilation and fails on the `http-media-json` module.

---

You can reproduce this with:
```shell
mvn -f http/media/json/pom.xml clean verify -DskipTests -Dverbose -Dmaven.test.skip=true
```

It shows the following error:
```
[ERROR] Unused declared dependencies found:
[ERROR]    io.helidon.common:helidon-common-types:jar:4.4.0-SNAPSHOT:compile
[ERROR]    io.helidon.common:helidon-common-buffers:jar:4.4.0-SNAPSHOT:compile
[ERROR]    io.helidon.json:helidon-json:jar:4.4.0-SNAPSHOT:compile
[ERROR]    io.helidon.service:helidon-service-registry:jar:4.4.0-SNAPSHOT:compile
```

---

If we remove the extra direct dependencies, we get the following errors:
```
[ERROR] Used undeclared dependencies found:
[ERROR]    io.helidon.common:helidon-common-types:jar:4.4.0-SNAPSHOT:compile
[ERROR]       class io.helidon.common.types.ResolvedType
[ERROR]       class io.helidon.common.types.TypeName
[ERROR]       class io.helidon.common.types.Annotation
[ERROR]    io.helidon.common:helidon-common-buffers:jar:4.4.0-SNAPSHOT:compile
[ERROR]       class io.helidon.common.buffers.Bytes
[ERROR]    io.helidon.json:helidon-json:jar:4.4.0-SNAPSHOT:compile
[ERROR]       class io.helidon.json.JsonParser
[ERROR]       class io.helidon.json.JsonGenerator
[ERROR]       class io.helidon.json.JsonException
[ERROR]    io.helidon.service:helidon-service-registry:jar:4.4.0-SNAPSHOT:compile
[ERROR]       class io.helidon.service.registry.ServiceDescriptor
[ERROR]       class io.helidon.service.registry.Qualifier
[ERROR]       class io.helidon.service.registry.DependencyContext
[ERROR]       class io.helidon.service.registry.InterceptionMetadata
[ERROR]       class io.helidon.service.registry.Service
[ERROR]       class io.helidon.service.registry.Dependency
```

The offending dependencies are already ignored for "Non-test scoped test only dependencies":
```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-dependency-plugin</artifactId>
    <executions>
        <execution>
            <id>check-dependencies</id>
            <phase>verify</phase>
            <configuration>
                <ignoredNonTestScopedDependencies>
                    <!-- Used from generated code, the plugin does not see this -->
                    <dependency>io.helidon.common:helidon-common-types::</dependency>
                    <dependency>io.helidon.service:helidon-service-registry::</dependency>
                    <dependency>io.helidon.json:helidon-json::</dependency>
                    <dependency>io.helidon.common:helidon-common-buffers::</dependency>
                </ignoredNonTestScopedDependencies>
            </configuration>
        </execution>
    </executions>
</plugin>
```

We can duplicate the configuration for "Used undeclared dependencies":
```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-dependency-plugin</artifactId>
    <executions>
        <execution>
            <id>check-dependencies</id>
            <phase>verify</phase>
            <configuration>
                <ignoredUsedUndeclaredDependencies>
                    <dependency>io.helidon.common:helidon-common-types::</dependency>
                    <dependency>io.helidon.service:helidon-service-registry::</dependency>
                    <dependency>io.helidon.json:helidon-json::</dependency>
                    <dependency>io.helidon.common:helidon-common-buffers::</dependency>
                </ignoredUsedUndeclaredDependencies>
                <ignoredNonTestScopedDependencies>
                    <dependency>io.helidon.common:helidon-common-types::</dependency>
                    <dependency>io.helidon.service:helidon-service-registry::</dependency>
                    <dependency>io.helidon.json:helidon-json::</dependency>
                    <dependency>io.helidon.common:helidon-common-buffers::</dependency>
                </ignoredNonTestScopedDependencies>
            </configuration>
        </execution>
    </executions>
</plugin>
```

Or we can use `ignoreDependencies` to address both error classes:
```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-dependency-plugin</artifactId>
    <executions>
        <execution>
            <id>check-dependencies</id>
            <phase>verify</phase>
            <configuration>
                <ignoredDependencies combine.children="append">
                    <dependency>io.helidon.common:helidon-common-types::</dependency>
                    <dependency>io.helidon.service:helidon-service-registry::</dependency>
                    <dependency>io.helidon.json:helidon-json::</dependency>
                    <dependency>io.helidon.common:helidon-common-buffers::</dependency>
                </ignoredDependencies>
            </configuration>
        </execution>
    </executions>
</plugin>
```

### Documentation

None.
