### PR TITLE
Fix addContentLiteral in content builder in class model

### DIFF
--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
@@ -84,7 +84,7 @@ public interface ContentBuilder<T extends ContentBuilder<T>> {
     default T addContentLiteral(String literal) {
         if (literal.contains("\n")) {
             // the simplest solution is to use multiline string
-            return addContent("\"\"\"\n" + literal + "\n\"\"\"");
+            return addContent("\"\"\"\n" + literal + "\"\"\"");
         }
         // escape tabs, double quote, and backslashes
         String toWrite = literal;

--- a/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/ContentBuilderTest.java
+++ b/codegen/class-model/src/test/java/io/helidon/codegen/classmodel/ContentBuilderTest.java
@@ -48,16 +48,9 @@ class ContentBuilderTest {
 
     @Test
     void testAddContentLiteralNewLine() {
-        var string = """
-                test string with
-                "quotes"
-                 lines""";
-
-        assertThat(string, is("test string with\n\"quotes\"\n lines"));
-
         var c = new TestContentBuilder();
         c.addContentLiteral("test string with\n lines");
 
-        assertThat(c.generatedString(), is("    \"\"\"\ntest string with\n lines\n\"\"\""));
+        assertThat(c.generatedString(), is("    \"\"\"\ntest string with\n lines\"\"\""));
     }
 }


### PR DESCRIPTION
To ensure we escape special characters (quotes, backslash, new line, tab).

Added a test, updated javadoc.

Resolves #11245 