### PR TITLE
Java 26 AOTCache work-around. See 11346. Can remove after move to 27

### DIFF
--- a/tests/integration/packaging/inject/pom.xml
+++ b/tests/integration/packaging/inject/pom.xml
@@ -206,8 +206,8 @@
                         <groupId>io.helidon.build-tools</groupId>
                         <artifactId>helidon-maven-plugin</artifactId>
                         <configuration>
-                            <!-- Java 26 currently fails to start the generated image with AOT cache enabled. -->
-                            <aotCache>cds</aotCache>
+                            <!-- Java 26 AOTCache work-around. See 11346. Can remove after move to Java 27 -->
+                            <additionalModules>jdk.compiler</additionalModules>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/tests/integration/packaging/se-1/pom.xml
+++ b/tests/integration/packaging/se-1/pom.xml
@@ -215,8 +215,8 @@
                         <groupId>io.helidon.build-tools</groupId>
                         <artifactId>helidon-maven-plugin</artifactId>
                         <configuration>
-                            <!-- Java 26 currently fails to start the generated image with AOT cache enabled. -->
-                            <aotCache>cds</aotCache>
+                            <!-- Java 26 AOTCache work-around. See 11346. Can remove after move to Java 27 -->
+                            <additionalModules>jdk.compiler</additionalModules>
                             <defaultJvmOptions>-Dapp.static.path=../../web</defaultJvmOptions>
                         </configuration>
                     </plugin>


### PR DESCRIPTION

### Description

Update tests that use AOTCache with the proper workaround for a Java 26 bug. See #11346
