### PR TITLE
Resolve deprecations in module `helidon-common-buffers` (27.x)

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/DataReader.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/DataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,30 +34,7 @@ public class DataReader {
     private DataListener listener;
     private Object context;
 
-    /**
-     * Data reader from a supplier of bytes.
-     *
-     * @param bytesSupplier supplier that can be pulled for more data
-     * @deprecated use {@link #create(java.util.function.Supplier)} instead
-     */
-    @Deprecated(forRemoval = true, since = "4.4.0")
-    public DataReader(Supplier<byte[]> bytesSupplier) {
-        this.ignoreLoneEol = false;
-        this.bytesSupplier = bytesSupplier;
-        // we cannot block until data is actually ready to be consumed
-        this.head = new Node(BufferData.EMPTY_BYTES);
-        this.tail = this.head;
-    }
-
-    /**
-     * Data reader from a supplier of bytes.
-     *
-     * @param bytesSupplier supplier that can be pulled for more data
-     * @param ignoreLoneEol ignore LF without CR and CR without LF
-     * @deprecated use {@link #create(java.util.function.Supplier, boolean)} instead
-     */
-    @Deprecated(forRemoval = true, since = "4.4.0")
-    public DataReader(Supplier<byte[]> bytesSupplier, boolean ignoreLoneEol) {
+    private DataReader(Supplier<byte[]> bytesSupplier, boolean ignoreLoneEol) {
         this.ignoreLoneEol = ignoreLoneEol;
         this.bytesSupplier = bytesSupplier;
         // we cannot block until data is actually ready to be consumed
@@ -72,7 +49,7 @@ public class DataReader {
      * @return data reader using the provided supplier and treating only {@code CRLF} as a new line
      */
     public static DataReader create(Supplier<byte[]> bytesSupplier) {
-        return new DataReader(bytesSupplier);
+        return new DataReader(bytesSupplier, false);
     }
 
     /**

--- a/http/media/multipart/src/test/java/io/helidon/http/media/multipart/ReadablePartLengthTest.java
+++ b/http/media/multipart/src/test/java/io/helidon/http/media/multipart/ReadablePartLengthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class ReadablePartLengthTest {
     public void testReadInt() throws IOException {
         MediaContext mediaContext = MediaContext.create();
         WritableHeaders<?> headers = WritableHeaders.create();
-        DataReader dataReader = new DataReader(() -> BUFFER);
+        DataReader dataReader = DataReader.create(() -> BUFFER);
         int index = 0;
         int partLength = 1;
 


### PR DESCRIPTION
Resolves #11459

Remove the deprecated `DataReader` constructors from `helidon-common-buffers` and update the remaining in-repo multipart test to use the supported `DataReader.create(...)` factory.
