### PR TITLE
4.3.4: Fixed parsing of HTTP prologue for big endian machines

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/Bytes.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/Bytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Backport #11051 to Helidon 4.3.4

### Description

The parsing of the HTTP prologue for HTTP messages of HTTP version 1 changed byte order of the parsed buffer depending on the endianess of the system. This led to an error when used on big endian system. The parsing of the HTTP prologue does not need to take endianess into account as the parsed buffer is ASCII text.

