### PR TITLE
4.x: Use deployment id for accessing staged artifacts from sonatype

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     environment: release
+    outputs:
+      deployment_id: ${{ steps.deploy.outputs.deployment_id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,14 +106,15 @@ jobs:
           pattern: io-helidon-artifacts-part-*
           path: staging
           merge-multiple: true
-      - shell: bash
+      - id: deploy
+        shell: bash
         env:
           CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
         run: |
           etc/scripts/upload.sh upload_release \
             --dir="staging" \
-            --description="Helidon v%{version}"
+            --description="Helidon v%{version}" >> ${GITHUB_OUTPUT}
       - uses: actions/upload-artifact@v4
         with:
           name: io-helidon-artifacts-${{ needs.create-tag.outputs.version }}
@@ -130,6 +133,7 @@ jobs:
         env:
           CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          DEPLOYMENT_ID: ${{ needs.deploy.outputs.deployment_id }}
         run: |
           ./etc/scripts/setup-central-settings.sh
       - uses: ./.github/actions/common
@@ -165,6 +169,7 @@ jobs:
         env:
           CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          DEPLOYMENT_ID: ${{ needs.deploy.outputs.deployment_id }}
         run: |
           ./etc/scripts/setup-central-settings.sh
       - uses: ./.github/actions/common

--- a/etc/scripts/setup-central-settings.sh
+++ b/etc/scripts/setup-central-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2025 Oracle and/or its affiliates.
+# Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,6 +69,12 @@ if [ -z "${CENTRAL_PASSWORD}" ] ; then
     exit 1
 fi
 
+if [ -z "${DEPLOYMENT_ID}" ] ; then
+    echo "ERROR: environment variable DEPLOYMENT_ID is required." >&2
+    usage
+    exit 1
+fi
+
 if [ -z "${DESTINATION_DIRECTORY}" ] ; then
     DESTINATION_DIRECTORY="${HOME}/.m2"
     mkdir -p "${DESTINATION_DIRECTORY}"
@@ -114,14 +120,14 @@ maven_settings() {
            <repository>
              <id>central.manual.testing</id>
              <name>Central Testing repository</name>
-             <url>https://central.sonatype.com/api/v1/publisher/deployments/download</url>
+             <url>https://central.sonatype.com/api/v1/publisher/deployment/${DEPLOYMENT_ID}/download</url>
            </repository>
          </repositories>
          <pluginRepositories>
              <pluginRepository>
                  <id>central.manual.testing</id>
                  <name>Central Testing repository</name>
-                 <url>https://central.sonatype.com/api/v1/publisher/deployments/download</url>
+                 <url>https://central.sonatype.com/api/v1/publisher/deployment/${DEPLOYMENT_ID}/download</url>
              </pluginRepository>
          </pluginRepositories>
        </profile>

--- a/etc/scripts/upload.sh
+++ b/etc/scripts/upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2025 Oracle and/or its affiliates.
+# Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ $(basename "${0}") [OPTIONS] --directory=DIR CMD
   CMD:
 
     upload_release
-        Upload staging directory to a release repository
+        Upload staging directory to a release repository. Prints deployment ID
 
     upload_snapshot
         Uploading staging directory to a snapshots repository
@@ -186,12 +186,13 @@ upload_release() {
   version=$(find_version)
 
   # Make sure version does NOT end in -SNAPSHOT
-  if [[ "${v}" = *-SNAPSHOT ]]; then
+  if [[ "${version}" = *-SNAPSHOT ]]; then
     echo "ERROR: Version ${version} is a SNAPSHOT version" >&2
     exit 1
   fi
 
   deployment_id="$(central_upload "${CENTRAL_URL}" "${STAGING_DIR}")"
+  printf "deployment_id=%s\n" "${deployment_id}" >&6
   central_finish "${deployment_id}"
 }
 


### PR DESCRIPTION
### Description

Updates the release job to use the sonatype deployment ID when downloading staged bits for testing.  This is more correct and avoids a performance issue we were seeing with sonatype publishing portal.

