### PR TITLE
4.x Tolerate test log tracing output that has attributes with no value

### DIFF
--- a/telemetry/testing/tracing/pom.xml
+++ b/telemetry/testing/tracing/pom.xml
@@ -52,10 +52,15 @@
             <artifactId>hamcrest-all</artifactId>
         </dependency>
         <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <scope>test</scope>
-    </dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/telemetry/testing/tracing/src/test/java/io/helidon/telemetry/testing/tracing/JsonLogConverterTest.java
+++ b/telemetry/testing/tracing/src/test/java/io/helidon/telemetry/testing/tracing/JsonLogConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 
 class JsonLogConverterTest {
@@ -39,5 +41,133 @@ class JsonLogConverterTest {
                 .forEach(span -> logger.log(Level.INFO, "Second msg"));
         assertThat("Fetch of spans during update", testLogHandler.resourceSpans(), hasSize(2));
 
+    }
+
+    @Test
+    void testEmptyStringValueAttribute() throws Exception {
+        /*
+        Mimic the default (empty) helidon socket attribute.
+        {"key":"helidon.socket","value":{}}
+         */
+
+        Logger logger = Logger.getLogger(JsonLogConverterTest.class.getName());
+        try (var converter = new JsonLogConverterImpl(logger)) {
+
+            logger.log(Level.INFO, """
+                    {
+                       "resource" : {
+                         "attributes" : [ {
+                           "key" : "service.name",
+                           "value" : {
+                             "stringValue" : "otel-config-example"
+                           }
+                         }, {
+                           "key" : "telemetry.sdk.language",
+                           "value" : {
+                             "stringValue" : "java"
+                           }
+                         }, {
+                           "key" : "telemetry.sdk.name",
+                           "value" : {
+                             "stringValue" : "opentelemetry"
+                           }
+                         }, {
+                           "key" : "telemetry.sdk.version",
+                           "value" : {
+                             "stringValue" : "1.58.0"
+                           }
+                         }, {
+                           "key" : "x",
+                           "value" : {
+                             "stringValue" : "x-value"
+                           }
+                         }, {
+                           "key" : "y",
+                           "value" : {
+                             "intValue" : "9"
+                           }
+                         } ]
+                       },
+                       "scopeSpans" : [ {
+                         "scope" : {
+                           "name" : "otel-config-example",
+                           "attributes" : [ ]
+                         },
+                         "spans" : [ {
+                           "traceId" : "6edae103f4de519e341ed47e84888e6f",
+                           "spanId" : "89076986e7a0b27e",
+                           "name" : "GET",
+                           "kind" : 2,
+                           "startTimeUnixNano" : "1769634903759517000",
+                           "endTimeUnixNano" : "1769634931221218583",
+                           "attributes" : [ {
+                             "key" : "server.address",
+                             "value" : {
+                               "stringValue" : "helidon-unit"
+                             }
+                           }, {
+                             "key" : "net.host.name",
+                             "value" : {
+                               "stringValue" : "helidon-unit"
+                             }
+                           }, {
+                             "key" : "user_agent.original",
+                             "value" : {
+                               "stringValue" : "Helidon 4.4.0-SNAPSHOT"
+                             }
+                           }, {
+                             "key" : "url.path",
+                             "value" : {
+                               "stringValue" : "/greeting/Joe"
+                             }
+                           }, {
+                             "key" : "http.request.method",
+                             "value" : {
+                               "stringValue" : "GET"
+                             }
+                           }, {
+                             "key" : "helidon.socket",
+                             "value" : { }
+                           }, {
+                             "key" : "server.port",
+                             "value" : {
+                               "stringValue" : "8080"
+                             }
+                           }, {
+                             "key" : "http.response.status_code",
+                             "value" : {
+                               "stringValue" : "404"
+                             }
+                           }, {
+                             "key" : "url.scheme",
+                             "value" : {
+                               "stringValue" : "http"
+                             }
+                           }, {
+                             "key" : "net.host.port",
+                             "value" : {
+                               "intValue" : "8080"
+                             }
+                           } ],
+                           "events" : [ ],
+                           "links" : [ ],
+                           "status" : { },
+                           "flags" : 257
+                         } ]
+                       } ]
+                     }""");
+
+            var logSpan = converter.resourceSpans(1).getFirst()
+                    .scopeSpans().getFirst()
+                    .logSpans().getFirst();
+
+            /*
+            The presence of helidon.socket with an empty value caused a problem in the converter that should be fixed.
+             */
+            assertThat("Attributes", logSpan.attributes(), allOf(
+                    hasEntry("server.address", "helidon-unit"),
+                    hasEntry("url.path", "/greeting/Joe"),
+                    hasEntry("helidon.socket", "")));
+        }
     }
 }


### PR DESCRIPTION
### Description
Resolves #11086 

A test class for capturing OpenTelemetry tracing spans in-memory (for checking by tests) did not tolerate a span attribute with an empty string value.

This PR fixes the test class and includes a new test for the test.

With this fix in place, the failing examples build described in the linked issue also works successfully now.

### Documentation
No impact