### PR TITLE
Fix a bug in config expression resolution, where the `:` separating c…

### DIFF
--- a/config/config/src/main/java/io/helidon/config/ConfigBuilderSupport.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigBuilderSupport.java
@@ -286,6 +286,8 @@ public final class ConfigBuilderSupport {
                 if (defaultValue == null || configValues.isPresent())  {
                     return Set.copyOf(configValues.orElseGet(List::of));
                 } else {
+                    // remove the : which is part of this group
+                    defaultValue = defaultValue.substring(1);
                     return Stream.of(defaultValue.split(","))
                             .map(String::trim)
                             .collect(Collectors.toSet());

--- a/config/tests/integration-tests/src/test/java/io/helidon/config/tests/ResolveExpressionTest.java
+++ b/config/tests/integration-tests/src/test/java/io/helidon/config/tests/ResolveExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 package io.helidon.config.tests;
 
 import java.util.Map;
+import java.util.Set;
 
+import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigSources;
@@ -25,6 +27,9 @@ import io.helidon.config.ConfigSources;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.config.ConfigBuilderSupport.resolveExpression;
+import static io.helidon.config.ConfigBuilderSupport.resolveSetExpressions;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -90,5 +95,47 @@ class ResolveExpressionTest {
                                                                     "${my-service.schema:http}://${my-service"
                                                                             + ".host:localhost}:${my-service.port}/service"));
 
+    }
+
+    @Test
+    void testResolveSetExpressionNoConfig() {
+        var config = Config.empty();
+
+        assertThat(resolveSetExpressions(config, Set.of("${app.cors.allow-origins:http://www.example.com}")),
+                   hasItem("http://www.example.com"));
+    }
+
+    @Test
+    void testResolveSetExpressionNoConfigStringList() {
+        var config = Config.empty();
+
+        assertThat(resolveSetExpressions(config,
+                                         Set.of("${app.cors.allow-origins:http://www.example.com, http://www.foo.com}")),
+                   hasItems("http://www.example.com", "http://www.foo.com"));
+    }
+
+    @Test
+    void testResolveSetExpressionNoConfigSet() {
+        var config = Config.empty();
+
+        assertThat(resolveSetExpressions(config, Set.of("http://www.example.com", "http://www.foo.com")),
+                   hasItems("http://www.example.com", "http://www.foo.com"));
+    }
+
+    @Test
+    void testResolveSetExpressionConfig() {
+        var config = Config.just("app.cors.allow-origins: \"http://www.foo.com\"", MediaTypes.APPLICATION_YAML);
+
+        assertThat(resolveSetExpressions(config, Set.of("${app.cors.allow-origins:http://www.example.com}")),
+                   hasItem("http://www.foo.com"));
+    }
+
+    @Test
+    void testResolveSetExpressionConfigArray() {
+        var config = Config.just("app.cors.allow-origins: [\"http://www.foo.com\", \"http://www.bar.com\"]",
+                                 MediaTypes.APPLICATION_YAML);
+
+        assertThat(resolveSetExpressions(config, Set.of("${app.cors.allow-origins:http://www.example.com}")),
+                   hasItems("http://www.foo.com", "http://www.bar.com"));
     }
 }


### PR DESCRIPTION
…onfig key and defaults was added to the default value for Set operations.

Added tests.

Resolves #11199