### PR TITLE
4.3.4: Add support for SSE event sources to JsonRpcResponse

### DIFF
--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientRequestImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,9 +142,11 @@ class JsonRpcClientRequestImpl implements JsonRpcClientRequest {
         if (rpcMethod == null) {
             throw new IllegalStateException("rpcMethod is null");
         }
-        HttpClientResponse res = delegate.header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_JSON_VALUE)
-                .header(HeaderNames.ACCEPT, MediaTypes.APPLICATION_JSON_VALUE)
-                .submit(asJsonObject());
+        delegate.header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_JSON_VALUE);
+        if (!delegate.headers().contains(HeaderNames.ACCEPT)) {
+            delegate.header(HeaderNames.ACCEPT, MediaTypes.APPLICATION_JSON_VALUE);
+        }
+        HttpClientResponse res = delegate.submit(asJsonObject());
         return new JsonRpcClientResponseImpl(res);
     }
 

--- a/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseImpl.java
+++ b/webclient/jsonrpc/src/main/java/io/helidon/webclient/jsonrpc/JsonRpcClientResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.webclient.jsonrpc;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.helidon.common.GenericType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.ClientResponseTrailers;
@@ -28,6 +29,7 @@ import io.helidon.jsonrpc.core.JsonRpcError;
 import io.helidon.jsonrpc.core.JsonRpcResult;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.spi.Source;
 
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
@@ -120,5 +122,10 @@ class JsonRpcClientResponseImpl implements JsonRpcClientResponse {
     @Override
     public ClientUri lastEndpointUri() {
         return delegate.lastEndpointUri();
+    }
+
+    @Override
+    public <T extends Source<?>> void source(GenericType<T> sourceType, T source) {
+        delegate.source(sourceType, source);
     }
 }


### PR DESCRIPTION
Backport #11031 to Helidon 4.3.4

### Description

Add support for SSE event sources to JsonRpcResponse. This allows switching to SSE in response to a JSON-RPC request. See issue #11030.

