### PR TITLE
Ensure that decorator methods for Set and List are called with correctly types values

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -259,7 +259,7 @@ public final class Prototype {
          * Decorate a list of values, when a setter that replaces values is called.
          *
          * @param builder      the target builder being decorated
-         * @param optionValues option values set by the caller of the setter method
+         * @param optionValues option values set by the caller of the setter method, this is a read-only list
          */
         default void decorateSetList(B builder, List<T> optionValues) {
         }
@@ -268,7 +268,7 @@ public final class Prototype {
          * Decorate a list of values, when a setter that adds values is called.
          *
          * @param builder      the target builder being decorated
-         * @param optionValues option values set by the caller of the setter method
+         * @param optionValues option values set by the caller of the setter method, this is a read-only list
          */
         default void decorateAddList(B builder, List<T> optionValues) {
         }
@@ -277,7 +277,7 @@ public final class Prototype {
          * Decorate a set of values, when a setter that replaces values is called.
          *
          * @param builder      the target builder being decorated
-         * @param optionValues option values set by the caller of the setter method
+         * @param optionValues option values set by the caller of the setter method, this is a read-only set
          */
         default void decorateSetSet(B builder, Set<T> optionValues) {
         }
@@ -286,7 +286,7 @@ public final class Prototype {
          * Decorate a set of values, when a setter that adds values is called.
          *
          * @param builder      the target builder being decorated
-         * @param optionValues option values set by the caller of the setter method
+         * @param optionValues option values set by the caller of the setter method, this is a read-only set
          */
         default void decorateAddSet(B builder, Set<T> optionValues) {
         }

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/TypeHandlerCollection.java
@@ -237,8 +237,10 @@ abstract class TypeHandlerCollection extends TypeHandlerContainer {
                             .addContent("().")
                             .addContent(decoratorSetMethodName())
                             .addContent("(this, ")
+                            .addContent(collectionType)
+                            .addContent(".copyOf(")
                             .addContent(name)
-                            .addContentLine(");"));
+                            .addContentLine("));"));
 
             extraSetterContent(it);
             it.addContentLine("this." + name + ".clear();")
@@ -283,8 +285,10 @@ abstract class TypeHandlerCollection extends TypeHandlerContainer {
                             .addContent("().")
                             .addContent(decoratorAddMethodName())
                             .addContent("(this, ")
+                            .addContent(collectionType)
+                            .addContent(".copyOf(")
                             .addContent(name)
-                            .addContentLine(");"));
+                            .addContentLine("));"));
 
             it.addContentLine("this." + name + ".addAll(" + name + ");")
                     .addContentLine("return self();");

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/OptionDecoratorsBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/OptionDecoratorsBlueprint.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+interface OptionDecoratorsBlueprint {
+    @Option.Singular
+    @Option.Decorator(OptionDecoratorsSupport.FooDecorator.class)
+    List<Foo> foos();
+
+    @Option.Singular
+    @Option.Decorator(OptionDecoratorsSupport.FooDecorator.class)
+    Set<Foo> goos();
+
+    @Option.Singular
+    @Option.Decorator(OptionDecoratorsSupport.StringDecorator.class)
+    List<String> bars();
+
+    @Option.Singular
+    @Option.Decorator(OptionDecoratorsSupport.StringDecorator.class)
+    Set<String> mars();
+
+    record Foo(String a, int b) { }
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/OptionDecoratorsSupport.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/OptionDecoratorsSupport.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.builder.api.Prototype;
+
+final class OptionDecoratorsSupport {
+    private OptionDecoratorsSupport() {
+    }
+
+    static final class FooDecorator
+            implements Prototype.OptionDecorator<OptionDecorators.BuilderBase<?, ?>, OptionDecoratorsBlueprint.Foo> {
+        FooDecorator() {
+            super();
+        }
+
+        @Override
+        public void decorate(OptionDecorators.BuilderBase<?, ?> builder, OptionDecoratorsBlueprint.Foo optionValue) {
+        }
+
+        @Override
+        public void decorateSetList(OptionDecorators.BuilderBase<?, ?> builder,
+                                    List<OptionDecoratorsBlueprint.Foo> optionValues) {
+
+        }
+
+        @Override
+        public void decorateAddList(OptionDecorators.BuilderBase<?, ?> builder,
+                                    List<OptionDecoratorsBlueprint.Foo> optionValues) {
+
+        }
+
+        @Override
+        public void decorateSetSet(OptionDecorators.BuilderBase<?, ?> builder,
+                                   Set<OptionDecoratorsBlueprint.Foo> optionValues) {
+
+        }
+
+        @Override
+        public void decorateAddSet(OptionDecorators.BuilderBase<?, ?> builder,
+                                   Set<OptionDecoratorsBlueprint.Foo> optionValues) {
+
+        }
+    }
+
+    static final class StringDecorator implements Prototype.OptionDecorator<OptionDecorators.BuilderBase<?, ?>, String> {
+        StringDecorator() {
+            super();
+        }
+
+        @Override
+        public void decorate(OptionDecorators.BuilderBase<?, ?> builder, String optionValue) {
+        }
+
+        @Override
+        public void decorateSetList(OptionDecorators.BuilderBase<?, ?> builder,
+                                    List<String> optionValues) {
+
+        }
+
+        @Override
+        public void decorateAddList(OptionDecorators.BuilderBase<?, ?> builder,
+                                    List<String> optionValues) {
+
+        }
+
+        @Override
+        public void decorateSetSet(OptionDecorators.BuilderBase<?, ?> builder, Set<String> optionValues) {
+            Prototype.OptionDecorator.super.decorateSetSet(builder, optionValues);
+        }
+
+        @Override
+        public void decorateAddSet(OptionDecorators.BuilderBase<?, ?> builder, Set<String> optionValues) {
+            Prototype.OptionDecorator.super.decorateAddSet(builder, optionValues);
+        }
+    }
+
+}


### PR DESCRIPTION
Also ensures that the value is read only, so the decorator cannot modify the list (as we cannot depend on implementation detail of the caller).

Resolves #11194 

The problem was that the decorator interface expects `List<T>`, but the builder uses `List<? extends T>` which is not compatible.

The new implementation uses `List.copyOf` or `Set.copyOf` to ensure the types match.