### PR TITLE
4.x: Require CDI qualifier(s) to resolve JUnit method parameter from CDI

### DIFF
--- a/docs/src/main/asciidoc/mp/testing/testing-common.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing-common.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2025 Oracle and/or its affiliates.
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -258,9 +258,6 @@ Here are all the built-in types that can be injected:
 |`String`
 |A raw URI representing the current server
 
-|link:{jakarta-cdi-javadoc-url}/inject/se/SeContainer.html[`SeContainer`]
-| The current CDI container instance
-
 |===
 
 NOTE: Types that reflect the current server require link:{mp-server-javadoc-url}/ServerCdiExtension.html[`ServerCdiExtension`]
@@ -277,6 +274,15 @@ Use link:{mp-testing-javadoc-url}/Socket.html[`@Socket`] to specify the socket f
 .Inject a JAX-RS client for the admin socket
 ----
 include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_14, indent=0]
+----
+
+NOTE: Except link:{jakarta-jaxrs-javadoc-url}/client/WebTarget.html[`WebTarget`], all types require the
+link:{mp-testing-javadoc-url}/Socket.html[`@Socket`] annotation
+
+[source,java]
+.Inject a URI for the default socket
+----
+include::{sourcedir}/mp/testing/TestingSnippets.java[tag=snippet_20, indent=0]
 ----
 // end::usage[]
 

--- a/docs/src/main/asciidoc/mp/testing/testing.adoc
+++ b/docs/src/main/asciidoc/mp/testing/testing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -69,9 +69,31 @@ include::{rootdir}/mp/testing/testing-common.adoc[tag=usage]
 NOTE: All the injectable types are also available as method parameters.
 
 [source,java]
-.Using a method parameter
+.Get a JAX-RS client for the default socket
 ----
 include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_1, indent=0]
+----
+
+[source,java]
+.Get a URI for the default socket
+----
+include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_6, indent=0]
+----
+
+The current CDI link:{jakarta-cdi-javadoc-url}/inject/se/SeContainer.html[`container`] is also available as a method parameter.
+
+[source,java]
+.Get the current CDI container
+----
+include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_7, indent=0]
+----
+
+NOTE: You can also use CDI qualifier annotations to resolve a method parameter using CDI.
+
+[source,java]
+.Resolve a CDI bean
+----
+include::{sourcedir}/mp/testing/TestingJunit5Snippets.java[tag=snippet_8, indent=0]
 ----
 
 === Test Instance Lifecyle

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingJunit5Snippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,22 @@
  */
 package io.helidon.docs.mp.testing;
 
+import io.helidon.microprofile.testing.Socket;
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 import io.helidon.microprofile.testing.AddBean;
 import io.helidon.microprofile.testing.DisableDiscovery;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.net.URI;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -165,5 +168,49 @@ class TestingJunit5Snippets {
             }
         }
         // end::snippet_5[]
+    }
+
+    class Snippet6 {
+
+        // tag::snippet_6[]
+        @HelidonTest
+        class MyTest {
+
+            @Test
+            void testOne(@Socket("@default") URI uri) {
+            }
+        }
+        // end::snippet_6[]
+    }
+
+    class Snippet7 {
+
+        // tag::snippet_7[]
+        @HelidonTest
+        class MyTest {
+
+            @Test
+            void testOne(SeContainer container) {
+            }
+        }
+        // end::snippet_7[]
+    }
+
+
+
+    class Snippet8 {
+
+        // tag::snippet_8[]
+        @HelidonTest
+        class MyTest {
+
+            @Test
+            void testOne(@Default MyBean myBean) {
+            }
+        }
+        // end::snippet_8[]
+
+        class MyBean {
+        }
     }
 }

--- a/docs/src/main/java/io/helidon/docs/mp/testing/TestingSnippets.java
+++ b/docs/src/main/java/io/helidon/docs/mp/testing/TestingSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.docs.mp.testing;
 
+import java.net.URI;
 import java.util.Map;
 
 import io.helidon.config.mp.MpConfigSources;
@@ -377,5 +378,18 @@ class TestingSnippets {
         class MyTest {
         }
         // end::snippet_19[]
+    }
+
+    class Snippet20 {
+
+        // tag::snippet_20[]
+        @HelidonTest
+        class MyTest {
+
+            @Inject
+            @Socket("@default")
+            URI uri;
+        }
+        // end::snippet_20[]
     }
 }

