### PR TITLE
Use EngineKit instead of io.helidon.build.common.test.utils.JUnitLaun…

### DIFF
--- a/common/testing/junit5/src/main/java/io/helidon/common/testing/junit5/FileMatchers.java
+++ b/common/testing/junit5/src/main/java/io/helidon/common/testing/junit5/FileMatchers.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.testing.junit5;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Hamcrest matchers for {@link java.nio.file.Path}.
+ */
+public final class FileMatchers {
+    private FileMatchers() {
+    }
+
+    /**
+     * A matcher that tests if a {@link java.nio.file.Path} exists.
+     *
+     * @return matcher validating the {@link java.nio.file.Path} exists
+     */
+    public static Matcher<Path> fileExists() {
+        return new FileExistMatcher();
+    }
+
+    private static final class FileExistMatcher extends TypeSafeMatcher<Path> {
+
+        private FileExistMatcher() {
+        }
+
+        @Override
+        protected boolean matchesSafely(Path actual) {
+            return Files.exists(actual);
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("File exists");
+        }
+
+        @Override
+        protected void describeMismatchSafely(Path path, Description mismatchDescription) {
+            mismatchDescription.appendText("File does not exist: " + path);
+        }
+    }
+}

--- a/service/tests/maven-plugin/pom.xml
+++ b/service/tests/maven-plugin/pom.xml
@@ -45,8 +45,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -55,14 +55,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.build-tools.common</groupId>
-            <artifactId>helidon-build-common-test-utils</artifactId>
-            <version>${version.plugin.helidon-build-tools}</version>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -136,5 +140,28 @@
             </plugin>
         </plugins>
     </build>
-
+    <profiles>
+        <profile>
+            <id>debug-invoker</id>
+            <activation>
+                <property>
+                    <name>env.MAVEN_DEBUG_OPTS</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <configuration>
+                            <environmentVariables>
+                                <!--suppress LongLine -->
+                                <MAVEN_DEBUG_OPTS>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8001</MAVEN_DEBUG_OPTS>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/service/tests/maven-plugin/src/it/projects/test1/postbuild.groovy
+++ b/service/tests/maven-plugin/src/it/projects/test1/postbuild.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,41 @@
  * limitations under the License.
  */
 
-import io.helidon.build.common.test.utils.JUnitLauncher
 import io.helidon.service.tests.inject.maven.plugin.ProjectsTestIT
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.testkit.engine.EngineTestKit
 
-//noinspection GroovyAssignabilityCheck,GrUnresolvedAccess
-JUnitLauncher.builder()
-        .select(ProjectsTestIT.class, "test1", String.class)
-        .parameter("basedir", basedir.getAbsolutePath())
-        .reportsDir(basedir)
-        .outputFile(new File(basedir, "test.log"))
-        .suiteId("helidon-service-maven-plugin-it-test1")
-        .suiteDisplayName("Helidon Service Maven Plugin Integration Test 1")
-        .build()
-        .launch()
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod
+
+def currentThread = Thread.currentThread()
+def originalContextClassLoader = currentThread.getContextClassLoader()
+try {
+    currentThread.setContextClassLoader(getClass().getClassLoader())
+
+    //noinspection GroovyAssignabilityCheck,GrUnresolvedAccess
+    def results = EngineTestKit.engine("junit-jupiter")
+            .selectors(selectMethod(ProjectsTestIT.class, "test1"))
+            .execute()
+
+    def allEvents = results.allEvents()
+    def failures = allEvents.stream()
+            .flatMap { event -> event.getPayload(TestExecutionResult.class).stream() }
+            .flatMap { result -> result.getThrowable().stream() }
+            .toList()
+
+    if (!failures.isEmpty()) {
+        throw failures[0]
+    }
+
+    results.testEvents().assertStatistics { stats -> stats
+            .started(1)
+            .succeeded(1)
+            .failed(0)
+            .aborted(0)
+            .skipped(0)
+    }
+
+    true
+} finally {
+    currentThread.setContextClassLoader(originalContextClassLoader)
+}

