### PR TITLE
Resolve deprecations in module helidon-config-metadata (27.x)

### DIFF
--- a/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/TypeHandler.java
+++ b/config/metadata/codegen/src/main/java/io/helidon/config/metadata/codegen/TypeHandler.java
@@ -157,9 +157,7 @@ class TypeHandler {
         var options = new TreeSet<CmOption>();
         var optionLiterals = annot.annotationValues("options").orElseGet(List::of);
         for (var a : optionLiterals) {
-            if (a.booleanValue("configured").orElse(true)) {
-                options.add(option(a, typeInfo, typeInfo));
-            }
+            options.add(option(a, typeInfo, typeInfo));
         }
         var typeName = typeInfo.typeName().genericTypeName();
         for (var e : typeInfo.elementInfo()) {
@@ -171,15 +169,10 @@ class TypeHandler {
                     if (e.hasAnnotation(ConfigMetadataTypes.OPTIONS)) {
                         var annots = e.annotation(ConfigMetadataTypes.OPTIONS).annotationValues().orElseGet(List::of);
                         for (var a : annots) {
-                            if (a.booleanValue("configured").orElse(true)) {
-                                options.add(option(a, typeInfo, e));
-                            }
+                            options.add(option(a, typeInfo, e));
                         }
                     } else if (e.hasAnnotation(ConfigMetadataTypes.OPTION)) {
-                        var a = e.annotation(ConfigMetadataTypes.OPTION);
-                        if (a.booleanValue("configured").orElse(true)) {
-                            options.add(option(e.annotation(ConfigMetadataTypes.OPTION), typeInfo, e));
-                        }
+                        options.add(option(e.annotation(ConfigMetadataTypes.OPTION), typeInfo, e));
                     }
                 }
             }

--- a/config/metadata/metadata/src/main/java/io/helidon/config/metadata/ConfiguredOption.java
+++ b/config/metadata/metadata/src/main/java/io/helidon/config/metadata/ConfiguredOption.java
@@ -122,14 +122,12 @@ public @interface ConfiguredOption {
 
     /**
      * Set to true if the configuration may be provided by another module not know to us.
-     * The provider must then be configured to {@link Configured#provides()} this type.
-     * In addition, the {@link #providerType()} must be set to the correct service provider interface,
-     * so code can be correctly generated.
+     * The provider must then be configured to {@link Configured#provides()} this type so code can be correctly
+     * generated.
      * <p>
      * If the method returns a list, the provider configuration must be under config key {@code providers} under
      * the configured option. On the same level as {@code providers}, there can be {@code discover-services} boolean
-     * defining whether to look for services from service loader even if not configured in the configuration (this would
-     * override {@link #providerDiscoverServices()} defined on this annotation).
+     * defining whether to look for services from service loader even if not configured in the configuration.
      * <p>
      * Option called {@code myProvider} that returns a single provider, or an {@link java.util.Optional} provider example
      * in configuration:
@@ -145,7 +143,7 @@ public @interface ConfiguredOption {
      * <pre>
      * my-type:
      *   my-providers:
-     *     discover-services: true # default of this value is controlled by annotation
+     *     discover-services: true
      *     providers:
      *       provider-id:
      *         provider-key1: "providerValue"
@@ -155,31 +153,8 @@ public @interface ConfiguredOption {
      * </pre>
      *
      * @return whether this requires a provider with configuration, defaults to {@code false}
-     * @see #providerDiscoverServices()
      */
     boolean provider() default false;
-
-    /**
-     * If {@link #provider()}, this points to the provider interface that is used to discover
-     * implementations.
-     *
-     * @return type of the provider.
-     * @deprecated This attribute is unsupported and will be removed in the next major release
-     */
-    @Deprecated(since = "4.4.0", forRemoval = true)
-    Class<?> providerType() default ConfiguredOption.class;
-
-    /**
-     * Whether to discover all services using a service loader by default.
-     * When set to true, all services discovered by the service loader will be added (even if no configuration
-     * node exists for them). When se to false, only services that have a configuration node will be added.
-     * This can be overridden by {@code discover-services} configuration option under this option's key.
-     *
-     * @return whether to discover services by default for a provider
-     * @deprecated This attribute is unsupported and will be removed in the next major release
-     */
-    @Deprecated(since = "4.4.0", forRemoval = true)
-    boolean providerDiscoverServices() default true;
 
     /**
      * For options that have a predefined set of allowed values.
@@ -202,26 +177,6 @@ public @interface ConfiguredOption {
      * @return whether to merge the child nodes directly with parent node without a key
      */
     boolean mergeWithParent() default false;
-
-    /**
-     * Is this method also available as a public builder method, or is it only used for configuration.
-     *
-     * @return whether the method is also a builder method ({@code true}), or only config method ({@code false})
-     * @deprecated This attribute is unsupported and will be removed in the next major release
-     */
-    @Deprecated(since = "4.4.0", forRemoval = true)
-    boolean builderMethod() default true;
-
-    /**
-     * This can be set to {@code false} for options, where this annotation is used for other purposes, and in fact does not
-     * indicate something to be loaded from configuration.
-     *
-     * @return whether this option should be configured from configuration
-     * @deprecated This attribute is unsupported and will be removed in the next major release
-     */
-    @Deprecated(since = "4.4.0", forRemoval = true)
-    boolean configured() default true;
-
     /**
      * Option kind.
      */

--- a/config/metadata/tests/test-codegen/src/test/java/io/helidon/config/metadata/test/codegen/TypeHandlerTest.java
+++ b/config/metadata/tests/test-codegen/src/test/java/io/helidon/config/metadata/test/codegen/TypeHandlerTest.java
@@ -52,6 +52,7 @@ class TypeHandlerTest {
                         package com.acme;
                         
                         import io.helidon.config.metadata.Configured;
+                        import io.helidon.config.metadata.ConfiguredOption;
                         
                         /**
                          * ACME listener configuration.
@@ -145,6 +146,7 @@ class TypeHandlerTest {
                         package com.acme;
                         
                         import io.helidon.config.metadata.Configured;
+                        import io.helidon.config.metadata.ConfiguredOption;
                         
                         /**
                          * ACME listener configuration.
@@ -230,6 +232,7 @@ class TypeHandlerTest {
                         package com.acme;
                         
                         import io.helidon.config.metadata.Configured;
+                        import io.helidon.config.metadata.ConfiguredOption;
                         
                         /**
                          * ACME listener configuration.
@@ -619,7 +622,6 @@ class TypeHandlerTest {
                         package com.acme;
                         
                         import io.helidon.config.metadata.Configured;
-                        import io.helidon.config.metadata.ConfiguredOption;
                         
                         /**
                          * ACME listener configuration.
@@ -629,8 +631,6 @@ class TypeHandlerTest {
                             @Configured
                             interface Builder extends io.helidon.common.Builder<Builder, AcmeListenerConfig> {
                         
-                                @SuppressWarnings("removal")
-                                @ConfiguredOption(configured = false)
                                 Builder host(String host);
                             }
                         }

--- a/config/tests/config-metadata-meta-api/src/main/java/io/helidon/config/tests/config/metadata/meta/api/MyBuilder.java
+++ b/config/tests/config-metadata-meta-api/src/main/java/io/helidon/config/tests/config/metadata/meta/api/MyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,12 +44,6 @@ class MyBuilder extends AbstractBuilder<MyBuilder, MyTarget> {
 
     // this is not a configured option
     MyBuilder ignored(String ignored) {
-        return this;
-    }
-
-    // this is also not a configured option
-    @ConfiguredOption(configured = false)
-    MyBuilder ignoredToo(String ignored) {
         return this;
     }
 }

--- a/config/tests/config-metadata-processor/src/main/java/io/helidon/config/tests/config/metadata/processor/MyBuilder.java
+++ b/config/tests/config-metadata-processor/src/main/java/io/helidon/config/tests/config/metadata/processor/MyBuilder.java
@@ -46,10 +46,4 @@ class MyBuilder extends AbstractBuilder<MyBuilder, MyTarget> {
     MyBuilder ignored(String ignored) {
         return this;
     }
-
-    // this is also not a configured option
-    @ConfiguredOption(configured = false)
-    MyBuilder ignoredToo(String ignored) {
-        return this;
-    }
 }


### PR DESCRIPTION
Resolves #11471

Remove the deprecated `ConfiguredOption` compatibility attributes from `helidon-config-metadata`, stop the
metadata codegen from reading the removed `configured` flag, and retire the in-repo test fixtures that still used
the deprecated annotation surface.
