### PR TITLE
Scope SE fault-tolerance handlers to FtService routes

### DIFF
--- a/archetypes/archetypes/src/main/archetype/se/custom/extra-output.xml
+++ b/archetypes/archetypes/src/main/archetype/se/custom/extra-output.xml
@@ -40,23 +40,8 @@
                     <value key="artifactId">helidon-fault-tolerance</value>
                 </map>
             </list>
-            <list key="Main-helidon-imports" if="${extra} contains 'fault-tolerance'">
-                <value>io.helidon.http.Status</value>
-                <value>io.helidon.faulttolerance.BulkheadException</value>
-                <value>io.helidon.faulttolerance.CircuitBreakerOpenException</value>
-                <value>io.helidon.faulttolerance.TimeoutException</value>
-            </list>
             <list key="Main-routing-builder" if="${extra} contains 'fault-tolerance'">
-                <value><![CDATA[.register("/", new FtService())
-                .error(BulkheadException.class,
-                        (req, res, ex) -> res.status(Status.SERVICE_UNAVAILABLE_503).send("bulkhead"))
-                .error(CircuitBreakerOpenException.class,
-                        (req, res, ex) -> res.status(Status.SERVICE_UNAVAILABLE_503).send("circuit breaker"))
-                .error(TimeoutException.class,
-                        (req, res, ex) -> res.status(Status.REQUEST_TIMEOUT_408).send("timeout"))
-                .error(Throwable.class,
-                        (req, res, ex) -> res.status(Status.INTERNAL_SERVER_ERROR_500)
-                                .send(ex.getClass().getName() + ": " + ex.getMessage()))]]>
+                <value><![CDATA[.register("/", new FtService())]]>
                 </value>
             </list>
             <list key="Abstract-tests" if="${extra} contains 'fault-tolerance'">

--- a/archetypes/archetypes/src/main/archetype/se/custom/files/src/main/java/__pkg__/FtService.java.mustache
+++ b/archetypes/archetypes/src/main/archetype/se/custom/files/src/main/java/__pkg__/FtService.java.mustache
@@ -8,10 +8,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.helidon.faulttolerance.Async;
 import io.helidon.faulttolerance.Bulkhead;
 import io.helidon.faulttolerance.CircuitBreaker;
+import io.helidon.faulttolerance.CircuitBreakerOpenException;
 import io.helidon.faulttolerance.Fallback;
 import io.helidon.faulttolerance.FallbackConfig;
 import io.helidon.faulttolerance.Retry;
 import io.helidon.faulttolerance.Timeout;
+import io.helidon.faulttolerance.TimeoutException;
+import io.helidon.http.Status;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.ServerRequest;
@@ -59,7 +62,11 @@ public class FtService implements HttpService {
     private void timeoutHandler(ServerRequest request, ServerResponse response) {
         long sleep = request.path().pathParameters().first("millis").getLong();
 
-        response.send(timeout.invoke(() -> sleep(sleep)));
+        try {
+            response.send(timeout.invoke(() -> sleep(sleep)));
+        } catch (TimeoutException ex) {
+            response.status(Status.REQUEST_TIMEOUT_408).send("timeout");
+        }
     }
 
     private void retryHandler(ServerRequest request, ServerResponse response) {
@@ -68,14 +75,19 @@ public class FtService implements HttpService {
         AtomicInteger call = new AtomicInteger(1);
         AtomicInteger failures = new AtomicInteger();
 
-        response.send(retry.invoke(() -> {
-            int current = call.getAndIncrement();
-            if (current < count) {
-                failures.incrementAndGet();
-                return reactiveFailure();
-            }
-            return "calls/failures: " + current + "/" + failures.get();
-        }));
+        try {
+            response.send(retry.invoke(() -> {
+                int current = call.getAndIncrement();
+                if (current < count) {
+                    failures.incrementAndGet();
+                    return reactiveFailure();
+                }
+                return "calls/failures: " + current + "/" + failures.get();
+            }));
+        } catch (RuntimeException ex) {
+            response.status(Status.INTERNAL_SERVER_ERROR_500)
+                    .send(ex.getClass().getName() + ": " + ex.getMessage());
+        }
     }
 
     private void fallbackHandler(ServerRequest request, ServerResponse response) {
@@ -89,10 +101,14 @@ public class FtService implements HttpService {
 
     private void circuitBreakerHandler(ServerRequest request, ServerResponse response) {
         boolean success = request.path().pathParameters().first("success").getBoolean();
-        if (success) {
-            response.send(circuitBreaker.invoke(this::reactiveData));
-        } else {
-            response.send(circuitBreaker.invoke(this::reactiveFailure));
+        try {
+            if (success) {
+                response.send(circuitBreaker.invoke(this::reactiveData));
+            } else {
+                response.send(circuitBreaker.invoke(this::reactiveFailure));
+            }
+        } catch (CircuitBreakerOpenException ex) {
+            response.status(Status.SERVICE_UNAVAILABLE_503).send("circuit breaker");
         }
     }
 


### PR DESCRIPTION
## Summary
- remove route-wide SE fault-tolerance error handlers from generated `Main`
- keep `Main` limited to registering `FtService`
- handle fault-tolerance-specific exceptions inside generated `FtService`

## Problem
When the SE `custom` starter included fault tolerance together with unrelated routes, the generated `Main` installed global error handlers, including a catch-all `Throwable` handler. That changed exceptions from unrelated routes as well.

In the verified database case, `/db` `NotFoundException` responses that should remain `404` were converted to `500`, causing the generated project tests to fail.

## Fix
Scope the fault-tolerance error handling to `FtService` routes only:
- `TimeoutException` -> `408 timeout`
- `CircuitBreakerOpenException` -> `503 circuit breaker`
- retry exhaustion -> `500` with the generated runtime exception message

## Result
Generated SE starters keep the expected fault-tolerance behavior on FT routes without changing the error handling of unrelated routes such as `/db`.