### PR TITLE
4.3.4: Log warnings (if not configured to suppress) upon multiple instantiations of `MMeterRegistry`

### DIFF
--- a/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/MetricsConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MMeterRegistry.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MMeterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactoryProvider.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestMultipleRegistryLogging.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestMultipleRegistryLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Backport #10859 to Helidon 4.3.4

### Description
Resolves #10858 

## Release Note
____
Helidon now logs warnings if more than one meter registry is instantiated (unless suppressed by setting `metrics.warn-on-multiple-registries` to `false`).
____

## PR background
The Helidon implementation of the `MeterRegistry` interface for the Micrometer implementation (`MMeterRegistry`) now:
* Records in a static field the stack trace of its first instantiation.
* On instantiations 2 through n logs a warning message, showing the original stack trace and the stack trace of the subsequent instantiation so developers can identify exactly which code is triggering the later instantiations.

See the issue for a summary of the most frequent case where this has been a problem.

The PR includes tests which divert `System.err` to a local stream so it can be inspected to make sure the expected log messages appear and unexpected ones do not appear.

### Documentation
No doc update.

