### PR TITLE
Fix HTTP/2 Set-Cookie header folding

### DIFF
--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -445,12 +445,21 @@ public class Http2Headers {
         }
 
         for (Header header : headers) {
-            // send all values of the header
-            String value = header.values();
+            HeaderName headerName = header.headerName();
             boolean shouldIndex = !header.changing();
             boolean neverIndex = header.sensitive();
 
-            writeHeader(huffman, table, growingBuffer, header.headerName(), value, shouldIndex, neverIndex);
+            // check count to call header.get() instead of header.allValues()
+            if (header.valueCount() == 1) {
+                writeHeader(huffman, table, growingBuffer, headerName, header.get(), shouldIndex, neverIndex);
+            } else if (headerName == HeaderNames.SET_COOKIE) {      // cannot combine, commas allowed
+                for (String value : header.allValues()) {
+                    writeHeader(huffman, table, growingBuffer, headerName, value, shouldIndex, neverIndex);
+                }
+            } else {
+                String value = header.values();         // send all combined values in single header
+                writeHeader(huffman, table, growingBuffer, headerName, value, shouldIndex, neverIndex);
+            }
         }
     }
 

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SetCookieHeaderTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SetCookieHeaderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.SetCookie;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.testing.junit5.http2.Http2TestClient;
+import io.helidon.webserver.testing.junit5.http2.Http2TestConnection;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.http.Method.GET;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class SetCookieHeaderTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder router) {
+        router.route(Http2Route.route(GET, "/cookies", (req, res) -> {
+            res.headers().addCookie(SetCookie.builder("first-cookie", "value,1")
+                                             .path("/")
+                                             .build());
+            res.headers().addCookie(SetCookie.builder("second-cookie", "value,2")
+                                             .path("/")
+                                             .build());
+            res.send("ok");
+        }));
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder server) {
+        server.addProtocol(Http2Config.builder().build());
+    }
+
+    @Test
+    void testMultiValuedCookie(Http2TestClient client) {
+        Http2TestConnection connection = client.createConnection();
+        connection.request(1, GET, "/cookies", WritableHeaders.create(), BufferData.create(new byte[0]));
+
+        connection.assertSettings(TIMEOUT);
+        connection.assertWindowsUpdate(0, TIMEOUT);
+        connection.assertSettings(TIMEOUT);
+
+        Http2Headers headers = connection.assertHeaders(1, TIMEOUT);
+        assertThat(headers.status(), is(Status.OK_200));
+        assertThat(headers.httpHeaders().contains(HeaderNames.SET_COOKIE), is(true));
+
+        List<String> cookieValues = headers.httpHeaders().get(HeaderNames.SET_COOKIE).allValues();
+        assertThat(cookieValues.size(), is(2));
+
+        SetCookie firstCookie = SetCookie.parse(cookieValues.get(0));
+        SetCookie secondCookie = SetCookie.parse(cookieValues.get(1));
+
+        assertThat(firstCookie.name(), is("first-cookie"));
+        assertThat(firstCookie.value(), is("value,1"));
+        assertThat(firstCookie.path(), is(Optional.of("/")));
+        assertThat(secondCookie.name(), is("second-cookie"));
+        assertThat(secondCookie.value(), is("value,2"));
+        assertThat(secondCookie.path(), is(Optional.of("/")));
+    }
+}


### PR DESCRIPTION
### Description

Fix HTTP/2 Set-Cookie header folding. Emit each Set-Cookie value as a separate HTTP/2 header field instead of joining multi-valued headers with commas. Keep the common single-value path fast and add an HTTP/2 regression test covering cookie values that contain commas. See issue #11542.

### Documentation

None