### PR TITLE
Resolve deprecations in module `helidon-webclient-api` (27.x)

### DIFF
--- a/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ConnectionKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package io.helidon.webclient.api;
 
-import java.time.Duration;
 import java.util.Objects;
 
 import io.helidon.common.tls.Tls;
@@ -33,36 +32,17 @@ public final class ConnectionKey {
     private final DnsResolver dnsResolver;
     private final DnsAddressLookup dnsAddressLookup;
     private final Proxy proxy;
-    private final Duration readTimeout;
 
-
-    /**
-     * Create new instance.
-     *
-     * @param scheme           uri address scheme
-     * @param host             uri address host
-     * @param port             uri address port
-     * @param readTimeout      SO read timeout
-     * @param tls              TLS to be used in connection
-     * @param dnsResolver      DNS resolver to be used
-     * @param dnsAddressLookup DNS address lookup strategy
-     * @param proxy            Proxy server to use for outgoing requests
-     * @deprecated readTimeout is deprecated to be part of the connection key.
-     * Use {@link #create(String, String, int, Tls, DnsResolver, DnsAddressLookup, Proxy)} instead.
-     */
-    @Deprecated(forRemoval = true, since = "4.2.4")
-    public ConnectionKey(String scheme,
-                         String host,
-                         int port,
-                         Duration readTimeout,
-                         Tls tls,
-                         DnsResolver dnsResolver,
-                         DnsAddressLookup dnsAddressLookup,
-                         Proxy proxy) {
+    private ConnectionKey(String scheme,
+                          String host,
+                          int port,
+                          Tls tls,
+                          DnsResolver dnsResolver,
+                          DnsAddressLookup dnsAddressLookup,
+                          Proxy proxy) {
         this.scheme = scheme;
         this.host = host;
         this.port = port;
-        this.readTimeout = readTimeout;
         this.tls = tls;
         this.dnsResolver = dnsResolver;
         this.dnsAddressLookup = dnsAddressLookup;
@@ -88,7 +68,7 @@ public final class ConnectionKey {
                                        DnsResolver dnsResolver,
                                        DnsAddressLookup dnsAddressLookup,
                                        Proxy proxy) {
-        return new ConnectionKey(scheme, host, port, Duration.ZERO, tls, dnsResolver, dnsAddressLookup, proxy);
+        return new ConnectionKey(scheme, host, port, tls, dnsResolver, dnsAddressLookup, proxy);
     }
 
     /**
@@ -116,16 +96,6 @@ public final class ConnectionKey {
      */
     public int port() {
         return port;
-    }
-
-    /**
-     * Socket read timeout.
-     *
-     * @return socket read timeout
-     */
-    @Deprecated(forRemoval = true, since = "4.2.4")
-    public Duration readTimeout() {
-        return readTimeout;
     }
 
     /**
@@ -176,7 +146,6 @@ public final class ConnectionKey {
         return Objects.equals(this.scheme, that.scheme)
                 && Objects.equals(this.host, that.host)
                 && this.port == that.port
-                && Objects.equals(this.readTimeout, that.readTimeout)
                 && Objects.equals(this.tls, that.tls)
                 && Objects.equals(this.dnsResolver, that.dnsResolver)
                 && Objects.equals(this.dnsAddressLookup, that.dnsAddressLookup)
@@ -185,7 +154,7 @@ public final class ConnectionKey {
 
     @Override
     public int hashCode() {
-        return Objects.hash(scheme, host, port, readTimeout, tls, dnsResolver, dnsAddressLookup, proxy);
+        return Objects.hash(scheme, host, port, tls, dnsResolver, dnsAddressLookup, proxy);
     }
 
     @Override
@@ -194,7 +163,6 @@ public final class ConnectionKey {
                 + "scheme=" + scheme + ", "
                 + "host=" + host + ", "
                 + "port=" + port + ", "
-                + "readTimeout=" + readTimeout + ", "
                 + "tls=" + tls + ", "
                 + "dnsResolver=" + dnsResolver + ", "
                 + "dnsAddressLookup=" + dnsAddressLookup + ", "

--- a/webclient/api/src/main/java/io/helidon/webclient/api/DefaultDnsResolver.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/DefaultDnsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,11 +38,6 @@ public final class DefaultDnsResolver implements DnsResolver {
      */
     public static DefaultDnsResolver create() {
         return new DefaultDnsResolver();
-    }
-
-    @Override
-    public boolean useDefaultJavaResolver() {
-        return true;
     }
 
     @Override

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -17,7 +17,6 @@
 package io.helidon.webclient.api;
 
 import java.net.SocketAddress;
-import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +30,6 @@ import io.helidon.common.media.type.ParserMode;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriQuery;
-import io.helidon.config.Config;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
 import io.helidon.http.WritableHeaders;
@@ -49,18 +47,6 @@ import io.helidon.webclient.spi.WebClientServiceProvider;
 @Prototype.Blueprint(decorator = HttpClientConfigSupport.HttpBuilderDecorator.class)
 @Prototype.CustomMethods(HttpClientConfigSupport.HttpCustomMethods.class)
 interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
-    /**
-     * This method is internal only and was used from the builder and will be removed without replacement.
-     * You can easily map ClientUri from config using {@code config.asString().map(ClientUri::create)}.
-     *
-     * @param config config instance
-     * @return client URI mapped
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    static ClientUri createBaseUri(Config config) {
-        return config.as(URI.class).map(ClientUri::create).orElseThrow();
-    }
-
     /**
      * Base uri used by the client in all requests.
      *

--- a/webclient/api/src/main/java/io/helidon/webclient/spi/DnsResolver.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/spi/DnsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,19 +24,6 @@ import io.helidon.webclient.api.DnsAddressLookup;
  * DNS resolving interface.
  */
 public interface DnsResolver {
-
-    /**
-     * Whether to use standard Java DNS resolver.
-     * If this method returns true, {@link #resolveAddress(String, io.helidon.webclient.api.DnsAddressLookup)}
-     * method is not invoked and no {@link DnsAddressLookup} preferences will be applied.
-     *
-     * @return use standard Java resolver
-     * @deprecated this method is no longer invoked and may be removed in the future
-     */
-    @Deprecated(forRemoval = true, since = "4.0.4")
-    default boolean useDefaultJavaResolver() {
-        return false;
-    }
 
     /**
      * Resolve hostname to {@link InetAddress}.


### PR DESCRIPTION
Resolves #11487

Remove the remaining deprecated compatibility APIs from `helidon-webclient-api`.
This drops the old `ConnectionKey` timeout constructor/getter, the unused DNS SPI fallback hook,
and the redundant blueprint base-URI helper.
