### PR TITLE
4.3.4: Upgrade Jackson, Kafka client, jinjava

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -74,7 +74,7 @@
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.jackson>2.21.0</version.lib.jackson>
+        <version.lib.jackson>2.21.1</version.lib.jackson>
         <version.lib.jakarta.activation-api>2.1.3</version.lib.jakarta.activation-api>
         <version.lib.jakarta.annotation-api>2.1.1</version.lib.jakarta.annotation-api>
         <version.lib.jakarta.cdi-api>4.0.1</version.lib.jakarta.cdi-api>
@@ -105,7 +105,7 @@
         <version.lib.jgit>7.3.0.202506031305-r</version.lib.jgit>
         <version.lib.junit>5.9.3</version.lib.junit>
         <version.lib.junit-platform-testkit>1.11.3</version.lib.junit-platform-testkit>
-        <version.lib.kafka>3.9.1</version.lib.kafka>
+        <version.lib.kafka>3.9.2</version.lib.kafka>
         <!-- Kotlin: dependency convergence requirement, we never use this directly -->
         <version.lib.kotlin>1.9.10</version.lib.kotlin>
         <version.lib.langchain4j>1.6.0</version.lib.langchain4j>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -253,5 +253,45 @@ https://github.com/jeremylong/DependencyCheck/issues/7019
    <cve>CVE-2025-15104</cve>
 </suppress>
 
+   <!-- False Positive.
+     This CVE is against Neo4J database, not the driver
+-->
+   <suppress>
+      <notes><![CDATA[
+   file name: neo4j-java-driver-5.28.3.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.neo4j\.driver/neo4j-java-driver@.*$</packageUrl>
+      <cve>CVE-2026-1337</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+   file name: neo4j-bolt-connection-1.0.0.jar
+   file name: neo4j-bolt-connection-netty-1.0.0.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.neo4j\.bolt/neo4j-bolt-connection.*$</packageUrl>
+      <cve>CVE-2026-1337</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+   file name: io.helidon.integrations.neo4j:helidon-integrations-neo4j:4.4.0-SNAPSHOT
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/io\.helidon\.integrations\.neo4j/helidon-integrations-neo4j.*$</packageUrl>
+      <cve>CVE-2026-1337</cve>
+   </suppress>
+
+   <!--
+        This CVE is old and was fixed in Kotlin 1.4.21. The CPE recently changed in NVD.
+        Will keep an eye on this to see if the CPE in NVD is bad, or if there is something new.
+   -->
+   <suppress>
+      <notes><![CDATA[
+   file name: kotlin-stdlib-1.9.10.jar
+   file name: kotlin-stdlib-jdk7-1.9.10.jar
+   file name: kotlin-stdlib-jdk8-1.9.10.jar
+   file name: kotlin-stdlib-common-1.9.10.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib.*$</packageUrl>
+      <cve>CVE-2020-29582</cve>
+   </suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.lib.checkstyle>10.12.5</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <!-- Force upgrade fourth party dependency of jlama langchain4j provider  -->
-        <version.lib.jinjava>2.8.1</version.lib.jinjava>
+        <version.lib.jinjava>2.8.3</version.lib.jinjava>
         <!-- Dependencies convergence via jinjava -->
         <version.lib.immutables-exceptions>1.9</version.lib.immutables-exceptions>
         <version.lib.microprofile-core-profile>10.0.3</version.lib.microprofile-core-profile>


### PR DESCRIPTION
### Description

- Upgrade Jackson to 2.21.1
- Upgrade Kafka client to 3.9.2
- Upgrade jinjava to 2.8.3
- Add suppressions for neo4j and kotlin

