### PR TITLE
4.x: Upgrade commons-logging to 1.3.5

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -45,7 +45,7 @@
         <version.lib.commons-compress>1.27.1</version.lib.commons-compress>
         <version.lib.commons-io>2.16.1</version.lib.commons-io>
         <version.lib.commons-lang>3.18.0</version.lib.commons-lang>
-        <version.lib.commons-logging>1.2</version.lib.commons-logging>
+        <version.lib.commons-logging>1.3.5</version.lib.commons-logging>
         <version.lib.cron-utils>9.2.1</version.lib.cron-utils>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.dropwizard.metrics>4.1.36</version.lib.dropwizard.metrics>


### PR DESCRIPTION
### Description

Upgrade commons-logging to 1.3.5

