### PR TITLE
[4.x] Add validation support for MultipleOf constraints

### DIFF
--- a/docs/src/main/asciidoc/se/injection/declarative.adoc
+++ b/docs/src/main/asciidoc/se/injection/declarative.adoc
@@ -295,6 +295,7 @@ Constraints for types that extend `java.lang.Number`. These constraints accept a
 - link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Number.Min.html[`io.helidon.validation.Validation.Number.Min`] - the value must be at least the specified minimal value (`>= min`), value is defined as a `String`
 - link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Number.Max.html[`io.helidon.validation.Validation.Number.Max`] - the value must be at most the specified maximal value (`&lt;= max`), value is defined as a `String`
 - link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Number.Digits.html[`io.helidon.validation.Validation.Number.Digits`] - the number must have at most the specified number of integer and fractional digits
+- link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Number.MultipleOf.html[`io.helidon.validation.Validation.Number.MultipleOf`] - the value must be evenly divisible by the specified positive factor, which is defined as a `String`
 
 Constraints for `Integer` data types. These constraints accept `int, long, byte, char, short` and their boxed counterparts.
 `byte` is always converted as an unsigned number, i.e. its values are from `0` to `255` inclusive.
@@ -302,11 +303,13 @@ These are convenience annotation that use `int` data type:
 
 - link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Integer.Min.html[`io.helidon.validation.Validation.Integer.Min`] - the value must be at least the specified minimal value (`>= min`)
 - link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Integer.Max.html[`io.helidon.validation.Validation.Integer.Max`] - the value must be at most the specified maximal value (`&lt;= max`)
+- link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Integer.MultipleOf.html[`io.helidon.validation.Validation.Integer.MultipleOf`] - the value must be evenly divisible by the specified positive integer factor
 
 Constraints for `Long` and `long` data types. No other type is supported:
 
 - link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Long.Min.html[`io.helidon.validation.Validation.Long.Min`] - the value must be at least the specified minimal value (`>= min`)
 - link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Long.Max.html[`io.helidon.validation.Validation.Long.Max`] - the value must be at most the specified maximal value (`&lt;= max`)
+- link:{validation-javadoc-base-url}/io/helidon/validation/Validation.Long.MultipleOf.html[`io.helidon.validation.Validation.Long.MultipleOf`] - the value must be evenly divisible by the specified positive long factor
 
 Constraints for `Boolean` and `boolean` data type. No other type is supported:
 
@@ -605,4 +608,3 @@ include::{sourcedir}/se/inject/DeclarativeExample.java[tag=snippet_18, indent=0]
 
 To add a declarative health check, create a service that implements io.helidon.health.HealthCheck or produces an instance of it.
 The WebServer health observer discovers all such services and uses them to contribute to the health response. Because the lookup is performed only once, you must not use the @Service.PerRequest scope. The recommended scope is @Service.Singleton.
-

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package io.helidon.validation.tests.validation;
+
+import java.math.BigDecimal;
 
 import io.helidon.testing.junit5.Testing;
 import io.helidon.validation.TypeValidation;
