### PR TITLE
4.3.4: Upgrade Jackson to 2.21.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -74,7 +74,7 @@
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.20.0</version.lib.jackson>
+        <version.lib.jackson>2.21.0</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.1.3</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.1.1</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>4.0.1</version.lib.jakarta.cdi-api>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -241,4 +241,17 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <cve>CVE-2025-43714</cve>
 </suppress>
 
+<!-- False Positive.
+     This CVE is against Nu Html Checker, not hibernate validator.
+     https://github.com/dependency-check/DependencyCheck/issues/8249
+-->
+<suppress>
+   <notes><![CDATA[
+   file name: hibernate-validator-cdi-8.0.2.Final.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.hibernate\.validator/hibernate-validator-cdi@.*$</packageUrl>
+   <cve>CVE-2025-15104</cve>
+</suppress>
+
+
 </suppressions>


### PR DESCRIPTION
Backport #11052 to Helidon 4.3.4

### Description

Upgrade Jackson to 2.21.0 which is an LTS version: https://github.com/FasterXML/jackson/wiki/Jackson-Releases

Also suppresses a false positive on hibernate-validator
