### PR TITLE
4.3.4: Upgrade slf4j to 2.0.17

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -159,7 +159,7 @@
         <version.lib.postgresql>42.7.2</version.lib.postgresql>
         <version.lib.prometheus>0.16.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
-        <version.lib.slf4j>2.0.16</version.lib.slf4j>
+        <version.lib.slf4j>2.0.17</version.lib.slf4j>
         <version.lib.smallrye-openapi>3.3.4</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>2.5</version.lib.snakeyaml>
         <version.lib.testcontainers>1.19.8</version.lib.testcontainers>


### PR DESCRIPTION
Backport #11083 to Helidon 4.3.4

### Description

Upgrade slf4j to 2.0.17
