### PR TITLE
Remove deprecated FaultTolerance helpers (27.x)

### DIFF
--- a/docs/src/main/asciidoc/se/fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/se/fault-tolerance.adoc
@@ -229,10 +229,9 @@ The supplier `() -> Thread.currentThread()` is executed in a new thread and
 the value it produces printed by the consumer and passed to `thenAccept`.
 
 By default, asynchronous tasks are executed using a _new virtual thread per
-task_ based on the `ExecutorService` defined in
-`io.helidon.faulttolerance.FaultTolerance` and
-configurable by an application. Alternatively, an `ExecutorService` can be specified
-when building a non-standard `Async` instance.
+task_ based on the default `ExecutorService` used by the Fault Tolerance
+module. Alternatively, an `ExecutorService` can be specified when building a
+non-standard `Async` instance.
 
 === Handler Composition
 
@@ -306,8 +305,9 @@ closed to open state
 === Enabling Metrics Programmatically
 
 Metrics can be enabled programmatically either globally or, if disabled globally, individually for
-each command instance. To enable metrics globally, call `FaultTolerance.config(Config)` passing
-a Config instance that sets `ft.metrics.default-enabled=true`. This must be done on application startup,
+each command instance. To enable metrics globally, configure the application `Config` with
+`ft.metrics.default-enabled=true` and make that config available through the service registry, for example
+by calling `io.helidon.service.registry.Services.set(Config.class, config)` on application startup,
 before any command instances are created.
 
 If metrics are not enabled globally, they can be enabled programmatically on each command instance

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,7 +200,7 @@ class CircuitBreakerImpl implements CircuitBreaker {
 
     private void scheduleHalf() {
         schedule.set(executor.submit(
-                FaultTolerance.toDelayedCallable(() -> {
+                FaultTolerance.delayedCallable(() -> {
                     state.compareAndSet(State.OPEN, State.HALF_OPEN);
                     schedule.set(null);
                     return true;

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -20,13 +20,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.configurable.ThreadPoolSupplier;
-import io.helidon.config.Config;
-import io.helidon.service.registry.Services;
 
 import static java.lang.System.Logger.Level.ERROR;
 
@@ -57,45 +54,13 @@ public final class FaultTolerance {
     public static final String FT_METRICS_DEFAULT_ENABLED = "ft.metrics.default-enabled";
 
     private static final System.Logger LOGGER = System.getLogger(FaultTolerance.class.getName());
-    private static final AtomicReference<LazyValue<ExecutorService>> EXECUTOR = new AtomicReference<>();
-    private static final AtomicReference<Config> CONFIG = new AtomicReference<>();
-
-    static {
-        EXECUTOR.set(LazyValue.create(() -> ThreadPoolSupplier.builder()
-                .threadNamePrefix("helidon-ft-")
-                .virtualThreads(true)
-                .build()
-                .get()));
-    }
+    private static final LazyValue<ExecutorService> EXECUTOR = LazyValue.create(() -> ThreadPoolSupplier.builder()
+            .threadNamePrefix("helidon-ft-")
+            .virtualThreads(true)
+            .build()
+            .get());
 
     private FaultTolerance() {
-    }
-
-    /**
-     * Configure Helidon wide defaults from a config instance.
-     * The default is now to use {@link io.helidon.service.registry.Services#get(Class)} to get
-     * a configuration. This method will work as it used to, but fallback will always
-     * be to the config instance provided by service registry.
-     *
-     * @param config config to read fault tolerance configuration
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    public static void config(Config config) {
-        CONFIG.set(config);
-    }
-
-    /**
-     * Configure Helidon wide executor service for Fault Tolerance.
-     *
-     * @param executor executor service to use
-     * @deprecated this method will be removed without replacement; each fault tolerance component that supports executor
-     * service can be configured with such explicitly in its builder
-     * (i.e. {@link io.helidon.faulttolerance.AsyncConfig.Builder#executor(java.util.concurrent.ExecutorService)}). When using
-     * declarative, the executor service can be configured as a named service.
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    public static void executor(Supplier<? extends ExecutorService> executor) {
-        EXECUTOR.set(LazyValue.create(executor::get));
     }
 
     /**
@@ -117,17 +82,7 @@ public final class FaultTolerance {
         return new TypedBuilder<>();
     }
 
-    /**
-     * Converts a {@code Runnable} into another that sleeps for {@code millis} before
-     * executing. Simulates a scheduled executor when using VTs.
-     *
-     * @param runnable the runnable
-     * @param millis the time to sleep
-     * @return the new runnable
-     * @deprecated this method was not intended for public use, and will be removed in a future version of Helidon
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    public static Runnable toDelayedRunnable(Runnable runnable, long millis) {
+    static Runnable delayedRunnable(Runnable runnable, long millis) {
         return () -> {
             try {
                 Thread.sleep(millis);
@@ -139,18 +94,7 @@ public final class FaultTolerance {
         };
     }
 
-    /**
-     * Converts a {@code Callable} into another that sleeps for {@code millis} before
-     * executing. Simulates a scheduled executor when using VTs.
-     *
-     * @param callable the callable
-     * @param millis the time to sleep
-     * @return the new callable
-     * @param <T> type of value returned
-     * @deprecated this method was not intended for public use, and will be removed in a future version of Helidon
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    public static <T> Callable<T> toDelayedCallable(Callable<T> callable, long millis) {
+    static <T> Callable<T> delayedCallable(Callable<T> callable, long millis) {
         return () -> {
             try {
                 Thread.sleep(millis);
@@ -163,15 +107,7 @@ public final class FaultTolerance {
     }
 
     static LazyValue<? extends ExecutorService> executor() {
-        return EXECUTOR.get();
-    }
-
-    static Config config() {
-        var config = CONFIG.get();
-        if (config == null) {
-            return Services.get(Config.class);
-        }
-        return config;
+        return EXECUTOR;
     }
 
     abstract static class BaseBuilder<B extends BaseBuilder<B>> {

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/MetricsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
+import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Gauge;
 import io.helidon.metrics.api.MeterRegistry;
@@ -26,6 +27,7 @@ import io.helidon.metrics.api.Metrics;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
+import io.helidon.service.registry.Services;
 
 import static io.helidon.faulttolerance.FaultTolerance.FT_METRICS_DEFAULT_ENABLED;
 import static io.helidon.metrics.api.Meter.Scope.VENDOR;
@@ -46,7 +48,7 @@ class MetricsUtils {
      * @return value of metrics flag
      */
     static boolean defaultEnabled() {
-        return FaultTolerance.config()
+        return Services.get(Config.class)
                 .get(FT_METRICS_DEFAULT_ENABLED)
                 .asBoolean()
                 .orElse(false);

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ class TimeoutImpl implements Timeout {
             AtomicBoolean callReturned = new AtomicBoolean(false);
             AtomicBoolean interrupted = new AtomicBoolean(false);
 
-            Future<?> monitor = executor.submit(FaultTolerance.toDelayedRunnable(() -> {
+            Future<?> monitor = executor.submit(FaultTolerance.delayedRunnable(() -> {
                 interruptLock.lock();
                 try {
                     if (callReturned.compareAndSet(false, true)) {

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsEnableTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/MetricsEnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.NoSuchElementException;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Tag;
+import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
 
 import org.hamcrest.Matchers;
@@ -41,7 +42,7 @@ class MetricsEnableTest extends CircuitBreakerBaseTest {
 
     @BeforeAll
     static void setupTest() {
-        FaultTolerance.config(Config.empty());      // empty config
+        Services.set(Config.class, Config.empty());      // empty config
     }
 
     @Test

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryMetricsTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,10 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import io.helidon.config.Config;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.Tag;
 import io.helidon.testing.junit5.Testing;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -33,11 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Testing.Test
 class RetryMetricsTest {
-
-    @BeforeAll
-    static void setupTest() {
-        FaultTolerance.config(Config.create());
-    }
 
     @Test
     void testRetry() {


### PR DESCRIPTION
Resolves #11472

Remove the deprecated public `FaultTolerance` config, executor, and delayed helper methods.
Keep the delayed execution support internal, and update the fault-tolerance tests and docs to use the service-registry config path.
