### PR TITLE
Fix loading of metadata when we have a split package

### DIFF
--- a/service/tests/pom.xml
+++ b/service/tests/pom.xml
@@ -57,6 +57,7 @@
         <module>events</module>
         <module>maven-plugin</module>
         <module>system-exit</module>
+        <module>splitpackage</module>
     </modules>
 
 </project>

--- a/service/tests/splitpackage/pom.xml
+++ b/service/tests/splitpackage/pom.xml
@@ -103,11 +103,6 @@
                             <artifactId>helidon-service-codegen</artifactId>
                             <version>${project.version}</version>
                         </path>
-                        <path>
-                            <groupId>io.helidon.codegen</groupId>
-                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
-                            <version>${project.version}</version>
-                        </path>
                     </annotationProcessorPaths>
                 </configuration>
                 <dependencies>
@@ -121,35 +116,7 @@
                         <artifactId>helidon-service-codegen</artifactId>
                         <version>${project.version}</version>
                     </dependency>
-                    <dependency>
-                        <groupId>io.helidon.codegen</groupId>
-                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
-                        <version>${project.version}</version>
-                    </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-jakarta-not-included</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <exclude>jakarta.inject:jakarta.inject-api</exclude>
-                                        <exclude>jakarta.annotation:jakarta.annotation-api</exclude>
-                                    </excludes>
-                                </bannedDependencies>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/service/tests/splitpackage/pom.xml
+++ b/service/tests/splitpackage/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.service.tests</groupId>
+        <artifactId>helidon-service-tests-project</artifactId>
+        <version>4.4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-service-tests-packagesplit</artifactId>
+    <name>Helidon Service Tests Package Split</name>
+    <description>
+        Test that we can "survive" service descriptors in the same location referenced from manifest.
+        The package split will be caused by main and test locations using the same scope
+    </description>
+
+    <properties>
+        <helidon.services.skip>true</helidon.services.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgument>-Ahelidon.codegen.scope=production</compilerArgument>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgument>-Ahelidon.codegen.scope=production</compilerArgument>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-jakarta-not-included</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>jakarta.inject:jakarta.inject-api</exclude>
+                                        <exclude>jakarta.annotation:jakarta.annotation-api</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/service/tests/splitpackage/src/main/java/io/helidon/service/tests/splitpackage/MyContract.java
+++ b/service/tests/splitpackage/src/main/java/io/helidon/service/tests/splitpackage/MyContract.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.splitpackage;
+
+import io.helidon.service.registry.Service;
+
+@Service.Contract
+interface MyContract {
+    String name();
+}

--- a/service/tests/splitpackage/src/main/java/io/helidon/service/tests/splitpackage/Service1.java
+++ b/service/tests/splitpackage/src/main/java/io/helidon/service/tests/splitpackage/Service1.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.splitpackage;
+
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+class Service1 implements MyContract {
+    @Override
+    public String name() {
+        return "1";
+    }
+}

--- a/service/tests/splitpackage/src/test/java/io/helidon/service/tests/splitpackage/Service2.java
+++ b/service/tests/splitpackage/src/test/java/io/helidon/service/tests/splitpackage/Service2.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.splitpackage;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.service.registry.Service;
+
+@Service.Singleton
+@Weight(Weighted.DEFAULT_WEIGHT + 100)
+class Service2 implements MyContract {
+    @Override
+    public String name() {
+        return "2";
+    }
+}

--- a/service/tests/splitpackage/src/test/java/io/helidon/service/tests/splitpackage/SplitPackageTest.java
+++ b/service/tests/splitpackage/src/test/java/io/helidon/service/tests/splitpackage/SplitPackageTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.splitpackage;
+
+import java.util.List;
+
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.testing.junit5.Testing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+@Testing.Test
+public class SplitPackageTest {
+    private final ServiceRegistry registry;
+
+    public SplitPackageTest(ServiceRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Test
+    public void testSplitPackage() {
+        List<MyContract> services = registry.all(MyContract.class);
+
+        assertThat(services, hasSize(2));
+        assertThat("Test service has higher weight, should be first", services.get(0).name(), is("2"));
+        assertThat(services.get(1).name(), is("1"));
+    }
+}


### PR DESCRIPTION
 (such as main and test compilation using the same scope)

Resolves #11158 

### Description
This PR makes sure all resources are loaded from `META-INF/helidon/manifest` and not just the first one, in case there is are two manifests pointint to the same location.

This can be caused by incorrectly guessing scope of the codegen, or if it is explicitly set to the same scope using annotation processor property - see test.