@@ -35,12 +37,12 @@ public class TypeValidationTest {
 
     @Test
     public void validateType() {
-        ValidatedType validatedType = new ValidatedType("test_value", 42);
+        ValidatedType validatedType = new ValidatedType("test_value", 42, new BigDecimal("1.10"));
 
         ValidationResponse response = validator.validate(ValidatedType.class, validatedType);
         assertThat(response.valid(), is(true));
 
-        validatedType = new ValidatedType("test_value", 41);
+        validatedType = new ValidatedType("test_value", 41, new BigDecimal("1.10"));
         response = validator.validate(ValidatedType.class, validatedType);
         assertThat(response.valid(), is(false));
         assertThat(response.message(), is("41 is less than 42"));
@@ -48,10 +50,14 @@ public class TypeValidationTest {
 
     @Test
     public void validateTypeProperty() {
-        var response = validator.validate(ValidatedType.class, new ValidatedType("test_value", 43), "first");
+        var response = validator.validate(ValidatedType.class,
+                                          new ValidatedType("test_value", 43, new BigDecimal("1.10")),
+                                          "first");
         assertThat(response.valid(), is(true));
 
-        response = validator.validate(ValidatedType.class, new ValidatedType("bad_value", 43), "first");
+        response = validator.validate(ValidatedType.class,
+                                      new ValidatedType("bad_value", 43, new BigDecimal("1.10")),
+                                      "first");
         assertThat(response.valid(), is(false));
         assertThat(response.message(), is("does not match pattern \".*test.*\" with flags 0"));
     }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidatedMultiplesType.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidatedMultiplesType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,9 @@
 
 package io.helidon.validation.tests.validation;
 
-import java.math.BigDecimal;
-
 import io.helidon.validation.Validation;
 
 @Validation.Validated
-record ValidatedType(@Validation.String.Pattern(".*test.*") String first,
-                     @Validation.Integer.Min(42) int second,
-                     @Validation.Number.MultipleOf("0.05") BigDecimal third) {
-
+record ValidatedMultiplesType(@Validation.Integer.MultipleOf(5) int integerValue,
+                              @Validation.Long.MultipleOf(10L) long longValue) {
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidatedService.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidatedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,10 @@ public class ValidatedService {
             return "";
         }
         return "Bad";
+    }
+
+    String process(@Validation.Valid @Validation.NotNull ValidatedMultiplesType type) {
+        return "Good";
     }
 
     // TODO ignored valid now that Size was added

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
@@ -192,7 +192,7 @@ public class ValidationTest {
     }
 
     @Test
-    public void testInvalidParameterMultipleOf() {
+    public void testNumberMultipleOf() {
         var result = assertThrows(ValidationException.class,
                                   () -> service.process(new ValidatedType("good_test_value",
                                                                           42,
@@ -217,7 +217,7 @@ public class ValidationTest {
     }
 
     @Test
-    public void testInvalidParameterIntegerMultipleOf() {
+    public void testIntMultipleOf() {
         var result = assertThrows(ValidationException.class,
                                   () -> service.process(new ValidatedMultiplesType(11, 20L)));
 
@@ -240,7 +240,7 @@ public class ValidationTest {
     }
 
     @Test
-    public void testInvalidParameterLongMultipleOf() {
+    public void testLongMultipleOf() {
         var result = assertThrows(ValidationException.class,
                                   () -> service.process(new ValidatedMultiplesType(10, 21L)));
 

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.validation.tests.validation;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,14 +47,17 @@ public class ValidationTest {
 
     @Test
     public void testValid() {
-        var response = service.process(new ValidatedType("good_test_value", 42));
+        var response = service.process(new ValidatedType("good_test_value", 42, new BigDecimal("1.10")));
 
         assertThat(response, is("Good"));
     }
 
     @Test
     public void testInvalidResponse() {
-        var result = assertThrows(ValidationException.class, () -> service.process(new ValidatedType("good_test_value", 43)));
+        var result = assertThrows(ValidationException.class,
+                                  () -> service.process(new ValidatedType("good_test_value",
+                                                                          43,
+                                                                          new BigDecimal("1.10"))));
 
         var violations = result.violations();
 
@@ -75,7 +79,10 @@ public class ValidationTest {
 
     @Test
     public void testInvalidParameterMinValue() {
-        var result = assertThrows(ValidationException.class, () -> service.process(new ValidatedType("good_test_value", 40)));
+        var result = assertThrows(ValidationException.class,
+                                  () -> service.process(new ValidatedType("good_test_value",
+                                                                          40,
+                                                                          new BigDecimal("1.10"))));
 
         var violations = result.violations();
 
@@ -97,7 +104,10 @@ public class ValidationTest {
 
     @Test
     public void testInvalidParameterPattern() {
-        var result = assertThrows(ValidationException.class, () -> service.process(new ValidatedType("invalid_text", 42)));
+        var result = assertThrows(ValidationException.class,
+                                  () -> service.process(new ValidatedType("invalid_text",
+                                                                          42,
+                                                                          new BigDecimal("1.10"))));
 
         var violations = result.violations();
 
@@ -119,7 +129,10 @@ public class ValidationTest {
 
     @Test
     public void testMoreViolations() {
-        var result = assertThrows(ValidationException.class, () -> service.process(new ValidatedType("invalid_text", 40)));
+        var result = assertThrows(ValidationException.class,
+                                  () -> service.process(new ValidatedType("invalid_text",
+                                                                          40,
+                                                                          new BigDecimal("1.10"))));
 
         var violations = result.violations();
 
@@ -155,7 +168,9 @@ public class ValidationTest {
     @Test
     public void testInvalidParameterList() {
         var result = assertThrows(ValidationException.class,
-                                  () -> service.process(List.of(new ValidatedType("invalid_text", 42))));
+                                  () -> service.process(List.of(new ValidatedType("invalid_text",
+                                                                                  42,
+                                                                                  new BigDecimal("1.10")))));
 
         var violations = result.violations();
 
@@ -174,6 +189,77 @@ public class ValidationTest {
         assertThat(violation.rootObject(), is(Optional.of(service)));
         assertThat(violation.rootType(), sameInstance(ValidatedService.class));
         assertThat(violation.annotation().typeName(), is(TypeName.create(Validation.String.Pattern.class)));
+    }
+
+    @Test
+    public void testInvalidParameterMultipleOf() {
+        var result = assertThrows(ValidationException.class,
+                                  () -> service.process(new ValidatedType("good_test_value",
+                                                                          42,
+                                                                          new BigDecimal("1.11"))));
+
+        var violations = result.violations();
+
+        assertThat(violations, hasSize(1));
+
+        var violation = violations.getFirst();
+        List<PathElement> location = violation.location();
+        assertThat(location, contains(PathElement.create(Location.TYPE, ValidatedService.class.getName()),
+                                      PathElement.create(Location.METHOD,
+                                                         "process(io.helidon.validation.tests.validation.ValidatedType)"),
+                                      PathElement.create(Location.PARAMETER, "type"),
+                                      PathElement.create(Location.TYPE, ValidatedType.class.getName()),
+                                      PathElement.create(Location.RECORD_COMPONENT, "third")));
+        assertThat(violation.message(), containsString("is not a multiple of 0.05"));
+        assertThat(violation.rootObject(), is(Optional.of(service)));
+        assertThat(violation.rootType(), sameInstance(ValidatedService.class));
+        assertThat(violation.annotation().typeName(), is(TypeName.create(Validation.Number.MultipleOf.class)));
+    }
+
+    @Test
+    public void testInvalidParameterIntegerMultipleOf() {
+        var result = assertThrows(ValidationException.class,
+                                  () -> service.process(new ValidatedMultiplesType(11, 20L)));
+
+        var violations = result.violations();
+
+        assertThat(violations, hasSize(1));
+
+        var violation = violations.getFirst();
+        List<PathElement> location = violation.location();
+        assertThat(location, contains(PathElement.create(Location.TYPE, ValidatedService.class.getName()),
+                                      PathElement.create(Location.METHOD,
+                                                         "process(io.helidon.validation.tests.validation.ValidatedMultiplesType)"),
+                                      PathElement.create(Location.PARAMETER, "type"),
+                                      PathElement.create(Location.TYPE, ValidatedMultiplesType.class.getName()),
+                                      PathElement.create(Location.RECORD_COMPONENT, "integerValue")));
+        assertThat(violation.message(), containsString("is not a multiple of 5"));
+        assertThat(violation.rootObject(), is(Optional.of(service)));
+        assertThat(violation.rootType(), sameInstance(ValidatedService.class));
+        assertThat(violation.annotation().typeName(), is(TypeName.create(Validation.Integer.MultipleOf.class)));
+    }
+
+    @Test
+    public void testInvalidParameterLongMultipleOf() {
+        var result = assertThrows(ValidationException.class,
+                                  () -> service.process(new ValidatedMultiplesType(10, 21L)));
+
+        var violations = result.violations();
+
+        assertThat(violations, hasSize(1));
+
+        var violation = violations.getFirst();
+        List<PathElement> location = violation.location();
+        assertThat(location, contains(PathElement.create(Location.TYPE, ValidatedService.class.getName()),
+                                      PathElement.create(Location.METHOD,
+                                                         "process(io.helidon.validation.tests.validation.ValidatedMultiplesType)"),
+                                      PathElement.create(Location.PARAMETER, "type"),
+                                      PathElement.create(Location.TYPE, ValidatedMultiplesType.class.getName()),
+                                      PathElement.create(Location.RECORD_COMPONENT, "longValue")));
+        assertThat(violation.message(), containsString("is not a multiple of 10"));
+        assertThat(violation.rootObject(), is(Optional.of(service)));
+        assertThat(violation.rootType(), sameInstance(ValidatedService.class));
+        assertThat(violation.annotation().typeName(), is(TypeName.create(Validation.Long.MultipleOf.class)));
     }
 
     @Test

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidatorsTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidatorsTest.java
@@ -233,7 +233,7 @@ public class ValidatorsTest {
     }
 
     @Test
-    public void testMultipleOf() {
+    public void testNumberMultipleOf() {
         var response = Validators.validateMultipleOf(1.10, "0.05");
         assertThat(response.valid(), is(true));
 
@@ -272,7 +272,7 @@ public class ValidatorsTest {
     }
 
     @Test
-    public void testIntegerMultipleOf() {
+    public void testIntMultipleOf() {
         var response = Validators.validateMultipleOf(10, 5);
         assertThat(response.valid(), is(true));
 

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidatorsTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,6 +233,19 @@ public class ValidatorsTest {
     }
 
     @Test
+    public void testMultipleOf() {
+        var response = Validators.validateMultipleOf(1.10, "0.05");
+        assertThat(response.valid(), is(true));
+
+        response = Validators.validateMultipleOf(1.11, "0.05");
+        assertThat(response.valid(), is(false));
+        assertThat(response.message(), is("1.11 is not a multiple of 0.05"));
+
+        Validators.checkMultipleOf(1.10, "0.05");
+        assertThrows(ValidationException.class, () -> Validators.checkMultipleOf(1.11, "0.05"));
+    }
+
+    @Test
     public void testIntegerMin() {
         var response = Validators.validateMin(10, 5);
         assertThat(response.valid(), is(true));
@@ -259,6 +272,19 @@ public class ValidatorsTest {
     }
 
     @Test
+    public void testIntegerMultipleOf() {
+        var response = Validators.validateMultipleOf(10, 5);
+        assertThat(response.valid(), is(true));
+
+        response = Validators.validateMultipleOf(11, 5);
+        assertThat(response.valid(), is(false));
+        assertThat(response.message(), is("11 is not a multiple of 5"));
+
+        Validators.checkMultipleOf(10, 5);
+        assertThrows(ValidationException.class, () -> Validators.checkMultipleOf(11, 5));
+    }
+
+    @Test
     public void testLongMin() {
         var response = Validators.validateMin(10L, 5L);
         assertThat(response.valid(), is(true));
@@ -282,6 +308,19 @@ public class ValidatorsTest {
 
         Validators.checkMax(5L, 10L);
         assertThrows(ValidationException.class, () -> Validators.checkMax(15L, 10L));
+    }
+
+    @Test
+    public void testLongMultipleOf() {
+        var response = Validators.validateMultipleOf(10L, 5L);
+        assertThat(response.valid(), is(true));
+
+        response = Validators.validateMultipleOf(11L, 5L);
+        assertThat(response.valid(), is(false));
+        assertThat(response.message(), is("11 is not a multiple of 5"));
+
+        Validators.checkMultipleOf(10L, 5L);
+        assertThrows(ValidationException.class, () -> Validators.checkMultipleOf(11L, 5L));
     }
 
     @Test

--- a/validation/validation/src/main/java/io/helidon/validation/Validation.java
+++ b/validation/validation/src/main/java/io/helidon/validation/Validation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -568,6 +568,41 @@ public final class Validation {
             int fraction() default -1;
         }
 
+        /**
+         * The value must be a multiple of the specified {@link #value()}.
+         * <p>
+         * The factor must be greater than zero and will be converted to a {@link java.math.BigDecimal}, so it must
+         * match its rules.
+         * <p>
+         * Bytes are considered unsigned values (always between 0 and 255 inclusive).
+         */
+        @Target({
+                ElementType.METHOD, // return type
+                ElementType.PARAMETER,  // parameter of a method
+                ElementType.ANNOTATION_TYPE, // annotation to inherit
+                ElementType.TYPE_USE, // Map<Key, @NotNull Value>
+                ElementType.RECORD_COMPONENT // components of a record
+        })
+        @Validation.Constraint
+        public @interface MultipleOf {
+            /**
+             * Message to return instead of the default one of the validator.
+             * The message can be a string format, where the first (and only) parameter will be the actual value
+             * that is being validated.
+             *
+             * @return message to describe the constraint validation error
+             */
+            java.lang.String message() default "";
+
+            /**
+             * Positive factor. This value will be converted to a {@link java.math.BigDecimal}, so it must match its
+             * rules.
+             *
+             * @return the factor the value must be divisible by
+             */
+            java.lang.String value();
+        }
+
     }
 
     /**
@@ -640,6 +675,37 @@ public final class Validation {
              */
             int value();
         }
+
+        /**
+         * The value must be a multiple of the specified {@link #value()}.
+         * <p>
+         * Bytes are considered unsigned values (always between 0 and 255 inclusive).
+         */
+        @Target({
+                ElementType.METHOD, // return type
+                ElementType.PARAMETER,  // parameter of a method
+                ElementType.ANNOTATION_TYPE, // annotation to inherit
+                ElementType.TYPE_USE, // Map<Key, @NotNull Value>
+                ElementType.RECORD_COMPONENT // components of a record
+        })
+        @Validation.Constraint
+        public @interface MultipleOf {
+            /**
+             * Message to return instead of the default one of the validator.
+             * The message can be a string format, where the first (and only) parameter will be the actual value
+             * that is being validated.
+             *
+             * @return message to describe the constraint validation error
+             */
+            java.lang.String message() default "";
+
+            /**
+             * Positive factor.
+             *
+             * @return the factor the value must be divisible by
+             */
+            int value();
+        }
     }
 
     /**
@@ -709,6 +775,35 @@ public final class Validation {
              * Maximal value.
              *
              * @return max value
+             */
+            long value();
+        }
+
+        /**
+         * The value must be a multiple of the specified {@link #value()}.
+         */
+        @Target({
+                ElementType.METHOD, // return type
+                ElementType.PARAMETER,  // parameter of a method
+                ElementType.ANNOTATION_TYPE, // annotation to inherit
+                ElementType.TYPE_USE, // Map<Key, @NotNull Value>
+                ElementType.RECORD_COMPONENT // components of a record
+        })
+        @Validation.Constraint
+        public @interface MultipleOf {
+            /**
+             * Message to return instead of the default one of the validator.
+             * The message can be a string format, where the first (and only) parameter will be the actual value
+             * that is being validated.
+             *
+             * @return message to describe the constraint validation error
+             */
+            java.lang.String message() default "";
+
+            /**
+             * Positive factor.
+             *
+             * @return the factor the value must be divisible by
              */
             long value();
         }

--- a/validation/validation/src/main/java/io/helidon/validation/Validators.java
+++ b/validation/validation/src/main/java/io/helidon/validation/Validators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -386,6 +386,32 @@ public class Validators {
     }
 
     /**
+     * Check that the number value is a multiple of the specified factor.
+     *
+     * @param value value to check
+     * @param factor positive factor
+     * @return validation response
+     */
+    public static ValidationResponse validateMultipleOf(Number value, String factor) {
+        var ctx = validationContext(value);
+        Services.get(ValidatorsService.class).validateNumberMultipleOf(ctx, value, factor);
+        return ctx.response();
+    }
+
+    /**
+     * Check that the number value is a multiple of the specified factor.
+     *
+     * @param value value to check
+     * @param factor positive factor
+     * @throws ValidationException if the validation fails
+     */
+    public static void checkMultipleOf(Number value, String factor) {
+        var ctx = validationContext(value);
+        Services.get(ValidatorsService.class).validateNumberMultipleOf(ctx, value, factor);
+        ctx.throwOnFailure();
+    }
+
+    /**
      * Check that the integer value is greater than or equal to the minimum value.
      *
      * @param value value to check
@@ -438,6 +464,32 @@ public class Validators {
     }
 
     /**
+     * Check that the integer value is a multiple of the specified factor.
+     *
+     * @param value value to check
+     * @param factor positive factor
+     * @return validation response
+     */
+    public static ValidationResponse validateMultipleOf(Integer value, int factor) {
+        var ctx = validationContext(value);
+        Services.get(ValidatorsService.class).validateIntegerMultipleOf(ctx, value, factor);
+        return ctx.response();
+    }
+
+    /**
+     * Check that the integer value is a multiple of the specified factor.
+     *
+     * @param value value to check
+     * @param factor positive factor
+     * @throws ValidationException if the validation fails
+     */
+    public static void checkMultipleOf(Integer value, int factor) {
+        var ctx = validationContext(value);
+        Services.get(ValidatorsService.class).validateIntegerMultipleOf(ctx, value, factor);
+        ctx.throwOnFailure();
+    }
+
+    /**
      * Check that the long value is greater than or equal to the minimum value.
      *
      * @param value value to check
@@ -486,6 +538,32 @@ public class Validators {
     public static void checkMax(Long value, long maxValue) {
         var ctx = validationContext(value);
         Services.get(ValidatorsService.class).validateLongMax(ctx, value, maxValue);
+        ctx.throwOnFailure();
+    }
+
+    /**
+     * Check that the long value is a multiple of the specified factor.
+     *
+     * @param value value to check
+     * @param factor positive factor
+     * @return validation response
+     */
+    public static ValidationResponse validateMultipleOf(Long value, long factor) {
+        var ctx = validationContext(value);
+        Services.get(ValidatorsService.class).validateLongMultipleOf(ctx, value, factor);
+        return ctx.response();
+    }
+
+    /**
+     * Check that the long value is a multiple of the specified factor.
+     *
+     * @param value value to check
+     * @param factor positive factor
+     * @throws ValidationException if the validation fails
+     */
+    public static void checkMultipleOf(Long value, long factor) {
+        var ctx = validationContext(value);
+        Services.get(ValidatorsService.class).validateLongMultipleOf(ctx, value, factor);
         ctx.throwOnFailure();
     }
 

--- a/validation/validation/src/main/java/io/helidon/validation/ValidatorsService.java
+++ b/validation/validation/src/main/java/io/helidon/validation/ValidatorsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/validation/validation/src/main/java/io/helidon/validation/ValidatorsService.java
+++ b/validation/validation/src/main/java/io/helidon/validation/ValidatorsService.java
@@ -67,10 +67,13 @@ class ValidatorsService {
     private final ConstraintValidatorProvider numberMinProvider;
     private final ConstraintValidatorProvider numberMaxProvider;
     private final ConstraintValidatorProvider numberDigitsProvider;
+    private final ConstraintValidatorProvider numberMultipleOfProvider;
     private final ConstraintValidatorProvider integerMinProvider;
     private final ConstraintValidatorProvider integerMaxProvider;
+    private final ConstraintValidatorProvider integerMultipleOfProvider;
     private final ConstraintValidatorProvider longMinProvider;
     private final ConstraintValidatorProvider longMaxProvider;
+    private final ConstraintValidatorProvider longMultipleOfProvider;
     private final ConstraintValidatorProvider collectionSizeProvider;
     private final ConstraintValidatorProvider calendarFutureProvider;
     private final ConstraintValidatorProvider calendarFutureOrPresentProvider;
@@ -92,10 +95,13 @@ class ValidatorsService {
             @NamedByType(Validation.Number.Min.class) ConstraintValidatorProvider numberMinProvider,
             @NamedByType(Validation.Number.Max.class) ConstraintValidatorProvider numberMaxProvider,
             @NamedByType(Validation.Number.Digits.class) ConstraintValidatorProvider numberDigitsProvider,
+            @NamedByType(Validation.Number.MultipleOf.class) ConstraintValidatorProvider numberMultipleOfProvider,
             @NamedByType(Validation.Integer.Min.class) ConstraintValidatorProvider integerMinProvider,
             @NamedByType(Validation.Integer.Max.class) ConstraintValidatorProvider integerMaxProvider,
+            @NamedByType(Validation.Integer.MultipleOf.class) ConstraintValidatorProvider integerMultipleOfProvider,
             @NamedByType(Validation.Long.Min.class) ConstraintValidatorProvider longMinProvider,
             @NamedByType(Validation.Long.Max.class) ConstraintValidatorProvider longMaxProvider,
+            @NamedByType(Validation.Long.MultipleOf.class) ConstraintValidatorProvider longMultipleOfProvider,
             @NamedByType(Validation.Boolean.True.class) ConstraintValidatorProvider booleanTrueProvider,
             @NamedByType(Validation.Boolean.False.class) ConstraintValidatorProvider booleanFalseProvider,
             @NamedByType(Validation.Calendar.Future.class) ConstraintValidatorProvider calendarFutureProvider,
@@ -144,10 +150,13 @@ class ValidatorsService {
         this.numberMinProvider = numberMinProvider;
         this.numberMaxProvider = numberMaxProvider;
         this.numberDigitsProvider = numberDigitsProvider;
+        this.numberMultipleOfProvider = numberMultipleOfProvider;
         this.integerMinProvider = integerMinProvider;
         this.integerMaxProvider = integerMaxProvider;
+        this.integerMultipleOfProvider = integerMultipleOfProvider;
         this.longMinProvider = longMinProvider;
         this.longMaxProvider = longMaxProvider;
+        this.longMultipleOfProvider = longMultipleOfProvider;
         this.calendarFutureProvider = calendarFutureProvider;
         this.calendarFutureOrPresentProvider = calendarFutureOrPresentProvider;
         this.calendarPastProvider = calendarPastProvider;
@@ -238,6 +247,15 @@ class ValidatorsService {
         ctx.check(validator, value);
     }
 
+    void validateNumberMultipleOf(ValidationContext ctx, Number value, String factor) {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .value(factor)
+                .build();
+        ConstraintValidator validator = numberMultipleOfProvider.create(NUMBER_TYPE, annotation);
+        ctx.check(validator, value);
+    }
+
     void validateIntegerMin(ValidationContext ctx, Integer value, int minValue) {
         Annotation annotation = Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.Min.class))
@@ -256,6 +274,15 @@ class ValidatorsService {
         ctx.check(validator, value);
     }
 
+    void validateIntegerMultipleOf(ValidationContext ctx, Integer value, int factor) {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", factor)
+                .build();
+        ConstraintValidator validator = integerMultipleOfProvider.create(TypeNames.BOXED_INT, annotation);
+        ctx.check(validator, value);
+    }
+
     void validateLongMin(ValidationContext ctx, Long value, long minValue) {
         Annotation annotation = Annotation.builder()
                 .typeName(TypeName.create(Validation.Long.Min.class))
@@ -271,6 +298,15 @@ class ValidatorsService {
                 .putValue("value", maxValue)
                 .build();
         ConstraintValidator validator = longMaxProvider.create(TypeNames.BOXED_LONG, annotation);
+        ctx.check(validator, value);
+    }
+
+    void validateLongMultipleOf(ValidationContext ctx, Long value, long factor) {
+        Annotation annotation = Annotation.builder()
+                .typeName(TypeName.create(Validation.Long.MultipleOf.class))
+                .property("value", factor)
+                .build();
+        ConstraintValidator validator = longMultipleOfProvider.create(TypeNames.BOXED_LONG, annotation);
         ctx.check(validator, value);
     }
 

--- a/validation/validation/src/main/java/io/helidon/validation/validators/IntegerMultipleOfValidatorProvider.java
+++ b/validation/validation/src/main/java/io/helidon/validation/validators/IntegerMultipleOfValidatorProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.validators;
+
+import java.util.Locale;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+import io.helidon.validation.ValidationException;
+import io.helidon.validation.spi.ConstraintValidator;
+import io.helidon.validation.spi.ConstraintValidatorProvider;
+
+import static io.helidon.validation.validators.IntegerMaxValidatorProvider.charToString;
+
+@Service.NamedByType(Validation.Integer.MultipleOf.class)
+@Service.Singleton
+@Weight(Weighted.DEFAULT_WEIGHT - 30)
+class IntegerMultipleOfValidatorProvider implements ConstraintValidatorProvider {
+    @Override
+    public ConstraintValidator create(TypeName type, Annotation constraintAnnotation) {
+        int factor = constraintAnnotation.intValue().orElse(0);
+
+        if (factor <= 0) {
+            throw new IllegalArgumentException("Validation.Integer.MultipleOf value must be greater than zero: "
+                                                       + factor);
+        }
+
+        if (type.equals(TypeNames.PRIMITIVE_INT) || type.equals(TypeNames.BOXED_INT)) {
+            return new BaseValidator(constraintAnnotation,
+                                     "%d is not a multiple of " + factor,
+                                     it -> it instanceof Integer value && value % factor == 0);
+        }
+
+        if (type.equals(TypeNames.PRIMITIVE_LONG) || type.equals(TypeNames.BOXED_LONG)) {
+            return new BaseValidator(constraintAnnotation,
+                                     "%d is not a multiple of " + factor,
+                                     it -> it instanceof Long value && value % factor == 0);
+        }
+
+        if (type.equals(TypeNames.PRIMITIVE_SHORT) || type.equals(TypeNames.BOXED_SHORT)) {
+            return new BaseValidator(constraintAnnotation,
+                                     "%d is not a multiple of " + factor,
+                                     it -> it instanceof Short value && value % factor == 0);
+        }
+
+        if (type.equals(TypeNames.PRIMITIVE_BYTE) || type.equals(TypeNames.BOXED_BYTE)) {
+            return new BaseValidator(constraintAnnotation,
+                                     "0x%1$02x is not a multiple of 0x"
+                                             + Integer.toHexString(factor).toUpperCase(Locale.ROOT),
+                                     it -> it instanceof Byte value && (value & 0xFF) % factor == 0);
+        }
+
+        if (type.equals(TypeNames.PRIMITIVE_CHAR) || type.equals(TypeNames.BOXED_CHAR)) {
+            return new CharValidator(constraintAnnotation, factor);
+        }
+
+        throw new ValidationException("Invalid type of Integer.MultipleOf: " + type.fqName());
+    }
+
+    private static class CharValidator extends BaseValidator {
+        private CharValidator(Annotation constraintAnnotation, int factor) {
+            super(constraintAnnotation,
+                  "'%1$c' (%1$d) is not a multiple of " + charToString(factor),
+                  it -> it instanceof Character value && value % factor == 0);
+        }
+
+        @Override
+        protected Object convertValue(Object object) {
+            if (object instanceof Character c) {
+                return (int) c;
+            }
+            return object;
+        }
+    }
+}

--- a/validation/validation/src/main/java/io/helidon/validation/validators/IntegerMultipleOfValidatorProvider.java
+++ b/validation/validation/src/main/java/io/helidon/validation/validators/IntegerMultipleOfValidatorProvider.java
@@ -35,6 +35,7 @@ import static io.helidon.validation.validators.IntegerMaxValidatorProvider.charT
 @Service.Singleton
 @Weight(Weighted.DEFAULT_WEIGHT - 30)
 class IntegerMultipleOfValidatorProvider implements ConstraintValidatorProvider {
+
     @Override
     public ConstraintValidator create(TypeName type, Annotation constraintAnnotation) {
         int factor = constraintAnnotation.intValue().orElse(0);
@@ -77,6 +78,7 @@ class IntegerMultipleOfValidatorProvider implements ConstraintValidatorProvider 
     }
 
     private static class CharValidator extends BaseValidator {
+
         private CharValidator(Annotation constraintAnnotation, int factor) {
             super(constraintAnnotation,
                   "'%1$c' (%1$d) is not a multiple of " + charToString(factor),

--- a/validation/validation/src/main/java/io/helidon/validation/validators/LongMultipleOfValidatorProvider.java
+++ b/validation/validation/src/main/java/io/helidon/validation/validators/LongMultipleOfValidatorProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.validators;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeName;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+import io.helidon.validation.spi.ConstraintValidator;
+import io.helidon.validation.spi.ConstraintValidatorProvider;
+
+@Service.NamedByType(Validation.Long.MultipleOf.class)
+@Service.Singleton
+@Weight(Weighted.DEFAULT_WEIGHT - 30)
+class LongMultipleOfValidatorProvider implements ConstraintValidatorProvider {
+    @Override
+    public ConstraintValidator create(TypeName type, Annotation constraintAnnotation) {
+        long factor = constraintAnnotation.longValue().orElse(0L);
+
+        if (factor <= 0L) {
+            throw new IllegalArgumentException("Validation.Long.MultipleOf value must be greater than zero: "
+                                                       + factor);
+        }
+
+        return new BaseValidator(constraintAnnotation,
+                                 "%s is not a multiple of " + factor,
+                                 it -> it instanceof Long value && value % factor == 0L);
+    }
+}

--- a/validation/validation/src/main/java/io/helidon/validation/validators/LongMultipleOfValidatorProvider.java
+++ b/validation/validation/src/main/java/io/helidon/validation/validators/LongMultipleOfValidatorProvider.java
@@ -29,6 +29,7 @@ import io.helidon.validation.spi.ConstraintValidatorProvider;
 @Service.Singleton
 @Weight(Weighted.DEFAULT_WEIGHT - 30)
 class LongMultipleOfValidatorProvider implements ConstraintValidatorProvider {
+
     @Override
     public ConstraintValidator create(TypeName type, Annotation constraintAnnotation) {
         long factor = constraintAnnotation.longValue().orElse(0L);

--- a/validation/validation/src/main/java/io/helidon/validation/validators/NumberHelper.java
+++ b/validation/validation/src/main/java/io/helidon/validation/validators/NumberHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,19 @@ final class NumberHelper {
             return bd.stripTrailingZeros();
         } else if (number instanceof BigInteger bi) {
             return new BigDecimal(bi);
+        // keep exact decimal text for known JDK number types used by multipleOf checks
         } else if (number instanceof Byte b) {
             return new BigDecimal(b & 0xFF);
+        } else if (number instanceof Short s) {
+            return BigDecimal.valueOf(s.longValue());
+        } else if (number instanceof Integer i) {
+            return BigDecimal.valueOf(i.longValue());
+        } else if (number instanceof Long l) {
+            return BigDecimal.valueOf(l);
+        } else if (number instanceof Float f) {
+            return new BigDecimal(Float.toString(f)).stripTrailingZeros();
+        } else if (number instanceof Double d) {
+            return BigDecimal.valueOf(d).stripTrailingZeros();
         } else {
             return new BigDecimal(String.valueOf(number.doubleValue())).stripTrailingZeros();
         }

--- a/validation/validation/src/main/java/io/helidon/validation/validators/NumberMultipleOfValidatorProvider.java
+++ b/validation/validation/src/main/java/io/helidon/validation/validators/NumberMultipleOfValidatorProvider.java
@@ -32,6 +32,7 @@ import io.helidon.validation.spi.ConstraintValidatorProvider;
 @Service.Singleton
 @Weight(Weighted.DEFAULT_WEIGHT - 30)
 class NumberMultipleOfValidatorProvider implements ConstraintValidatorProvider {
+
     @Override
     public ConstraintValidator create(TypeName type, Annotation constraintAnnotation) {
         String multipleOf = constraintAnnotation.value().orElseThrow();
@@ -49,6 +50,7 @@ class NumberMultipleOfValidatorProvider implements ConstraintValidatorProvider {
     }
 
     private static final class ValidatorFromString extends BaseValidator {
+
         private ValidatorFromString(Annotation annotation, BigDecimal factor) {
             super(annotation,
                   "%s is not a multiple of " + factor,
@@ -70,6 +72,7 @@ class NumberMultipleOfValidatorProvider implements ConstraintValidatorProvider {
     }
 
     private static final class ValidatorFromNumber extends BaseValidator {
+
         private ValidatorFromNumber(Annotation annotation, BigDecimal factor) {
             super(annotation,
                   "%s is not a multiple of " + factor,

--- a/validation/validation/src/main/java/io/helidon/validation/validators/NumberMultipleOfValidatorProvider.java
+++ b/validation/validation/src/main/java/io/helidon/validation/validators/NumberMultipleOfValidatorProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation.validators;
+
+import java.math.BigDecimal;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.service.registry.Service;
+import io.helidon.validation.Validation;
+import io.helidon.validation.spi.ConstraintValidator;
+import io.helidon.validation.spi.ConstraintValidatorProvider;
+
+@Service.NamedByType(Validation.Number.MultipleOf.class)
+@Service.Singleton
+@Weight(Weighted.DEFAULT_WEIGHT - 30)
+class NumberMultipleOfValidatorProvider implements ConstraintValidatorProvider {
+    @Override
+    public ConstraintValidator create(TypeName type, Annotation constraintAnnotation) {
+        String multipleOf = constraintAnnotation.value().orElseThrow();
+        BigDecimal factor = new BigDecimal(multipleOf).stripTrailingZeros();
+
+        if (factor.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Validation.Number.MultipleOf value must be greater than zero: "
+                                                       + multipleOf);
+        }
+
+        if (type.equals(TypeNames.STRING) || type.equals(TypeName.create(CharSequence.class))) {
+            return new ValidatorFromString(constraintAnnotation, factor);
+        }
+        return new ValidatorFromNumber(constraintAnnotation, factor);
+    }
+
+    private static final class ValidatorFromString extends BaseValidator {
+        private ValidatorFromString(Annotation annotation, BigDecimal factor) {
+            super(annotation,
+                  "%s is not a multiple of " + factor,
+                  it -> validate(it, factor));
+        }
+
+        private static boolean validate(Object value, BigDecimal factor) {
+            if (!(value instanceof CharSequence chars)) {
+                return false;
+            }
+
+            try {
+                BigDecimal bd = new BigDecimal(chars.toString());
+                return bd.remainder(factor).compareTo(BigDecimal.ZERO) == 0;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+    }
+
+    private static final class ValidatorFromNumber extends BaseValidator {
+        private ValidatorFromNumber(Annotation annotation, BigDecimal factor) {
+            super(annotation,
+                  "%s is not a multiple of " + factor,
+                  it -> validate(it, factor));
+        }
+
+        private static boolean validate(Object value, BigDecimal factor) {
+            if (!(value instanceof Number number)) {
+                return false;
+            }
+
+            BigDecimal asBd = NumberHelper.toBigDecimal(number);
+            return asBd.remainder(factor).compareTo(BigDecimal.ZERO) == 0;
+        }
+    }
+}

--- a/validation/validation/src/main/java/module-info.java
+++ b/validation/validation/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,9 @@ import io.helidon.common.features.api.HelidonFlavor;
  * The constraints are grouped (through container classes) based on types that can be constrained.
  * Some constraints are for convenience - such as {@link io.helidon.validation.Validation.Integer.Max} and
  * {@link io.helidon.validation.Validation.Long.Max} - this allows usage of properly typed constants, as the general number
- * constraint {@link io.helidon.validation.Validation.Number.Max} must use a String value (as it can be used for any number,
- * ranging from {@link java.lang.Byte} to a {@link java.math.BigDecimal}.
+ * constraints such as {@link io.helidon.validation.Validation.Number.Max} and
+ * {@link io.helidon.validation.Validation.Number.MultipleOf} must use a String value
+ * (as they can be used for any number, ranging from {@link java.lang.Byte} to a {@link java.math.BigDecimal}).
  *
  * <h2>Object constraints</h2>
  * Any type can be annotated with (see details in the following list):
@@ -68,6 +69,7 @@ import io.helidon.common.features.api.HelidonFlavor;
  * <ul>
  *     <li>{@link io.helidon.validation.Validation.Integer.Max} - maximal value</li>
  *     <li>{@link io.helidon.validation.Validation.Integer.Min} - minimal value</li>
+ *     <li>{@link io.helidon.validation.Validation.Integer.MultipleOf} - number must be divisible by the configured factor</li>
  * </ul>
  * Note that byte is always considered to be unsigned (i.e. values are from 0 to 255 inclusive).
  *
@@ -76,6 +78,7 @@ import io.helidon.common.features.api.HelidonFlavor;
  * <ul>
  *     <li>{@link io.helidon.validation.Validation.Long.Max} - maximal value</li>
  *     <li>{@link io.helidon.validation.Validation.Long.Min} - minimal value</li>
+ *     <li>{@link io.helidon.validation.Validation.Long.MultipleOf} - number must be divisible by the configured factor</li>
  * </ul>
  *
  * <h2>Number constraints</h2>
@@ -84,6 +87,7 @@ import io.helidon.common.features.api.HelidonFlavor;
  *     <li>{@link io.helidon.validation.Validation.Number.Digits} - max number of integer and fractional digits</li>
  *     <li>{@link io.helidon.validation.Validation.Number.Max} - maximal value</li>
  *     <li>{@link io.helidon.validation.Validation.Number.Min} - minimal value</li>
+ *     <li>{@link io.helidon.validation.Validation.Number.MultipleOf} - number must be divisible by the configured factor</li>
  *     <li>{@link io.helidon.validation.Validation.Number.Negative} - number must be negative (negative zero for longs is a zero)</li>
  *     <li>{@link io.helidon.validation.Validation.Number.NegativeOrZero} - number must not be positive</li>
  *     <li>{@link io.helidon.validation.Validation.Number.Positive} - number must be positive (zero is not positive)</li>

--- a/validation/validation/src/test/java/io/helidon/validation/IntegerMultipleOfValidatorProviderTest.java
+++ b/validation/validation/src/test/java/io/helidon/validation/IntegerMultipleOfValidatorProviderTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation;
+
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
+import io.helidon.validation.spi.ConstraintValidatorProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Testing.Test
+public class IntegerMultipleOfValidatorProviderTest {
+    private final ConstraintValidatorProvider validatorProvider;
+    private final ValidatorContext ctx;
+
+    IntegerMultipleOfValidatorProviderTest() {
+        this.validatorProvider = Services.getNamed(ConstraintValidatorProvider.class,
+                                                   Validation.Integer.MultipleOf.class.getName().replace('$', '.'));
+        this.ctx = new ValidatorContextImpl();
+    }
+
+    @Test
+    public void testValidIntegers() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, 10).valid(), is(true));
+        assertThat(validator.check(ctx, 0).valid(), is(true));
+        assertThat(validator.check(ctx, -15).valid(), is(true));
+    }
+
+    @Test
+    public void testInvalidIntegers() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, 11).valid(), is(false));
+        assertThat(validator.check(ctx, -14).valid(), is(false));
+    }
+
+    @Test
+    public void testCustomMessage() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .property("message", "Integer must be divisible by 5")
+                .build());
+
+        var response = validator.check(ctx, 11);
+
+        assertThat(response.valid(), is(false));
+        assertThat(response.message(), is("Integer must be divisible by 5"));
+    }
+
+    @Test
+    public void testNonIntegerValues() {
+        assertThrows(ValidationException.class, () -> validatorProvider.create(TypeNames.STRING, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .build()));
+    }
+
+    @Test
+    public void testNullValue() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, null).valid(), is(true));
+    }
+
+    @Test
+    public void testByteType() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_BYTE, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, (byte) 10).valid(), is(true));
+
+        var response = validator.check(ctx, (byte) 9);
+        assertThat(response.valid(), is(false));
+        assertThat(response.message(), is("0x09 is not a multiple of 0x5"));
+    }
+
+    @Test
+    public void testShortType() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_SHORT, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, (short) 10).valid(), is(true));
+        assertThat(validator.check(ctx, (short) 12).valid(), is(false));
+    }
+
+    @Test
+    public void testLongType() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, 10L).valid(), is(true));
+        assertThat(validator.check(ctx, 12L).valid(), is(false));
+    }
+
+    @Test
+    public void testCharacterValues() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_CHAR, Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, 'A').valid(), is(true));
+
+        var response = validator.check(ctx, 'C');
+        assertThat(response.valid(), is(false));
+        assertThat(response.message(), is("'C' (67) is not a multiple of 5"));
+    }
+
+    @Test
+    public void testInvalidFactor() {
+        var annotation = Annotation.builder()
+                .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
+                .property("value", 0)
+                .build();
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> validatorProvider.create(TypeNames.PRIMITIVE_INT, annotation));
+    }
+}

--- a/validation/validation/src/test/java/io/helidon/validation/IntegerMultipleOfValidatorProviderTest.java
+++ b/validation/validation/src/test/java/io/helidon/validation/IntegerMultipleOfValidatorProviderTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Testing.Test
 public class IntegerMultipleOfValidatorProviderTest {
+
     private final ConstraintValidatorProvider validatorProvider;
     private final ValidatorContext ctx;
 
@@ -41,7 +42,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testValidIntegers() {
+    public void testValid() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -53,7 +54,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testInvalidIntegers() {
+    public void testInvalid() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -64,7 +65,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testCustomMessage() {
+    public void testMessage() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -78,7 +79,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testNonIntegerValues() {
+    public void testUnsupportedType() {
         assertThrows(ValidationException.class, () -> validatorProvider.create(TypeNames.STRING, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -86,7 +87,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testNullValue() {
+    public void testNull() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -96,7 +97,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testByteType() {
+    public void testByte() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_BYTE, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -110,7 +111,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testShortType() {
+    public void testShort() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_SHORT, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -121,7 +122,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testLongType() {
+    public void testLong() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -132,7 +133,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testCharacterValues() {
+    public void testChar() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_CHAR, Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 5)
@@ -146,7 +147,7 @@ public class IntegerMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testInvalidFactor() {
+    public void testZeroFactor() {
         var annotation = Annotation.builder()
                 .typeName(TypeName.create(Validation.Integer.MultipleOf.class))
                 .property("value", 0)

--- a/validation/validation/src/test/java/io/helidon/validation/LongMultipleOfValidatorProviderTest.java
+++ b/validation/validation/src/test/java/io/helidon/validation/LongMultipleOfValidatorProviderTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Testing.Test
 public class LongMultipleOfValidatorProviderTest {
+
     private final ConstraintValidatorProvider validatorProvider;
     private final ValidatorContext ctx;
 
@@ -41,7 +42,7 @@ public class LongMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testValidLongs() {
+    public void testValid() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
                 .typeName(TypeName.create(Validation.Long.MultipleOf.class))
                 .property("value", 10L)
@@ -53,7 +54,7 @@ public class LongMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testInvalidLongs() {
+    public void testInvalid() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
                 .typeName(TypeName.create(Validation.Long.MultipleOf.class))
                 .property("value", 10L)
@@ -64,7 +65,7 @@ public class LongMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testCustomMessage() {
+    public void testMessage() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
                 .typeName(TypeName.create(Validation.Long.MultipleOf.class))
                 .property("value", 10L)
@@ -78,7 +79,7 @@ public class LongMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testNonLongValues() {
+    public void testUnsupported() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
                 .typeName(TypeName.create(Validation.Long.MultipleOf.class))
                 .property("value", 10L)
@@ -91,7 +92,7 @@ public class LongMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testNullValue() {
+    public void testNull() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
                 .typeName(TypeName.create(Validation.Long.MultipleOf.class))
                 .property("value", 10L)
@@ -101,7 +102,7 @@ public class LongMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testInvalidFactor() {
+    public void testZeroFactor() {
         var annotation = Annotation.builder()
                 .typeName(TypeName.create(Validation.Long.MultipleOf.class))
                 .property("value", 0L)

--- a/validation/validation/src/test/java/io/helidon/validation/LongMultipleOfValidatorProviderTest.java
+++ b/validation/validation/src/test/java/io/helidon/validation/LongMultipleOfValidatorProviderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation;
+
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
+import io.helidon.validation.spi.ConstraintValidatorProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Testing.Test
+public class LongMultipleOfValidatorProviderTest {
+    private final ConstraintValidatorProvider validatorProvider;
+    private final ValidatorContext ctx;
+
+    LongMultipleOfValidatorProviderTest() {
+        this.validatorProvider = Services.getNamed(ConstraintValidatorProvider.class,
+                                                   Validation.Long.MultipleOf.class.getName().replace('$', '.'));
+        this.ctx = new ValidatorContextImpl();
+    }
+
+    @Test
+    public void testValidLongs() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
+                .typeName(TypeName.create(Validation.Long.MultipleOf.class))
+                .property("value", 10L)
+                .build());
+
+        assertThat(validator.check(ctx, 10L).valid(), is(true));
+        assertThat(validator.check(ctx, 0L).valid(), is(true));
+        assertThat(validator.check(ctx, -20L).valid(), is(true));
+    }
+
+    @Test
+    public void testInvalidLongs() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
+                .typeName(TypeName.create(Validation.Long.MultipleOf.class))
+                .property("value", 10L)
+                .build());
+
+        assertThat(validator.check(ctx, 11L).valid(), is(false));
+        assertThat(validator.check(ctx, -21L).valid(), is(false));
+    }
+
+    @Test
+    public void testCustomMessage() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
+                .typeName(TypeName.create(Validation.Long.MultipleOf.class))
+                .property("value", 10L)
+                .property("message", "Long must be divisible by 10")
+                .build());
+
+        var response = validator.check(ctx, 11L);
+
+        assertThat(response.valid(), is(false));
+        assertThat(response.message(), is("Long must be divisible by 10"));
+    }
+
+    @Test
+    public void testNonLongValues() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
+                .typeName(TypeName.create(Validation.Long.MultipleOf.class))
+                .property("value", 10L)
+                .build());
+
+        assertThat(validator.check(ctx, "hello").valid(), is(false));
+        assertThat(validator.check(ctx, true).valid(), is(false));
+        assertThat(validator.check(ctx, new Object()).valid(), is(false));
+        assertThat(validator.check(ctx, 10).valid(), is(false));
+    }
+
+    @Test
+    public void testNullValue() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_LONG, Annotation.builder()
+                .typeName(TypeName.create(Validation.Long.MultipleOf.class))
+                .property("value", 10L)
+                .build());
+
+        assertThat(validator.check(ctx, null).valid(), is(true));
+    }
+
+    @Test
+    public void testInvalidFactor() {
+        var annotation = Annotation.builder()
+                .typeName(TypeName.create(Validation.Long.MultipleOf.class))
+                .property("value", 0L)
+                .build();
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> validatorProvider.create(TypeNames.PRIMITIVE_LONG, annotation));
+    }
+}

--- a/validation/validation/src/test/java/io/helidon/validation/NumberMultipleOfValidatorProviderTest.java
+++ b/validation/validation/src/test/java/io/helidon/validation/NumberMultipleOfValidatorProviderTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.validation;
+
+import java.math.BigDecimal;
+
+import io.helidon.common.types.Annotation;
+import io.helidon.common.types.TypeName;
+import io.helidon.common.types.TypeNames;
+import io.helidon.service.registry.Services;
+import io.helidon.testing.junit5.Testing;
+import io.helidon.validation.spi.ConstraintValidatorProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Testing.Test
+public class NumberMultipleOfValidatorProviderTest {
+    private final ConstraintValidatorProvider validatorProvider;
+    private final ValidatorContext ctx;
+
+    NumberMultipleOfValidatorProviderTest() {
+        this.validatorProvider = Services.getNamed(ConstraintValidatorProvider.class,
+                                                   Validation.Number.MultipleOf.class.getName().replace('$', '.'));
+        this.ctx = new ValidatorContextImpl();
+    }
+
+    @Test
+    public void testValidNumbers() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, 10).valid(), is(true));
+        assertThat(validator.check(ctx, 0).valid(), is(true));
+        assertThat(validator.check(ctx, -15).valid(), is(true));
+        assertThat(validator.check(ctx, new BigDecimal("20")).valid(), is(true));
+    }
+
+    @Test
+    public void testInvalidNumbers() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", 5)
+                .build());
+
+        assertThat(validator.check(ctx, 11).valid(), is(false));
+        assertThat(validator.check(ctx, -14).valid(), is(false));
+        assertThat(validator.check(ctx, new BigDecimal("4")).valid(), is(false));
+    }
+
+    @Test
+    public void testValidDecimalNumbers() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", "0.05")
+                .build());
+
+        assertThat(validator.check(ctx, 1.10d).valid(), is(true));
+        assertThat(validator.check(ctx, 0.15f).valid(), is(true));
+        assertThat(validator.check(ctx, -0.20d).valid(), is(true));
+        assertThat(validator.check(ctx, new BigDecimal("0.35")).valid(), is(true));
+    }
+
+    @Test
+    public void testInvalidDecimalNumbers() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", "0.05")
+                .build());
+
+        assertThat(validator.check(ctx, 1.11d).valid(), is(false));
+        assertThat(validator.check(ctx, new BigDecimal("0.071")).valid(), is(false));
+    }
+
+    @Test
+    public void testStringNumbers() {
+        var validator = validatorProvider.create(TypeNames.STRING, Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", "0.05")
+                .build());
+
+        assertThat(validator.check(ctx, "1.10").valid(), is(true));
+        assertThat(validator.check(ctx, "-0.20").valid(), is(true));
+        assertThat(validator.check(ctx, "1.11").valid(), is(false));
+        assertThat(validator.check(ctx, "invalid").valid(), is(false));
+        assertThat(validator.check(ctx, "").valid(), is(false));
+    }
+
+    @Test
+    public void testCustomMessage() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", "0.05")
+                .property("message", "Number must be divisible by 0.05")
+                .build());
+
+        var response = validator.check(ctx, 1.11d);
+
+        assertThat(response.valid(), is(false));
+        assertThat(response.message(), is("Number must be divisible by 0.05"));
+    }
+
+    @Test
+    public void testNonNumberValues() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", "0.05")
+                .build());
+
+        assertThat(validator.check(ctx, "hello").valid(), is(false));
+        assertThat(validator.check(ctx, true).valid(), is(false));
+        assertThat(validator.check(ctx, new Object()).valid(), is(false));
+    }
+
+    @Test
+    public void testNullValue() {
+        var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", "0.05")
+                .build());
+
+        assertThat(validator.check(ctx, null).valid(), is(true));
+    }
+
+    @Test
+    public void testInvalidFactor() {
+        var annotation = Annotation.builder()
+                .typeName(TypeName.create(Validation.Number.MultipleOf.class))
+                .property("value", "0")
+                .build();
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, annotation));
+    }
+}

--- a/validation/validation/src/test/java/io/helidon/validation/NumberMultipleOfValidatorProviderTest.java
+++ b/validation/validation/src/test/java/io/helidon/validation/NumberMultipleOfValidatorProviderTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Testing.Test
 public class NumberMultipleOfValidatorProviderTest {
+
     private final ConstraintValidatorProvider validatorProvider;
     private final ValidatorContext ctx;
 
@@ -43,7 +44,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testValidNumbers() {
+    public void testValid() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", 5)
@@ -56,7 +57,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testInvalidNumbers() {
+    public void testInvalid() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_INT, Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", 5)
@@ -68,7 +69,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testValidDecimalNumbers() {
+    public void testValidDecimal() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", "0.05")
@@ -81,7 +82,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testInvalidDecimalNumbers() {
+    public void testInvalidDecimal() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", "0.05")
@@ -92,7 +93,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testStringNumbers() {
+    public void testString() {
         var validator = validatorProvider.create(TypeNames.STRING, Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", "0.05")
@@ -106,7 +107,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testCustomMessage() {
+    public void testMessage() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", "0.05")
@@ -120,7 +121,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testNonNumberValues() {
+    public void testUnsupported() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", "0.05")
@@ -132,7 +133,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testNullValue() {
+    public void testNull() {
         var validator = validatorProvider.create(TypeNames.PRIMITIVE_DOUBLE, Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", "0.05")
@@ -142,7 +143,7 @@ public class NumberMultipleOfValidatorProviderTest {
     }
 
     @Test
-    public void testInvalidFactor() {
+    public void testZeroFactor() {
         var annotation = Annotation.builder()
                 .typeName(TypeName.create(Validation.Number.MultipleOf.class))
                 .property("value", "0")


### PR DESCRIPTION
## Description

Add validation support for MultipleOf constraints. Update Number, Integer, and Long validation constraints. Update related docs and add new tests. See issue https://github.com/helidon-io/helidon/issues/11614. Port of #11570.