### PR TITLE
4.x: Accounts for Hibernate 6.6 and future versions' unique interpretation of an area of the JPA spec

### DIFF
--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedSynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedSynchronizedEntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -319,7 +319,24 @@ class TestJpaTransactionScopedSynchronizedEntityManager {
         tm.begin();
         assertThat(em.isJoinedToTransaction(), is(true));
         assertThat(transactionScopedContext.isActive(), is(true));
-        author1 = em.merge(author1);
+        // Hibernate versions above 6.6 seem to violate the very explicit JPA specification. See
+        // https://docs.jboss.org/hibernate/orm/6.6/migration-guide/migration-guide.html#merge-versioned-deleted Then
+        // see
+        // https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#merging-detached-entity-state,
+        // first bullet point, which reads:
+        //
+        //  "If X is a detached entity, the state of X is copied onto a pre-existing managed entity instance X' of the
+        //  same identity **or a new managed copy X' of X is created.**"
+        //
+        // We have to handle this by hand here by creating a new, functionally interchangeable author1 and persisting
+        // it. Note that Eclipselink follows the specification text to the letter.
+        if (em.getDelegate().getClass().getName().startsWith("org.hibernate.")) {
+            author1 = new Author("Abraham Lincoln");
+            em.persist(author1);
+        } else {
+            author1 = em.merge(author1);
+        }
+        assertThat(em.contains(author1), is(true));
         tm.commit();
         assertThat(em.isJoinedToTransaction(), is(false));
         assertThat(em.contains(author1), is(false));

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestRollbackScenarios.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestRollbackScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -271,12 +271,28 @@ class TestRollbackScenarios {
         }
         tm.rollback();
 
-        // Remove the author properly.
+        // Remove the (detached) author properly.
         tm.begin();
         assertThat(tm.getStatus(), is(Status.STATUS_ACTIVE));
         assertThat(em.isJoinedToTransaction(), is(true));
         assertThat(em.contains(author), is(false));
-        author = em.merge(author);
+        // Hibernate versions above 6.6 seem to violate the very explicit JPA specification. See
+        // https://docs.jboss.org/hibernate/orm/6.6/migration-guide/migration-guide.html#merge-versioned-deleted Then
+        // see
+        // https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#merging-detached-entity-state,
+        // first bullet point, which reads:
+        //
+        //  "If X is a detached entity, the state of X is copied onto a pre-existing managed entity instance X' of the
+        //  same identity **or a new managed copy X' of X is created.**"
+        //
+        // We have to handle this by hand here by creating a new, functionally interchangeable author and persisting
+        // it. Note that Eclipselink follows the specification text to the letter.
+        if (em.getDelegate().getClass().getName().startsWith("org.hibernate.")) {
+            author = new Author("John Kennedy");
+            em.persist(author);
+        } else {
+            author = em.merge(author);
+        }
         em.remove(author);
         tm.commit();
         assertThat(em.contains(author), is(false));


### PR DESCRIPTION
This PR is deliberately very small and targeted.

This PR accounts for the way that Hibernate 6.6 and greater versions uniquely interpret the Jakarta Persistence specification in the area of merging detached entities. In short, although the specification seems to explicitly allow (or even require) the merging of detached entities, Hibernate 6.6+ has deliberately changed so that it does not. See https://docs.jboss.org/hibernate/orm/6.6/migration-guide/migration-guide.html#merge-versioned-deleted and https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1#merging-detached-entity-state.

Regardless of the correctness or incorrectness of the above, our unit tests in `jpa-cdi` will continue to block upgrades of Hibernate unless we _very carefully_ permit this one area of spec contention. This tiny PR hopefully unlocks such future upgrades.

This PR may be required for any fix to #11180.