### PR TITLE
Restore env-backed nested config nodes (27.x)

### DIFF
--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -173,6 +173,13 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <environmentVariables>
+                        <JAVA_HOME>${java.home}</JAVA_HOME>
+                        <HELIDON_ENV_TREE_BRANCH_LEAF>tree-leaf</HELIDON_ENV_TREE_BRANCH_LEAF>
+                        <HELIDON_ENV_TREE_BRANCH_CHILD_GRANDCHILD>tree-grandchild</HELIDON_ENV_TREE_BRANCH_CHILD_GRANDCHILD>
+                        <HELIDON_ENV_TREE_BRANCH_UNDERSCORE_LEAF>underscore-leaf</HELIDON_ENV_TREE_BRANCH_UNDERSCORE_LEAF>
+                        <HELIDON_ENV_TREE_BRANCHES_OTHER>boundary-other</HELIDON_ENV_TREE_BRANCHES_OTHER>
+                        <HELIDON_ENV_TREE_SERVICE_dash_FOO_MAX_dash_POOL_dash_SIZE>42</HELIDON_ENV_TREE_SERVICE_dash_FOO_MAX_dash_POOL_dash_SIZE>
+                        <HELIDON_ENV_TREE_SERVICE_dash_FOO_CORE_dash_POOL_dash_SIZE>21</HELIDON_ENV_TREE_SERVICE_dash_FOO_CORE_dash_POOL_dash_SIZE>
                         <simple>unmapped-env-value</simple>
                         <FOO_BAR>mapped-env-value</FOO_BAR>
                         <_underscore>mapped-env-value</_underscore>

