### PR TITLE
Resolve deprecations in module `helidon-codegen-apt` (27.x)

### DIFF
--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptAnnotationFactory.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptAnnotationFactory.java
@@ -34,7 +34,6 @@ import io.helidon.common.types.TypeNames;
 /**
  * Factory for annotations.
  */
-@SuppressWarnings("removal")
 final class AptAnnotationFactory {
     private AptAnnotationFactory() {
     }

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptContext.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,8 @@ import io.helidon.common.types.TypeName;
 
 /**
  * Annotation processing code generation context.
- * @deprecated this API will be package local in the future, use through Helidon codegen only
  */
-@Deprecated(forRemoval = true, since = "4.1.0")
-public interface AptContext extends CodegenContext {
+interface AptContext extends CodegenContext {
     /**
      * Create context from the processing environment, and a set of additional supported options.
      *

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptContextImpl.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
 
-@SuppressWarnings("removal")
 class AptContextImpl extends CodegenContextBase implements AptContext {
     private static final Pattern SCOPE_PATTERN = Pattern.compile("(\\w+).*classes");
 

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptModuleFactory.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptModuleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import io.helidon.common.types.ModuleInfoOpens;
 import io.helidon.common.types.ModuleTypeInfo;
 import io.helidon.common.types.TypeName;
 
-@SuppressWarnings("removal")
 class AptModuleFactory extends TypeInfoFactoryBase {
     private AptModuleFactory() {
     }

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptProcessor.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptProcessor.java
@@ -39,6 +39,7 @@ import javax.tools.Diagnostic;
 import io.helidon.codegen.Codegen;
 import io.helidon.codegen.CodegenEvent;
 import io.helidon.codegen.CodegenException;
+import io.helidon.codegen.ElementInfoPredicates;
 import io.helidon.codegen.Option;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ModuleTypeInfo;
@@ -56,7 +57,6 @@ import static java.lang.System.Logger.Level.WARNING;
  * This code and its internal interfaces are subject to change or deletion without notice.</b>
  * </p>
  */
-@SuppressWarnings("removal")
 public final class AptProcessor extends AbstractProcessor {
     private static final TypeName GENERATOR = TypeName.create(AptProcessor.class);
 
@@ -238,7 +238,9 @@ public final class AptProcessor extends AbstractProcessor {
         types.values()
                 .stream()
                 .flatMap(element -> {
-                    Optional<TypeInfo> typeInfo = AptTypeInfoFactory.create(ctx, element);
+                    Optional<TypeInfo> typeInfo = AptTypeInfoFactory.create(ctx,
+                                                                            element,
+                                                                            ElementInfoPredicates.ALL_PREDICATE);
 
                     if (typeInfo.isEmpty()) {
                         ctx.logger().log(CodegenEvent.builder()

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptTypeFactory.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,11 +52,8 @@ import static io.helidon.common.types.TypeName.createFromGenericDeclaration;
 
 /**
  * Factory for types.
- *
- * @deprecated this is intended for internal use. This will be a package private type in the future.
  */
-@Deprecated(forRemoval = true, since = "4.2.0")
-public final class AptTypeFactory {
+final class AptTypeFactory {
     private static final Pattern NESTED_TYPES = Pattern.compile("(?<!\\$)\\$(?!\\$)");
 
     private AptTypeFactory() {

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptTypeInfoFactory.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptTypeInfoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,14 +65,8 @@ import static java.util.function.Predicate.not;
 
 /**
  * Factory to analyze processed types and to provide {@link io.helidon.common.types.TypeInfo} for them.
- *
- * @deprecated this is an internal API, all usage should be done through {@code helidon-codegen} APIs,
- *         such as {@link io.helidon.codegen.CodegenContext#typeInfo(io.helidon.common.types.TypeName)};
- *         this type will be package local in the future
  */
-@SuppressWarnings("removal")
-@Deprecated(forRemoval = true)
-public final class AptTypeInfoFactory extends TypeInfoFactoryBase {
+final class AptTypeInfoFactory extends TypeInfoFactoryBase {
 
     // we expect that annotations themselves are not code generated, and can be cached
     private static final Map<TypeName, List<Annotation>> META_ANNOTATION_CACHE = new ConcurrentHashMap<>();
@@ -116,30 +110,6 @@ public final class AptTypeInfoFactory extends TypeInfoFactoryBase {
     }
 
     /**
-     * Create type information from a type element, reading all child elements.
-     *
-     * @param ctx         annotation processor processing context
-     * @param typeElement type element of the type we want to analyze
-     * @return type info for the type element
-     * @throws IllegalArgumentException when the element cannot be resolved into type info (such as if you ask for
-     *                                  a primitive type)
-     * @deprecated this is an internal API, all usage should be done through {@code helidon-codegen} APIs,
-     *         such as {@link io.helidon.codegen.CodegenContext#typeInfo(io.helidon.common.types.TypeName)}
-     */
-    @Deprecated(forRemoval = true)
-    public static Optional<TypeInfo> create(AptContext ctx,
-                                            TypeElement typeElement) {
-
-        TypeName typeName = AptTypeFactory.createTypeName(typeElement.asType()).orElse(null);
-
-        if (typeName == null) {
-            return Optional.empty();
-        }
-
-        return create(ctx, typeName);
-    }
-
-    /**
      * Create type information from a type element.
      *
      * @param ctx              annotation processor processing context
@@ -174,6 +144,7 @@ public final class AptTypeInfoFactory extends TypeInfoFactoryBase {
                                                                                Elements elements) {
         return createTypedElementInfoFromElement(ctx, processedType, v, elements, false);
     }
+
     /**
      * Creates an instance of a {@link io.helidon.common.types.TypedElementInfo} given its type and variable element from
      * annotation processing. If the passed in element is not a {@link io.helidon.common.types.ElementKind#FIELD},
@@ -332,112 +303,6 @@ public final class AptTypeInfoFactory extends TypeInfoFactoryBase {
             AptTypeFactory.createTypeName(enclosingElement).ifPresent(builder::enclosingType);
         }
 
-        Optional.ofNullable(defaultValue).ifPresent(builder::defaultValue);
-
-        return mapElement(ctx, builder.build());
-    }
-
-    /**
-     * Creates an instance of a {@link io.helidon.common.types.TypedElementInfo} given its type and variable element from
-     * annotation processing. If the passed in element is not a {@link io.helidon.common.types.ElementKind#FIELD},
-     * {@link io.helidon.common.types.ElementKind#METHOD},
-     * {@link io.helidon.common.types.ElementKind#CONSTRUCTOR}, or {@link io.helidon.common.types.ElementKind#PARAMETER}
-     * then this method may return empty.
-     * <p>
-     * This method does not include inherited annotations.
-     *
-     * @param ctx      annotation processing context
-     * @param v        the element (from annotation processing)
-     * @param elements the elements
-     * @return the created instance
-     * @deprecated use
-     *         {@link #createTypedElementInfoFromElement(AptContext, io.helidon.common.types.TypeName,
-     *         javax.lang.model.element.Element, javax.lang.model.util.Elements)}
-     *         instead
-     */
-    @Deprecated(since = "4.0.10", forRemoval = true)
-    public static Optional<TypedElementInfo> createTypedElementInfoFromElement(AptContext ctx,
-                                                                               Element v,
-                                                                               Elements elements) {
-        TypeName type = AptTypeFactory.createTypeName(v).orElse(null);
-        TypeMirror typeMirror = null;
-        String defaultValue = null;
-        List<TypedElementInfo> params = List.of();
-        List<TypeName> componentTypeNames = List.of();
-        List<Annotation> elementTypeAnnotations = List.of();
-        Set<String> modifierNames = v.getModifiers()
-                .stream()
-                .map(Modifier::toString)
-                .collect(Collectors.toSet());
-        Set<TypeName> thrownChecked = Set.of();
-
-        if (v instanceof ExecutableElement ee) {
-            typeMirror = Objects.requireNonNull(ee.getReturnType());
-            params = ee.getParameters().stream()
-                    .map(it -> createTypedElementInfoFromElement(ctx, it, elements).orElseThrow(() -> {
-                        return new CodegenException("Failed to create element info for parameter: " + it + ", either it uses "
-                                                            + "invalid type, or it was removed by an element mapper. This would"
-                                                            + " result in an invalid TypeInfo model.",
-                                                    it);
-                    }))
-                    .toList();
-            AnnotationValue annotationValue = ee.getDefaultValue();
-            defaultValue = (annotationValue == null) ? null
-                    : String.valueOf(annotationValue.accept(new ToAnnotationValueVisitor(elements)
-                                                                    .mapBooleanToNull(true)
-                                                                    .mapVoidToNull(true)
-                                                                    .mapBlankArrayToNull(true)
-                                                                    .mapEmptyStringToNull(true)
-                                                                    .mapToSourceDeclaration(true), null));
-
-            thrownChecked = ee.getThrownTypes()
-                    .stream()
-                    .filter(it -> isCheckedException(ctx, it))
-                    .flatMap(it -> AptTypeFactory.createTypeName(it).stream())
-                    .collect(Collectors.toSet());
-        } else if (v instanceof VariableElement ve) {
-            typeMirror = Objects.requireNonNull(ve.asType());
-        }
-
-        if (typeMirror != null) {
-            if (type == null) {
-                Element element = ctx.aptEnv().getTypeUtils().asElement(typeMirror);
-                if (element instanceof TypeElement typeElement) {
-                    type = AptTypeFactory.createTypeName(typeElement, typeMirror)
-                            .orElse(createFromGenericDeclaration(typeMirror.toString()));
-                } else {
-                    type = AptTypeFactory.createTypeName(typeMirror)
-                            .orElse(createFromGenericDeclaration(typeMirror.toString()));
-                }
-            }
-            if (typeMirror instanceof DeclaredType) {
-                List<? extends TypeMirror> args = ((DeclaredType) typeMirror).getTypeArguments();
-                componentTypeNames = args.stream()
-                        .map(AptTypeFactory::createTypeName)
-                        .filter(Optional::isPresent)
-                        .map(Optional::orElseThrow)
-                        .collect(Collectors.toList());
-                elementTypeAnnotations =
-                        createAnnotations(ctx, ((DeclaredType) typeMirror).asElement(), elements);
-            }
-        }
-        String javadoc = ctx.aptEnv().getElementUtils().getDocComment(v);
-        javadoc = javadoc == null || javadoc.isBlank() ? "" : javadoc;
-
-        TypedElementInfo.Builder builder = TypedElementInfo.builder()
-                .description(javadoc)
-                .typeName(type)
-                .componentTypes(componentTypeNames)
-                .elementName(v.getSimpleName().toString())
-                .kind(kind(v.getKind()))
-                .annotations(createAnnotations(ctx, v, elements))
-                .elementTypeAnnotations(elementTypeAnnotations)
-                .elementModifiers(modifiers(ctx, modifierNames))
-                .accessModifier(accessModifier(modifierNames))
-                .throwsChecked(thrownChecked)
-                .parameterArguments(params)
-                .originatingElement(v);
-        AptTypeFactory.createTypeName(v.getEnclosingElement()).ifPresent(builder::enclosingType);
         Optional.ofNullable(defaultValue).ifPresent(builder::defaultValue);
 
         return mapElement(ctx, builder.build());

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/ToAnnotationValueVisitor.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/ToAnnotationValueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,6 @@ class ToAnnotationValueVisitor implements AnnotationValueVisitor<Object, Object>
         return s;
     }
 
-    @SuppressWarnings("removal")
     @Override
     public Object visitType(TypeMirror t, Object o) {
         var maybeType = AptTypeFactory.createTypeName(t);
@@ -143,7 +142,6 @@ class ToAnnotationValueVisitor implements AnnotationValueVisitor<Object, Object>
         return type;
     }
 
-    @SuppressWarnings("removal")
     @Override
     public Object visitEnumConstant(VariableElement c, Object o) {
         var maybeType = AptTypeFactory.createTypeName(c.getEnclosingElement());

--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/package-info.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,5 @@
 
 /**
  * Implementation of codegen tools for Java annotation processing.
- *
- * @see io.helidon.codegen.apt.AptContext
- * @see io.helidon.codegen.apt.AptTypeFactory
- * @see io.helidon.codegen.apt.AptTypeInfoFactory
  */
 package io.helidon.codegen.apt;


### PR DESCRIPTION
Resolves #11456

Narrow the deprecated `codegen/apt` helper types to package scope and remove the obsolete `AptTypeInfoFactory` overloads. This keeps the internal APT model on the supported call paths only.

Validation:
- `mvn -pl codegen/apt -am test`
