### PR TITLE
Force upgrade jinjava to 2.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.lib.checkstyle>10.12.5</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <!-- Force upgrade fourth party dependency of jlama langchain4j provider  -->
-        <version.lib.jinjava>2.8.1</version.lib.jinjava>
+        <version.lib.jinjava>2.8.3</version.lib.jinjava>
         <!-- Dependencies convergence via jinjava -->
         <version.lib.immutables-exceptions>1.9</version.lib.immutables-exceptions>
         <version.lib.microprofile-core-profile>10.0.3</version.lib.microprofile-core-profile>


### PR DESCRIPTION
### Description

Force upgrade of jinjava to 2.8.3

This is a transitive dependency of dev.langchain4j/langchain4j-jlama