### PR TITLE
4.x: Replace internal usage of Config.map and Config.mapList

### DIFF
--- a/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientBuilderBase.java
+++ b/dbclient/dbclient/src/main/java/io/helidon/dbclient/DbClientBuilderBase.java
@@ -73,7 +73,7 @@ public abstract class DbClientBuilderBase<T extends DbClientBuilderBase<T>>
     @Override
     public T config(Config config) {
         config.get("missing-map-parameters-as-null").as(Boolean.class).ifPresent(this::missingMapParametersAsNull);
-        config.get("statements").map(DbStatements::create).ifPresent(this::statements);
+        config.get("statements").as(DbStatements::create).ifPresent(this::statements);
         return identity();
     }
 

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcClientBuilder.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcClientBuilder.java
@@ -53,7 +53,7 @@ public final class JdbcClientBuilder
     @Override
     public JdbcClientBuilder config(Config config) {
         super.config(config);
-        config.get("connection").detach().map(JdbcConnectionPool::create).ifPresent(this::connectionPool);
+        config.get("connection").detach().as(JdbcConnectionPool::create).ifPresent(this::connectionPool);
         Config parameters = config.get("parameters");
         if (parameters.exists()) {
             this.parametersConfig = JdbcParametersConfig.create(parameters);

--- a/http/http/src/main/java/io/helidon/http/RequestedUriDiscoveryContext.java
+++ b/http/http/src/main/java/io/helidon/http/RequestedUriDiscoveryContext.java
@@ -178,7 +178,7 @@ public interface RequestedUriDiscoveryContext {
                     .asList(RequestedUriDiscoveryType.class)
                     .ifPresent(this::types);
             requestedUriDiscoveryConfig.get("trusted-proxies")
-                    .map(AllowList::create)
+                    .as(AllowList::create)
                     .ifPresent(this::trustedProxies);
             return this;
         }

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -1179,7 +1179,7 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
             config.get("propagate").asBoolean().ifPresent(this::propagate);
             config.get("allow-impersonation").asBoolean().ifPresent(this::allowImpersonation);
             config.get("principal-type").asString().as(SubjectType::valueOf).ifPresent(this::subjectType);
-            config.get("atn-token.handler").map(TokenHandler::create).ifPresent(this::atnTokenHandler);
+            config.get("atn-token.handler").as(TokenHandler::create).ifPresent(this::atnTokenHandler);
             config.get("atn-token").asNode().ifPresent(this::verifyKeys);
             config.get("atn-token.jwt-audience").asString().ifPresent(this::expectedAudience);
             config.get("atn-token.default-key-id").asString().ifPresent(this::defaultKeyId);
@@ -1366,14 +1366,14 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
         }
 
         private void verifyKeys(Config config) {
-            config.get("jwk.resource").map(Resource::create).ifPresent(this::verifyJwk);
+            config.get("jwk.resource").as(Resource::create).ifPresent(this::verifyJwk);
         }
 
         private void outbound(Config config) {
             config.get("jwt-issuer").asString().ifPresent(this::issuer);
 
             // jwk is optional, we may be propagating existing token
-            config.get("jwk.resource").map(Resource::create).ifPresent(this::signJwk);
+            config.get("jwk.resource").as(Resource::create).ifPresent(this::signJwk);
         }
     }
 

