### PR TITLE
Fix codegen to generate a for cycle instead of a for-each lambda

### DIFF
--- a/data/jakarta-persistence/codegen/src/main/java/io/helidon/data/jakarta/persistence/codegen/JakartaStatementGenerator.java
+++ b/data/jakarta-persistence/codegen/src/main/java/io/helidon/data/jakarta/persistence/codegen/JakartaStatementGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves #11205

As compiler (sometimes) failed with compiler cannot find symbol "symbol: class <captured wildcard>" on the generated line

This is needed for examples once the API stability processor is merged.
In Java 21 it just failed, in Java 25 I got a line and column reported, so I could pinpoint the problem and fix it.

Original code:
```java
executor.run(em -> entities.forEach(e -> em.remove(em.contains(e) ? e : em.merge(e))));
```

New code: 
```java
executor.run(em ->  {
    for (var e : entities) {
        em.remove(em.contains(e) ? e : em.merge(e));
    }
});
```