### PR TITLE
Resolve deprecations in module `helidon-common-socket` (27.x)

### DIFF
--- a/common/socket/src/main/java/io/helidon/common/socket/HelidonSocket.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/HelidonSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,16 +42,6 @@ public interface HelidonSocket extends SocketContext, Supplier<byte[]> {
      * @return true if connected
      */
     boolean isConnected();
-
-    /**
-     * Read bytes from the socket. This method blocks until at least 1 byte is available.
-     *
-     * @param buffer buffer to read to
-     * @return number of bytes read
-     * @deprecated this method is not used in Helidon, and will be removed
-     */
-    @Deprecated(forRemoval = true, since = "4.4.0")
-    int read(BufferData buffer);
 
     /**
      * Write teh buffer to the underlying socket. This method blocks until all bytes are written.

--- a/common/socket/src/main/java/io/helidon/common/socket/NioSocket.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/NioSocket.java
@@ -122,21 +122,6 @@ public sealed class NioSocket implements HelidonSocket permits TlsNioSocket {
         return delegate.isOpen();
     }
 
-    @SuppressWarnings("removal")
-    @Override
-    public int read(BufferData buffer) {
-        try {
-            if (readBuffer.remaining() == 0) {
-                readBuffer.clear();
-                delegate.read(readBuffer);
-                readBuffer.flip();
-            }
-            return buffer.readFrom(readBuffer);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
     @Override
     public void write(BufferData buffer) {
         try {

--- a/common/socket/src/main/java/io/helidon/common/socket/PlainSocket.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/PlainSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,11 +126,6 @@ public sealed class PlainSocket implements HelidonSocket permits TlsSocket {
     @Override
     public boolean isConnected() {
         return !inputStream.isClosed();
-    }
-
-    @Override
-    public int read(BufferData buffer) {
-        return buffer.readFrom(inputStream);
     }
 
     @Override

--- a/common/socket/src/main/java/io/helidon/common/socket/TlsNioSocket.java
+++ b/common/socket/src/main/java/io/helidon/common/socket/TlsNioSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,15 +178,6 @@ public final class TlsNioSocket extends NioSocket {
     }
 
     @Override
-    public int read(BufferData buffer) {
-        try {
-            return doRead(buffer);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    @Override
     public void write(BufferData buffer) {
         try {
             doWrite(buffer);
@@ -347,38 +338,6 @@ public final class TlsNioSocket extends NioSocket {
         }
     }
 
-    private int doRead(BufferData buf) throws IOException {
-        peerNetData.clear();
-        var bytesRead = read(peerNetData);
-        if (bytesRead > 0) {
-            peerNetData.flip();
-            while (peerNetData.hasRemaining()) {
-                peerAppData.clear();
-                var result = engine.unwrap(peerNetData, peerAppData);
-                switch (result.getStatus()) {
-                case OK:
-                    peerAppData.flip();
-                    break;
-                case BUFFER_OVERFLOW:
-                    peerAppData = bufferOverflow(peerAppData, engine.getSession().getApplicationBufferSize());
-                    break;
-                case BUFFER_UNDERFLOW:
-                    peerNetData = bufferUnderflow(peerNetData, engine.getSession().getApplicationBufferSize());
-                    break;
-                case CLOSED:
-                    close();
-                    return -1;
-                default:
-                    throw new IllegalStateException("Invalid status: " + result.getStatus());
-                }
-            }
-
-        } else if (bytesRead == -1) {
-            engine.closeInbound();
-        }
-        return buf.readFrom(peerAppData);
-    }
-
     private void doWrite(BufferData buffer) throws IOException {
         while (!buffer.consumed()) {
             myAppData.clear();
@@ -444,20 +403,6 @@ public final class TlsNioSocket extends NioSocket {
         }
         newBuffer.put(buffer);
         return newBuffer;
-    }
-
-    private ByteBuffer bufferOverflow(ByteBuffer buf, int proposedCapacity) {
-        if (proposedCapacity > buf.capacity()) {
-            return ByteBuffer.allocate(proposedCapacity);
-        }
-        return buf.compact();
-    }
-
-    private ByteBuffer bufferUnderflow(ByteBuffer buf, int proposedCapacity) {
-        if (proposedCapacity <= buf.capacity()) {
-            return buf;
-        }
-        return ByteBuffer.allocate(proposedCapacity).put(buf.flip());
     }
 
     /**

--- a/webclient/api/src/test/java/io/helidon/webclient/api/BufferedDataWriterTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/BufferedDataWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,11 +134,6 @@ class BufferedDataWriterTest {
         @Override
         public boolean isConnected() {
             return false;
-        }
-
-        @Override
-        public int read(BufferData buffer) {
-            return 0;
         }
 
         @Override

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -893,11 +893,6 @@ header.writeHttp1Header(entityBuffer);
         }
 
         @Override
-        public int read(BufferData buffer) {
-            return 0;
-        }
-
-        @Override
         public void write(BufferData buffer) {
 
         }

--- a/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/DirectSocket.java
+++ b/webserver/testing/junit5/junit5/src/main/java/io/helidon/webserver/testing/junit5/DirectSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,11 +83,6 @@ public class DirectSocket implements HelidonSocket {
     @Override
     public boolean isConnected() {
         return true;
-    }
-
-    @Override
-    public int read(BufferData buffer) {
-        return 0;
     }
 
     @Override


### PR DESCRIPTION
Resolves #11467

Remove the deprecated `HelidonSocket.read(BufferData)` API from `helidon-common-socket`, delete the obsolete socket implementation overrides, and clean up the remaining in-repo test and helper doubles that only implemented the removed method.
