### PR TITLE
4.3.4: Upgrade GSON to 2.13.2 

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -63,7 +63,7 @@
         <version.lib.graalvm>23.1.0</version.lib.graalvm>
         <version.lib.graphql-java>22.1</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>22.0</version.lib.graphql-java.extended.scalars>
-        <version.lib.gson>2.13.1</version.lib.gson>
+        <version.lib.gson>2.13.2</version.lib.gson>
         <version.lib.grpc>1.73.0</version.lib.grpc>
         <version.lib.guava>32.0.1-jre</version.lib.guava>
         <version.lib.h2>2.4.240</version.lib.h2>


### PR DESCRIPTION
Backport #11082 to Helidon 4.3.4

### Description

Upgrade GSON to 2.13.2

