### PR TITLE
Log setup of configuration - filters, config sources, parsers etc.

### DIFF
--- a/config/config/src/main/java/io/helidon/config/BuilderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/BuilderImpl.java
@@ -16,6 +16,7 @@
 
 package io.helidon.config;
 
+import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -52,6 +53,8 @@ import io.helidon.service.registry.ServiceRegistry;
  * {@link Config} Builder implementation.
  */
 class BuilderImpl implements Config.Builder {
+    private static final System.Logger LOGGER = System.getLogger(Config.Builder.class.getName());
+
     /*
      * Config sources
      */
@@ -334,6 +337,19 @@ class BuilderImpl implements Config.Builder {
         ConfigContextImpl context = new ConfigContextImpl(changesExecutor, buildParsers(parserServicesEnabled, parsers));
         ConfigSourcesRuntime configSources = buildConfigSources(context);
 
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            for (var filterProvider : filterProviders) {
+                LOGGER.log(Level.TRACE, "[" + System.identityHashCode(this)
+                        + "] Adding filter provider: " + filterProvider);
+            }
+            LOGGER.log(Level.TRACE, "[" + System.identityHashCode(this)
+                    + "] Key resolving enabled: " + keyResolving);
+            LOGGER.log(Level.TRACE, "[" + System.identityHashCode(this)
+                    + "] Key resolving fail on missing: " + keyResolvingFailOnMissing);
+            LOGGER.log(Level.TRACE, "[" + System.identityHashCode(this)
+                    + "] Cache filter results: " + cachingEnabled);
+        }
+
         //config provider
         return createProvider(configMapperManager,
                               configSources,
@@ -442,6 +458,13 @@ class BuilderImpl implements Config.Builder {
                     .forEach(targetSources::add);
         }
 
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            for (ConfigSourceRuntimeImpl targetSource : targetSources) {
+                LOGGER.log(Level.TRACE, "[" + System.identityHashCode(this)
+                        + "] Adding config source: " + targetSource.configSource());
+            }
+        }
+
         // targetSources now contain runtimes correctly ordered for each config source
         return new ConfigSourcesRuntime(targetSources, mergingStrategy);
     }
