### PR TITLE
Intermittent DbClient MapperTest failure (4.x)

### DIFF
--- a/dbclient/dbclient/src/test/java/io/helidon/dbclient/MapperTest.java
+++ b/dbclient/dbclient/src/test/java/io/helidon/dbclient/MapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves #11425

Backport of #11426 to `helidon-4.x`.

Use fixed date and time examples in `MapperTest` so the DB client mapper coverage does not depend on current daylight saving behavior.
