### PR TITLE
Resolve deprecations in module `helidon-metadata` (27.x)

### DIFF
--- a/metadata/metadata/README.md
+++ b/metadata/metadata/README.md
@@ -12,7 +12,6 @@ the file name is the only element we can use for grouping.
 The following files are expected in a single location on classpath, and will not work with shaded jar, unless correctly merged (this will not cause runtime failures):
 - `default-media-types.properties` - default media types (there should be exactly one instance of this file used by Helidon)
 - `config-metadata.json` - configuration metadata, may be used by tooling to find all configurable options (i.e. from IDE), not used at runtime of Helidon
-- `feature-metadata.properties` - deprecated feature metadata
 
 
 The following files are expected to be under `META-INF/helidon` directory structure.

--- a/metadata/metadata/src/main/java/io/helidon/metadata/MetadataConstants.java
+++ b/metadata/metadata/src/main/java/io/helidon/metadata/MetadataConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,16 +52,6 @@ public final class MetadataConstants {
      * File name is: {@value}
      */
     public static final String FEATURE_REGISTRY_FILE = "feature-registry.json";
-    /**
-     * Feature metadata properties.
-     * This file is deprecated, because it cannot be merged.
-     * <p>
-     * File name is: {@value}
-     *
-     * @deprecated Use {@link #FEATURE_REGISTRY_FILE} instead.
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    public static final String FEATURE_METADATA_FILE = "feature-metadata.properties";
     /**
      * Configuration metadata JSON.
      * <p>

--- a/metadata/metadata/src/main/java/io/helidon/metadata/MetadataDiscoveryContext.java
+++ b/metadata/metadata/src/main/java/io/helidon/metadata/MetadataDiscoveryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,12 @@ package io.helidon.metadata;
 import java.util.Set;
 
 record MetadataDiscoveryContext(ClassLoader classLoader, Set<String> metadataFiles, String location, String manifestFile) {
-    @SuppressWarnings("removal")
     private static final Set<String> METADATA_FILES = Set.of(MetadataConstants.SERVICE_REGISTRY_FILE,
                                                              MetadataConstants.FEATURE_REGISTRY_FILE,
                                                              MetadataConstants.CONFIG_METADATA_FILE,
                                                              MetadataConstants.SERVICE_LOADER_FILE,
                                                              MetadataConstants.SERIAL_CONFIG_FILE,
-                                                             MetadataConstants.MEDIA_TYPES_FILE,
-                                                             MetadataConstants.FEATURE_METADATA_FILE);
+                                                             MetadataConstants.MEDIA_TYPES_FILE);
 
     static MetadataDiscoveryContext create(ClassLoader cl) {
         return new MetadataDiscoveryContext(cl,

--- a/metadata/metadata/src/test/java/io/helidon/metadata/MetadataTest.java
+++ b/metadata/metadata/src/test/java/io/helidon/metadata/MetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 
 public class MetadataTest {
 
     @Test
     public void testDefaultDiscovery() {
         MetadataDiscovery metadata = MetadataDiscovery.create(MetadataDiscovery.Mode.RESOURCES);
+
+        assertThat(metadata.list("feature-metadata.properties"), empty());
 
         var serviceLoaders = metadata.list("service.loader")
                 .stream()
@@ -52,6 +55,8 @@ public class MetadataTest {
     public void testClasspathScanning() {
         MetadataDiscovery metadata = MetadataDiscoveryImpl.
                 createFromClasspathScanning(MetadataDiscoveryContext.create(MetadataTest.class.getClassLoader()));
+
+        assertThat(metadata.list("feature-metadata.properties"), empty());
 
         var serviceLoaders = metadata.list("service.loader")
                 .stream()

--- a/metadata/metadata/src/test/resources/META-INF/helidon/feature-metadata.properties
+++ b/metadata/metadata/src/test/resources/META-INF/helidon/feature-metadata.properties
@@ -1,1 +1,16 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name=test-feature

--- a/metadata/metadata/src/test/resources/META-INF/helidon/feature-metadata.properties
+++ b/metadata/metadata/src/test/resources/META-INF/helidon/feature-metadata.properties
@@ -1,0 +1,1 @@
+name=test-feature

--- a/metadata/metadata/src/test/resources/META-INF/helidon/io.helidon.metadata/feature-metadata.properties
+++ b/metadata/metadata/src/test/resources/META-INF/helidon/io.helidon.metadata/feature-metadata.properties
@@ -1,1 +1,16 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 name=test-feature

--- a/metadata/metadata/src/test/resources/META-INF/helidon/io.helidon.metadata/feature-metadata.properties
+++ b/metadata/metadata/src/test/resources/META-INF/helidon/io.helidon.metadata/feature-metadata.properties
@@ -1,0 +1,1 @@
+name=test-feature


### PR DESCRIPTION
Resolves #11475

Remove the deprecated `MetadataConstants.FEATURE_METADATA_FILE` constant and stop `helidon-metadata`
from discovering `feature-metadata.properties` by default.

Refresh the module README and add regression coverage that keeps the deprecated resource ignored in
both resource and classpath-scanning discovery modes.
