### PR TITLE
3.x: File ConfigSource fails generating MD5 digest

### DIFF
--- a/config/config/src/main/java/io/helidon/config/FileSourceHelper.java
+++ b/config/config/src/main/java/io/helidon/config/FileSourceHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,12 @@ import java.util.stream.Collectors;
  */
 public final class FileSourceHelper {
 
+    /**
+     * Property used for specifying the algorithm that will be used to generate digest of a config file.
+     */
+    public static final String PROPERTY_DIGEST_ALGORITHM = "io.helidon.config.file.digest.algorithm";
+    static final String ALGORITHM_MD5 = "MD5";
+    static final String ALGORITHM_SHA256 = "SHA-256";
     private static final Logger LOGGER = Logger.getLogger(FileSourceHelper.class.getName());
     private static final int FILE_BUFFER_SIZE = 4096;
 
@@ -110,7 +116,9 @@ public final class FileSourceHelper {
     }
 
     /**
-     * Returns an MD5 digest of the specified file or null if the file cannot be read.
+     * Returns an MD5 digest of the specified file or null if the file cannot be read. If MD5 is not available,
+     * SHA-256 will be used instead. Alternatively, a digest algorithm can be specified using
+     * {@value PROPERTY_DIGEST_ALGORITHM} system property.
      * <p>
      * The file is locked before the reading and the lock is released immediately after the reading.
      *
@@ -219,12 +227,23 @@ public final class FileSourceHelper {
         }
     }
 
-    private static MessageDigest digest() {
-        try {
-            return MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            throw new ConfigException("Cannot get MD5 digest algorithm.", e);
+    static MessageDigest digest() {
+        String algorithm = System.getProperty(PROPERTY_DIGEST_ALGORITHM);
+        if (algorithm == null) {
+            return digest(ALGORITHM_MD5, ALGORITHM_SHA256);
         }
+        return digest(algorithm);
+    }
+
+    private static MessageDigest digest(String... algorithms) {
+        for (String algorithm : algorithms) {
+            try {
+                return MessageDigest.getInstance(algorithm);
+            } catch (NoSuchAlgorithmException e) {
+                LOGGER.log(Level.FINEST, e, () -> "Cannot get " + algorithm + " digest algorithm.");
+            }
+        }
+        throw new ConfigException("Cannot get digest algorithm(s): " + String.join(", ", algorithms));
     }
 
     /**

--- a/config/config/src/test/java/io/helidon/config/FileConfigSourceTest.java
+++ b/config/config/src/test/java/io/helidon/config/FileConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.Provider;
+import java.security.Security;
 import java.util.Optional;
 
 import io.helidon.config.spi.ConfigParser;
@@ -30,11 +32,13 @@ import io.helidon.config.test.infra.TemporaryFolderExt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.typeCompatibleWith;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -120,6 +124,32 @@ public class FileConfigSourceTest {
         assertThat(maybeStamp, not(Optional.empty()));
         Object stamp = maybeStamp.get();
         assertThat(configSource.isModified((byte[]) stamp), is(false));
+    }
+
+    @Test
+    public void testLoadWithoutMD5Digest() {
+        Provider sunProvider = Security.getProvider("SUN");
+        try {
+            Security.removeProvider(sunProvider.getName());
+            FileConfigSource configSource = ConfigSources.file("application.conf").build();
+            Exception e = assertThrows(ConfigException.class, configSource::load);
+            assertThat(e.getMessage(), containsString(FileSourceHelper.ALGORITHM_SHA256));
+        } finally {
+            Security.addProvider(sunProvider);
+        }
+    }
+
+    @Test
+    public void testLoadWithSpecifiedDigestAlgorithm() {
+        String dummyAlgorithm = "dummy-algorithm";
+        System.setProperty(FileSourceHelper.PROPERTY_DIGEST_ALGORITHM, dummyAlgorithm);
+        try {
+            FileConfigSource configSource = ConfigSources.file("application.conf").build();
+            Exception e = assertThrows(ConfigException.class, configSource::load);
+            assertThat(e.getMessage(), containsString(dummyAlgorithm));
+        } finally {
+            System.clearProperty(FileSourceHelper.PROPERTY_DIGEST_ALGORITHM);
+        }
     }
 
     @Test

--- a/config/config/src/test/java/io/helidon/config/FileSourceHelperTest.java
+++ b/config/config/src/test/java/io/helidon/config/FileSourceHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,20 @@ package io.helidon.config;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.Provider;
+import java.security.Security;
 
 import io.helidon.config.test.infra.TemporaryFolderExt;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link io.helidon.config.FileSourceHelper}.
@@ -54,6 +59,36 @@ public class FileSourceHelperTest {
         Files.write(file2.toPath(), "test file2".getBytes());
 
         assertThat(FileSourceHelper.digest(file1.toPath()), not(equalTo(FileSourceHelper.digest(file2.toPath()))));
+    }
+
+    @Test
+    public void testDigestMD5() {
+        MessageDigest md = FileSourceHelper.digest();
+        assertThat(md.getAlgorithm().toUpperCase(), equalTo(FileSourceHelper.ALGORITHM_MD5));
+    }
+
+    @Test
+    public void testDigestSHA256() {
+        Provider sunProvider = Security.getProvider("SUN");
+        try {
+            Security.removeProvider(sunProvider.getName());
+            Exception e = assertThrows(ConfigException.class, FileSourceHelper::digest);
+            assertThat(e.getMessage(), containsString(FileSourceHelper.ALGORITHM_SHA256));
+        } finally {
+            Security.addProvider(sunProvider);
+        }
+    }
+
+    @Test
+    public void testDigestSpecified() {
+        String dummyAlgorithm = "dummy-algorithm";
+        System.setProperty(FileSourceHelper.PROPERTY_DIGEST_ALGORITHM, dummyAlgorithm);
+        try {
+            Exception e = assertThrows(ConfigException.class, FileSourceHelper::digest);
+            assertThat(e.getMessage(), containsString(dummyAlgorithm));
+        } finally {
+            System.clearProperty(FileSourceHelper.PROPERTY_DIGEST_ALGORITHM);
+        }
     }
 
 }


### PR DESCRIPTION
Backport #11233 to 3.x

### Description
When Sun JCE provider is removed, and a FIPS provider is added, retrieving content of a File ConfigSource will fail on generating an MD5 digest.

### Documentation
File ConfigSource will generate a digest using MD5 by default, and will fall back to SHA-256 if it fails. Alternatively,  a digest algorithm can be specified using **io.helidon.config.file.digest.algorithm** system property.

If no doc impact: JavaDoc is updated to reflect the change, but can also be noted on Advance Configuration Topics of Config from the Helidon Documentation.
