### PR TITLE
Prevent recursion when getting global config in the deprecated way.

### DIFF
--- a/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
+++ b/common/config/src/main/java/io/helidon/common/config/GlobalConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,7 +156,10 @@ public final class GlobalConfig {
     @Deprecated(forRemoval = true, since = "4.3.0")
     public static void config(Config config, boolean fromServiceRegistry) {
         GLOBAL_FROM_REGISTRY.set(fromServiceRegistry);
-        CONFIG.set(config);
+        if (!fromServiceRegistry) {
+            // only set if not from service registry, as otherwise we may cause recursion of lookups
+            CONFIG.set(config);
+        }
     }
 
     static Config create() {


### PR DESCRIPTION
### Description
Resolves #11160 

Problem: 
we used to set `CONFIG` in the `GlobalConfig` even when from service registry.
This caused method `isConfigured` to return true, even though when requested we would use `ServiceRegistry` to get the instance . 
As this is done from the config factory itself, we ended in a loop that was detected by `ServiceRegistry`

Solution:
only set `CONFIG` when not using `ServiceRegistry` in `GlobalConfig`