### PR TITLE
Resolve deprecations in module helidon-common-mapper (4.x)

### DIFF
--- a/common/mapper/src/main/java/io/helidon/common/mapper/OptionalValue.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/OptionalValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,16 +35,32 @@ public interface OptionalValue<T> extends Value<T> {
      * Create an empty value.
      * Empty value is not backed by data and all of its methods consider it is empty.
      *
+     * @param name       name of the value
+     * @param <T>        type of the value
+     * @param qualifiers qualifiers of the mapper
+     * @return an empty value
+     */
+    static <T> OptionalValue<T> createEmpty(String name, String... qualifiers) {
+        Objects.requireNonNull(name, "Name of the Value must not be null");
+        return new ValueEmpty<>(name, qualifiers);
+    }
+
+    /**
+     * Create an empty value.
+     * Empty value is not backed by data and all of its methods consider it is empty.
+     *
      * @param mapperManager mapper manager to use for mapping types
      * @param name          name of the value
      * @param type          type of the value, to correctly handle mapping exceptions
      * @param <T>           type of the value
      * @param qualifiers    qualifiers of the mapper
      * @return an empty value
+     * @deprecated use {@link #createEmpty(String, String...)}, as mappers are not needed for empty values
      */
+    @Deprecated(forRemoval = true, since = "4.4.1")
     static <T> OptionalValue<T> create(Mappers mapperManager, String name, Class<T> type, String... qualifiers) {
         Objects.requireNonNull(name, "Name of the Value must not be null");
-        return create(mapperManager, name, GenericType.create(type), qualifiers);
+        return createEmpty(name, qualifiers);
     }
 
     /**
@@ -57,10 +73,12 @@ public interface OptionalValue<T> extends Value<T> {
      * @param qualifiers    qualifiers of the mapper
      * @param <T>           type of the value
      * @return an empty value
+     * @deprecated use {@link #createEmpty(String, String...)}, as mappers are not needed for empty values
      */
+    @Deprecated(forRemoval = true, since = "4.4.1")
     static <T> OptionalValue<T> create(Mappers mapperManager, String name, GenericType<T> type, String... qualifiers) {
         Objects.requireNonNull(name, "Name of the Value must not be null");
-        return new ValueEmpty<>(mapperManager, type, name, qualifiers);
+        return createEmpty(name, qualifiers);
     }
 
     /**
@@ -75,7 +93,9 @@ public interface OptionalValue<T> extends Value<T> {
      */
     static <T> OptionalValue<T> create(Mappers mapperManager, String name, T value, String... qualifiers) {
         Objects.requireNonNull(name, "Name of the Value must not be null");
-        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        Objects.requireNonNull(value,
+                               "Value content for Value " + name
+                                       + " must not be null, use createEmpty(String) instead");
         return new ValueBacked<>(mapperManager, name, value, qualifiers);
     }
 
@@ -96,7 +116,9 @@ public interface OptionalValue<T> extends Value<T> {
                                        GenericType<T> type,
                                        String... qualifiers) {
         Objects.requireNonNull(name, "Name of the Value must not be null");
-        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        Objects.requireNonNull(value,
+                               "Value content for Value " + name
+                                       + " must not be null, use createEmpty(String) instead");
         return new ValueBacked<>(mapperManager, name, value, type, qualifiers);
     }
 

--- a/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,9 @@ public interface Value<T> {
      */
     static <T> Value<T> create(Mappers mapperManager, String name, T value, String... qualifiers) {
         Objects.requireNonNull(name, "Name of the Value must not be null");
-        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        Objects.requireNonNull(value,
+                               "Value content for Value " + name
+                                       + " must not be null, use OptionalValue.createEmpty(String) instead");
         return new ValueBacked<>(mapperManager, name, value, qualifiers);
     }
 
@@ -61,7 +63,9 @@ public interface Value<T> {
      */
     static <T> Value<T> create(Mappers mapperManager, String name, T value, GenericType<T> type, String... qualifiers) {
         Objects.requireNonNull(name, "Name of the Value must not be null");
-        Objects.requireNonNull(value, "Value content for Value " + name + " must not be null, use empty(String) instead");
+        Objects.requireNonNull(value,
+                               "Value content for Value " + name
+                                       + " must not be null, use OptionalValue.createEmpty(String) instead");
         return new ValueBacked<>(mapperManager, name, value, type, qualifiers);
     }
 

--- a/common/mapper/src/main/java/io/helidon/common/mapper/ValueEmpty.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/ValueEmpty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,14 +24,10 @@ import java.util.function.Function;
 import io.helidon.common.GenericType;
 
 class ValueEmpty<T> implements OptionalValue<T> {
-    private final Mappers mapperManager;
-    private final GenericType<T> type;
     private final String name;
     private final String[] qualifiers;
 
-    ValueEmpty(Mappers mapperManager, GenericType<T> type, String name, String[] qualifiers) {
-        this.mapperManager = mapperManager;
-        this.type = type;
+    ValueEmpty(String name, String[] qualifiers) {
         this.name = name;
         this.qualifiers = qualifiers;
     }
@@ -52,21 +48,18 @@ class ValueEmpty<T> implements OptionalValue<T> {
         return (OptionalValue<N>) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <N> OptionalValue<N> as(Class<N> type) throws MapperException {
-        GenericType<N> wantedType = GenericType.create(type);
-        if (mapperManager.mapper(this.type, wantedType, qualifiers).isPresent()) {
-            return new ValueEmpty<>(mapperManager, wantedType, name, qualifiers);
-        }
-        throw new MapperException(this.type, wantedType, "Cannot find mapper for " + name());
+        // Empty values can be represented as any target type without invoking mappers.
+        return (OptionalValue<N>) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <N> OptionalValue<N> as(GenericType<N> type) throws MapperException {
-        if (mapperManager.mapper(this.type, type, qualifiers).isPresent()) {
-            return new ValueEmpty<>(mapperManager, type, name, qualifiers);
-        }
-        throw new MapperException(this.type, type, "Cannot find mapper for " + name());
+        // Empty values can be represented as any target type without invoking mappers.
+        return (OptionalValue<N>) this;
     }
 
     @Override

--- a/common/mapper/src/test/java/io/helidon/common/mapper/MapperManagerTestDeprecated.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/MapperManagerTestDeprecated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -209,9 +209,6 @@ class MapperManagerTestDeprecated {
 
     @Test
     void testEmptyValue() {
-        // int -> double
-        // not double to int
-
         MapperManager mapperManager = MapperManager.builder()
                 .useBuiltIn(true)
                 .addMapperProvider((t1, t2, qualifier) -> {
@@ -242,7 +239,10 @@ class MapperManagerTestDeprecated {
         assertThat(doubleValue.isPresent(), is(false));
         assertThat(doubleValue.isEmpty(), is(true));
 
-        assertThrows(MapperException.class, () -> doubleValue.as(Integer.class));
+        integerValue = doubleValue.as(Integer.class);
+        assertThrows(NoSuchElementException.class, integerValue::get);
+        assertThat(integerValue.isPresent(), is(false));
+        assertThat(integerValue.isEmpty(), is(true));
     }
 
     @Test

--- a/common/mapper/src/test/java/io/helidon/common/mapper/MappersTest.java
+++ b/common/mapper/src/test/java/io/helidon/common/mapper/MappersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -222,20 +222,7 @@ class MappersTest {
 
     @Test
     void testEmptyValue() {
-        // int -> double
-        // not double to int
-
-        Mappers mapperManager = Mappers.builder()
-                .useBuiltInMappers(true)
-                .addMapperProvider((t1, t2, qualifier) -> {
-                    if (t1.equals(Integer.class) && t2.equals(Double.class)) {
-                        return new ProviderResponse(MapperProvider.Support.SUPPORTED, anInt -> ((Integer) anInt).doubleValue());
-                    }
-                    return ProviderResponse.unsupported();
-                })
-                .build();
-
-        OptionalValue<String> value = OptionalValue.create(mapperManager, "name", String.class);
+        OptionalValue<String> value = OptionalValue.createEmpty("name");
         assertThrows(NoSuchElementException.class, value::get);
         assertThat(value.isPresent(), is(false));
         assertThat(value.isEmpty(), is(true));
@@ -255,7 +242,24 @@ class MappersTest {
         assertThat(doubleValue.isPresent(), is(false));
         assertThat(doubleValue.isEmpty(), is(true));
 
-        assertThrows(MapperException.class, () -> doubleValue.as(Integer.class));
+        integerValue = doubleValue.as(Integer.class);
+        assertThrows(NoSuchElementException.class, integerValue::get);
+        assertThat(integerValue.isPresent(), is(false));
+        assertThat(integerValue.isEmpty(), is(true));
+    }
+
+    @SuppressWarnings("removal")
+    @Test
+    void testDeprecatedEmptyFactoryMethods() {
+        Mappers mapperManager = Mappers.create();
+
+        OptionalValue<String> classValue = OptionalValue.create(mapperManager, "className", String.class);
+        assertThat(classValue.isEmpty(), is(true));
+        assertThat(classValue.as(Integer.class).isEmpty(), is(true));
+
+        OptionalValue<String> genericValue = OptionalValue.create(mapperManager, "genericName", GenericType.STRING);
+        assertThat(genericValue.isEmpty(), is(true));
+        assertThat(genericValue.as(GenericType.create(Long.class)).isEmpty(), is(true));
     }
 
     @Test


### PR DESCRIPTION
Resolves #11548

Adds `OptionalValue.createEmpty(...)`, deprecates the `Mappers`-based empty factory overloads, and updates empty-value behavior and tests in `helidon-common-mapper`.

This is a needed pre-requeisite for our work in `main`, where we want to remove the methods that are deprecated in this PR.
