### PR TITLE
Resolve deprecations in module helidon-webserver-observe-log (27.x)

### DIFF
--- a/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogStreamConfigBlueprint.java
+++ b/webserver/observe/log/src/main/java/io/helidon/webserver/observe/log/LogStreamConfigBlueprint.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
-import io.helidon.config.Config;
 import io.helidon.http.HttpMediaType;
 
 /**
@@ -29,18 +28,6 @@ import io.helidon.http.HttpMediaType;
 @Prototype.Blueprint
 @Prototype.Configured
 interface LogStreamConfigBlueprint {
-    /**
-     * This method is internal only and was used from the builder and will be removed without replacement.
-     * You can easily map HTTP media type from config using {@code config.asString().map(HttpMediaType::create)}.
-     *
-     * @param config config instance
-     * @return media type mapped
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    static HttpMediaType createContentType(Config config) {
-        return config.asString().map(HttpMediaType::create).orElseThrow();
-    }
-
     /**
      * Whether stream is enabled.
      *


### PR DESCRIPTION
Resolves #11490

Remove the deprecated `LogStreamConfigBlueprint#createContentType` compatibility helper from
`helidon-webserver-observe-log`. Config mapping still uses `LogObserverConfigSupport`, so
the observe-log runtime behavior stays unchanged.
