### PR TITLE
Upgrade junit to 5.12.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -102,7 +102,6 @@
         <version.lib.jetbrains.annotations>17.0.0</version.lib.jetbrains.annotations>
         <version.lib.jgit>7.3.0.202506031305-r</version.lib.jgit>
         <version.lib.junit>5.12.2</version.lib.junit>
-        <version.lib.junit-platform-testkit>1.12.2</version.lib.junit-platform-testkit>
         <version.lib.kafka>3.9.1</version.lib.kafka>
         <!-- Kotlin: dependency convergence requirement, we never use this directly -->
         <version.lib.kotlin>1.9.10</version.lib.kotlin>
@@ -1256,21 +1255,6 @@
 
             <!-- Section 4: Testing -->
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${version.lib.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${version.lib.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${version.lib.junit}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${version.lib.hamcrest}</version>
@@ -1279,11 +1263,6 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
                 <version>${version.lib.hamcrest}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-testkit</artifactId>
-                <version>${version.lib.junit-platform-testkit}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
@@ -1484,6 +1463,13 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-bom</artifactId>
                 <version>${version.lib.slf4j}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${version.lib.junit}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
         <version.lib.microprofile-restful-tck>3.1.5</version.lib.microprofile-restful-tck>
         <version.lib.jsoup>1.15.3</version.lib.jsoup>
         <version.lib.junit4>4.13.1</version.lib.junit4>
-        <version.lib.junit-platform>1.9.3</version.lib.junit-platform>
         <version.lib.kafka-junit5>3.2.3</version.lib.kafka-junit5>
         <version.lib.mockito>2.23.4</version.lib.mockito>
         <version.lib.mockserver>5.15.0</version.lib.mockserver>
@@ -1294,16 +1293,6 @@
                         <artifactId>jsr305</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-launcher</artifactId>
-                <version>${version.lib.junit-platform}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-suite-engine</artifactId>
-                <version>${version.lib.junit-platform}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian.junit</groupId>


### PR DESCRIPTION
### Description

Upgrade junit to 5.12.2 to align with  build-tools.

Upgrading beyond 5.12.2 will require some code changes. See https://github.com/helidon-io/helidon-build-tools/issues/1151 and #10810.
