### PR TITLE
4.x: Upgrades Hibernate to 6.6.44.Final

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -68,8 +68,8 @@
         <version.lib.h2>2.4.240</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.handlebars>4.4.0</version.lib.handlebars>
-        <version.lib.hibernate.family>6.3</version.lib.hibernate.family>
-        <version.lib.hibernate>${version.lib.hibernate.family}.1.Final</version.lib.hibernate>
+        <version.lib.hibernate.family>6.6</version.lib.hibernate.family>
+        <version.lib.hibernate>${version.lib.hibernate.family}.44.Final</version.lib.hibernate>
         <version.lib.hibernate-validator>8.0.2.Final</version.lib.hibernate-validator>
         <version.lib.hikaricp>5.0.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>


### PR DESCRIPTION
Addresses #11253 

Subject to pipelines passing; see #11188 