### PR TITLE
Change 'requires' to 'requires static' for features API in Jaeger exporter

### DIFF
--- a/tracing/exporter-jaeger/src/main/java/module-info.java
+++ b/tracing/exporter-jaeger/src/main/java/module-info.java
@@ -43,7 +43,7 @@ module io.helidon.tracing.exporter.jaeger {
     requires com.google.protobuf;
     requires java.annotation;
     requires io.grpc.protobuf;
-    requires io.helidon.common.features.api;
+    requires static io.helidon.common.features.api;
 
     exports io.helidon.tracing.exporter.jaeger;
 


### PR DESCRIPTION
### Description
Resolves #11394 

Port of #11392 

### Documentation
No impact.