### PR TITLE
Preserve Tyrus handshake rejection headers in websocket upgrade failu…

### DIFF
--- a/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusUpgrader.java
+++ b/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/TyrusUpgrader.java
@@ -20,6 +20,7 @@ import java.lang.System.Logger.Level;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -35,6 +36,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.http.DirectHandler;
+import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpPrologue;
@@ -140,12 +142,7 @@ public class TyrusUpgrader extends WsUpgrader {
             return null;
         }
         if (upgradeInfo.getStatus() != WebSocketEngine.UpgradeStatus.SUCCESS) {
-            TyrusUpgradeResponse upgradeResponse = handshake.upgradeResponse();
-            throw RequestException.builder()
-                    .type(DirectHandler.EventType.OTHER)
-                    .status(Status.create(upgradeResponse.getStatus(), upgradeResponse.getReasonPhrase()))
-                    .message("WebSocket handshake rejected")
-                    .build();
+            throw rejectedHandshakeException(handshake.upgradeResponse(), handshake.responseHeaders());
         }
 
         // todo support subprotocols (must be provided by route)
@@ -188,16 +185,28 @@ public class TyrusUpgrader extends WsUpgrader {
         final TyrusUpgradeResponse upgradeResponse = new TyrusUpgradeResponse();
         final WebSocketEngine.UpgradeInfo upgradeInfo = engine.get(routing).upgrade(requestContext, upgradeResponse);
 
-        // Map Tyrus response headers back to Helidon
+        Set<Header> responseHeaders = new LinkedHashSet<>();
         upgradeResponse.getHeaders()
-                .forEach((key, value) -> headers.add(
+                .forEach((key, value) -> responseHeaders.add(
                         HeaderValues.create(
                                 HeaderNames.create(key, key.toLowerCase(Locale.ROOT)),
                                 value)));
-        return new TyrusHandshake(upgradeInfo, upgradeResponse);
+        return new TyrusHandshake(upgradeInfo, upgradeResponse, Set.copyOf(responseHeaders));
     }
 
-    private record TyrusHandshake(WebSocketEngine.UpgradeInfo upgradeInfo, TyrusUpgradeResponse upgradeResponse) {
+    private record TyrusHandshake(WebSocketEngine.UpgradeInfo upgradeInfo,
+                                  TyrusUpgradeResponse upgradeResponse,
+                                  Set<Header> responseHeaders) {
+    }
+
+    static RequestException rejectedHandshakeException(TyrusUpgradeResponse upgradeResponse,
+                                                       Set<Header> responseHeaders) {
+        RequestException.Builder builder = RequestException.builder()
+                .type(DirectHandler.EventType.OTHER)
+                .status(Status.create(upgradeResponse.getStatus(), upgradeResponse.getReasonPhrase()))
+                .message("WebSocket handshake rejected");
+        responseHeaders.forEach(builder::header);
+        return builder.build();
     }
 
     // to initialize Tyrus only once

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketUpgraderTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketUpgraderTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tyrus;
+
+import java.util.Set;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.RequestException;
+import io.helidon.http.Status;
+
+import org.glassfish.tyrus.core.TyrusUpgradeResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class WebSocketUpgraderTest {
+
+    @Test
+    void testRejectedHandshakeHeaders() {
+        TyrusUpgradeResponse upgradeResponse = new TyrusUpgradeResponse();
+        upgradeResponse.setStatus(403);
+        upgradeResponse.setReasonPhrase("Forbidden");
+
+        Header authenticate = HeaderValues.create(HeaderNames.WWW_AUTHENTICATE, "Bearer realm=test");
+        RequestException exception = TyrusUpgrader.rejectedHandshakeException(upgradeResponse, Set.of(authenticate));
+
+        assertThat(exception.status(), is(Status.FORBIDDEN_403));
+        assertThat(exception.responseHeaders().contains(HeaderNames.WWW_AUTHENTICATE), is(true));
+        assertThat(exception.responseHeaders().get(HeaderNames.WWW_AUTHENTICATE).get(), is("Bearer realm=test"));
+    }
+}


### PR DESCRIPTION
### Description

Preserve Tyrus handshake rejection headers in websocket upgrade failures. Relates to issue #11348. Enhancement backported from https://github.com/helidon-io/helidon-microprofile/pull/25/.

### Documentation

None