--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/JerseySecurityFeature.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/JerseySecurityFeature.java
@@ -325,7 +325,7 @@ public final class JerseySecurityFeature implements Feature {
             Config myConfig = config.get("defaults");
             myConfig.get("authorize-annotated-only").asBoolean().ifPresent(this::authorizeAnnotatedOnly);
             myConfig.get("authenticate-annotated-only").asBoolean().ifPresent(this::authenticateAnnotatedOnly);
-            myConfig.get("query-params").mapList(QueryParamHandler::create).ifPresent(this::addQueryParamHandlers);
+            myConfig.get("query-params").asList(QueryParamHandler::create).ifPresent(this::addQueryParamHandlers);
             myConfig.get("debug").asBoolean().filter(bool -> bool).ifPresent(bool -> this.debug());
 
             return this;

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/OutboundConfig.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/OutboundConfig.java
@@ -112,7 +112,7 @@ public final class OutboundConfig {
     static OutboundConfig createFromConfig(Config providerConfig, OutboundTarget[] defaults) {
         Config config = providerConfig.get(CONFIG_OUTBOUND);
 
-        List<OutboundTarget> configuredTargets = config.mapList(OutboundTarget::create).orElse(List.of());
+        List<OutboundTarget> configuredTargets = config.asList(OutboundTarget::create).orElse(List.of());
 
         boolean useDefaults = configuredTargets.stream().noneMatch(targetConfig -> "default".equals(targetConfig.name()))
                 && (null != defaults);

--- a/security/providers/google-login/src/main/java/io/helidon/security/providers/google/login/GoogleTokenProvider.java
+++ b/security/providers/google-login/src/main/java/io/helidon/security/providers/google/login/GoogleTokenProvider.java
@@ -569,7 +569,7 @@ public final class GoogleTokenProvider implements AuthenticationProvider, Outbou
             config.get("proxy-host").asString().ifPresent(this::proxyHost);
             config.get("proxy-port").asInt().ifPresent(this::proxyPort);
             config.get("realm").asString().ifPresent(this::realm);
-            config.get("token").map(TokenHandler::create).ifPresent(this::tokenProvider);
+            config.get("token").as(TokenHandler::create).ifPresent(this::tokenProvider);
             // OutboundConfig.create() expects provider configuration, not outbound
             config.get("outbound").asNode().ifPresent(outbound -> outboundConfig(OutboundConfig.create(config)));
 

--- a/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnOutboundConfig.java
+++ b/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnOutboundConfig.java
@@ -152,7 +152,7 @@ public class HeaderAtnOutboundConfig {
          * @return updated builder instance
          */
         public Builder config(Config config) {
-            config.get("outbound-token").map(TokenHandler::create)
+            config.get("outbound-token").as(TokenHandler::create)
                     .ifPresent(this::tokenHandler);
             config.get("username").asString().ifPresent(this::explicitUser);
 

--- a/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnProvider.java
+++ b/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnProvider.java
@@ -248,10 +248,10 @@ public class HeaderAtnProvider implements AuthenticationProvider, OutboundSecuri
             config.get("authenticate").asBoolean().ifPresent(this::authenticate);
             config.get("propagate").asBoolean().ifPresent(this::propagate);
             config.get("principal-type").asString().map(SubjectType::valueOf).ifPresent(this::subjectType);
-            config.get("atn-token").map(TokenHandler::create).ifPresent(this::atnTokenHandler);
-            config.get("outbound-token").map(TokenHandler::create).ifPresent(this::outboundTokenHandler);
+            config.get("atn-token").as(TokenHandler::create).ifPresent(this::atnTokenHandler);
+            config.get("outbound-token").as(TokenHandler::create).ifPresent(this::outboundTokenHandler);
 
-            config.get("outbound").mapList(OutboundTarget::create)
+            config.get("outbound").asList(OutboundTarget::create)
                     .ifPresent(it -> it.forEach(outboundBuilder::addTarget));
 
             return this;

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
@@ -365,7 +365,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
 
                         @Override
                         public SecureUserStore create(Config config) {
-                            return usersConfig.map(ConfigUserStore::create)
+                            return usersConfig.as(ConfigUserStore::create)
                                     .orElseThrow(() -> new HttpAuthException(
                                             "No users configured! Key \"users\" must be in configuration"));
                         }
@@ -379,7 +379,7 @@ public class HttpBasicAuthProvider implements AuthenticationProvider, OutboundSe
                         addUserStore(userStoreService.create(config.get(userStoreService.configKey())));
                     });
 
-            config.get("outbound").mapList(OutboundTarget::create)
+            config.get("outbound").asList(OutboundTarget::create)
                     .ifPresent(it -> it.forEach(outboundBuilder::addTarget));
 
             return this;

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicOutboundConfig.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicOutboundConfig.java
@@ -181,7 +181,7 @@ public class HttpBasicOutboundConfig {
          * @return updated builder instance
          */
         public Builder config(Config config) {
-            config.get("outbound-token").map(TokenHandler::create)
+            config.get("outbound-token").as(TokenHandler::create)
                     .ifPresent(this::tokenHandler);
             config.get("username").asString().ifPresent(this::explicitUser);
             config.get("password").asString().ifPresent(this::explicitPassword);

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthProvider.java
@@ -338,7 +338,7 @@ public final class HttpDigestAuthProvider implements AuthenticationProvider {
         public Builder config(Config config) {
             config.get("optional").asBoolean().ifPresent(this::optional);
             config.get("realm").asString().ifPresent(this::realm);
-            config.get("users").map(ConfigUserStore::create).ifPresent(this::userStore);
+            config.get("users").as(ConfigUserStore::create).ifPresent(this::userStore);
             config.get("algorithm").asString().as(HttpDigest.Algorithm::valueOf).ifPresent(this::digestAlgorithm);
             config.get("nonce-timeout-millis").asLong()
                     .ifPresent(timeout -> this.digestNonceTimeout(timeout, TimeUnit.MILLISECONDS));
@@ -349,7 +349,7 @@ public final class HttpDigestAuthProvider implements AuthenticationProvider {
                     .map(String::toCharArray)
                     .ifPresent(this::digestServerSecret);
 
-            config.get("qop").mapList(HttpDigest.Qop::create).ifPresent(qop -> {
+            config.get("qop").asList(HttpDigest.Qop::create).ifPresent(qop -> {
                 if (qop.isEmpty()) {
                     noDigestQop();
                 } else {

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignProvider.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignProvider.java
@@ -92,9 +92,11 @@ public final class HttpSignProvider implements AuthenticationProvider, OutboundS
         this.outboundConfig = builder.outboundConfig;
         this.backwardCompatibleEol = builder.backwardCompatibleEol;
 
-        outboundConfig.targets().forEach(target -> target.getConfig().ifPresent(targetConfig -> {
+        outboundConfig.targets().forEach(target -> target.getConfig()
+                .ifPresent(targetConfig -> {
             OutboundTargetDefinition outboundTargetDefinition = targetConfig.get("signature")
-                    .map(OutboundTargetDefinition::create)
+                    .map(Config::config)
+                    .as(OutboundTargetDefinition::create)
                     .get();
             targetKeys.put(target.name(), outboundTargetDefinition);
         }));
@@ -367,7 +369,7 @@ public final class HttpSignProvider implements AuthenticationProvider, OutboundS
             config.get("headers").asList(HttpSignHeader.class).ifPresent(list -> list.forEach(this::addAcceptHeader));
             config.get("optional").asBoolean().ifPresent(this::optional);
             config.get("realm").asString().ifPresent(this::realm);
-            config.get("sign-headers").map(SignedHeadersConfig::create).ifPresent(this::inboundRequiredHeaders);
+            config.get("sign-headers").as(SignedHeadersConfig::create).ifPresent(this::inboundRequiredHeaders);
             outboundConfig = OutboundConfig.create(config);
 
             config.get("inbound.keys")

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/InboundClientDefinition.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/InboundClientDefinition.java
@@ -303,7 +303,7 @@ public class InboundClientDefinition {
             keyId(config.get("key-id").asString().get());
             config.get("principal-name").asString().ifPresent(this::principalName);
             config.get("principal-type").asString().as(SubjectType::valueOf).ifPresent(this::subjectType);
-            config.get("public-key").map(Keys::create).ifPresent(this::publicKeyConfig);
+            config.get("public-key").as(Keys::create).ifPresent(this::publicKeyConfig);
             config.get("hmac.secret").asString().ifPresent(this::hmacSecret);
             config.get("algorithm").asString().ifPresent(this::algorithm);
 

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/OutboundTargetDefinition.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/OutboundTargetDefinition.java
@@ -350,8 +350,8 @@ public final class OutboundTargetDefinition {
         public Builder config(Config config) {
             this.keyId(config.get("key-id").asString().get());      // mandatory
             config.get("header").asString().map(HttpSignHeader::valueOf).ifPresent(this::header);
-            config.get("sign-headers").map(SignedHeadersConfig::create).ifPresent(this::signedHeaders);
-            config.get("private-key").map(Keys::create).ifPresent(this::privateKeyConfig);
+            config.get("sign-headers").as(SignedHeadersConfig::create).ifPresent(this::signedHeaders);
+            config.get("private-key").as(Keys::create).ifPresent(this::privateKeyConfig);
             config.get("hmac.secret").asString().ifPresent(this::hmacSecret);
 
             // last, as we configure defaults based on configuration

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentSignedHeadersConfigTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentSignedHeadersConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ class CurrentSignedHeadersConfigTest {
 
     @Test
     void testFromConfig() {
-        SignedHeadersConfig shc = config.get("http-signatures.sign-headers").map(SignedHeadersConfig::create).get();
+        SignedHeadersConfig shc = config.get("http-signatures.sign-headers").as(SignedHeadersConfig::create).get();
 
         testThem(shc);
     }

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
@@ -366,9 +366,9 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
         public B config(Config config) {
             super.config(config);
 
-            config.get("cache-config").map(EvictableCache::<MtCacheKey, List<Grant>>create).ifPresent(this::cache);
-            config.get("idcs-tenant-handler").map(TokenHandler::create).ifPresent(this::idcsTenantTokenHandler);
-            config.get("idcs-app-name-handler").map(TokenHandler::create).ifPresent(this::idcsAppNameTokenHandler);
+            config.get("cache-config").as(EvictableCache::<MtCacheKey, List<Grant>>create).ifPresent(this::cache);
+            config.get("idcs-tenant-handler").as(TokenHandler::create).ifPresent(this::idcsTenantTokenHandler);
+            config.get("idcs-app-name-handler").as(TokenHandler::create).ifPresent(this::idcsAppNameTokenHandler);
 
             return me;
         }

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
@@ -262,7 +262,7 @@ public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implement
         @Override
         public B config(Config config) {
             super.config(config);
-            config.get("cache-config").map(EvictableCache::<String, List<Grant>>create).ifPresent(this::roleCache);
+            config.get("cache-config").as(EvictableCache::<String, List<Grant>>create).ifPresent(this::roleCache);
 
             return me;
         }

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
@@ -320,7 +320,7 @@ public abstract class IdcsRoleMapperProviderBase implements SubjectMappingProvid
                 oidcConfig(builder.build());
             });
 
-            config.get("subject-types").mapList(cfg -> cfg.asString().map(SubjectType::valueOf).get())
+            config.get("subject-types").asList(cfg -> cfg.asString().map(SubjectType::valueOf).get())
                     .ifPresent(list -> list.forEach(this::addSubjectType));
             config.get("default-idcs-subject-type").asString().ifPresent(this::defaultIdcsSubjectType);
             return me;

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -558,7 +558,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
              */
             public Builder config(Config config) {
                 config.get("outbound-token")
-                        .map(TokenHandler::create)
+                        .as(TokenHandler::create)
                         .ifPresent(this::tokenHandler);
 
                 config.get("jwt-kid").asString().ifPresent(this::jwtKid);
@@ -871,7 +871,7 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
             config.get("propagate").asBoolean().ifPresent(this::propagate);
             config.get("allow-impersonation").asBoolean().ifPresent(this::allowImpersonation);
             config.get("principal-type").asString().map(SubjectType::valueOf).ifPresent(this::subjectType);
-            config.get("atn-token.handler").map(TokenHandler::create).ifPresent(this::atnTokenHandler);
+            config.get("atn-token.handler").as(TokenHandler::create).ifPresent(this::atnTokenHandler);
             Config atnToken = config.get("atn-token");
             if (atnToken.exists()) {
                 verifyKeys(atnToken);
@@ -913,14 +913,14 @@ public final class JwtProvider implements AuthenticationProvider, OutboundSecuri
         }
 
         private void verifyKeys(Config config) {
-            config.get("jwk.resource").map(Resource::create).ifPresent(this::verifyJwk);
+            config.get("jwk.resource").as(Resource::create).ifPresent(this::verifyJwk);
         }
 
         private void outbound(Config config) {
             config.get("jwt-issuer").asString().ifPresent(this::issuer);
 
             // jwk is optional, we may be propagating existing token
-            config.get("jwk.resource").map(Resource::create).ifPresent(this::signJwk);
+            config.get("jwk.resource").as(Resource::create).ifPresent(this::signJwk);
         }
     }
 }

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/BaseBuilder.java
@@ -124,10 +124,10 @@ public abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Bui
         config.get("identity-uri").as(URI.class).ifPresent(this::identityUri);
 
         // OIDC server configuration
-        config.get("oidc-metadata.resource").map(Resource::create).ifPresent(this::oidcMetadata);
+        config.get("oidc-metadata.resource").as(Resource::create).ifPresent(this::oidcMetadata);
         config.get("base-scopes").asString().ifPresent(this::baseScopes);
         // backward compatibility
-        config.get("oidc-metadata.resource").map(Resource::create).ifPresent(this::oidcMetadata);
+        config.get("oidc-metadata.resource").as(Resource::create).ifPresent(this::oidcMetadata);
         config.get("oidc-metadata-well-known").asBoolean().ifPresent(this::oidcMetadataWellKnown);
 
         config.get("scope-audience").asString().ifPresent(this::scopeAudience);
@@ -139,8 +139,8 @@ public abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Bui
         config.get("token-endpoint-uri").as(URI.class).ifPresent(this::tokenEndpointUri);
         config.get("logout-endpoint-uri").as(URI.class).ifPresent(this::logoutEndpointUri);
 
-        config.get("sign-jwk.resource").map(Resource::create).ifPresent(this::signJwk);
-        config.get("decryption-keys.resource").map(Resource::create).ifPresent(this::decryptionKeys);
+        config.get("sign-jwk.resource").as(Resource::create).ifPresent(this::signJwk);
+        config.get("decryption-keys.resource").as(Resource::create).ifPresent(this::decryptionKeys);
 
         config.get("introspect-endpoint-uri").as(URI.class).ifPresent(this::introspectEndpointUri);
         DeprecatedConfig.get(config, "validate-jwt-with-jwk", "validate-with-jwk")

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -1196,7 +1196,7 @@ public final class OidcConfig extends TenantConfigImpl {
             config.get("max-redirects").asInt().ifPresent(this::maxRedirects);
             config.get("force-https-redirects").asBoolean().ifPresent(this::forceHttpsRedirects);
 
-            config.get("cors").map(CrossOriginConfig::create).ifPresent(this::crossOriginConfig);
+            config.get("cors").as(CrossOriginConfig::create).ifPresent(this::crossOriginConfig);
 
             config.get("token-refresh-before-expiration").as(Duration.class).ifPresent(this::tokenRefreshSkew);
 

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
@@ -594,7 +594,8 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
                                         .orElse(true);
                                 TokenHandler handler = outboundTarget.getConfig()
                                         .flatMap(cfg -> cfg.get("outbound-token")
-                                                .map(TokenHandler::create)
+                                                .map(Config::config)
+                                                .as(TokenHandler::create)
                                                 .asOptional())
                                         .orElse(defaultTokenHandler);
                                 return new OidcOutboundTarget(propagate, handler);

--- a/security/security/src/main/java/io/helidon/security/QueryParamMapping.java
+++ b/security/security/src/main/java/io/helidon/security/QueryParamMapping.java
@@ -81,7 +81,7 @@ public final class QueryParamMapping {
      */
     public static QueryParamMapping create(Config config) {
         String name = config.get("name").asString().get();
-        TokenHandler handler = config.map(TokenHandler::create).get();
+        TokenHandler handler = config.as(TokenHandler::create).get();
         return create(name, handler);
     }
 

--- a/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
+++ b/tracing/providers/jaeger/src/main/java/io/helidon/tracing/providers/jaeger/JaegerTracerBuilder.java
@@ -292,9 +292,9 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
         config.get("path").asString().ifPresent(this::collectorPath);
         config.get("sampler-type").asString().as(SamplerType::create).ifPresent(this::samplerType);
         config.get("sampler-param").asDouble().ifPresent(this::samplerParam);
-        config.get("private-key-pem").map(io.helidon.common.configurable.Resource::create).ifPresent(this::privateKey);
-        config.get("client-cert-pem").map(io.helidon.common.configurable.Resource::create).ifPresent(this::clientCertificate);
-        config.get("trusted-cert-pem").map(io.helidon.common.configurable.Resource::create).ifPresent(this::trustedCertificates);
+        config.get("private-key-pem").as(io.helidon.common.configurable.Resource::create).ifPresent(this::privateKey);
+        config.get("client-cert-pem").as(io.helidon.common.configurable.Resource::create).ifPresent(this::clientCertificate);
+        config.get("trusted-cert-pem").as(io.helidon.common.configurable.Resource::create).ifPresent(this::trustedCertificates);
         config.get("propagation").asList(String.class)
                 .ifPresent(propagationStrings -> {
                     propagationStrings.stream()

--- a/webserver/service-common/src/main/java/io/helidon/webserver/servicecommon/HelidonFeatureSupport.java
+++ b/webserver/service-common/src/main/java/io/helidon/webserver/servicecommon/HelidonFeatureSupport.java
@@ -190,7 +190,7 @@ public abstract class HelidonFeatureSupport implements FeatureSupport {
                     .ifPresent(restServiceSettingsBuilder::routing);
 
             config.get(CorsEnabledServiceHelper.CORS_CONFIG_KEY)
-                    .map(CrossOriginConfig::create)
+                    .as(CrossOriginConfig::create)
                     .ifPresent(this::crossOriginConfig);
 
             return identity();


### PR DESCRIPTION
### Description

Both `Config.map(Function)` and `Config.mapList(Function)` are deprecated.
Replace usages with their alternative `Config.as(Function)` and `Config(Function)`

Alternatives are only available with `io.helidon.config.Config`, so use `Config.config` to wrap `io.helidon.common.config.Config` where needed.

### Documentation

None.
