### PR TITLE
27: Fixes type use annotations issue

### DIFF
--- a/codegen/apt/src/main/java/io/helidon/codegen/apt/AptTypeFactory.java
+++ b/codegen/apt/src/main/java/io/helidon/codegen/apt/AptTypeFactory.java
@@ -150,12 +150,12 @@ final class AptTypeFactory {
                 default -> throw new IllegalStateException("Unknown primitive type: " + kind);
             };
 
-            return Optional.of(TypeName.create(type));
+            return Optional.of(withTypeUseAnnotations(TypeName.create(type), typeMirror, elements));
         }
 
         switch (kind) {
         case VOID -> {
-            return Optional.of(TypeName.create(void.class));
+            return Optional.of(withTypeUseAnnotations(TypeName.create(void.class), typeMirror, elements));
         }
         case TYPEVAR -> {
             if (!inProgress.add(typeMirror)) {
@@ -170,7 +170,7 @@ final class AptTypeFactory {
                 handleBounds(elements, inProgress, typeVar.getUpperBound(), builder::addUpperBound);
                 handleBounds(elements, inProgress, typeVar.getLowerBound(), builder::addLowerBound);
 
-                return Optional.of(builder.build());
+                return Optional.of(withTypeUseAnnotations(builder.build(), typeMirror, elements));
             } finally {
                 inProgress.remove(typeMirror);
             }
@@ -185,10 +185,10 @@ final class AptTypeFactory {
             handleBounds(elements, inProgress, vt.getExtendsBound(), builder::addUpperBound);
             handleBounds(elements, inProgress, vt.getSuperBound(), builder::addLowerBound);
 
-            return Optional.of(builder.build());
+            return Optional.of(withTypeUseAnnotations(builder.build(), typeMirror, elements));
         }
         case ERROR -> {
-            return Optional.of(TypeName.create(typeMirror.toString()));
+            return Optional.of(withTypeUseAnnotations(TypeName.create(typeMirror.toString()), typeMirror, elements));
         }
         // this is most likely a type that is code generated as part of this round, best effort
         case NONE -> {
@@ -201,10 +201,12 @@ final class AptTypeFactory {
 
         if (typeMirror instanceof ArrayType arrayType) {
             TypeName typeName = createTypeName(elements, inProgress, arrayType.getComponentType()).orElseThrow();
-            return Optional.of(TypeName.builder(typeName)
-                                       .componentType(typeName)
-                                       .array(true)
-                                       .build());
+            return Optional.of(withTypeUseAnnotations(TypeName.builder(typeName)
+                                                       .componentType(typeName)
+                                                       .array(true)
+                                                       .build(),
+                                           typeMirror,
+                                           elements));
         }
 
         if (typeMirror instanceof DeclaredType declaredType) {
@@ -220,15 +222,7 @@ final class AptTypeFactory {
                 return Optional.empty();
             }
 
-            var annotationMirrors = declaredType.getAnnotationMirrors();
-            if (!annotationMirrors.isEmpty() && elements != null) {
-                // we cannot do this if elements is null
-                var newResultBuilder = TypeName.builder(result);
-                for (AnnotationMirror annotationMirror : annotationMirrors) {
-                    newResultBuilder.addAnnotation(AptAnnotationFactory.createAnnotation(annotationMirror, elements));
-                }
-                result = newResultBuilder.build();
-            }
+            result = withTypeUseAnnotations(result, typeMirror, elements);
 
             if (typeParams.isEmpty()) {
                 return Optional.ofNullable(result);
@@ -241,6 +235,36 @@ final class AptTypeFactory {
         }
 
         throw new IllegalStateException("Unknown type mirror: " + typeMirror);
+    }
+
+    /**
+     * Augments the supplied {@link TypeName}, if necessary, to carry any type use annotations present on the supplied
+     * {@link TypeMirror} from which it was originally built, by way of the [@link
+     * AptAnnotationFactory#createAnnotation(AnnotationMirror, Elements)} method.
+     *
+     * <p>This method helps fix <a href="https://github.com/helidon-io/helidon/issues/11532">Github issue 11532</a>.</p>
+     *
+     * @param typeName the non-{@code null} typeName that may need augmenting
+     * @param typeMirror the non-{@code null} {@link TypeMirror} {@code typeName} represents
+     * @param elements an {@link Elements}; if {@code null} no action will be taken
+     * @return the possibly augmented {@link TypeName}, or the supplied {@link TypeName} if no augmentation was needed
+     * @throws NullPointerException if {@code typeName} or {@code typeMirror} is {@code null}
+     */
+    private static TypeName withTypeUseAnnotations(TypeName typeName, TypeMirror typeMirror, Elements elements) {
+        if (elements == null) {
+            return typeName;
+        }
+
+        var annotationMirrors = typeMirror.getAnnotationMirrors();
+        if (annotationMirrors.isEmpty()) {
+            return typeName;
+        }
+
+        var builder = TypeName.builder(typeName);
+        for (AnnotationMirror annotationMirror : annotationMirrors) {
+            builder.addAnnotation(AptAnnotationFactory.createAnnotation(annotationMirror, elements));
+        }
+        return builder.build();
     }
 
     private static void handleBounds(Elements elements,

--- a/codegen/tests/test-codegen-use/src/main/java/io/helidon/codegen/test/codegen/use/TypeUseMarker.java
+++ b/codegen/tests/test-codegen-use/src/main/java/io/helidon/codegen/test/codegen/use/TypeUseMarker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,13 @@
 
 package io.helidon.codegen.test.codegen.use;
 
-import io.helidon.common.Weight;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-@Weight(48)
-final class TriggerType {
-    private transient volatile String field = "value";
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
-    public synchronized final String getField() {
-        return field;
-    }
-
-    public @TypeUseMarker long primitiveValue() {
-        return 48L;
-    }
-
-    public @TypeUseMarker DeclaredValueType declaredValue() {
-        return new DeclaredValueType(48L);
-    }
-
-    public String @TypeUseMarker [] arrayValue() {
-        return new String[0];
-    }
-}
-
-record DeclaredValueType(long value) {
+@Target(TYPE_USE)
+@Retention(CLASS)
+public @interface TypeUseMarker {
 }

--- a/codegen/tests/test-codegen-use/src/test/java/io/helidon/codegen/test/codegen/use/CodegenValidationTest.java
+++ b/codegen/tests/test-codegen-use/src/test/java/io/helidon/codegen/test/codegen/use/CodegenValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,6 +86,17 @@ public class CodegenValidationTest {
 
         assertThat(modifiers, containsString("transient"));
         assertThat(modifiers, containsString("volatile"));
+    }
+
+    @Test
+    void testTypeUseAnnotationsOnMethodReturnTypes() throws ReflectiveOperationException {
+        boolean primitivePresent = (boolean) clazz.getMethod("primitiveMethodTypeUseAnnotationPresent").invoke(instance);
+        boolean declaredPresent = (boolean) clazz.getMethod("declaredMethodTypeUseAnnotationPresent").invoke(instance);
+        boolean arrayPresent = (boolean) clazz.getMethod("arrayMethodTypeUseAnnotationPresent").invoke(instance);
+
+        assertThat("Primitive return type should retain top-level TYPE_USE annotations", primitivePresent, is(true));
+        assertThat("Declared return type should retain top-level TYPE_USE annotations", declaredPresent, is(true));
+        assertThat("Array return type should retain top-level TYPE_USE annotations", arrayPresent, is(true));
     }
 
     @Test

--- a/codegen/tests/test-codegen/src/main/java/io/helidon/codegen/test/codegen/TestCodegenExtension.java
+++ b/codegen/tests/test-codegen/src/main/java/io/helidon/codegen/test/codegen/TestCodegenExtension.java
@@ -37,6 +37,7 @@ import io.helidon.common.types.TypeNames;
 class TestCodegenExtension implements CodegenExtension {
     private static final TypeName CRAZY = TypeName.create("io.helidon.codegen.test.codegen.use.CrazyAnnotation");
     private static final TypeName TARGET = TypeName.create(Target.class);
+    private static final TypeName TYPE_USE_MARKER = TypeName.create("io.helidon.codegen.test.codegen.use.TypeUseMarker");
 
     private final CodegenContext ctx;
 
@@ -170,33 +171,43 @@ class TestCodegenExtension implements CodegenExtension {
                                             .stream()
                                             .map(Modifier::modifierName)
                                             .collect(Collectors.joining(",")))
-                        .addContentLine("\";"));
-
-        typeInfo.elementInfo()
-                .forEach(it -> {
-                    if (it.kind() == ElementKind.METHOD) {
-                        classModel.addMethod(methodMods -> methodMods
-                                .name("methodModifiers")
-                                .returnType(TypeNames.STRING)
-                                .addContent("return \"")
-                                .addContent(it.elementModifiers()
-                                                    .stream()
-                                                    .map(Modifier::modifierName)
-                                                    .collect(Collectors.joining(",")))
-                                .addContentLine("\";"));
-                    }
-                    if (it.kind() == ElementKind.FIELD) {
-                        classModel.addMethod(fieldMods -> fieldMods
-                                .name("fieldModifiers")
-                                .returnType(TypeNames.STRING)
-                                .addContent("return \"")
-                                .addContent(it.elementModifiers()
-                                                    .stream()
-                                                    .map(Modifier::modifierName)
-                                                    .collect(Collectors.joining(",")))
-                                .addContentLine("\";"));
-                    }
-                });
+                        .addContentLine("\";"))
+                .addMethod(methodMods -> methodMods
+                        .name("methodModifiers")
+                        .returnType(TypeNames.STRING)
+                        .addContent("return \"")
+                        .addContent(elementModifiers(typeInfo, ElementKind.METHOD, "getField"))
+                        .addContentLine("\";"))
+                .addMethod(fieldMods -> fieldMods
+                        .name("fieldModifiers")
+                        .returnType(TypeNames.STRING)
+                        .addContent("return \"")
+                        .addContent(elementModifiers(typeInfo, ElementKind.FIELD, "field"))
+                        .addContentLine("\";"))
+                .addMethod(method -> method
+                        .name("primitiveMethodTypeUseAnnotationPresent")
+                        .returnType(TypeNames.PRIMITIVE_BOOLEAN)
+                        .addContentLine("return "
+                                                + hasMethodReturnTypeAnnotation(typeInfo,
+                                                                               "primitiveValue",
+                                                                               TYPE_USE_MARKER)
+                                                + ";"))
+                .addMethod(method -> method
+                        .name("declaredMethodTypeUseAnnotationPresent")
+                        .returnType(TypeNames.PRIMITIVE_BOOLEAN)
+                        .addContentLine("return "
+                                                + hasMethodReturnTypeAnnotation(typeInfo,
+                                                                               "declaredValue",
+                                                                               TYPE_USE_MARKER)
+                                                + ";"))
+                .addMethod(method -> method
+                        .name("arrayMethodTypeUseAnnotationPresent")
+                        .returnType(TypeNames.PRIMITIVE_BOOLEAN)
+                        .addContentLine("return "
+                                                + hasMethodReturnTypeAnnotation(typeInfo,
+                                                                               "arrayValue",
+                                                                               TYPE_USE_MARKER)
+                                                + ";"));
 
         ctx.filer().writeSourceFile(classModel.build());
     }
@@ -237,7 +248,34 @@ class TestCodegenExtension implements CodegenExtension {
                 .build();
     }
 
-    private Annotation targetAnnotation(ElementType elementType) {
+    private static String elementModifiers(TypeInfo typeInfo, ElementKind kind, String elementName) {
+        if (kind != ElementKind.FIELD && kind != ElementKind.METHOD) {
+            throw new IllegalArgumentException("kind: " + kind);
+        }
+        return typeInfo.elementInfo()
+                .stream()
+                .filter(e -> e.kind() == kind && e.elementName().equals(elementName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Failed to find " + kind + " element named: " + elementName))
+                .elementModifiers()
+                .stream()
+                .map(Modifier::modifierName)
+                .collect(Collectors.joining(","));
+    }
+
+    private static boolean hasMethodReturnTypeAnnotation(TypeInfo typeInfo, String methodName, TypeName annotationType) {
+        return typeInfo.elementInfo()
+                .stream()
+                .filter(it -> it.kind() == ElementKind.METHOD && it.elementName().equals(methodName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Failed to find method: " + methodName))
+                .typeName()
+                .annotations()
+                .stream()
+                .anyMatch(it -> it.typeName().equals(annotationType));
+    }
+
+    private static Annotation targetAnnotation(ElementType elementType) {
         return Annotation.builder()
                 .typeName(TARGET)
                 .property("value", elementType)


### PR DESCRIPTION
Resolves #11532

Preserve type-use annotations when converting compiler type mirrors into codegen metadata, including primitive returns, array dimensions and components, type variables, and wildcards. Keep generic variable names separate from their annotations and preserve recursive generic bounds.

Add focused APT regression coverage for annotation placement and generic type structure.
