### PR TITLE
Remove incubating from Helidon JSON module

### DIFF
--- a/json/json/src/main/java/io/helidon/json/JsonArray.java
+++ b/json/json/src/main/java/io/helidon/json/JsonArray.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 
 /**
  * Represents a JSON array value containing an ordered list of JSON values.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public final class JsonArray extends JsonValue {
 

--- a/json/json/src/main/java/io/helidon/json/JsonBoolean.java
+++ b/json/json/src/main/java/io/helidon/json/JsonBoolean.java
@@ -18,6 +18,8 @@ package io.helidon.json;
 
 /**
  * Represents a JSON boolean value (true or false).
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public final class JsonBoolean extends JsonValue {
 

--- a/json/json/src/main/java/io/helidon/json/JsonGenerator.java
+++ b/json/json/src/main/java/io/helidon/json/JsonGenerator.java
@@ -26,11 +26,11 @@ import java.io.Writer;
  * allowing for efficient writing of large JSON documents without building
  * the entire content in memory first. It supports writing to output streams
  * and writers with automatic JSON formatting.
- * </p>
  * <p>
  * The generator provides fluent method chaining for building JSON structures
  * and handles proper JSON syntax including quotes, commas, and brackets.
- * </p>
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public interface JsonGenerator extends AutoCloseable {
 

--- a/json/json/src/main/java/io/helidon/json/JsonNull.java
+++ b/json/json/src/main/java/io/helidon/json/JsonNull.java
@@ -18,6 +18,8 @@ package io.helidon.json;
 
 /**
  * Represents a JSON null value.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public final class JsonNull extends JsonValue {
 

--- a/json/json/src/main/java/io/helidon/json/JsonNumber.java
+++ b/json/json/src/main/java/io/helidon/json/JsonNumber.java
@@ -20,6 +20,8 @@ import java.math.BigDecimal;
 
 /**
  * Represents a JSON number value.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public final class JsonNumber extends JsonValue {
 

--- a/json/json/src/main/java/io/helidon/json/JsonObject.java
+++ b/json/json/src/main/java/io/helidon/json/JsonObject.java
@@ -29,6 +29,8 @@ import java.util.stream.Collectors;
 
 /**
  * Represents a JSON object value containing key-value pairs.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public final class JsonObject extends JsonValue {
 

--- a/json/json/src/main/java/io/helidon/json/JsonParser.java
+++ b/json/json/src/main/java/io/helidon/json/JsonParser.java
@@ -26,7 +26,8 @@ import java.util.Objects;
  * <p>
  * The parser operates on a byte-by-byte basis, providing low-level access to
  * JSON tokens and values.
- * </p>
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public interface JsonParser {
 

--- a/json/json/src/main/java/io/helidon/json/JsonString.java
+++ b/json/json/src/main/java/io/helidon/json/JsonString.java
@@ -20,6 +20,8 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Represents a JSON string value.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public final class JsonString extends JsonValue {
 

--- a/json/json/src/main/java/io/helidon/json/JsonValue.java
+++ b/json/json/src/main/java/io/helidon/json/JsonValue.java
@@ -21,6 +21,8 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Base class for all JSON value types in Helidon JSON processing.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public abstract sealed class JsonValue
         permits JsonArray, JsonBoolean, JsonControlValue, JsonNoopValue, JsonNull, JsonNumber, JsonObject, JsonString {

--- a/json/json/src/main/java/io/helidon/json/JsonValueType.java
+++ b/json/json/src/main/java/io/helidon/json/JsonValueType.java
@@ -18,6 +18,8 @@ package io.helidon.json;
 
 /**
  * Enumeration of JSON value types.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public enum JsonValueType {
 

--- a/json/json/src/main/java/io/helidon/json/ObjectStartParser.java
+++ b/json/json/src/main/java/io/helidon/json/ObjectStartParser.java
@@ -19,6 +19,8 @@ package io.helidon.json;
 /**
  * An implementation of the {@link io.helidon.json.JsonParser} which enforces object start as the current value.
  * Delegates all other calls to the provided JsonParser.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 public final class ObjectStartParser implements JsonParser {
 

--- a/json/json/src/main/java/io/helidon/json/package-info.java
+++ b/json/json/src/main/java/io/helidon/json/package-info.java
@@ -17,6 +17,8 @@
 /**
  * Helidon JSON Processor.
  * Provides fundamental JSON parsing and generation capabilities.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  *
  * @see io.helidon.json.JsonParser
  * @see io.helidon.json.JsonGenerator

--- a/json/json/src/main/java/module-info.java
+++ b/json/json/src/main/java/module-info.java
@@ -20,18 +20,23 @@ import io.helidon.common.features.api.HelidonFlavor;
 /**
  * Helidon JSON Core.
  * Provides fundamental JSON processing capabilities.
+ * <p>
+ * This module is incubating. These APIs may change in any version of Helidon, including backward incompatible changes.
  */
 @Features.Name("JSON")
 @Features.Description("JSON processing")
 @Features.Flavor(HelidonFlavor.SE)
-@Features.Path("JSON")
-@Features.Incubating
 module io.helidon.json {
-
     requires static io.helidon.common.features.api;
 
     requires io.helidon.common;
     requires io.helidon.common.buffers;
 
     exports io.helidon.json;
+
+    /*
+    This module cannot be marked as @Features.Incubating, because it is used as a transitive dependency of health,
+    and will be used by metrics (and maybe other modules) as a replacement for Jakarta JSON-P.
+    We do not want to warn the users about use of incubating module, that is used by us
+    */
 }


### PR DESCRIPTION
As it is used as a transitive dependency of our own modules, such as Health observer.

### Description
Resolves #11198 
