### PR TITLE
[4.x] Change 'requires' to 'requires static' for features API

### DIFF
--- a/tracing/exporter-jaeger/src/main/java/module-info.java
+++ b/tracing/exporter-jaeger/src/main/java/module-info.java
@@ -43,7 +43,7 @@ module io.helidon.tracing.exporter.jaeger {
     requires com.google.protobuf;
     requires java.annotation;
     requires io.grpc.protobuf;
-    requires io.helidon.common.features.api;
+    requires static io.helidon.common.features.api;
 
     exports io.helidon.tracing.exporter.jaeger;
 


### PR DESCRIPTION
### Description
Resolves #11388 

#### Release note
____
Apps or libraries that depend on `helidon-tracing-exporter-jaeger` but did not also include `helidon-common-features-api` would fail at startup with `java.lang.module.FindException: Module io.helidon.common.features.api not found, required by io.helidon.tracing.exporter.jaeger`. Such failures no longer occur.
____

The new Helidon-provided Jaeger exporter's `module-info.java` incorrectly specified a "hard" `requires` instead of a `requires static` for the features API.

This PR fixes that. I verified separately in an _ad hoc_ manual test that without the fix a test app without the features API JAR present failed to start, but with the fix it starts correctly.

### Documentation
No impact.