--- a/service/tests/maven-plugin/src/it/projects/test2/postbuild.groovy
+++ b/service/tests/maven-plugin/src/it/projects/test2/postbuild.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,42 @@
  * limitations under the License.
  */
 
-import io.helidon.build.common.test.utils.JUnitLauncher
 import io.helidon.service.tests.inject.maven.plugin.ProjectsTestIT
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.testkit.engine.EngineTestKit
 
-//noinspection GroovyAssignabilityCheck,GrUnresolvedAccess
-JUnitLauncher.builder()
-        .select(ProjectsTestIT.class, "test2", String.class)
-        .parameter("basedir", basedir.getAbsolutePath())
-        .reportsDir(basedir)
-        .outputFile(new File(basedir, "test.log"))
-        .suiteId("helidon-service-maven-plugin-it-test2")
-        .suiteDisplayName("Helidon Service Maven Plugin Integration Test 2")
-        .build()
-        .launch()
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod
+
+def currentThread = Thread.currentThread()
+def originalContextClassLoader = currentThread.getContextClassLoader()
+
+try {
+    currentThread.setContextClassLoader(getClass().getClassLoader())
+
+    //noinspection GroovyAssignabilityCheck,GrUnresolvedAccess
+    def results = EngineTestKit.engine("junit-jupiter")
+            .selectors(selectMethod(ProjectsTestIT.class, "test2"))
+            .execute()
+
+    def allEvents = results.allEvents()
+    def failures = allEvents.stream()
+            .flatMap { event -> event.getPayload(TestExecutionResult.class).stream() }
+            .flatMap { result -> result.getThrowable().stream() }
+            .toList()
+
+    if (!failures.isEmpty()) {
+        throw failures[0]
+    }
+
+    results.testEvents().assertStatistics { stats -> stats
+            .started(1)
+            .succeeded(1)
+            .failed(0)
+            .aborted(0)
+            .skipped(0)
+    }
+
+    true
+} finally {
+    currentThread.setContextClassLoader(originalContextClassLoader)
+}

--- a/service/tests/maven-plugin/src/it/projects/test3/postbuild.groovy
+++ b/service/tests/maven-plugin/src/it/projects/test3/postbuild.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,42 @@
  * limitations under the License.
  */
 
-import io.helidon.build.common.test.utils.JUnitLauncher
 import io.helidon.service.tests.inject.maven.plugin.ProjectsTestIT
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.testkit.engine.EngineTestKit
 
-//noinspection GroovyAssignabilityCheck,GrUnresolvedAccess
-JUnitLauncher.builder()
-        .select(ProjectsTestIT.class, "test3", String.class)
-        .parameter("basedir", basedir.getAbsolutePath())
-        .reportsDir(basedir)
-        .outputFile(new File(basedir, "test.log"))
-        .suiteId("helidon-service-maven-plugin-it-test3")
-        .suiteDisplayName("Helidon Service Maven Plugin Integration Test 3")
-        .build()
-        .launch()
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod
+
+def currentThread = Thread.currentThread()
+def originalContextClassLoader = currentThread.getContextClassLoader()
+
+try {
+    currentThread.setContextClassLoader(getClass().getClassLoader())
+
+    //noinspection GroovyAssignabilityCheck,GrUnresolvedAccess
+    def results = EngineTestKit.engine("junit-jupiter")
+            .selectors(selectMethod(ProjectsTestIT.class, "test3"))
+            .execute()
+
+    def allEvents = results.allEvents()
+    def failures = allEvents.stream()
+            .flatMap { event -> event.getPayload(TestExecutionResult.class).stream() }
+            .flatMap { result -> result.getThrowable().stream() }
+            .toList()
+
+    if (!failures.isEmpty()) {
+        throw failures[0]
+    }
+
+    results.testEvents().assertStatistics { stats -> stats
+            .started(1)
+            .succeeded(1)
+            .failed(0)
+            .aborted(0)
+            .skipped(0)
+    }
+
+    true
+} finally {
+    currentThread.setContextClassLoader(originalContextClassLoader)
+}

