### PR TITLE
Fixes a bug in metadata discovery, where we failed to call next() before remove() on iterator

### DIFF
--- a/metadata/metadata/src/main/java/io/helidon/metadata/MetadataDiscoveryImpl.java
+++ b/metadata/metadata/src/main/java/io/helidon/metadata/MetadataDiscoveryImpl.java
@@ -506,6 +506,7 @@ class MetadataDiscoveryImpl implements MetadataDiscovery {
                 if (CACHE.size() > 10) {
                     var iterator = CACHE.entrySet().iterator();
                     while (CACHE.size() > 10 && iterator.hasNext()) {
+                        iterator.next();
                         iterator.remove();
                     }
                 }


### PR DESCRIPTION
This causes declarative examples build to fail, because it caches additional instances and the cache is full.