--- a/microprofile/testing/junit5/src/main/java/io/helidon/microprofile/testing/junit5/HelidonJunitExtension.java
+++ b/microprofile/testing/junit5/src/main/java/io/helidon/microprofile/testing/junit5/HelidonJunitExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package io.helidon.microprofile.testing.junit5;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -26,6 +29,9 @@ import io.helidon.microprofile.testing.HelidonTestScope;
 import io.helidon.microprofile.testing.Instrumented;
 import io.helidon.testing.junit5.TestJunitExtension;
 
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.inject.Qualifier;
+import jakarta.ws.rs.client.WebTarget;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -189,7 +195,14 @@ public class HelidonJunitExtension extends TestJunitExtension
         return supplyChecked(ctx, () -> {
             Store store = store(ctx, ctx.getRequiredTestMethod());
             HelidonTestContainerImpl container = requiredContainer(store);
-            return !container.initFailed() && container.isSupported(pc.getParameter().getType());
+            Class<?> type = pc.getParameter().getType();
+            if (type.equals(WebTarget.class) || type.equals(SeContainer.class)) {
+                return true;
+            }
+            Annotation[] qualifiers = qualifiers(pc.getParameter().getAnnotations());
+            return qualifiers.length > 0
+                   && !container.initFailed()
+                   && container.isSupported(type, qualifiers);
         });
     }
 
@@ -200,7 +213,9 @@ public class HelidonJunitExtension extends TestJunitExtension
         return supplyChecked(ctx, () -> {
             Store store = store(ctx, ctx.getRequiredTestMethod());
             HelidonTestContainerImpl container = requiredContainer(store);
-            return container.initFailed() ? null : container.resolveInstance(pc.getParameter().getType());
+            Parameter param = pc.getParameter();
+            return container.initFailed() ? null : container.resolveInstance(
+                    param.getType(), qualifiers(param.getAnnotations()));
         });
     }
 
@@ -240,5 +255,11 @@ public class HelidonJunitExtension extends TestJunitExtension
             c = c.getParent().orElseThrow();
         }
         return c;
+    }
+
+    private static Annotation[] qualifiers(Annotation[] annotations) {
+        return Arrays.stream(annotations)
+                .filter(it -> it.annotationType().getAnnotation(Qualifier.class) != null)
+                .toArray(Annotation[]::new);
     }
 }

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestContainer.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.helidon.microprofile.testing;
 
 import java.lang.System.Logger.Level;
