### PR TITLE
Fix OutputStreamMulti buffer size for write(byte[], off, len)

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamMulti.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamMulti.java
@@ -129,7 +129,7 @@ public class OutputStreamMulti extends OutputStream implements Multi<ByteBuffer>
     }
 
     private void publish(byte[] b, int off, int len) throws IOException {
-        ByteBuffer emitBuffer = ByteBuffer.allocate(len - off);
+        ByteBuffer emitBuffer = ByteBuffer.allocate(len);
         emitBuffer.put(b, off, len);
         emitBuffer.flip();
         doPublish(emitBuffer);

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -119,6 +120,22 @@ public class MultiFromOutputStreamTest {
         ByteBuffer bb = subscriber.getItems().get(0);
         assertThat(new String(bb.array()), is(equalTo("foo")));
     }
+
+    @Test
+    void testByteArrayWriteWithOffset() throws IOException {
+        OutputStreamMulti publisher = IoMulti.outputStreamMulti();
+        TestSubscriber<ByteBuffer> subscriber = new TestSubscriber<>();
+
+        publisher.subscribe(subscriber);
+        subscriber.requestMax();
+
+        publisher.write(new byte[] {10, 20, 30, 40}, 1, 2);
+        publisher.close();
+
+        subscriber.assertItemCount(1).assertComplete();
+        assertArrayEquals(new byte[] {20, 30}, subscriber.getItems().get(0).array());
+    }
+
 
     @Test
     void testCloseOnNoDataWritten() throws IOException {


### PR DESCRIPTION
This change fixes a bug in io.helidon.common.reactive.OutputStreamMulti where write(byte[], int, int) delegates to publish(byte[], int, int), which incorrectly allocated the emit buffer as ByteBuffer.allocate(len - off).

Per the OutputStream contract, the third argument is the number of bytes to write, not an end index. Using len - off can allocate too few bytes when off > 0, causing a BufferOverflowException before the data is published (e.g. write(new byte[] {10, 20, 30, 40}, 1, 2) should emit {20, 30}).

Change: allocate ByteBuffer.allocate(len) and keep put(b, off, len) unchanged.

Regression test: testByteArrayWriteWithOffset in MultiFromOutputStreamTest, matching the scenario in the issue.

This bug was called out while reviewing #11509 but is not introduced by that PR; it is already present on main (see [#11521](https://github.com/helidon-io/helidon/issues/11521)).