### PR TITLE
Resolve service registry deprecations (27.x)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/InterceptorGenerator.java
@@ -134,17 +134,11 @@ class InterceptorGenerator {
     }
 
     private boolean isService(TypeInfo type) {
-        // must be annotated with @Service.Provider, or @Service.Scope
-        if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER)) {
-            return true;
-        }
+        // must be annotated with a scope annotation
         if (type.hasAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE)) {
             return true;
         }
         for (Annotation annotation : type.annotations()) {
-            if (annotation.hasMetaAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER)) {
-                return true;
-            }
             if (annotation.hasMetaAnnotation(ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE)) {
                 return true;
             }

--- a/service/README.md
+++ b/service/README.md
@@ -34,9 +34,10 @@ obtained from a `ServiceRegistryManager`.
 
 ## Declare a service
 
-Use `io.helidon.service.registry.Service.Provider` annotation on your service provider type (implementation of a contract).
- Alternatively, 
-`java.util.function.Supplier` can also be used in this scenario.
+Use one of the `io.helidon.service.registry.Service.Scope` annotations, such as
+`io.helidon.service.registry.Service.Singleton` or `io.helidon.service.registry.Service.PerLookup`,
+on your service provider type (implementation of a contract). Service factories implemented as
+`java.util.function.Supplier` use the same scope annotations.
 
 Use `io.helidon.service.registry.Service.Descriptor` to create a hand-crafted service descriptor (see below "Behind the scenes")
 
