### PR TITLE
Fix: Http1ServerResponse.sink() does not mark response as having an entity

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -310,7 +310,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         for (SinkProvider<?> p : SINK_PROVIDERS) {
             if (p.supports(sinkType, request)) {
                 try {
-                    return (X) p.create(new SinkProviderContext() {
+                    X sink = (X) p.create(new SinkProviderContext() {
                         @Override
                         public ServerResponse serverResponse() {
                             return Http1ServerResponse.this;
@@ -335,9 +335,13 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                             };
                         }
                     });
+                    this.isSent = true;
+                    return sink;
                 } catch (UnsupportedOperationException e) {
                     // deprecated - will be removed in 5.x
-                    return (X) p.create(this, this::handleSinkData, this::commit);
+                    X sink = (X) p.create(this, this::handleSinkData, this::commit);
+                    this.isSent = true;
+                    return sink;
                 }
             }
         }


### PR DESCRIPTION
## Bug Fix: Http1ServerResponse.sink() does not mark response as having an entity

### Problem
When `Http1ServerResponse.sink()` creates an SSE sink, it writes status+headers to the wire immediately, but never marks the response as having an entity. This causes Helidon's routing layer to throw:

```
IllegalStateException: A route MUST call either send, reroute, or next on ServerResponse
```

even though the response was already sent via the sink.

### Root Cause
- `isSent` is only set in the sink's `closeRunnable()`, which runs when the sink closes
- `streamingEntity` is only set by `outputStream()`, which SSE sinks bypass entirely
- After the handler returns, `hasEntity()` returns `false`, triggering the false error

### Solution
Set `isSent = true` immediately after `p.create()` succeeds in the `sink()` method, because the sink's constructor already writes status+headers to the wire and has taken control of the response.

### Changes
- `helidon/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java`
  - Line ~313: Primary sink creation path - capture sink, set `isSent`, return
  - Line ~343: Deprecated fallback path - capture sink, set `isSent`, return

### Testing
Verified with Server-Sent Events (SSE) handlers that emit events without calling `res.send()`. The routing layer now correctly recognizes the response as handled without requiring workarounds.

### Impact
This fix allows SSE-based handlers to work correctly without requiring developers to call `res.send()` after emitting SSE events (which was a workaround for this bug).