### PR TITLE
Resolve deprecations in module `helidon-codegen` (27.x)

### DIFF
--- a/codegen/codegen/src/main/java/io/helidon/codegen/Codegen.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/Codegen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,18 +128,6 @@ public class Codegen {
      */
     public static Set<Option<?>> supportedOptions() {
         return SUPPORTED_APT_OPTIONS;
-    }
-
-    /**
-     * Process all types discovered.
-     * This method analyzes the types and invokes each extension with the correct subset.
-     *
-     * @param allTypes all types for this processing round
-     * @deprecated use {@link #process(java.util.List, java.util.List)} instead
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    public void process(List<TypeInfo> allTypes) {
-        process(allTypes, List.of());
     }
 
     /**


### PR DESCRIPTION
Resolves #11455

Remove the deprecated `Codegen.process(List<TypeInfo>)` overload from `helidon-codegen`. The remaining in-repo call paths already use `process(List<TypeInfo>, List<ModuleTypeInfo>)`.

Validation:
- `mvn -pl codegen/apt -am test`