--- a/service/tests/maven-plugin/src/test/java/io/helidon/service/tests/inject/maven/plugin/ProjectsTestIT.java
+++ b/service/tests/maven-plugin/src/test/java/io/helidon/service/tests/inject/maven/plugin/ProjectsTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
 
 package io.helidon.service.tests.inject.maven.plugin;
 
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import io.helidon.build.common.test.utils.ConfigurationParameterSource;
-
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
 
-import static io.helidon.build.common.test.utils.FileMatchers.fileExists;
+import static io.helidon.common.testing.junit5.FileMatchers.fileExists;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -32,13 +31,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * Integration test that verifies the projects under {@code src/it/projects}.
  */
 public class ProjectsTestIT {
-    @ParameterizedTest
-    @ConfigurationParameterSource("basedir")
+    @Test
     @DisplayName("Test default binding and main class names")
-    void test1(String basedir) {
+    void test1() {
         // test the first project under src/it/projects/test1 (referenced from postbuild.groovy)
         // make sure all the required types are created
-        Path projectPath = Paths.get(basedir);
+        Path projectPath = projectPath("test1");
         Path compiledClasses = projectPath.resolve("target/classes/my/module");
         Path generatedSources = projectPath.resolve("target/generated-sources/annotations/my/module");
 
@@ -66,13 +64,12 @@ public class ProjectsTestIT {
 
     }
 
-    @ParameterizedTest
-    @ConfigurationParameterSource("basedir")
+    @Test
     @DisplayName("Test custom binding and main class names and custom package")
-    void test2(String basedir) {
+    void test2() {
         // test the first project under src/it/projects/test1 (referenced from postbuild.groovy)
         // make sure all the required types are created
-        Path projectPath = Paths.get(basedir);
+        Path projectPath = projectPath("test2");
         Path compiledClasses = projectPath.resolve("target/classes/my/module");
         Path compiledCustomClasses = projectPath.resolve("target/classes/my/updated");
         Path generatedSources = projectPath.resolve("target/generated-sources/annotations/my/module");
@@ -110,13 +107,12 @@ public class ProjectsTestIT {
 
     }
 
-    @ParameterizedTest
-    @ConfigurationParameterSource("basedir")
+    @Test
     @DisplayName("Test binding and main class generation disabled")
-    void test3(String basedir) {
+    void test3() {
         // test the first project under src/it/projects/test1 (referenced from postbuild.groovy)
         // make sure all the required types are created
-        Path projectPath = Paths.get(basedir);
+        Path projectPath = projectPath("test3");
         Path compiledClasses = projectPath.resolve("target/classes/my/module");
         Path generatedSources = projectPath.resolve("target/generated-sources/annotations/my/module");
 
@@ -150,5 +146,15 @@ public class ProjectsTestIT {
                    not(fileExists()));
         assertThat("Compiled service", compiledClasses.resolve("ServiceType.class"), fileExists());
 
+    }
+
+    private Path projectPath(String projectName) {
+        try {
+            var testClasses = Paths.get(getClass().getProtectionDomain()
+                    .getCodeSource().getLocation().toURI());
+            return testClasses.resolve("../it/projects").resolve(projectName).normalize();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Cannot resolve invoker project path for " + projectName, e);
+        }
     }
 }


### PR DESCRIPTION
### Description

Decouple JUnit dependency from build-tools.

- Replace usage of `io.helidon.build.common.test.utils.JUnitLauncher` with `EngineKit`
- Remove parameter resolver, use class protection domain to resolve test-classes
- Remove dependency on `helidon-build-common-test-utils`

### Documentation

None.
