### PR TITLE
Fix handling of generic type for client response.

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
@@ -39,6 +39,7 @@ import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.Annotations;
 import io.helidon.common.types.ElementKind;
+import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
@@ -463,6 +464,26 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         boolean hasResponse = !(
                 method.returnType().equals(TypeNames.BOXED_VOID)
                         || method.returnType().equals(TypeNames.PRIMITIVE_VOID));
+        var returnType = method.returnType();
+        boolean useGenericType;
+        String genericTypeField;
+        if (hasResponse && !returnType.typeArguments().isEmpty() && !returnType.isOptional()) {
+            // we have a return type, and it has type arguments
+            useGenericType = true;
+            TypeName genType = TypeName.builder(TypeNames.GENERIC_TYPE)
+                    .addTypeArgument(returnType)
+                    .build();
+            genericTypeField = fieldHandler.constant("GTYPE", genType, ResolvedType.create(genType), constant -> {
+                constant.addContent("new ")
+                        .addContent(TypeNames.GENERIC_TYPE)
+                        .addContent("<")
+                        .addContent(returnType)
+                        .addContent(">() {}");
+            });
+        } else {
+            useGenericType = false;
+            genericTypeField = null;
+        }
 
         /*
         neither - call request() without any parameters, try with resources
@@ -473,17 +494,27 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         if (hasEntity && hasResponse) {
             it.addContent("var declarative__response = declarative__builder.submit(")
                     .addContent(method.entityParameter().get().name())
-                    .addContent(", ")
-                    .addContent(method.returnType())
-                    .addContentLine(".class);");
+                    .addContent(", ");
+            if (useGenericType) {
+                it.addContent(genericTypeField);
+            } else {
+                it.addContent(method.returnType())
+                        .addContent(".class");
+            }
+            it.addContentLine(");");
         } else if (hasEntity) {
             it.addContent("try (var declarative__response = declarative__builder.submit(")
                     .addContent(method.entityParameter().get().name())
                     .addContentLine(")) {");
         } else if (hasResponse) {
-            it.addContent("var declarative__response = declarative__builder.request(")
-                    .addContent(method.returnType())
-                    .addContentLine(".class);");
+            it.addContent("var declarative__response = declarative__builder.request(");
+            if (useGenericType) {
+                it.addContent(genericTypeField);
+            } else {
+                it.addContent(method.returnType())
+                        .addContent(".class");
+            }
+            it.addContentLine(");");
         } else {
             it.addContentLine("try (var declarative__response = declarative__builder.request()) {");
         }
@@ -491,9 +522,15 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         it.addContentLine("var declarative__headers = declarative__builder.headers();");
 
         if (hasResponse) {
-            it.addContent("errorHandling.handle(declarative__uri, declarative__headers, declarative__response, ")
-                    .addContent(method.returnType())
-                    .addContentLine(".class);");
+            if (useGenericType) {
+                it.addContent("errorHandling.handle(declarative__uri, declarative__headers, declarative__response, ")
+                        .addContent(genericTypeField)
+                        .addContentLine(");");
+            } else {
+                it.addContent("errorHandling.handle(declarative__uri, declarative__headers, declarative__response, ")
+                        .addContent(method.returnType())
+                        .addContentLine(".class);");
+            }
         } else {
             it.addContentLine("errorHandling.handle(declarative__uri, declarative__headers, declarative__response);");
         }

--- a/declarative/tests/http/pom.xml
+++ b/declarative/tests/http/pom.xml
@@ -39,7 +39,11 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonp</artifactId>
+            <artifactId>helidon-http-media-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-json-binding</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
@@ -68,10 +72,6 @@
         <dependency>
             <groupId>io.helidon.health</groupId>
             <artifactId>helidon-health-checks</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.logging</groupId>

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/FaultToleranceErrorHandler.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/FaultToleranceErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,16 @@
 
 package io.helidon.declarative.tests.http;
 
-import java.util.Map;
-
 import io.helidon.faulttolerance.FaultToleranceException;
 import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.ErrorHandler;
 import io.helidon.webserver.http.spi.ErrorHandlerProvider;
 
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
-
 @SuppressWarnings("deprecation")
 @Service.Singleton
 class FaultToleranceErrorHandler implements ErrorHandlerProvider<FaultToleranceException> {
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
-
     @Override
     public Class<FaultToleranceException> errorType() {
         return FaultToleranceException.class;
@@ -41,8 +34,8 @@ class FaultToleranceErrorHandler implements ErrorHandlerProvider<FaultToleranceE
     @Override
     public ErrorHandler<FaultToleranceException> create() {
         return (req, res, t) -> {
-            JsonObject jsonErrorObject = JSON.createObjectBuilder()
-                    .add("error", t.getMessage())
+            JsonObject jsonErrorObject = JsonObject.builder()
+                    .set("error", t.getMessage())
                     .build();
 
             res.status(Status.SERVICE_UNAVAILABLE_503)

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetService.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package io.helidon.declarative.tests.http;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Http;
+import io.helidon.json.JsonObject;
 import io.helidon.webclient.api.RestClient;
 import io.helidon.webserver.http.RestServer;
-
-import jakarta.json.JsonObject;
 
 @SuppressWarnings("deprecation")
 @Http.Path("/greet")
@@ -39,6 +39,10 @@ interface GreetService {
     @Http.GET
     @Http.Path("/ft/fallback")
     String failingFallback(@Http.HeaderParam(HeaderNames.HOST_NAME) String host);
+
+    @Http.GET
+    @Http.Path("/all")
+    List<GreetingDto> greetings();
 
     @Http.GET
     @Http.Path("/ft/retry")

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.helidon.declarative.tests.http;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -32,14 +32,11 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.Http;
 import io.helidon.http.HttpException;
 import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
 import io.helidon.security.SecurityContext;
 import io.helidon.security.abac.role.RoleValidator;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
-
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
 
 /**
  * A simple endpoint to greet you. Examples:
@@ -61,7 +58,6 @@ import jakarta.json.JsonObject;
 @SuppressWarnings("deprecation")
 class GreetServiceEndpoint implements GreetService {
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
     private static final AtomicInteger RETRY_CALLS = new AtomicInteger();
     private static volatile Instant lastCall = Instant.now();
 
@@ -94,6 +90,15 @@ class GreetServiceEndpoint implements GreetService {
     @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
     public JsonObject getDefaultMessageHandler() {
         return response("World");
+    }
+
+    @Override
+    public List<GreetingDto> greetings() {
+        var current = this.greeting.get();
+        if (current.equals("Hello")) {
+            return List.of(new GreetingDto("Hello"));
+        }
+        return List.of(new GreetingDto(this.greeting.get()), new GreetingDto("Hello"));
     }
 
     @Ft.Fallback(value = "fallback", applyOn = IllegalStateException.class)
@@ -167,7 +172,7 @@ class GreetServiceEndpoint implements GreetService {
             throw new QuickstartException(Status.BAD_REQUEST_400, "No greeting provided");
         }
 
-        greeting.set(greetingMessage.getString("greeting"));
+        greeting.set(greetingMessage.stringValue("greeting", greeting.get()));
     }
 
     /**
@@ -183,7 +188,7 @@ class GreetServiceEndpoint implements GreetService {
             throw new QuickstartException(Status.BAD_REQUEST_400, "No greeting provided");
         }
         JsonObject response = response("World");
-        greeting.set(greetingMessage.getString("greeting"));
+        greeting.set(greetingMessage.stringValue("greeting", greeting.get()));
         return response;
     }
 
@@ -198,12 +203,6 @@ class GreetServiceEndpoint implements GreetService {
 
     String fallback(String host) {
         return "Fallback " + host;
-    }
-
-    private JsonObject response(String name) {
-        return JSON.createObjectBuilder()
-                .add("message", stringResponse(name))
-                .build();
     }
 
     /**
@@ -224,10 +223,15 @@ class GreetServiceEndpoint implements GreetService {
             throw new QuickstartException(Status.BAD_REQUEST_400, "No greeting provided");
         }
         JsonObject response = response(securityContext.userName());
-        greeting.set(greetingMessage.getString("greeting"));
+        greeting.set(greetingMessage.stringValue("greeting", greeting.get()));
         return response;
     }
 
+    private JsonObject response(String name) {
+        return JsonObject.builder()
+                .set("message", stringResponse(name))
+                .build();
+    }
 
     private String stringResponse(String name) {
         return String.format("%s %s!", greeting.get(), name);

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetingDto.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetingDto.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import io.helidon.json.binding.Json;
+
+@Json.Entity
+record GreetingDto(String greeting) {
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/QuickstartErrorHandler.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/QuickstartErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,10 @@ package io.helidon.declarative.tests.http;
 
 import java.util.Map;
 
+import io.helidon.json.JsonObject;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.ErrorHandler;
 import io.helidon.webserver.http.spi.ErrorHandlerProvider;
-
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
 
 /**
  * Example of an HTTP error handler to have an easy approach to returning well-formatted error messages
@@ -33,8 +30,6 @@ import jakarta.json.JsonObject;
 @SuppressWarnings("deprecation")
 @Service.Singleton
 class QuickstartErrorHandler implements ErrorHandlerProvider<QuickstartException> {
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
-
     @Override
     public Class<QuickstartException> errorType() {
         return QuickstartException.class;
@@ -43,8 +38,8 @@ class QuickstartErrorHandler implements ErrorHandlerProvider<QuickstartException
     @Override
     public ErrorHandler<QuickstartException> create() {
         return (req, res, t) -> {
-            JsonObject jsonErrorObject = JSON.createObjectBuilder()
-                    .add("error", t.getMessage())
+            JsonObject jsonErrorObject = JsonObject.builder()
+                    .set("error", t.getMessage())
                     .build();
             res.status(t.status())
                     .send(jsonErrorObject);

--- a/declarative/tests/http/src/main/java/module-info.java
+++ b/declarative/tests/http/src/main/java/module-info.java
@@ -19,7 +19,6 @@ module io.helidon.declarative.tests.http {
     requires io.helidon.common.media.type;
     requires io.helidon.webserver;
     requires io.helidon.service.registry;
-    requires jakarta.json;
     requires io.helidon.config.yaml;
     requires io.helidon.logging.common;
     requires io.helidon.metrics.systemmeters;
@@ -27,6 +26,8 @@ module io.helidon.declarative.tests.http {
     requires io.helidon.webclient.api;
     requires io.helidon.faulttolerance;
     requires io.helidon.metrics.api;
+    requires io.helidon.json.binding;
+    requires io.helidon.json;
 
     // Security related dependencies
     requires io.helidon.security;

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package io.helidon.declarative.tests.http;
 
 import java.net.URI;
-import java.util.Map;
 import java.util.Optional;
 
 import io.helidon.http.HeaderName;
@@ -25,6 +24,7 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpException;
 import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
 import io.helidon.service.registry.Lookup;
 import io.helidon.service.registry.Qualifier;
 import io.helidon.service.registry.ServiceRegistry;
@@ -32,12 +32,10 @@ import io.helidon.webclient.api.RestClient;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webserver.testing.junit5.ServerTest;
 
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,8 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("deprecation")
 @ServerTest
 class DeclarativeHttpTest {
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
-
     private final Http1Client client;
     private final ServiceRegistry registry;
     private final URI serverUri;
@@ -71,10 +67,22 @@ class DeclarativeHttpTest {
 
         assertThat(response.status(), is(Status.OK_200));
         JsonObject json = response.entity();
-        assertThat(json.getString("message"), is("Hello World!"));
+        assertThat(json.stringValue("message", "bad"), is("Hello World!"));
 
         assertThat(SomeEntryPointInterceptor.executions(),
                    hasItems(GreetServiceEndpoint.class.getName() + ".getDefaultMessageHandler()"));
+    }
+
+    @Test
+    void testGreetingList() {
+        GreetServiceClient typedClient = registry.get(Lookup.builder()
+                                                              .addContract(GreetServiceClient.class)
+                                                              .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                              .build());
+
+        var all = typedClient.greetings();
+
+        assertThat(all, hasItem(is(new GreetingDto("Hello"))));
     }
 
     @Test
@@ -97,15 +105,15 @@ class DeclarativeHttpTest {
 
     @Test
     void testErrorHandler() {
-        JsonObject badEntity = JSON.createObjectBuilder().build();
+        JsonObject badEntity = JsonObject.builder().build();
 
         var response = client.put("/greet/greeting").submit(badEntity, JsonObject.class);
         assertThat(response.status(), is(Status.BAD_REQUEST_400));
         JsonObject entity = response.entity();
-        assertThat(entity.getString("error"), is("No greeting provided"));
+        assertThat(entity.stringValue("error", "bad"), is("No greeting provided"));
 
         assertThat(SomeEntryPointInterceptor.executions(),
-                   hasItems(GreetServiceEndpoint.class.getName() + ".updateGreetingHandler(jakarta.json.JsonObject)"));
+                   hasItems(GreetServiceEndpoint.class.getName() + ".updateGreetingHandler(io.helidon.json.JsonObject)"));
     }
 
     @Test
@@ -161,7 +169,7 @@ class DeclarativeHttpTest {
         assertThat(message, is("Hello World!"));
 
         JsonObject jsonMessage = typedClient.getDefaultMessageHandler();
-        assertThat(jsonMessage.getString("message"), is("Hello World!"));
+        assertThat(jsonMessage.stringValue("message", "bad"), is("Hello World!"));
 
         message = typedClient.failingFallback(serverUri.getAuthority());
         assertThat(message, is("Fallback " + serverUri.getAuthority()));
@@ -179,17 +187,17 @@ class DeclarativeHttpTest {
         assertThat(exception.status(), is(Status.SERVICE_UNAVAILABLE_503));
 
         jsonMessage = typedClient.getMessageHandler("test");
-        assertThat(jsonMessage.getString("message"), is("Hello test!"));
+        assertThat(jsonMessage.stringValue("message", "bad"), is("Hello test!"));
 
-        JsonObject newGreeting = JSON.createObjectBuilder()
-                .add("greeting", "Ahoj")
+        JsonObject newGreeting = JsonObject.builder()
+                .set("greeting", "Ahoj")
                 .build();
         typedClient.updateGreetingHandler(newGreeting);
 
-        newGreeting = JSON.createObjectBuilder()
-                .add("greeting", "Hello")
+        newGreeting = JsonObject.builder()
+                .set("greeting", "Hello")
                 .build();
         jsonMessage = typedClient.updateGreetingHandlerReturningCurrent(newGreeting);
-        assertThat(jsonMessage.getString("message"), is("Ahoj World!"));
+        assertThat(jsonMessage.stringValue("message", "bad"), is("Ahoj World!"));
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequest.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
 
+import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.tls.Tls;
@@ -283,6 +284,19 @@ public interface ClientRequest<T extends ClientRequest<T>> {
     }
 
     /**
+     * Request without sending an entity.
+     *
+     * @param type generic type of entity
+     * @param <E>  type of entity
+     * @return correctly typed response
+     * @see #request()
+     */
+    default <E> ClientResponseTyped<E> request(GenericType<E> type) {
+        HttpClientResponse response = request();
+        return new ClientResponseTypedImpl<>(response, type);
+    }
+
+    /**
      * Request entity without sending a request entity, asking for entity only.
      * This method will fail if the status is not in successful family.
      *
@@ -292,6 +306,26 @@ public interface ClientRequest<T extends ClientRequest<T>> {
      * @param <E> type of the entity to read from the response
      */
     default <E> E requestEntity(Class<E> type) throws HttpException {
+        ClientResponseTyped<E> typedResponse = request(type);
+        if (typedResponse.status().family() == Status.Family.SUCCESSFUL) {
+            return typedResponse.entity();
+        }
+        if (typedResponse.status() == Status.BAD_REQUEST_400) {
+            throw new IllegalArgumentException("Failed to read entity, received bad request");
+        }
+        throw new IllegalStateException(typedResponse.status() + ": Failed to read entity, as response status is not success");
+    }
+
+    /**
+     * Request entity without sending a request entity, asking for entity only.
+     * This method will fail if the status is not in successful family.
+     *
+     * @param type generic type of requested entity
+     * @return correctly typed entity
+     * @throws io.helidon.http.HttpException in case the response status is not success
+     * @param <E> type of the entity to read from the response
+     */
+    default <E> E requestEntity(GenericType<E> type) throws HttpException {
         ClientResponseTyped<E> typedResponse = request(type);
         if (typedResponse.status().family() == Status.Family.SUCCESSFUL) {
             return typedResponse.entity();
@@ -315,10 +349,23 @@ public interface ClientRequest<T extends ClientRequest<T>> {
      *
      * @param entity        request entity
      * @param requestedType type of response entity
-     * @param <T>           type of response entity
+     * @param <E>           type of response entity
      * @return correctly typed response
      */
-    default <T> ClientResponseTyped<T> submit(Object entity, Class<T> requestedType) {
+    default <E> ClientResponseTyped<E> submit(Object entity, Class<E> requestedType) {
+        HttpClientResponse response = submit(entity);
+        return new ClientResponseTypedImpl<>(response, requestedType);
+    }
+
+    /**
+     * Submit an entity and request a specific type.
+     *
+     * @param entity        request entity
+     * @param requestedType generic type of response entity
+     * @param <E>           type of response entity
+     * @return correctly typed response
+     */
+    default <E> ClientResponseTyped<E> submit(Object entity, GenericType<E> requestedType) {
         HttpClientResponse response = submit(entity);
         return new ClientResponseTypedImpl<>(response, requestedType);
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.api;
 
+import io.helidon.common.GenericType;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.ClientResponseTrailers;
 import io.helidon.http.Status;
@@ -33,6 +34,23 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
         RuntimeException thrown;
         try {
             entity = response.as(entityType);
+            thrown = null;
+        } catch (RuntimeException e) {
+            thrown = e;
+            entity = null;
+        }
+        this.thrown = thrown;
+        this.entity = entity;
+    }
+
+    ClientResponseTypedImpl(HttpClientResponse response, GenericType<T> entityType) {
+        this.response = response;
+
+        // Read the entity immediately, as this type is not going to be autocloseable, so we need to read the whole thing
+        T entity;
+        RuntimeException thrown;
+        try {
+            entity = response.entity().as(entityType);
             thrown = null;
         } catch (RuntimeException e) {
             thrown = e;

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.GenericType;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HttpException;
 import io.helidon.service.registry.Service;
@@ -47,7 +48,7 @@ class DefaultErrorHandling implements RestClient.ErrorHandling {
     }
 
     @Override
-    public void handle(String uri, ClientRequestHeaders requestHeaders, ClientResponseTyped<?> response, Class<?> type) {
+    public void handle(String uri, ClientRequestHeaders requestHeaders, ClientResponseTyped<?> response, GenericType<?> type) {
         for (RestClient.ErrorHandler errorHandler : errorHandlers) {
             if (errorHandler.handles(uri, requestHeaders, response.status(), response.headers())) {
                 var maybeException = errorHandler.handleError(uri, requestHeaders, response, type);
@@ -77,7 +78,7 @@ class DefaultErrorHandling implements RestClient.ErrorHandling {
         public Optional<? extends RuntimeException> handleError(String requestUri,
                                                                 ClientRequestHeaders requestHeaders,
                                                                 ClientResponseTyped<?> response,
-                                                                Class<?> type) {
+                                                                GenericType<?> type) {
             return Optional.of(new HttpException("Failed when invoking a client call to " + requestUri
                                                          + ", status: " + response.status(),
                                                  response.status()));

--- a/webclient/api/src/main/java/io/helidon/webclient/api/RestClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/RestClient.java
@@ -24,6 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Optional;
 
+import io.helidon.common.GenericType;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.Status;
@@ -224,14 +225,14 @@ public final class RestClient {
          * @param requestUri     requested URI
          * @param requestHeaders request headers
          * @param typedResponse  response we received from the server
-         * @param type           entity class (type of the typed response)
+         * @param type           type of the typed response
          * @return possible exception to throw, if empty, the invocation will be considered a success, even if the
          *         status denoted an error
          */
         Optional<? extends RuntimeException> handleError(String requestUri,
                                                          ClientRequestHeaders requestHeaders,
                                                          ClientResponseTyped<?> typedResponse,
-                                                         Class<?> type);
+                                                         GenericType<?> type);
     }
 
     /**
@@ -257,7 +258,19 @@ public final class RestClient {
          * @param response response
          * @param type type of the response
          */
-        void handle(String uri, ClientRequestHeaders requestHeaders, ClientResponseTyped<?> response, Class<?> type);
+        default void handle(String uri, ClientRequestHeaders requestHeaders, ClientResponseTyped<?> response, Class<?> type) {
+            handle(uri, requestHeaders, response, GenericType.create(type));
+        }
+
+        /**
+         * Handle an exception for a typed response.
+         *
+         * @param uri invoked URI
+         * @param requestHeaders headers of the request
+         * @param response response
+         * @param type type of the typed response
+         */
+        void handle(String uri, ClientRequestHeaders requestHeaders, ClientResponseTyped<?> response, GenericType<?> type);
     }
 
 }


### PR DESCRIPTION
Extend declarative REST client generation and webclient typed request handling to support generic response types, then updates the HTTP declarative tests to exercise that path
  with JSON-binding DTOs.

  - Add GenericType-based request, submit, and error-handling support in webclient/api, including typed no-entity requests and generic entity reads.
  - Update declarative REST client code generation to emit GenericType constants for parameterized return types and use them when creating requests and invoking error handling.
  - Migrate declarative HTTP test fixtures from jakarta.json to io.helidon.json / JSON binding.
  - Introduce GreetingDto as a JSON-bound record and add a new GET /all endpoint returning List<GreetingDto> to verify generic collection responses.
  - Refresh the declarative HTTP tests to validate the new typed list response and align JSON assertions/builders with the Helidon JSON APIs.

Resolves #11301