### PR TITLE
4.3.4: 4.x: Upgrade log4j to 2.25.3

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -110,7 +110,7 @@
         <version.lib.kotlin>1.9.10</version.lib.kotlin>
         <version.lib.langchain4j>1.6.0</version.lib.langchain4j>
         <version.lib.langchain4j-community>1.6.0-beta12</version.lib.langchain4j-community>
-        <version.lib.log4j>2.21.1</version.lib.log4j>
+        <version.lib.log4j>2.25.3</version.lib.log4j>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.micrometer>1.15.2</version.lib.micrometer>

--- a/logging/log4j/pom.xml
+++ b/logging/log4j/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>log4j-jpl</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/logging/log4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-log4j/native-image.properties
+++ b/logging/log4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-log4j/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -126,4 +126,20 @@ Args=-Dlog4j2.disable.jmx=true \
   --initialize-at-build-time=org.apache.logging.log4j.jul.LogManager \
   --initialize-at-build-time=org.apache.logging.log4j.jul.WrappedLogger \
   --initialize-at-build-time=org.apache.logging.log4j.jul.LevelTranslator \
-  --initialize-at-build-time=org.apache.logging.log4j.core.impl.ContextDataFactory
+  --initialize-at-build-time=org.apache.logging.log4j.core.impl.ContextDataFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.util.SystemPropertiesPropertySource \
+  --initialize-at-build-time=org.apache.logging.log4j.util.EnvironmentPropertySource \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.AppenderControlArraySet \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.StandardLevel \
+  --initialize-at-build-time=org.apache.logging.log4j.status.StatusLogger$InstanceHolder \
+  --initialize-at-build-time=org.apache.logging.log4j.core.async.ThreadNameCachingStrategy$2 \
+  --initialize-at-build-time=org.apache.logging.log4j.status.StatusLogger$Config \
+  --initialize-at-build-time=org.apache.logging.log4j.util.OsgiServiceLocator \
+  --initialize-at-build-time=org.apache.logging.log4j.jpl.Log4jSystemLogger \
+  --initialize-at-build-time=org.apache.logging.log4j.jpl.Log4jSystemLogger$1 \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.ExecutorServices \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.internal.SystemUtils \
+  --initialize-at-build-time=org.apache.logging.log4j.util.PropertyFilePropertySource \
+  --initialize-at-build-time=org.apache.logging.log4j.core.impl.Log4jProvider \
+  --initialize-at-build-time=org.apache.logging.log4j.util.ProviderUtil \
+  --initialize-at-build-time=org.apache.logging.log4j.core.async.ThreadNameCachingStrategy 


### PR DESCRIPTION
Backport #10518 to Helidon 4.3.4

### Description

* Upgrades Log4j to 2.25.3
* Updates native-image.properties to support new version. It looks like we failed to update this with previous upgrades. With these changes you can build native-image for the logging examples https://github.com/helidon-io/helidon-examples/tree/helidon-4.x/examples/logging 