@@ -45,7 +46,7 @@ Service example:
 ```java
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.Singleton
 class MyService implements MyContract {
     MyService() {
     }
@@ -62,7 +63,7 @@ Service with dependency example:
 ```java
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.Singleton
 class MyService2 implements MyContract2 {
     private final MyContract dependency;
 
@@ -84,10 +85,10 @@ import java.util.function.Supplier;
 
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.PerLookup
 // the type must be fully qualified, as it is code generated
 class MyService3 implements Supplier<Optional<com.foo.bar.MyContract3>> {
-    
+
     MyService3() {
     }
 
@@ -240,9 +241,6 @@ Services are:
       messaging message)
 2. Any class with `@Service.Inject` annotation that does not have a scope annotation. In such a case, the
    service will be `@Service.PerLookup`.
-3. Any `core` service defined for Helidon Service Registry (using annotation `Service.Provider`), the scope is `PerLookup` if the
-   service implements a `Supplier`, and `@Singleton` otherwise; all dependencies are considered injection points
-
 Only services can have Injection points.
 
 ## Qualifiers
@@ -691,9 +689,8 @@ resolved only once you call `get()` on the supplier.
 
 | Term            | Description                                                                                                                                                                                                   |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Core Service    | A class annotated with `@Service.Provider`                                                                                                                                                                    |
 | Contract        | A class extended by a service, or an interface implemented by a service, can be used to lookup instances                                                                                                      |
-| Dependency      | A "Core Service" constructor parameter (type must be another service or a "Contract")                                                                                                                         |
-| Service         | A class annotated with one of the scope annotations, or a core service                                                                                                                                        |
-| Factory         | A "Core Service" or "Service" that implements one of the factory interfaces; Core service is a factory only if it implements a `Supplier                                                                      |
+| Dependency      | A service constructor parameter (type must be another service or a "Contract")                                                                                                                                |
+| Service         | A class annotated with one of the scope annotations, or with `@Service.Inject` and no scope annotation                                                                                                       |
+| Factory         | A `Service` that implements one of the factory interfaces                                                                                                                                                     |
 | Injection Point | Field annotated with `@Service.Inject`, or a constructor parameter of a constructor used for injection (either the only accessible constructor, or the only constructor annotated with `@Service.Inject`) |

--- a/service/codegen/README.md
+++ b/service/codegen/README.md
@@ -5,7 +5,7 @@ Service Codegen
 
 | Annotation           | Description                                                                         |
 |----------------------|-------------------------------------------------------------------------------------|
-| @Service.Provider    | Generates a core service descriptor                                                 |
+| @Service.Scope-annotated annotations (such as `@Service.Singleton` and `@Service.PerLookup`) | Generates a service descriptor |
 | @Service.Inject      | Type with an injection point is a per lookup service unless it has scope annotation |
 | @Service.Describe    | Generates a service descriptor for a contract without a service implementation      |
 | @Service.PerInstance | A service instantiated based on another service                                     |
@@ -19,4 +19,4 @@ Options can be configured as annotation processor options, when running via anno
 |-------------------------------------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `helidon.registry.autoAddNonContractInterfaces` | `true`     | If set to `true`, all implemented interfaces and super types are considered a contract; by default, `@Service.Contract` or `@Service.ExternalContracts` must be in place |
 | `helidon.registry.interceptionStrategy`         | `EXPLICIT` | How to handle generation of interceptor invokers (NONE, EXPLICIT, ALL_RUNTIME, ALL_RETAINED)                                                                             |
-| `helidon.registry.scopeMetaAnnotations`         | N/A        | Set of annotations that mark scopes that are not Helidon scopes                                                                                                          
+| `helidon.registry.scopeMetaAnnotations`         | N/A        | Set of annotations that mark scopes that are not Helidon scopes

--- a/service/codegen/src/main/java/io/helidon/service/codegen/DescribedType.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/DescribedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,12 +30,8 @@ import io.helidon.common.types.TypeName;
  * A described type (class, interface).
  * User service can have up to two types - one is the service itself, another one is a provided contract,
  * if the service is a provider.
- *
- * @deprecated this class is not part of public API and does not have any public elements, it will be package private in
- *      a future release
  */
-@Deprecated(forRemoval = true, since = "4.4.0")
-public class DescribedType {
+class DescribedType {
     private final TypeInfo typeInfo;
     private final boolean isAbstract;
     private final TypeName typeName;

--- a/service/codegen/src/main/java/io/helidon/service/codegen/HelidonMetaInfServices.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/HelidonMetaInfServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,7 @@ import io.helidon.service.metadata.Descriptors;
  * Support for reading and writing Helidon services to the resource.
  * <p>
  * Helidon replacement for Java {@link java.util.ServiceLoader}.
- * Each service annotated with appropriate annotation
- * ({@link io.helidon.service.codegen.ServiceCodegenTypes#SERVICE_ANNOTATION_PROVIDER})
- * will have a service descriptor generated at build time.
+ * Each supported service or described contract annotation results in a service descriptor generated at build time.
  * <p>
  * The service descriptor is then discoverable at runtime through our own resource in
  * {@value Descriptors#SERVICE_REGISTRY_LOCATION}.

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,15 +25,11 @@ import io.helidon.common.types.TypeNames;
  */
 public final class ServiceCodegenTypes {
     /**
-     * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.Provider}.
-     */
-    public static final TypeName SERVICE_ANNOTATION_PROVIDER = TypeName.create("io.helidon.service.registry.Service.Provider");
-    /**
      * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.Singleton}.
      */
     public static final TypeName SERVICE_ANNOTATION_SINGLETON = TypeName.create("io.helidon.service.registry.Service.Singleton");
     /**
-     * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.Singleton}.
+     * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.PerLookup}.
      */
     public static final TypeName SERVICE_ANNOTATION_PER_LOOKUP = TypeName.create("io.helidon.service.registry.Service.PerLookup");
     /**

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceDescriptorCodegen.java
@@ -76,7 +76,6 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_NAMED;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_PER_LOOKUP;
-import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_QUALIFIER;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_RUN_LEVEL;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE;
@@ -643,17 +642,6 @@ public class ServiceDescriptorCodegen {
         }
 
         if (service.hasAnnotation(SERVICE_ANNOTATION_PER_INSTANCE)) {
-            return SERVICE_ANNOTATION_SINGLETON;
-        }
-
-        if (service.hasAnnotation(SERVICE_ANNOTATION_PROVIDER)) {
-            // if supplier, per lookup, otherwise singleton; will be removed once we remove Service.Provider (if we remove it)
-            if (service.interfaceTypeInfo()
-                    .stream()
-                    .map(TypeInfo::typeName)
-                    .anyMatch(TypeNames.SUPPLIER::equals)) {
-                return SERVICE_ANNOTATION_PER_LOOKUP;
-            }
             return SERVICE_ANNOTATION_SINGLETON;
         }
 

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceExtensionProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtensionProvider;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_DESCRIBE;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_PER_INSTANCE;
-import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_PROVIDER;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_SCOPE;
 
 /**
@@ -67,8 +66,7 @@ public class ServiceExtensionProvider implements RegistryCodegenExtensionProvide
 
     @Override
     public Set<TypeName> supportedAnnotations() {
-        return Set.of(SERVICE_ANNOTATION_PROVIDER,
-                      SERVICE_ANNOTATION_DESCRIBE,
+        return Set.of(SERVICE_ANNOTATION_DESCRIBE,
                       SERVICE_ANNOTATION_PER_INSTANCE,
                       SERVICE_ANNOTATION_INJECT);
     }

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -41,54 +41,6 @@ public final class Service {
     }
 
     /**
-     * A service provider. This is similar to {@link java.util.ServiceLoader} service providers.
-     * <p>
-     * The provider is an implementation of a {@link io.helidon.service.registry.Service.Contract} that is discoverable by
-     * the service registry.
-     * A service provider annotated with this annotation must provide either of:
-     * <ul>
-     *     <li>an accessible no-argument constructor
-     *      (package private is sufficient), and must itself be at least package private</li>
-     *      <li>an accessible constructor with arguments that are all services as well</li>
-     * </ul>
-     *
-     * The support for providing constructor arguments is limited to the following types:
-     * <ul>
-     *     <li>{@code Contract} - obtain an instance of a service providing that contract</li>
-     *     <li>{@code Optional<Contract>} - the other service may not be available</li>
-     *     <li>{@code List<Contract>} - obtain all instances of services providing the contract</li>
-     *     <li>{@code Supplier<Contract>} - and <b>suppliers of all above</b>, to break instantiation chaining, and to support
-     *     cyclic
-     *                  service references, just make sure you call the {@code get} method outside of the constructor</li>
-     * </ul>
-     *
-     * A service provider may implement the contract in two ways:
-     * <ul>
-     *     <li>Direct implementation of interface (or extending an abstract class)</li>
-     *     <li>Implementing a {@link java.util.function.Supplier} of the contract; when using supplier, service registry
-     *     supports the capability to return {@link java.util.Optional} in case the service cannot provide a value; such
-     *     a service will be ignored and only other implementations (with lower weight) would be used. Supplier will be
-     *     called each time the dependency is used, or each time a method on registry is called to request an instance. If the
-     *     provided instance should be singleton-like as well, use {@link io.helidon.common.LazyValue} or
-     *     similar approach to create it once and return the same instance every time</li>
-     * </ul>
-     *
-     * @deprecated use one of the scope annotations instead ({@link io.helidon.service.registry.Service.Singleton},
-     *         {@link io.helidon.service.registry.Service.PerLookup}).
-     */
-    @Documented
-    @Retention(RetentionPolicy.CLASS)
-    @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
-    @Inherited
-    @Deprecated(forRemoval = true, since = "4.2.0")
-    public @interface Provider {
-        /**
-         * Type name of this annotation.
-         */
-        TypeName TYPE = TypeName.create(Provider.class);
-    }
-
-    /**
      * Scope annotation.
      * A scope defines the cardinality of instances. This is a meta-annotation used to define that an annotation is a scope.
      * Note that a single service can only have one scope annotation, and that scopes are not inheritable.

--- a/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
+++ b/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,10 +68,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@SuppressWarnings("deprecation")
 @Testing.Test
 class ServiceCodegenTypesTest {
-    @SuppressWarnings("removal")
     @Test
     void testTypes() {
         // it is really important to test ALL constants on the class, so let's use reflection
@@ -93,7 +91,6 @@ class ServiceCodegenTypesTest {
             fields.put(name, declaredField);
         }
 
-        checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_PROVIDER", Service.Provider.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_PRE_DESTROY", Service.PreDestroy.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_POST_CONSTRUCT", Service.PostConstruct.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_CONTRACT", Service.Contract.class);

--- a/service/tests/inject/src/main/java/io/helidon/service/tests/inject/MutableService.java
+++ b/service/tests/inject/src/main/java/io/helidon/service/tests/inject/MutableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package io.helidon.service.tests.inject;
 import io.helidon.common.Weight;
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.Singleton
 @Service.Contract
 @Weight(5)
 class MutableService {

--- a/service/tests/inject/src/main/java/io/helidon/service/tests/inject/ServiceSupplier.java
+++ b/service/tests/inject/src/main/java/io/helidon/service/tests/inject/ServiceSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.PerLookup
 class ServiceSupplier implements Supplier<SuppliedContract> {
     private static final AtomicInteger COUNTER = new AtomicInteger();
 

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/MyService.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/MyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.helidon.service.test.registry;
 
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.Singleton
 class MyService implements MyContract {
     static int instances = 0;
 

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/MyService2.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/MyService2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package io.helidon.service.test.registry;
 import io.helidon.common.Weight;
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.Singleton
 @Weight(102)
 class MyService2 implements MyContract {
     static int instances;

--- a/service/tests/registry/src/main/java/io/helidon/service/test/registry/TestLifecycleService.java
+++ b/service/tests/registry/src/main/java/io/helidon/service/test/registry/TestLifecycleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.service.registry.Service;
 
-@Service.Provider
+@Service.Singleton
 class TestLifecycleService implements TestLifecycle {
     static final AtomicInteger PRE_DESTROY = new AtomicInteger();
 


### PR DESCRIPTION
Resolves #11483
Resolves #11484

Remove the deprecated `Service.Provider` annotation from the service registry API, make
`service-codegen`'s `DescribedType` package-private, and switch the remaining in-repo service fixtures and docs
to explicit scope annotations.