+import java.lang.annotation.Annotation;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -107,33 +108,32 @@ public class HelidonTestContainer {
      * Resolve an unqualified bean of the given type.
      *
      * @param type type
+     * @param qualifiers qualifiers
      * @param <T>  type
      * @return resolved instance
      * @throws InitializationFailed if the container previusly failed to
      *                              start
      */
     @SuppressWarnings("resource")
-    public <T> T resolveInstance(Class<T> type) throws InitializationFailed {
+    public <T> T resolveInstance(Class<T> type, Annotation... qualifiers) throws InitializationFailed {
         if (type.isAssignableFrom(SeContainer.class)) {
             return type.cast(container());
         }
-        return container().select(type).get();
+        return container().select(type, qualifiers).get();
     }
 
     /**
      * Test if the given type is supported for injection.
      *
      * @param type type
+     * @param qualifiers qualifiers
      * @return {@code true} if supported, {@code false} otherwise
      * @throws InitializationFailed if the container previusly failed to
      *                              start
      */
     @SuppressWarnings("resource")
-    public boolean isSupported(Class<?> type) throws InitializationFailed {
-        if (type.isAssignableFrom(SeContainer.class)) {
-            return true;
-        }
-        return !container().select(type).isUnsatisfied();
+    public boolean isSupported(Class<?> type, Annotation... qualifiers) throws InitializationFailed {
+        return !container().select(type, qualifiers).isUnsatisfied();
     }
 
     private SeContainer container() {

--- a/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestExtension.java
+++ b/microprofile/testing/testing/src/main/java/io/helidon/microprofile/testing/HelidonTestExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -312,6 +312,13 @@ public abstract class HelidonTestExtension implements Extension {
 
             // methods
             for (AnnotatedMethod<?> method : type.getMethods()) {
+
+                // method parameters
+                for (AnnotatedParameter<?> parameter : method.getParameters()) {
+                    processAnnotated(parameter, fieldAnnotationTypes(), this::processParameterAnnotation);
+                }
+
+                // method annotations
                 processAnnotated(method, methodAnnotationTypes(), a -> {
                     if (method.isStatic()) {
                         processStaticMethodAnnotation(a, method.getJavaMember());

--- a/microprofile/tests/testing/junit5/pom.xml
+++ b/microprofile/tests/testing/junit5/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>junit-platform-testkit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestConstructorInjection.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestConstructorInjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,24 @@
 
 package io.helidon.microprofile.tests.testing.junit5;
 
+import java.net.URI;
+
+import io.helidon.microprofile.testing.junit5.AddJaxRs;
+import io.helidon.microprofile.testing.junit5.Socket;
 import io.helidon.microprofile.testing.junit5.AddBean;
 import io.helidon.microprofile.testing.junit5.DisableDiscovery;
 import io.helidon.microprofile.testing.junit5.HelidonTest;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.ws.rs.client.WebTarget;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -34,17 +42,30 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @HelidonTest
 @DisableDiscovery
 @AddBean(TestConstructorInjection.MyBean.class)
+@AddJaxRs
 class TestConstructorInjection {
     private final int currentPort;
+    private final URI uri;
+    private final String rawUri;
+    private final WebTarget target;
 
     @Inject
-    public TestConstructorInjection(@Named("port") int currentPort) {
+    public TestConstructorInjection(@Named("port") int currentPort,
+                                    @Socket("@default") URI uri,
+                                    @Socket("@default") String rawUri,
+                                    WebTarget target) {
         this.currentPort = currentPort;
+        this.uri = uri;
+        this.rawUri = rawUri;
+        this.target = target;
     }
 
     @Test
     void testIt() {
         assertThat(currentPort, is(423));
+        assertThat(uri, not(nullValue()));
+        assertThat(rawUri, not(nullValue()));
+        assertThat(target, not(nullValue()));
     }
 
     public static class MyBean {

--- a/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestMethodParams.java
+++ b/microprofile/tests/testing/junit5/src/test/java/io/helidon/microprofile/tests/testing/junit5/TestMethodParams.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testing.junit5;
+
+import java.net.URI;
+
+import io.helidon.microprofile.testing.AddJaxRs;
+import io.helidon.microprofile.testing.Socket;
+import io.helidon.microprofile.testing.junit5.AddBean;
+import io.helidon.microprofile.testing.junit5.DisableDiscovery;
+import io.helidon.microprofile.testing.junit5.HelidonTest;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.inject.Named;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.WebTarget;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@DisableDiscovery
+@AddBean(TestMethodParams.MyBean.class)
+@AddBean(TestMethodParams.MyResource.class)
+@AddJaxRs
+class TestMethodParams {
+
+    @Test
+    void testDefaultQualifierParam(@Default String greeting) {
+        assertThat(greeting, is("unqualified"));
+    }
+
+    @Test
+    void testNamedParam(@Named("test") int numbers) {
+        assertThat(numbers, is(123));
+    }
+
+    @Test
+    void testUriMethodParam(@Socket("@default") URI uri) {
+        assertThat(uri, notNullValue());
+    }
+
+    @Test
+    void testRawUriMethodParam(@Socket("@default") String uri) {
+        assertThat(uri, notNullValue());
+    }
+
+    @Test
+    void testWebTargetDefaultQualifier(@Default WebTarget target) {
+        testWebTargetNoQualifier(target);
+    }
+
+    @Test
+    void testWebTargetNoQualifier(WebTarget target) {
+        assertThat(target, notNullValue());
+        String response = target.path("/test")
+                .request()
+                .get(String.class);
+        assertThat(response, is("Hello from ResourceClass"));
+    }
+
+    @Test
+    void testSeContainerNoQualifier(SeContainer seContainer) {
+        assertThat(seContainer, notNullValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"one", "two", "three"})
+    void testParameterized(String param) {
+        assertThat(param, anyOf(is("one"), is("two"), is("three")));
+    }
+
+    @Path("/test")
+    @ApplicationScoped
+    public static class MyResource {
+
+        @GET
+        public String get() {
+            return "Hello from ResourceClass";
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyBean {
+
+        @Produces
+        @Default
+        public String unqualified() {
+            return "unqualified";
+        }
+
+        @Produces
+        @Named("test")
+        public int named() {
+            return 123;
+        }
+    }
+}


### PR DESCRIPTION
### Description

Require CDI qualifier(s) to resolve JUnit method parameter from CDI

 - Avoids conflicts with other ParameterResolver implementations
 - Follows best-practice: ParameterResolver implementations should only support annotated parameters
 - WebTarget and SeContainer are exceptions to the rule and do not require qualifiers annotations

The behavior introduced in 4.2.0 with PR #9695 where all method parameters are resolved with CDI is considered a bug. Thus, WebTarget and SeContainer are supported without CDI qualifier annotations to support the behavior prior to 4.2.0.

In 4.2.0, `String` and `URI` injection points were discovered via the `@Socket` annotation (constructors only).
 as a result it was possible to resolve those for the defautl socket without using the `@Socket` annotation explicitly on the method parameter.

E.g.
```java
@Helidon
@DisableDiscovery
@AddJaxRs
class MyTest {

    @Inject
    @Socket("default") // String and URI are only added as beans when required
    URI uri;

    @Test
    void testOne(URI uri) {
    }
}
```

This will no longer work and will now require using the `@Socket` annotation explicitly on the method parameter. The implementation has also been updated to discover method parameters injections points.

Instead, the new minimal equivalent looks like this:
```java
@Helidon
@DisableDiscovery
@AddJaxRs
class MyTest {

    @Test
    void testOne(@Socket("@default") URI uri) {
    }
}
```

### Documentation

Documentation has been updated to reflect the changes.
