### PR TITLE
11433: Prevent extra data requests on zero-length reads

### DIFF
--- a/http/media/media/src/main/java/io/helidon/http/media/ReadableEntityBase.java
+++ b/http/media/media/src/main/java/io/helidon/http/media/ReadableEntityBase.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -301,6 +302,7 @@ public abstract class ReadableEntityBase implements ReadableEntity {
 
         @Override
         public int read(byte[] b, int off, int len) {
+            Objects.checkFromIndexSize(off, len, b.length);
             if (len == 0) {
                 return 0;
             }

--- a/http/media/media/src/test/java/io/helidon/http/media/ReadableEntityBaseTest.java
+++ b/http/media/media/src/test/java/io/helidon/http/media/ReadableEntityBaseTest.java
@@ -113,6 +113,16 @@ class ReadableEntityBaseTest {
         inputStream.close();
     }
 
+    @Test
+    void testZeroLengthReadStillValidatesArguments() throws IOException {
+        try (InputStream inputStream = new ReadableEntityImpl(new Readable(), 1024).inputStream()) {
+            assertThrows(NullPointerException.class, () -> inputStream.read(null, 0, 0));
+        }
+        try (InputStream inputStream = new ReadableEntityImpl(new Readable(), 1024).inputStream()) {
+            assertThrows(IndexOutOfBoundsException.class, () -> inputStream.read(new byte[1], 2, 0));
+        }
+    }
+
     static class Readable implements Function<Integer, BufferData> {
         private boolean done;
 


### PR DESCRIPTION
Resolves #11433

Prevent `ReadableEntityBase` from requesting more data when `InputStream.read(byte[], int, int)` is called with `len == 0`, and add regression coverage for the previous behavior.
