### PR TITLE
4.x: Fix MapperManager service caching

### DIFF
--- a/common/mapper/src/main/java/io/helidon/common/mapper/MappersFactory.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MappersFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,8 @@ import io.helidon.common.mapper.spi.MapperProvider;
 import io.helidon.service.registry.Service;
 
 @Service.Singleton
-class MappersFactory implements Supplier<Mappers> {
+@SuppressWarnings("removal")
+class MappersFactory implements Supplier<MapperManager> {
     private final List<MapperProvider> mapperProviders;
     private final List<Mapper<?, ?>> mappers;
 
@@ -34,12 +35,12 @@ class MappersFactory implements Supplier<Mappers> {
     }
 
     @Override
-    public Mappers get() {
-        return Mappers.builder()
+    public MapperManager get() {
+        return new MappersImpl(Mappers.builder()
                 .mapperProvidersDiscoverServices(false)
                 .mappersDiscoverServices(false)
                 .update(it -> mappers.forEach(it::addMapper))
                 .update(it -> mapperProviders.forEach(it::addMapperProvider))
-                .build();
+                .buildPrototype());
     }
 }

--- a/common/mapper/src/main/java/io/helidon/common/mapper/MappersImpl.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/MappersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import java.util.function.BiFunction;
 import io.helidon.common.GenericType;
 import io.helidon.common.Weights;
 import io.helidon.common.mapper.spi.MapperProvider;
-import io.helidon.service.registry.Service;
 
 /**
  * Implementation of {@link io.helidon.common.mapper.Mappers}.
@@ -40,7 +39,6 @@ final class MappersImpl implements MapperManager, Mappers {
     private final List<MapperProvider> providers;
     private final MappersConfig prototype;
 
-    @Service.Inject
     MappersImpl() {
         this(MappersConfig.create());
     }

--- a/common/mapper/src/test/java/io/helidon/common/mapper/GlobalManagerTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/GlobalManagerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.mapper;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@SuppressWarnings("removal")
+class GlobalManagerTest {
+    @Test
+    void testGlobalMapperManagerUsesStableServiceInstance() {
+        MapperManager first = MapperManager.global();
+        MapperManager second = MapperManager.global();
+        assertSame(first,
+                   second,
+                   "Repeated global mapper manager lookups should reuse the same service instance");
+    }
+}


### PR DESCRIPTION
### Description

Fixes #11383

Expose `MappersFactory` as the registry-backed `Supplier<MapperManager>` so `Services.get(MapperManager.class)` can reuse the singleton service instance instead of repeatedly constructing a new mapper manager.

This change:
- switches the registry-exposed mapper service from `MappersImpl` to `MappersFactory`
- keeps `MappersImpl` as the implementation only
- adds a regression test proving repeated `MapperManager.global()` lookups return the same service instance

Benchmark:

```text
+----------------------------+-------------+-------------+-------------+-------------+-------------+
| Variant                    | Run 1 req/s | Run 2 req/s | Avg req/s   | Avg latency | Δ vs 4.3.4  |
+----------------------------+-------------+-------------+-------------+-------------+-------------+
| 4.3.4                      | 179,522.66  | 148,213.88  | 163,868.27  | 0.87 ms     | baseline    |
| 4.4.0                      |  19,165.34  |  20,385.67  |  19,775.51  | 10.60 ms    | -87.93%     |
| patched 4.4.0-SNAPSHOT     | 187,530.45  | 199,333.82  | 193,432.14  | 0.69 ms     | +18.04%     |
+----------------------------+-------------+-------------+-------------+-------------+-------------+
```

### Documentation

None
