### PR TITLE
Resolve deprecations in module helidon-common-mapper (27.x)

### DIFF
--- a/common/mapper/src/main/java/io/helidon/common/mapper/OptionalValue.java
+++ b/common/mapper/src/main/java/io/helidon/common/mapper/OptionalValue.java
@@ -86,45 +86,6 @@ public interface OptionalValue<T> extends Value<T> {
     }
 
     /**
-     * Create an empty value.
-     * Empty value is not backed by data and all of its methods consider it is empty.
-     *
-     * @param mapperManager mapper manager to use for mapping types
-     * @param name          name of the value
-     * @param type          type of the value, to correctly handle mapping exceptions
-     * @param <T>           type of the value
-     * @param qualifiers    qualifiers of the mapper
-     * @return an empty value
-     * @deprecated use {@link #createEmpty(String, String...)}, as mappers are not needed for empty values
-     */
-    @Deprecated(forRemoval = true, since = "27.0.0")
-    static <T> OptionalValue<T> create(Mappers mapperManager, String name, Class<T> type, String... qualifiers) {
-        Objects.requireNonNull(name, "Name of the Value must not be null");
-        return createEmpty(name, qualifiers);
-    }
-
-    /**
-     * Create an empty value.
-     * Empty value is not backed by data and all of its methods consider it is empty.
-     *
-     * @param mapperManager mapper manager to use for mapping types
-     * @param name          name of the value
-     * @param type          type of the value, to correctly handle mapping exceptions
-     * @param qualifiers    qualifiers of the mapper
-     * @param <T>           type of the value
-     * @return an empty value
-     * @deprecated use {@link #createEmpty(String, String...)}, as mappers are not needed for empty values
-     */
-    @Deprecated(forRemoval = true, since = "27.0.0")
-    static <T> OptionalValue<T> create(Mappers mapperManager,
-                                       String name,
-                                       GenericType<T> type,
-                                       String... qualifiers) {
-        Objects.requireNonNull(name, "Name of the Value must not be null");
-        return createEmpty(name, qualifiers);
-    }
-
-    /**
      * Create a value backed by data. The type of the value is "guessed" from the instance provided.
      *
      * @param mapperManager mapper manager to use for mapping types


### PR DESCRIPTION
Resolves #11465

Removes the deprecated empty `OptionalValue.create(Mappers, ...)` overloads from
`helidon-common-mapper` now that `createEmpty(...)` is the supported path.

Advances #11452.
