### PR TITLE
Support Optional declarative client 404 responses

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
@@ -467,7 +467,7 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         var returnType = method.returnType();
         boolean useGenericType;
         String genericTypeField;
-        if (hasResponse && !returnType.typeArguments().isEmpty() && !returnType.isOptional()) {
+        if (hasResponse && !returnType.typeArguments().isEmpty()) {
             // we have a return type, and it has type arguments
             useGenericType = true;
             TypeName genType = TypeName.builder(TypeNames.GENERIC_TYPE)

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceClient.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceClient.java
@@ -16,8 +16,11 @@
 
 package io.helidon.declarative.tests.http;
 
+import java.util.Optional;
+
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.Http;
+import io.helidon.json.JsonObject;
 import io.helidon.webclient.api.RestClient;
 
 /**
@@ -35,4 +38,19 @@ public interface GreetServiceClient extends GreetService {
     @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
     @RestClient.ComputedHeader(name = ClientHeaderFunction.HEADER_NAME, function = ClientHeaderFunction.SERVICE_NAME)
     String getDefaultMessageHandlerPlain();
+
+    @Http.GET
+    @Http.Path("/optional-present/{name}")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    Optional<JsonObject> optionalMessage(@Http.PathParam("name") String name);
+
+    @Http.GET
+    @Http.Path("/optional/empty")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    Optional<JsonObject> optionalMessageEmpty();
+
+    @Http.GET
+    @Http.Path("/optional/not-found")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    Optional<JsonObject> optionalMessageNotFound();
 }

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceClient.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,4 +53,9 @@ public interface GreetServiceClient extends GreetService {
     @Http.Path("/optional/not-found")
     @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
     Optional<JsonObject> optionalMessageNotFound();
+
+    @Http.GET
+    @Http.Path("/optional/not-found/handled")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    Optional<JsonObject> optionalMessageNotFoundHandled();
 }

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
@@ -169,6 +169,26 @@ class GreetServiceEndpoint implements GreetService {
         return "Success";
     }
 
+    @Http.GET
+    @Http.Path("/optional-present/{name}")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    JsonObject optionalMessage(@Http.PathParam("name") String name) {
+        return response(name);
+    }
+
+    @Http.GET
+    @Http.Path("/optional/empty")
+    @RestServer.Status(Status.NO_CONTENT_204_CODE)
+    void optionalMessageEmpty() {
+    }
+
+    @Http.GET
+    @Http.Path("/optional/not-found")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    Optional<JsonObject> optionalMessageNotFound() {
+        return Optional.empty();
+    }
+
     /**
      * Set the greeting to use in future messages.
      *

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
@@ -189,6 +189,13 @@ class GreetServiceEndpoint implements GreetService {
         return Optional.empty();
     }
 
+    @Http.GET
+    @Http.Path("/optional/not-found/handled")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    Optional<JsonObject> optionalMessageNotFoundHandled() {
+        return Optional.empty();
+    }
+
     /**
      * Set the greeting to use in future messages.
      *

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/Optional404ErrorHandler.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/Optional404ErrorHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.tests.http;
+
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.Status;
+import io.helidon.service.registry.Service;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.api.RestClient;
+
+@Service.Singleton
+@SuppressWarnings("deprecation")
+class Optional404ErrorHandler implements RestClient.ErrorHandler {
+    private static final String HANDLED_PATH = "/greet/optional/not-found/handled";
+
+    @Override
+    public boolean handles(String requestUri,
+                           ClientRequestHeaders requestHeaders,
+                           Status status,
+                           io.helidon.http.ClientResponseHeaders headers) {
+        return status == Status.NOT_FOUND_404 && requestUri.endsWith(HANDLED_PATH);
+    }
+
+    @Override
+    public Optional<? extends RuntimeException> handleError(String requestUri,
+                                                            ClientRequestHeaders requestHeaders,
+                                                            HttpClientResponse response) {
+        return Optional.of(new IllegalStateException("optional 404 handled"));
+    }
+
+    @Override
+    public Optional<? extends RuntimeException> handleError(String requestUri,
+                                                            ClientRequestHeaders requestHeaders,
+                                                            ClientResponseTyped<?> typedResponse,
+                                                            GenericType<?> type) {
+        return Optional.of(new IllegalStateException("optional 404 handled"));
+    }
+}

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -210,4 +210,30 @@ class DeclarativeHttpTest {
         assertThat(response.status(), is(Status.OK_200));
         assertThat(response.entity(), is("hello"));
     }
+
+    @Test
+    void testTypedClientOptionalResponse() {
+        GreetServiceClient typedClient = registry.get(Lookup.builder()
+                                                              .addContract(GreetServiceClient.class)
+                                                              .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                              .build());
+
+        JsonObject expected = typedClient.getMessageHandler("optional");
+        var rawPresent = client.get("/greet/optional-present/optional").request(JsonObject.class);
+        assertThat(rawPresent.status(), is(Status.OK_200));
+        assertThat(rawPresent.entity(), is(expected));
+        Optional<JsonObject> present = typedClient.optionalMessage("optional");
+        assertThat(present.isPresent(), is(true));
+        assertThat(present.orElseThrow(), is(expected));
+
+        var rawEmpty = client.get("/greet/optional/empty").request();
+        assertThat(rawEmpty.status(), is(Status.NO_CONTENT_204));
+        Optional<JsonObject> empty = typedClient.optionalMessageEmpty();
+        assertThat(empty.isEmpty(), is(true));
+
+        var rawNotFound = client.get("/greet/optional/not-found").request();
+        assertThat(rawNotFound.status(), is(Status.NOT_FOUND_404));
+        Optional<JsonObject> notFound = typedClient.optionalMessageNotFound();
+        assertThat(notFound.isEmpty(), is(true));
+    }
 }

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -236,4 +236,16 @@ class DeclarativeHttpTest {
         Optional<JsonObject> notFound = typedClient.optionalMessageNotFound();
         assertThat(notFound.isEmpty(), is(true));
     }
+
+    @Test
+    void testTypedClientOptionalResponseCustomErrorHandler() {
+        GreetServiceClient typedClient = registry.get(Lookup.builder()
+                                                              .addContract(GreetServiceClient.class)
+                                                              .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                              .build());
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                       typedClient::optionalMessageNotFoundHandled);
+        assertThat(exception.getMessage(), is("optional 404 handled"));
+    }
 }

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -226,13 +226,15 @@ class DeclarativeHttpTest {
         assertThat(present.isPresent(), is(true));
         assertThat(present.orElseThrow(), is(expected));
 
-        var rawEmpty = client.get("/greet/optional/empty").request();
-        assertThat(rawEmpty.status(), is(Status.NO_CONTENT_204));
+        try (var rawEmpty = client.get("/greet/optional/empty").request()) {
+            assertThat(rawEmpty.status(), is(Status.NO_CONTENT_204));
+        }
         Optional<JsonObject> empty = typedClient.optionalMessageEmpty();
         assertThat(empty.isEmpty(), is(true));
 
-        var rawNotFound = client.get("/greet/optional/not-found").request();
-        assertThat(rawNotFound.status(), is(Status.NOT_FOUND_404));
+        try (var rawNotFound = client.get("/greet/optional/not-found").request()) {
+            assertThat(rawNotFound.status(), is(Status.NOT_FOUND_404));
+        }
         Optional<JsonObject> notFound = typedClient.optionalMessageNotFound();
         assertThat(notFound.isEmpty(), is(true));
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
@@ -16,6 +16,10 @@
 
 package io.helidon.webclient.api;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
 import io.helidon.common.GenericType;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.ClientResponseTrailers;
@@ -50,7 +54,7 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
         T entity;
         RuntimeException thrown;
         try {
-            entity = response.entity().as(entityType);
+            entity = entity(response, entityType);
             thrown = null;
         } catch (RuntimeException e) {
             thrown = e;
@@ -92,5 +96,49 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
     @Override
     public void close() {
         response.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T entity(HttpClientResponse response, GenericType<T> entityType) {
+        GenericType<?> optionalEntityType = optionalEntityType(entityType);
+        if (optionalEntityType != null) {
+            if (noEntity(response)) {
+                return (T) Optional.empty();
+            }
+            return (T) response.entity().asOptional(optionalEntityType);
+        }
+        return response.entity().as(entityType);
+    }
+
+    private static boolean noEntity(HttpClientResponse response) {
+        Status status = response.status();
+        if (status.family() == Status.Family.INFORMATIONAL) {
+            return true;
+        }
+
+        int statusCode = status.code();
+        if (statusCode == Status.NO_CONTENT_204.code()
+                || statusCode == Status.RESET_CONTENT_205.code()
+                || statusCode == Status.NOT_MODIFIED_304.code()
+                || statusCode == Status.NOT_FOUND_404.code()) {
+            return true;
+        }
+
+        return response.headers().contentLength().orElse(-1) == 0;
+    }
+
+    private static GenericType<?> optionalEntityType(GenericType<?> entityType) {
+        if (!Optional.class.equals(entityType.rawType())) {
+            return null;
+        }
+        Type genericType = entityType.type();
+        if (!(genericType instanceof ParameterizedType parameterizedType)) {
+            return null;
+        }
+        Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+        if (actualTypeArguments.length != 1) {
+            return null;
+        }
+        return GenericType.create(actualTypeArguments[0]);
     }
 }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
@@ -24,6 +24,7 @@ import io.helidon.common.GenericType;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.ClientResponseTrailers;
 import io.helidon.http.Status;
+import io.helidon.http.media.ReadableEntity;
 
 class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
     private final HttpClientResponse response;
@@ -102,29 +103,45 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
     private static <T> T entity(HttpClientResponse response, GenericType<T> entityType) {
         GenericType<?> optionalEntityType = optionalEntityType(entityType);
         if (optionalEntityType != null) {
-            if (noEntity(response)) {
+            if (emptyOptionalResponse(response)) {
                 return (T) Optional.empty();
             }
-            return (T) response.entity().asOptional(optionalEntityType);
+            ReadableEntity readableEntity = response.entity();
+            if (response.status() == Status.NOT_FOUND_404) {
+                readableEntity.consume();
+                response.close();
+                return (T) Optional.empty();
+            }
+            if (!readableEntity.hasEntity()) {
+                response.close();
+                return (T) Optional.empty();
+            }
+            return (T) readableEntity.asOptional(optionalEntityType);
         }
         return response.entity().as(entityType);
     }
 
-    private static boolean noEntity(HttpClientResponse response) {
+    private static boolean emptyOptionalResponse(HttpClientResponse response) {
         Status status = response.status();
         if (status.family() == Status.Family.INFORMATIONAL) {
+            response.close();
             return true;
         }
 
         int statusCode = status.code();
         if (statusCode == Status.NO_CONTENT_204.code()
                 || statusCode == Status.RESET_CONTENT_205.code()
-                || statusCode == Status.NOT_MODIFIED_304.code()
-                || statusCode == Status.NOT_FOUND_404.code()) {
+                || statusCode == Status.NOT_MODIFIED_304.code()) {
+            response.close();
             return true;
         }
 
-        return response.headers().contentLength().orElse(-1) == 0;
+        if (response.headers().contentLength().orElse(-1) == 0) {
+            response.close();
+            return true;
+        }
+
+        return false;
     }
 
     private static GenericType<?> optionalEntityType(GenericType<?> entityType) {

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientResponseTypedImpl.java
@@ -106,12 +106,11 @@ class ClientResponseTypedImpl<T> implements ClientResponseTyped<T> {
             if (emptyOptionalResponse(response)) {
                 return (T) Optional.empty();
             }
-            ReadableEntity readableEntity = response.entity();
-            if (response.status() == Status.NOT_FOUND_404) {
-                readableEntity.consume();
+            if (response.status().code() == Status.NOT_FOUND_404.code()) {
                 response.close();
                 return (T) Optional.empty();
             }
+            ReadableEntity readableEntity = response.entity();
             if (!readableEntity.hasEntity()) {
                 response.close();
                 return (T) Optional.empty();

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import io.helidon.common.GenericType;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HttpException;
+import io.helidon.http.Status;
 import io.helidon.service.registry.Service;
 
 @Service.Singleton
@@ -49,6 +50,9 @@ class DefaultErrorHandling implements RestClient.ErrorHandling {
 
     @Override
     public void handle(String uri, ClientRequestHeaders requestHeaders, ClientResponseTyped<?> response, GenericType<?> type) {
+        if (Optional.class.equals(type.rawType()) && response.status() == Status.NOT_FOUND_404) {
+            return;
+        }
         for (RestClient.ErrorHandler errorHandler : errorHandlers) {
             if (errorHandler.handles(uri, requestHeaders, response.status(), response.headers())) {
                 var maybeException = errorHandler.handleError(uri, requestHeaders, response, type);

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
@@ -50,9 +50,6 @@ class DefaultErrorHandling implements RestClient.ErrorHandling {
 
     @Override
     public void handle(String uri, ClientRequestHeaders requestHeaders, ClientResponseTyped<?> response, GenericType<?> type) {
-        if (Optional.class.equals(type.rawType()) && response.status() == Status.NOT_FOUND_404) {
-            return;
-        }
         for (RestClient.ErrorHandler errorHandler : errorHandlers) {
             if (errorHandler.handles(uri, requestHeaders, response.status(), response.headers())) {
                 var maybeException = errorHandler.handleError(uri, requestHeaders, response, type);
@@ -83,6 +80,9 @@ class DefaultErrorHandling implements RestClient.ErrorHandling {
                                                                 ClientRequestHeaders requestHeaders,
                                                                 ClientResponseTyped<?> response,
                                                                 GenericType<?> type) {
+            if (Optional.class.equals(type.rawType()) && response.status() == Status.NOT_FOUND_404) {
+                return Optional.empty();
+            }
             return Optional.of(new HttpException("Failed when invoking a client call to " + requestUri
                                                          + ", status: " + response.status(),
                                                  response.status()));

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
@@ -80,9 +80,8 @@ class DefaultErrorHandling implements RestClient.ErrorHandling {
                                                                 ClientRequestHeaders requestHeaders,
                                                                 ClientResponseTyped<?> response,
                                                                 GenericType<?> type) {
-            if (Optional.class.equals(type.rawType()) 
-                    && response.status() == Status.NOT_FOUND_404) {
-
+            if (Optional.class.equals(type.rawType())
+                    && response.status().code() == Status.NOT_FOUND_404.code()) {
                 return Optional.empty();
             }
             return Optional.of(new HttpException("Failed when invoking a client call to " + requestUri

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultErrorHandling.java
@@ -80,7 +80,9 @@ class DefaultErrorHandling implements RestClient.ErrorHandling {
                                                                 ClientRequestHeaders requestHeaders,
                                                                 ClientResponseTyped<?> response,
                                                                 GenericType<?> type) {
-            if (Optional.class.equals(type.rawType()) && response.status() == Status.NOT_FOUND_404) {
+            if (Optional.class.equals(type.rawType()) 
+                    && response.status() == Status.NOT_FOUND_404) {
+
                 return Optional.empty();
             }
             return Optional.of(new HttpException("Failed when invoking a client call to " + requestUri

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientResponseTypedImplTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientResponseTypedImplTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.api;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.ClientResponseHeaders;
+import io.helidon.http.ClientResponseTrailers;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.media.ReadableEntity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class ClientResponseTypedImplTest {
+    private static final GenericType<Optional<String>> OPTIONAL_STRING = new GenericType<Optional<String>>() { };
+
+    @Test
+    void optionalNotFoundUsesStatusCodeAndClosesWithoutReadingEntity() {
+        TestHttpClientResponse response = new TestHttpClientResponse(Status.create(404, "Missing"));
+
+        var typedResponse = new ClientResponseTypedImpl<>(response, OPTIONAL_STRING);
+
+        assertThat(typedResponse.entity(), is(Optional.empty()));
+        assertThat(response.closed(), is(true));
+        assertThat(response.entityRequested(), is(false));
+        assertThat(response.entityConsumed(), is(false));
+    }
+
+    @Test
+    void defaultErrorHandlingUsesStatusCodeForOptionalNotFound() {
+        DefaultErrorHandling handling = new DefaultErrorHandling(List.of());
+        var response = new TestClientResponseTyped(Status.create(404, "Missing"));
+        ClientRequestHeaders requestHeaders = ClientRequestHeaders.create(WritableHeaders.create());
+
+        assertDoesNotThrow(() -> handling.handle("/missing", requestHeaders, response, OPTIONAL_STRING));
+    }
+
+    private static class TestHttpClientResponse implements HttpClientResponse {
+        private static final ClientResponseHeaders EMPTY_HEADERS =
+                ClientResponseHeaders.create(WritableHeaders.create());
+
+        private final Status status;
+        private final TestReadableEntity entity = new TestReadableEntity();
+        private boolean entityRequested;
+        private boolean closed;
+
+        TestHttpClientResponse(Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public Status status() {
+            return status;
+        }
+
+        @Override
+        public ClientResponseHeaders headers() {
+            return EMPTY_HEADERS;
+        }
+
+        @Override
+        public ClientResponseTrailers trailers() {
+            return ClientResponseTrailers.create();
+        }
+
+        @Override
+        public ClientUri lastEndpointUri() {
+            return ClientUri.create();
+        }
+
+        @Override
+        public ReadableEntity entity() {
+            entityRequested = true;
+            return entity;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        boolean closed() {
+            return closed;
+        }
+
+        boolean entityRequested() {
+            return entityRequested;
+        }
+
+        boolean entityConsumed() {
+            return entity.consumed();
+        }
+    }
+
+    private static class TestClientResponseTyped implements ClientResponseTyped<Optional<String>> {
+        private final Status status;
+
+        TestClientResponseTyped(Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public Status status() {
+            return status;
+        }
+
+        @Override
+        public ClientResponseHeaders headers() {
+            return ClientResponseHeaders.create(WritableHeaders.create());
+        }
+
+        @Override
+        public ClientResponseTrailers trailers() {
+            return ClientResponseTrailers.create();
+        }
+
+        @Override
+        public ClientUri lastEndpointUri() {
+            return ClientUri.create();
+        }
+
+        @Override
+        public Optional<String> entity() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class TestReadableEntity implements ReadableEntity {
+        private boolean consumed;
+
+        @Override
+        public InputStream inputStream() {
+            return fail("Entity should not be read");
+        }
+
+        @Override
+        public <T> T as(GenericType<T> type) {
+            return fail("Entity should not be read");
+        }
+
+        @Override
+        public <T> Optional<T> asOptional(GenericType<T> type) {
+            return fail("Entity should not be read");
+        }
+
+        @Override
+        public boolean hasEntity() {
+            return true;
+        }
+
+        @Override
+        public boolean consumed() {
+            return consumed;
+        }
+
+        @Override
+        public ReadableEntity copy(Runnable entityProcessedRunnable) {
+            return fail("Entity should not be copied");
+        }
+
+        @Override
+        public void consume() {
+            consumed = true;
+        }
+    }
+}

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/GreetService.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/GreetService.java
@@ -103,6 +103,7 @@ public class GreetService implements HttpService {
                 .get("/obtainedQuery", this::obtainedQuery)
                 .get("/pattern with space", this::getDefaultMessageHandler)
                 .put("/greeting", this::updateGreetingHandler)
+                .get("/not-found-with-entity", this::notFoundWithEntity)
                 .get("/contextCheck", this::contextCheck);
     }
 
@@ -238,6 +239,14 @@ public class GreetService implements HttpService {
 
         greeting.set(jo.getString("greeting"));
         response.status(Status.NO_CONTENT_204).send();
+    }
+
+    private void notFoundWithEntity(ServerRequest request, ServerResponse response) {
+        JsonObject jsonErrorObject = JSON.createObjectBuilder()
+                .add("error", "Not Found")
+                .build();
+        response.status(Status.NOT_FOUND_404)
+                .send(jsonErrorObject);
     }
 
     /**

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/RequestTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/RequestTest.java
@@ -18,7 +18,9 @@ package io.helidon.webclient.tests;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.Optional;
 
+import io.helidon.common.GenericType;
 import io.helidon.http.Status;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.http1.Http1ClientRequest;
@@ -113,9 +115,31 @@ class RequestTest extends TestParent {
         JsonObject jsonObject = client.get().requestEntity(JsonObject.class);
         assertThat(jsonObject.getString("message"), is("Hola World!"));
 
-        try (Http1ClientResponse response = client.put("/greeting").submit(JSON_OLD_GREETING)) {
-            assertThat(response.status().code(), is(204));
+        try (Http1ClientResponse restoreResponse = client.put("/greeting").submit(JSON_OLD_GREETING)) {
+            assertThat(restoreResponse.status().code(), is(204));
         }
+    }
+
+    @Test
+    void testOptionalTypedResponseNoContent() {
+        GenericType<Optional<JsonObject>> optionalJson = new GenericType<Optional<JsonObject>>() { };
+
+        var response = noServiceClient().put("/greeting").submit(JSON_NEW_GREETING, optionalJson);
+        assertThat(response.status(), is(Status.NO_CONTENT_204));
+        assertThat(response.entity(), is(Optional.empty()));
+
+        try (Http1ClientResponse restoreResponse = client.put("/greeting").submit(JSON_OLD_GREETING)) {
+            assertThat(restoreResponse.status().code(), is(204));
+        }
+    }
+
+    @Test
+    void testOptionalTypedResponseNotFound() {
+        GenericType<Optional<JsonObject>> optionalJson = new GenericType<Optional<JsonObject>>() { };
+
+        var response = noServiceClient().get("/incorrect").request(optionalJson);
+        assertThat(response.status(), is(Status.NOT_FOUND_404));
+        assertThat(response.entity(), is(Optional.empty()));
     }
 
     @Test

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/RequestTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/RequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,6 +138,15 @@ class RequestTest extends TestParent {
         GenericType<Optional<JsonObject>> optionalJson = new GenericType<Optional<JsonObject>>() { };
 
         var response = noServiceClient().get("/incorrect").request(optionalJson);
+        assertThat(response.status(), is(Status.NOT_FOUND_404));
+        assertThat(response.entity(), is(Optional.empty()));
+    }
+
+    @Test
+    void testOptionalTypedResponseNotFoundWithEntity() {
+        GenericType<Optional<JsonObject>> optionalJson = new GenericType<Optional<JsonObject>>() { };
+
+        var response = noServiceClient().get("/not-found-with-entity").request(optionalJson);
         assertThat(response.status(), is(Status.NOT_FOUND_404));
         assertThat(response.entity(), is(Optional.empty()));
     }


### PR DESCRIPTION
## Summary
- support Optional<T> declarative client methods
- return Optional.empty() for 404 responses (when the client return type is Optional)
- add tests

Fixes #11302