### PR TITLE
Enroll auto HTTP metrics provider filters only once

### DIFF
--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -109,10 +109,6 @@ class MetricsFeature {
 
     void register(HttpRouting.Builder routing, String endpoint) {
         configureVendorMetrics(routing);
-        Services.all(AutoHttpMetricsProvider.class)
-                .stream()
-                .map(conv -> conv.filter(metricsObserverConfig))
-                .forEach(filter -> filter.ifPresent(routing::addFilter));
         routing.register(endpoint, new MetricsService());
     }
 

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/MetricsFeature.java
@@ -36,7 +36,6 @@ import io.helidon.metrics.api.MetricsConfig;
 import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.SystemTagsManager;
 import io.helidon.metrics.spi.MeterRegistryFormatterProvider;
-import io.helidon.service.registry.Services;
 import io.helidon.webserver.KeyPerformanceIndicatorSupport;
 import io.helidon.webserver.http.Handler;
 import io.helidon.webserver.http.HttpRouting;
@@ -45,7 +44,6 @@ import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.SecureHandler;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
-import io.helidon.webserver.observe.metrics.spi.AutoHttpMetricsProvider;
 
 import jakarta.json.JsonObject;
 

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestAuthHttpMetrics.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestAuthHttpMetrics.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe.metrics;
+
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientRequest;
+import io.helidon.webserver.Route;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class TestAuthHttpMetrics {
+
+    private final Http1Client client;
+
+    TestAuthHttpMetrics(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void setup(HttpRouting.Builder builder) {
+        builder.get("/greet", (req, resp) -> resp.send("Hello, World!"));
+    }
+
+    @Test
+    void testAuthHttpMetrics() {
+        int beforeInvocation = TestAutoHttpMetricsProvider.counter();
+
+        try (var resp = client.get("/greet").request()) {
+            assertThat("Response status", resp.status().code(), is(equalTo(200)));
+            assertThat("Filter invocation count delta",
+                       TestAutoHttpMetricsProvider.counter() - beforeInvocation,
+                       is(1));
+        }
+    }
+}

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestAutoHttpMetricsProvider.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestAutoHttpMetricsProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.observe.metrics;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.Filter;
+import io.helidon.webserver.observe.metrics.spi.AutoHttpMetricsProvider;
+
+@Service.Singleton
+class TestAutoHttpMetricsProvider implements AutoHttpMetricsProvider {
+
+    private static final AtomicInteger COUNTER = new AtomicInteger();
+
+    @Override
+    public Optional<Filter> filter(MetricsObserverConfig config) {
+        return Optional.of((chain, req, resp) -> {
+            COUNTER.incrementAndGet();
+            chain.proceed();
+        });
+    }
+
+    static int counter() {
+        return COUNTER.get();
+    }
+}


### PR DESCRIPTION
### Description
Resolves #11617 

### Release note
____
HTTP filters added by `AutoHttpMetricsProvider`s are now invoked once per incoming HTTP request. 
____

### Overview
When we introduced the `AutoHttpMetricsProvider` (as a way of furnishing different varieties of automatic per-request metrics--for example, the legacy Helidon per-request count vs. the OpenTelemetry HTTP request semantic conventions), we incorrectly added the filter from each `AutoHttpMetricsProvider` _twice_, once in `MetricsFeature#register` and once in `MetricsObserver#prepareAutoMetrics`. 

As a result, the filters were invoke twice thereby double-updating the metrics.

The fix removes the addition of these filters from `MetricsFeature`.

The PR includes a new test that failed before the fix and passes after.

### Documentation
None.