### PR TITLE
Fix issue when a maven build does compilation without clean.

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
@@ -806,6 +806,31 @@ final class FactoryOption {
             );
             return;
         }
+        // first check if there is a factory method on the type itself (i.e. MyType create(Config))
+        // and lastly - maybe there is a config factory method on the type
+        var actualTypeInfo = roundContext.typeInfo(actualType);
+
+        if (actualTypeInfo.isPresent() && actualTypeInfo.get()
+                .elementInfo()
+                .stream()
+                .filter(ElementInfoPredicates::isMethod)
+                .filter(ElementInfoPredicates::isStatic)
+                .filter(not(ElementInfoPredicates::isPrivate))
+                .filter(it -> Utils.typesEqual(it.typeName(), actualType))
+                .filter(it -> it.parameterArguments().size() == 1)
+                .map(it -> it.parameterArguments().getFirst().typeName())
+                .anyMatch(it -> it.equals(COMMON_CONFIG) || it.equals(CONFIG))) {
+            // there is a config factory method on the type
+            configured.factoryMethod(fm -> fm
+                    .declaringType(actualType)
+                    .returnType(actualType)
+                    .methodName("create")
+                    .parameterType(COMMON_CONFIG)
+                    .optionName(optionName)
+            );
+            return;
+        }
+
         // check if a runtime type prototype is a configured prototype
         if (option.runtimeType().isPresent()) {
             var rt = option.runtimeType().get();
@@ -853,32 +878,7 @@ final class FactoryOption {
                         .parameterType(CONFIG)
                         .optionName(optionName)
                 );
-                return;
             }
-        }
-        // and lastly - maybe there is a config factory method on the type
-        var actualTypeInfo = roundContext.typeInfo(actualType);
-        if (actualTypeInfo.isEmpty()) {
-            return;
-        }
-        if (actualTypeInfo.get()
-                .elementInfo()
-                .stream()
-                .filter(ElementInfoPredicates::isMethod)
-                .filter(ElementInfoPredicates::isStatic)
-                .filter(not(ElementInfoPredicates::isPrivate))
-                .filter(it -> Utils.typesEqual(it.typeName(), actualType))
-                .filter(it -> it.parameterArguments().size() == 1)
-                .map(it -> it.parameterArguments().getFirst().typeName())
-                .anyMatch(it -> it.equals(COMMON_CONFIG) || it.equals(CONFIG))) {
-            // there is a config factory method on the type
-            configured.factoryMethod(fm -> fm
-                    .declaringType(actualType)
-                    .returnType(actualType)
-                    .methodName("create")
-                    .parameterType(COMMON_CONFIG)
-                    .optionName(optionName)
-            );
         }
     }
 

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -188,7 +188,7 @@ abstract class TypeHandlerCollection extends TypeHandlerContainer {
             generateFromConfig(method);
             method.addContent(".get()).");
             collector.accept(method);
-            method.addContent(").ifPresent(this::" + setterName + ");");
+            method.addContentLine(").ifPresent(this::" + setterName + ");");
         }
     }
 


### PR DESCRIPTION
### Description
If `integrations/langchain4j` is built using `mvn install` (without clean)  twice, the second build will fail on the mock provider.
This is because of different discovery in the builder, where we incorrectly found the wrong factory method for config.
This PR changes the order, so the method `TargetType.create(Config)` is always used as a preferred option.