### PR TITLE
Remove MP native image tests from pipeline, due to frequent failures

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -349,7 +349,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04, macos-14, windows-2022 ]
-        module: [ mp-1, mp-2, mp-3, se-1, inject ]
+        module: [ se-1, inject ]
         include:
           - { os: ubuntu-22.04, platform: linux }
           - { os: macos-14, platform: macos }


### PR DESCRIPTION
(because of a bug not going to be backported to v. 21)
