### PR TITLE
4.x: Exclude src/it from aggregated javadocs

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -222,6 +222,7 @@
                         <exclude>io.helidon.config.metadata:helidon-config-metadata-docs</exclude>
                     </dependencyExcludes>
                     <sourceExcludes>
+                        <exclude>**/src/it</exclude>
                         <exclude>**/src/main/templates</exclude>
                         <exclude>**/src/test/java</exclude>
                         <exclude>**/generated-test-sources</exclude>


### PR DESCRIPTION
### Description

On macOS, the local aggregated javadocs build fails with:

```
error: An internal exception has occurred.
  	(java.lang.NullPointerException: Cannot invoke "java.util.List.getClass()" because "list" is null)
Please file a bug against the javadoc tool via the Java bug reporting page
(https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com)
for duplicates. Include error messages and the following diagnostic in your report. Thank you.
java.lang.NullPointerException: Cannot invoke "java.util.List.getClass()" because "list" is null
	at java.base/java.util.Collections.unmodifiableList(Collections.java:1473)
	at jdk.compiler/com.sun.tools.javac.code.Symbol$ModuleSymbol.getDirectives(Symbol.java:1049)
	at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.ModuleWriterImpl.lambda$computeModulesData$7(ModuleWriterImpl.java:294)
	at java.base/java.util.TreeMap.forEach(TreeMap.java:1317)
	at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.ModuleWriterImpl.computeModulesData(ModuleWriterImpl.java:292)
	at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.ModuleWriterImpl.<init>(ModuleWriterImpl.java:166)
	at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.WriterFactoryImpl.getModuleSummaryWriter(WriterFactoryImpl.java:67)
	at jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.builders.BuilderFactory.getModuleSummaryBuilder(BuilderFactory.java:92)
	at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.HtmlDoclet.generateModuleFiles(HtmlDoclet.java:397)
	at jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.AbstractDoclet.startGeneration(AbstractDoclet.java:211)
	at jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.AbstractDoclet.run(AbstractDoclet.java:110)
	at jdk.javadoc/jdk.javadoc.doclet.StandardDoclet.run(StandardDoclet.java:104)
	at jdk.javadoc/jdk.javadoc.internal.tool.Start.parseAndExecute(Start.java:575)
	at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:398)
	at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:347)
	at jdk.javadoc/jdk.javadoc.internal.tool.Main.execute(Main.java:57)
	at jdk.javadoc/jdk.javadoc.internal.tool.Main.main(Main.java:46)
```

This seems to be caused by the inclusion of `integrations/openapi-ui/src/it/projects/test1` in the list of processed modules.

The test project contains a module-info named "it", and only modules named `io.helidon*` or `helidon*` are included.
It likely always scanned, and later excluded by the javadoc tool because of the module include configuration.

Not sure why this fails on macOS, maybe some ordering differences between Linux and macOS.

Nevertheless, we can fix this by adding `**/src/it` to `<sourceExcludes>`, the build passes.

### Documentation

None