### PR TITLE
Fix builder codegen to correctly handle provider "discoverServices"

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
@@ -378,36 +378,14 @@ class BuilderCodegen implements CodegenExtension {
         blueprintTypes.add(prototypeInfo);
 
         // now for each provider, add discoverServices builder option (this is required for our code to work)
-        List<OptionInfo> discoverServicesOptions = newOptions.stream()
-                .filter(it -> it.provider().isPresent() || it.registryService())
-                .map(it -> {
-                    boolean defaultValue = it.provider().map(OptionProvider::discoverServices).orElse(true);
-
-                    String name = it.name() + "DiscoverServices";
-                    String setterName = it.setterName() + "DiscoverServices";
-                    String getterName = it.getterName() + "DiscoverServices";
-                    return OptionInfo.builder()
-                            .accessModifier(it.accessModifier())
-                            .description("Service discovery flag for {@link #" + it.getterName()
-                                                 + "()}. If set to {@code true}, services will be discovered from Java service "
-                                                 + "loader, or Helidon ServiceRegistry.")
-                            .paramDescription("whether to enable automatic service discovery")
-                            .name(name)
-                            .setterName(setterName)
-                            .getterName(getterName)
-                            .builderOptionOnly(true)
-                            .declaredType(TypeNames.PRIMITIVE_BOOLEAN)
-                            .interfaceMethod(it.interfaceMethod())
-                            .defaultValue(defaultConsumer -> defaultConsumer.addContent(String.valueOf(defaultValue)))
-                            .update(optionBuilder -> copyConfiguredForDiscoverServices(it, optionBuilder))
-                            .update(optionBuilder -> it.deprecation().ifPresent(optionBuilder::deprecation))
-                            .build();
-                })
-                .toList();
+        List<OptionInfo> discoverServicesOptions = discoverServicesOptions(newOptions);
+        List<OptionInfo> existingDiscoverServicesOptions = discoverServicesOptions(existingOptions);
 
         // ensure mutability
         newOptions = new ArrayList<>(newOptions);
         newOptions.addAll(discoverServicesOptions);
+        existingOptions = new ArrayList<>(existingOptions);
+        existingOptions.addAll(existingDiscoverServicesOptions);
         configOption(prototypeInfo, newOptions, existingOptions);
         serviceRegistryOption(prototypeInfo, newOptions);
 
@@ -610,6 +588,35 @@ class BuilderCodegen implements CodegenExtension {
                 .merge(configured.merge())
                 .configKey(configured.configKey() + "-discover-services")
         );
+    }
+
+    private List<OptionInfo> discoverServicesOptions(List<OptionInfo> optionInfos) {
+        return optionInfos.stream()
+                .filter(it -> it.provider().isPresent() || it.registryService())
+                .map(it -> {
+                    boolean defaultValue = it.provider().map(OptionProvider::discoverServices).orElse(true);
+
+                    String name = it.name() + "DiscoverServices";
+                    String setterName = it.setterName() + "DiscoverServices";
+                    String getterName = it.getterName() + "DiscoverServices";
+                    return OptionInfo.builder()
+                            .accessModifier(it.accessModifier())
+                            .description("Service discovery flag for {@link #" + it.getterName()
+                                                 + "()}. If set to {@code true}, services will be discovered from Java service "
+                                                 + "loader, or Helidon ServiceRegistry.")
+                            .paramDescription("whether to enable automatic service discovery")
+                            .name(name)
+                            .setterName(setterName)
+                            .getterName(getterName)
+                            .builderOptionOnly(true)
+                            .declaredType(TypeNames.PRIMITIVE_BOOLEAN)
+                            .interfaceMethod(it.interfaceMethod())
+                            .defaultValue(defaultConsumer -> defaultConsumer.addContent(String.valueOf(defaultValue)))
+                            .update(optionBuilder -> copyConfiguredForDiscoverServices(it, optionBuilder))
+                            .update(optionBuilder -> it.deprecation().ifPresent(optionBuilder::deprecation))
+                            .build();
+                })
+                .toList();
     }
 
     private OptionInfo mergeOptions(List<OptionInfo> optionInfos) {

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithInheritedProviderBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/WithInheritedProviderBlueprint.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+@Prototype.Configured
+interface WithInheritedProviderBlueprint extends WithProviderBlueprint {
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.builder.test;
 import java.util.List;
 
 import io.helidon.builder.test.testsubjects.SomeProvider;
+import io.helidon.builder.test.testsubjects.WithInheritedProvider;
 import io.helidon.builder.test.testsubjects.WithProvider;
 import io.helidon.common.Errors;
 import io.helidon.config.Config;
@@ -152,6 +153,17 @@ class ProviderTest {
                 .from(value)
                 .build();
         assertThat(copy.listDiscover(), is(List.of()));
+    }
+
+    @Test
+    void testDisabledDiscoveryOnInheritedBuilder() {
+        SomeProvider.SomeService someService = new DummyService();
+        WithInheritedProvider value = WithInheritedProvider.builder()
+                .listDiscoverDiscoverServices(false)
+                .oneNotDiscover(someService)
+                .build();
+
+        assertThat(value.listDiscover(), is(List.of()));
     }
 
     @Test


### PR DESCRIPTION
... when inheriting from a parent. Added tests.

Resolves #11427 

