### PR TITLE
Fix #11299: Prevent write-after-done error in metrics OPTIONS request

### DIFF
--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -314,6 +314,7 @@ class MetricsFeature {
             res.header(ALLOW, "GET");
             res.status(METHOD_NOT_ALLOWED_405);
             res.send();
+            return; 
         }
 
         getOrOptionsMatching(mediaType, req, res, () -> outputMetadata(mediaType,


### PR DESCRIPTION
Prevents write-after-done error when OPTIONS request has unrecognized media type. Method now properly returns after sending error response instead of continuing execution.


### Description

Fixes #11299: Prevent write-after-done error in metrics OPTIONS request

The `MetricsFeature#optionsMatching` method fails to return after sending an error response for unrecognized media types on OPTIONS requests to the `/metrics` endpoint. This causes the method to continue execution and attempt to send additional data to an already-closed response, resulting in a "write-after-done" error.

**Problem Reproduction:**
```bash
curl -H "Accept: x/x" -X OPTIONS http://localhost:8080/metrics

### Documentation
Root Cause: The optionsMatching method sends a 405 METHOD_NOT_ALLOWED response when bestAcceptedForMetadata(req) returns null (indicating an unrecognized media type), but then continues execution instead of returning. This causes the subsequent call to getOrOptionsMatching() to attempt further writes to the closed response.

Solution: Added a missing return statement immediately after sending the error response in the optionsMatching method to prevent continued execution.

If enhancement: provide description with example code/config snippet or pointer to issue with the description

If feature: summarize feature and provide pointer to doc issue

None - This is a bug fix for incorrect error handling. No documentation changes required.