@@ -468,10 +491,16 @@ class BuilderImpl implements Config.Builder {
     //
     // utils
     //
-    static List<ConfigParser> buildParsers(boolean servicesEnabled, List<ConfigParser> userDefinedParsers) {
+    List<ConfigParser> buildParsers(boolean servicesEnabled, List<ConfigParser> userDefinedParsers) {
         List<ConfigParser> parsers = new LinkedList<>(userDefinedParsers);
         if (servicesEnabled) {
             parsers.addAll(loadParserServices());
+        }
+        if (LOGGER.isLoggable(Level.TRACE)) {
+            for (var parser : parsers) {
+                LOGGER.log(Level.TRACE, "[" + System.identityHashCode(this)
+                        + "] Adding parser: " + parser);
+            }
         }
         return parsers;
     }

--- a/config/config/src/main/java/io/helidon/config/ConfigFilters.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public final class ConfigFilters {
          * @return a provider of config filter
          */
         public Function<Config, ConfigFilter> build() {
-            return (c) -> new ValueResolvingFilter(failOnMissingReference);
+            return new FilterProvider(failOnMissingReference);
         }
 
         @Override
@@ -120,5 +120,22 @@ public final class ConfigFilters {
             return build();
         }
 
+        private static class FilterProvider implements Function<Config, ConfigFilter> {
+            private final boolean failOnMissingReference;
+
+            private FilterProvider(boolean failOnMissingReference) {
+                this.failOnMissingReference = failOnMissingReference;
+            }
+
+            @Override
+            public ConfigFilter apply(Config config) {
+                return new ValueResolvingFilter(failOnMissingReference);
+            }
+
+            @Override
+            public String toString() {
+                return "ValueResolvingFilterProvider(failOnMissingReference=" + failOnMissingReference + ")";
+            }
+        }
     }
 }

--- a/config/config/src/main/java/io/helidon/config/ConfigSourceRuntimeImpl.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSourceRuntimeImpl.java
@@ -209,6 +209,10 @@ class ConfigSourceRuntimeImpl implements ConfigSourceRuntime {
         return configSource.equals(that.configSource);
     }
 
+    ConfigSource configSource() {
+        return configSource;
+    }
+
     private synchronized void initialLoad() {
         if (dataLoaded) {
             return;

--- a/config/config/src/main/java/io/helidon/config/EmptyConfig.java
+++ b/config/config/src/main/java/io/helidon/config/EmptyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,7 @@ final class EmptyConfig {
                 .disableSystemPropertiesSource()
                 .disableParserServices()
                 .disableFilterServices()
+                .disableValueResolving()
                 .changesExecutor(command -> {})
                 .build();
 

--- a/config/config/src/main/java/io/helidon/config/PropertiesConfigParser.java
+++ b/config/config/src/main/java/io/helidon/config/PropertiesConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,4 +79,8 @@ public class PropertiesConfigParser implements ConfigParser {
         return ConfigUtils.mapToObjectNode(ConfigUtils.propertiesToMap(properties), true);
     }
 
+    @Override
+    public String toString() {
+        return "Properties(" + MEDIA_TYPE_TEXT_JAVA_PROPERTIES.text() + ")";
+    }
 }

--- a/config/config/src/test/java/io/helidon/config/BuilderImplParsersTest.java
+++ b/config/config/src/test/java/io/helidon/config/BuilderImplParsersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,14 +51,14 @@ public class BuilderImplParsersTest {
 
     @Test
     public void testServicesDisabled() {
-        List<ConfigParser> parsers = BuilderImpl.buildParsers(false, List.of());
+        List<ConfigParser> parsers = new BuilderImpl().buildParsers(false, List.of());
 
         assertThat(parsers, hasSize(0));
     }
 
     @Test
     public void testBuiltInParserLoaded() {
-        List<ConfigParser> parsers = BuilderImpl.buildParsers(true, List.of());
+        List<ConfigParser> parsers = new BuilderImpl().buildParsers(true, List.of());
 
         assertThat(parsers, hasSize(1));
         assertThat(parsers.get(0), instanceOf(PropertiesConfigParser.class));
@@ -66,7 +66,7 @@ public class BuilderImplParsersTest {
 
     @Test
     public void testUserDefinedHasPrecedence() {
-        List<ConfigParser> parsers = BuilderImpl.buildParsers(true, List.of(new MyConfigParser()));
+        List<ConfigParser> parsers = new BuilderImpl().buildParsers(true, List.of(new MyConfigParser()));
 
         assertThat(parsers, hasSize(2));
         assertThat(parsers.get(0), instanceOf(MyConfigParser.class));

--- a/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,6 +149,11 @@ public class HoconConfigParser implements ConfigParser {
     @Override
     public List<String> supportedSuffixes() {
         return SUPPORTED_SUFFIXES;
+    }
+
+    @Override
+    public String toString() {
+        return "HOCON(" + MediaTypes.APPLICATION_HOCON.text() + ")";
     }
 
     private static ObjectNode fromConfig(ConfigObject config) {

--- a/config/tests/test-default_config-5-env_vars/pom.xml
+++ b/config/tests/test-default_config-5-env_vars/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.testing</groupId>
             <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>

--- a/config/tests/test-default_config-5-env_vars/src/test/resources/logging.properties
+++ b/config/tests/test-default_config-5-env_vars/src/test/resources/logging.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %3$s %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO

--- a/config/yaml/src/main/java/io/helidon/config/yaml/YamlConfigParser.java
+++ b/config/yaml/src/main/java/io/helidon/config/yaml/YamlConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,6 +109,11 @@ public class YamlConfigParser implements ConfigParser {
         } catch (Exception e) {
             throw new ConfigParserException("Cannot read from source: " + e.getLocalizedMessage(), e);
         }
+    }
+
+    @Override
+    public String toString() {
+        return "YAML(" + MediaTypes.APPLICATION_YAML.text() + ")";
     }
 
     static Map toMap(Reader reader) {


### PR DESCRIPTION
Resolves #11078 

### Description
Adds logging in `TRACE` level that lists all parser, config sources, filter providers etc.
The log statement is prefixed with identity hash-code of the builder instance, to clearly correlate setup of a single instance.

Example of the (new) output:
```
2026.02.06 16:55:13.157 FINER io.helidon.config.Config$Builder [892555958] Adding parser: Properties(text/x-java-properties)
2026.02.06 16:55:13.157 FINER io.helidon.config.Config$Builder [892555958] Adding parser: HOCON(application/hocon)
2026.02.06 16:55:13.157 FINER io.helidon.config.Config$Builder [892555958] Adding parser: YAML(application/yaml)
2026.02.06 16:55:13.158 FINER io.helidon.config.Config$Builder [892555958] Adding config source: SystemPropertiesConfig[]
2026.02.06 16:55:13.158 FINER io.helidon.config.Config$Builder [892555958] Adding config source: EnvironmentVariablesConfig[]
2026.02.06 16:55:13.158 FINER io.helidon.config.Config$Builder [892555958] Adding config source: classpath: application.yaml
2026.02.06 16:55:13.158 FINER io.helidon.config.Config$Builder [892555958] Adding filter provider: ValueResolvingFilterProvider(failOnMissingReference=false)
2026.02.06 16:55:13.158 FINER io.helidon.config.Config$Builder [892555958] Key resolving enabled: true
2026.02.06 16:55:13.158 FINER io.helidon.config.Config$Builder [892555958] Key resolving fail on missing: false
2026.02.06 16:55:13.159 FINER io.helidon.config.Config$Builder [892555958] Cache filter results: true
```