--- a/config/config/src/main/java/io/helidon/config/EnvVars.java
+++ b/config/config/src/main/java/io/helidon/config/EnvVars.java
@@ -16,8 +16,12 @@
 
 package io.helidon.config;
 
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import io.helidon.config.spi.ConfigNode;
@@ -25,12 +29,24 @@ import io.helidon.config.spi.ConfigNode;
 class EnvVars {
     private static final Pattern DISALLOWED_CHARS = Pattern.compile("[^a-zA-Z0-9_]");
     private static final Pattern DISALLOWED_CHARS_ALLOW_DASH = Pattern.compile("[^a-zA-Z0-9_\\-]");
+    private static final Pattern DASH_PATTERN = Pattern.compile("_dash_|_DASH_");
     private static final String UNDERSCORE = "_";
+    private static final String DOUBLE_UNDERSCORE = "__";
+    private static final String DASH = "-";
+    private static final char UNDERSCORE_CHAR = '_';
+    private static final char DOT_CHAR = '.';
+    private static final char DOT_SEPARATOR = '.';
 
     private EnvVars() {
     }
 
     static Optional<ConfigNode> node(String key) {
+        Optional<ConfigNode> mapped = value(key).map(ConfigNode.ValueNode::create);
+
+        return mapped.or(() -> objectNode(key));
+    }
+
+    private static Optional<String> value(String key) {
         /*
             The rules (from most exact to the least exact match):
             1. as is (com.ACME.size)
@@ -44,30 +60,26 @@ class EnvVars {
         // 1. as is
         String result = System.getenv(key);
         if (result != null) {
-            return Optional.of(ConfigNode.ValueNode.create(result));
+            return Optional.of(result);
         }
 
         /*
         2. Replace special chars (., _-)
         com.ACME.t-shirt.size -> com_ACME_t_shirt_size
          */
-        String noSpecials = DISALLOWED_CHARS.matcher(key)
-                .replaceAll(UNDERSCORE);
+        String noSpecials = noSpecials(key);
         result = System.getenv(noSpecials);
         if (result != null) {
-            return Optional.of(ConfigNode.ValueNode.create(result));
+            return Optional.of(result);
         }
 
         /*
         3. Replace special chars except for - (dash), upper case, replace - (dash) with `_dash_`
          */
-        String dashReplacement = DISALLOWED_CHARS_ALLOW_DASH.matcher(key)
-                .replaceAll(UNDERSCORE)
-                .toUpperCase(Locale.ROOT)
-                .replaceAll("-", "_dash_");
+        String dashReplacement = dashReplacement(key);
         result = System.getenv(dashReplacement);
         if (result != null) {
-            return Optional.of(ConfigNode.ValueNode.create(result));
+            return Optional.of(result);
         }
 
         /*
@@ -76,7 +88,7 @@ class EnvVars {
         String dashReplacementUpper = dashReplacement.toUpperCase(Locale.ROOT);
         result = System.getenv(dashReplacementUpper);
         if (result != null) {
-            return Optional.of(ConfigNode.ValueNode.create(result));
+            return Optional.of(result);
         }
 
         /*
@@ -86,9 +98,109 @@ class EnvVars {
         String noSpecialsUppercase = noSpecials.toUpperCase(Locale.ROOT);
         result = System.getenv(noSpecialsUppercase);
         if (result != null) {
-            return Optional.of(ConfigNode.ValueNode.create(result));
+            return Optional.of(result);
         }
 
         return Optional.empty();
+    }
+
+    private static Optional<ConfigNode> objectNode(String key) {
+        if (key.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Set<String> prefixes = prefixes(key);
+        Set<String> candidateKeys = new LinkedHashSet<>();
+
+        System.getenv().keySet().stream()
+                .filter(envKey -> matchesAnyPrefix(envKey, prefixes))
+                .forEach(envKey -> candidateKeys.addAll(candidateKeys(envKey)));
+
+        if (candidateKeys.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<String, String> descendants = new HashMap<>();
+        for (String candidateKey : candidateKeys) {
+            if (isDescendant(key, candidateKey)) {
+                value(candidateKey).ifPresent(value -> descendants.put(relativeKey(key, candidateKey), value));
+            }
+        }
+
+        if (descendants.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(ConfigUtils.mapToObjectNode(descendants, false));
+    }
+
+    private static Set<String> prefixes(String key) {
+        Set<String> result = new LinkedHashSet<>();
+        result.add(key + DOT_SEPARATOR);
+
+        String noSpecials = noSpecials(key);
+        String noSpecialsUppercase = noSpecials.toUpperCase(Locale.ROOT);
+        String dashReplacement = dashReplacement(key);
+        String dashReplacementUpper = dashReplacement.toUpperCase(Locale.ROOT);
+
+        result.add(noSpecials + UNDERSCORE);
+        result.add(noSpecialsUppercase + UNDERSCORE);
+        result.add(dashReplacement + UNDERSCORE);
+        result.add(dashReplacementUpper + UNDERSCORE);
+        return result;
+    }
+
+    private static boolean matchesAnyPrefix(String envKey, Set<String> prefixes) {
+        for (String prefix : prefixes) {
+            if (envKey.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<String> candidateKeys(String envKey) {
+        Set<String> result = new LinkedHashSet<>();
+        result.add(envKey);
+
+        if (shouldAlias(envKey)) {
+            String dotted = DASH_PATTERN.matcher(envKey)
+                    .replaceAll(DASH)
+                    .replace(UNDERSCORE_CHAR, DOT_CHAR);
+            result.add(dotted);
+            result.add(dotted.toLowerCase(Locale.ROOT));
+        }
+
+        return result;
+    }
+
+    private static boolean shouldAlias(String name) {
+        int length = name.length();
+        return length > 2
+                && name.charAt(0) != UNDERSCORE_CHAR
+                && name.charAt(length - 1) != UNDERSCORE_CHAR
+                && name.contains(UNDERSCORE)
+                && !name.contains(DOUBLE_UNDERSCORE);
+    }
+
+    private static boolean isDescendant(String key, String candidateKey) {
+        return candidateKey.startsWith(key)
+                && candidateKey.length() > key.length()
+                && candidateKey.charAt(key.length()) == DOT_SEPARATOR;
+    }
+
+    private static String relativeKey(String key, String candidateKey) {
+        return candidateKey.substring(key.length() + 1);
+    }
+
+    private static String noSpecials(String key) {
+        return DISALLOWED_CHARS.matcher(key).replaceAll(UNDERSCORE);
+    }
+
+    private static String dashReplacement(String key) {
+        return DISALLOWED_CHARS_ALLOW_DASH.matcher(key)
+                .replaceAll(UNDERSCORE)
+                .toUpperCase(Locale.ROOT)
+                .replace("-", "_dash_");
     }
 }

--- a/config/config/src/test/java/io/helidon/config/ConfigSourcesTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigSourcesTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 
@@ -202,6 +203,28 @@ public class ConfigSourcesTest {
     }
 
     @Test
+    public void testEnvironmentVariableParentNode() {
+        String javaHome = System.getenv("JAVA_HOME");
+        assertThat(javaHome, notNullValue());
+
+        Config config = envOnlyConfig();
+
+        assertValue("java.home", javaHome, config);
+        assertThat(config.get("java").exists(), is(true));
+        assertThat(config.get("java").get("home").asString().get(), is(javaHome));
+    }
+
+    @Test
+    public void testEnvironmentVariableDashParentNode() {
+        Config config = envOnlyConfig();
+
+        assertValue("server.executor-service.max-pool-size", "mapped-env-value", config);
+        assertThat(config.get("server.executor-service").exists(), is(true));
+        assertThat(config.get("server.executor-service").get("max-pool-size").asString().get(),
+                   is("mapped-env-value"));
+    }
+
+    @Test
     public void testPrecedence() {
 
         // NOTE: This code should be kept in sync with MpcSourceEnvironmentVariablesTest.testPrecedence(), as we want
@@ -328,5 +351,12 @@ public class ConfigSourcesTest {
 
     static void assertNoValue(final String key, final Config config) {
         assertThat(config.get(key).exists(), is(false));
+    }
+
+    private static Config envOnlyConfig() {
+        return Config.builder()
+                .sources(List.of(ConfigSources::environmentVariables))
+                .disableSystemPropertiesSource()
+                .build();
     }
 }

--- a/config/config/src/test/java/io/helidon/config/EnvVarsTest.java
+++ b/config/config/src/test/java/io/helidon/config/EnvVarsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+import java.util.Map;
+
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.config.spi.ConfigNode.ObjectNode;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
+import static io.helidon.config.ValueNodeMatcher.valueNode;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+class EnvVarsTest {
+    @Test
+    void testValueNodes() {
+        String javaHome = System.getenv("JAVA_HOME");
+        assertThat(javaHome, notNullValue());
+
+        assertValueNode("simple", "unmapped-env-value");
+        assertValueNode("java.home", javaHome);
+        assertValueNode("server.executor-service.max-pool-size", "mapped-env-value");
+        assertValueNode("helidon.env.tree.branch.leaf", "tree-leaf");
+        assertValueNode("helidon.env.tree.service-foo.max-pool-size", "42");
+    }
+
+    @Test
+    void testJavaParentObjectNode() {
+        String javaHome = System.getenv("JAVA_HOME");
+        assertThat(javaHome, notNullValue());
+
+        ObjectNode javaNode = objectNode("java");
+
+        assertThat(javaNode.get("home").value(), optionalValue(is(javaHome)));
+    }
+
+    @Test
+    void testNestedObjectNode() {
+        ObjectNode root = objectNode("helidon.env.tree");
+
+        assertThat(ConfigHelper.flattenNodes(root), is(Map.of(
+                "branch.leaf", "tree-leaf",
+                "branch.child.grandchild", "tree-grandchild",
+                "branch.underscore.leaf", "underscore-leaf",
+                "branches.other", "boundary-other",
+                "service-foo.max-pool-size", "42",
+                "service-foo.core-pool-size", "21"
+        )));
+    }
+
+    @Test
+    void testNestedBranchObjectNodeBoundary() {
+        ObjectNode branch = objectNode("helidon.env.tree.branch");
+
+        assertThat(ConfigHelper.flattenNodes(branch), is(Map.of(
+                "leaf", "tree-leaf",
+                "child.grandchild", "tree-grandchild",
+                "underscore.leaf", "underscore-leaf"
+        )));
+    }
+
+    @Test
+    void testDashParentObjectNode() {
+        ObjectNode serviceFoo = objectNode("helidon.env.tree.service-foo");
+
+        assertThat(ConfigHelper.flattenNodes(serviceFoo), is(Map.of(
+                "max-pool-size", "42",
+                "core-pool-size", "21"
+        )));
+    }
+
+    private static void assertValueNode(String key, String expectedValue) {
+        ConfigNode node = EnvVars.node(key).orElseThrow(() -> new AssertionError("Missing env node for " + key));
+        assertThat(node, instanceOf(ConfigNode.ValueNode.class));
+        assertThat(node, valueNode(expectedValue));
+    }
+
+    private static ObjectNode objectNode(String key) {
+        ConfigNode node = EnvVars.node(key).orElseThrow(() -> new AssertionError("Missing env node for " + key));
+        assertThat(node, instanceOf(ObjectNode.class));
+        return (ObjectNode) node;
+    }
+}


### PR DESCRIPTION
Resolves #11546

Carry forward the 4.x fix for env-backed dotted config keys by restoring parent-node synthesis in `EnvVars` and adding focused regression coverage for nested trees, dash-encoded paths, and `JAVA_HOME` traversal.

Forward-port of #11545.
