### PR TITLE
Handle tokenized HTTP header values and fix HTTP/1 redirect probe framing (4.x)

### DIFF
--- a/http/http/src/main/java/io/helidon/http/Headers.java
+++ b/http/http/src/main/java/io/helidon/http/Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,43 @@ public interface Headers extends Iterable<Header> {
      * @return {@code true} if the header is defined
      */
     boolean contains(Header value);
+
+    /**
+     * Whether these headers contain all tokenized values from the provided header.
+     * This is useful for headers that are defined as comma-separated token lists, such as
+     * {@code Connection}, {@code TE}, or {@code Transfer-Encoding}.
+     *
+     * @param value expected header name and tokenized value(s)
+     * @return {@code true} if all expected tokens are present, ignoring case and surrounding whitespace
+     */
+    default boolean containsToken(Header value) {
+        List<String> actualValues = values(value.headerName());
+        if (actualValues.isEmpty()) {
+            return false;
+        }
+
+        for (String expectedValue : value.allValues()) {
+            for (String expectedToken : Utils.tokenize(',', "\"", true, expectedValue)) {
+                String trimmedExpected = expectedToken.trim();
+                if (trimmedExpected.isEmpty()) {
+                    continue;
+                }
+
+                boolean matched = false;
+                for (String actualValue : actualValues) {
+                    if (actualValue.trim().equalsIgnoreCase(trimmedExpected)) {
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
 
     /**
      * Get a header value.

--- a/http/http/src/main/java/io/helidon/http/HeadersImpl.java
+++ b/http/http/src/main/java/io/helidon/http/HeadersImpl.java
@@ -136,7 +136,7 @@ class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
             if (headerValue instanceof HeaderWriteable hvw) {
                 writable = hvw;
             } else {
-                writable = HeaderWriteable.create(header);
+                writable = HeaderWriteable.create(headerValue);
             }
             for (String value : header.allValues()) {
                 writable.addValue(value);

--- a/http/http/src/test/java/io/helidon/http/Http1HeadersParserTest.java
+++ b/http/http/src/test/java/io/helidon/http/Http1HeadersParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,48 @@ class Http1HeadersParserTest {
         testHeader(headers, "HeADer", "hv1", "hv2", "hv3");
     }
 
+    @Test
+    void testContainsTokenForRepeatedTransferEncoding() {
+        WritableHeaders<?> headers = headers("""
+                Transfer-Encoding: gzip\r
+                Transfer-Encoding: chunked\r
+                \r
+                """);
+
+        assertThat(headers.values(HeaderNames.TRANSFER_ENCODING), hasItems("gzip", "chunked"));
+        assertThat(headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED), is(true));
+    }
+
+    @Test
+    void testContainsTokenForCommaSeparatedTransferEncoding() {
+        WritableHeaders<?> headers = headers("""
+                Transfer-Encoding: gzip, chunked\r
+                \r
+                """);
+
+        assertThat(headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED), is(true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("tokenizedHeaders")
+    void testContainsTokenForTokenizedHeaders(String rawHeaders, Header expectedHeader) {
+        WritableHeaders<?> headers = headers(rawHeaders);
+
+        assertThat(headers.containsToken(expectedHeader), is(true));
+    }
+
+    @Test
+    void testContainsTokenForRepeatedConnectionValues() {
+        WritableHeaders<?> headers = headers("""
+                Connection: close\r
+                Connection: Upgrade\r
+                \r
+                """);
+
+        assertThat(headers.values(HeaderNames.CONNECTION), hasItems("close", "Upgrade"));
+        assertThat(headers.containsToken(HeaderValues.CONNECTION_CLOSE), is(true));
+    }
+
     @ParameterizedTest
     @MethodSource("headers")
     void testHeadersWithValidationEnabled(String headerName, String headerValue, boolean expectsValid) {
@@ -87,6 +129,11 @@ class Http1HeadersParserTest {
         return Http1HeadersParser.readHeaders(reader, 1024, validate);
     }
 
+    private static WritableHeaders<?> headers(String rawHeaders) {
+        DataReader reader = DataReader.create(() -> rawHeaders.getBytes(StandardCharsets.US_ASCII));
+        return Http1HeadersParser.readHeaders(reader, 1024, true);
+    }
+
     private static Stream<Arguments> headers() {
         return Stream.of(
                 // Invalid header names
@@ -111,6 +158,23 @@ class Http1HeadersParserTest {
                 arguments(VALID_HEADER_NAME, "H\u001ceaderValue1", false),
                 arguments(VALID_HEADER_NAME, "HeaderValue1, Header\u007fValue", false),
                 arguments(VALID_HEADER_NAME, "HeaderValue1\u001f, HeaderValue2", false)
+        );
+    }
+
+    private static Stream<Arguments> tokenizedHeaders() {
+        return Stream.of(
+                arguments("""
+                        Connection: Upgrade, keep-alive\r
+                        \r
+                        """, HeaderValues.CONNECTION_KEEP_ALIVE),
+                arguments("""
+                        Expect: something-else, 100-continue\r
+                        \r
+                        """, HeaderValues.EXPECT_100),
+                arguments("""
+                        Upgrade: h2c, websocket\r
+                        \r
+                        """, HeaderValues.create(HeaderNames.UPGRADE, "websocket"))
         );
     }
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,7 +289,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         if (responseHeaders.contains(HeaderNames.CONTENT_LENGTH)) {
             long length = responseHeaders.contentLength().getAsLong();
             inputStream = new ContentLengthInputStream(helidonSocket, reader, whenComplete, response, length);
-        } else if (responseHeaders.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+        } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
             inputStream = new ChunkedInputStream(helidonSocket, reader, whenComplete, response);
         } else {
             // we assume the rest of the connection is entity (valid for HTTP/1.0, HTTP CONNECT method etc.
@@ -308,7 +308,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         }
         if ((
                 responseHeaders.contains(HeaderNames.UPGRADE)
-                        && !responseHeaders.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED))) {
+                        && !responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED))) {
             // this is an upgrade response and there is no entity
             return false;
         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallEntityChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallEntityChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,9 @@ class Http1CallEntityChain extends Http1CallChainBase {
                                               DataReader reader,
                                               BufferData writeBuffer) {
 
-        headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, entity.length));
+        if (!originalRequest().outputStreamRedirect()) {
+            headers.set(HeaderValues.create(HeaderNames.CONTENT_LENGTH, entity.length));
+        }
 
         writeHeaders(connection, headers, writeBuffer, protocolConfig().validateRequestHeaders());
         // we have completed writing the headers

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,7 +217,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             this.clientConfig = clientConfig;
             this.protocolConfig = protocolConfig;
             this.contentLength = headers.contentLength().orElse(-1);
-            this.chunked = contentLength == -1 || headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            this.chunked = contentLength == -1 || headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED);
             this.request = request;
             this.originalRequest = originalRequest;
             this.lastRequest = originalRequest;
@@ -385,7 +385,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                     headers.set(HeaderValues.TRANSFER_ENCODING_CHUNKED);
                 } else {
                     // Add chunked encoding, if it's not part of existing transfer-encoding headers
-                    if (!headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+                    if (!headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
                         headers.add(HeaderValues.TRANSFER_ENCODING_CHUNKED);
                     }
                 }
@@ -496,6 +496,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                 Http1ClientResponseImpl response;
                 if (sendEntity) {
                     response = (Http1ClientResponseImpl) clientRequest
+                            .outputStreamRedirect(true)
                             .header(HeaderValues.EXPECT_100)
                             .header(HeaderValues.TRANSFER_ENCODING_CHUNKED)
                             .readTimeout(originalRequest.readContinueTimeout())

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
     private static final System.Logger LOGGER = System.getLogger(Http1ClientRequestImpl.class.getName());
     private final Http1ClientImpl http1Client;
     private final FullClientRequest<?> delegate;
+    private boolean outputStreamRedirect;
 
     Http1ClientRequestImpl(Http1ClientImpl http1Client,
                            Method method,
@@ -81,6 +82,7 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         followRedirects(request.followRedirects());
         maxRedirects(request.maxRedirects());
         tls(request.tls());
+        outputStreamRedirect(request.outputStreamRedirect());
     }
 
     @Override
@@ -268,6 +270,22 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
                                            mediaContext(),
                                            resolvedUri,
                                            complete);
+    }
+
+    /**
+     * Whether this request is part of an output stream redirection probe.
+     * Default is {@code false}.
+     *
+     * @param outputStreamRedirect whether this request is part of output stream redirection
+     * @return updated request
+     */
+    Http1ClientRequestImpl outputStreamRedirect(boolean outputStreamRedirect) {
+        this.outputStreamRedirect = outputStreamRedirect;
+        return this;
+    }
+
+    boolean outputStreamRedirect() {
+        return outputStreamRedirect;
     }
 
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -108,7 +108,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         OptionalLong contentLength = responseHeaders.contentLength();
         if (contentLength.isPresent()) {
             this.entityLength = contentLength.getAsLong();
-        } else if (responseHeaders.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+        } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
             this.entityLength = ENTITY_LENGTH_CHUNKED;
         }
 
@@ -153,7 +153,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     public void close() {
         if (closed.compareAndSet(false, true)) {
             try {
-                if (headers().contains(HeaderValues.CONNECTION_CLOSE)) {
+                if (headers().containsToken(HeaderValues.CONNECTION_CLOSE)) {
                     connection.closeResource();
                 } else {
                     if (entityFullyRead || entityLength == 0 || consumeUnreadEntity()) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ConnectionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,14 +118,14 @@ class Http1ConnectionCache extends ClientConnectionCache {
     }
 
     private boolean handleKeepAlive(boolean defaultKeepAlive, WritableHeaders<?> headers) {
-        if (headers.contains(HeaderValues.CONNECTION_CLOSE)) {
+        if (headers.containsToken(HeaderValues.CONNECTION_CLOSE)) {
             return false;
         }
         if (defaultKeepAlive) {
             headers.setIfAbsent(HeaderValues.CONNECTION_KEEP_ALIVE);
             return true;
         }
-        if (headers.contains(HeaderValues.CONNECTION_KEEP_ALIVE)) {
+        if (headers.containsToken(HeaderValues.CONNECTION_KEEP_ALIVE)) {
             return true;
         }
         headers.set(HeaderValues.CONNECTION_CLOSE);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -257,7 +257,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             stream.writeHeaders(http2Headers, false);
             whenSent.complete(request);
 
-            if (headers.contains(HeaderValues.EXPECT_100)) {
+            if (headers.containsToken(HeaderValues.EXPECT_100)) {
                 Status status = stream.waitFor100Continue();
 
                 if (status != Status.CONTINUE_100) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -291,7 +291,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      */
     public void writeHeaders(Http2Headers http2Headers, boolean endOfStream) {
         this.state = Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, true, endOfStream, true);
-        this.readState = readState.check(http2Headers.httpHeaders().contains(HeaderValues.EXPECT_100)
+        this.readState = readState.check(http2Headers.httpHeaders().containsToken(HeaderValues.EXPECT_100)
                                                  ? ReadState.CONTINUE_100_HEADERS
                                                  : ReadState.HEADERS);
         Http2Flag.HeaderFlags flags;

--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsClientImpl.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,6 @@ class WsClientImpl implements WsClient {
 
     private static final System.Logger LOGGER = System.getLogger(WsClient.class.getName());
     private static final Header HEADER_CONN_UPGRADE = HeaderValues.create(HeaderNames.CONNECTION, "Upgrade");
-    private static final Header HEADER_CONN_UPGRADE_LOWERCASE = HeaderValues.create(HeaderNames.CONNECTION, "upgrade");
     private static final HeaderName HEADER_WS_ACCEPT = HeaderNames.create("Sec-WebSocket-Accept");
     private static final HeaderName HEADER_WS_KEY = HeaderNames.create("Sec-WebSocket-Key");
     private static final LazyValue<Random> RANDOM = LazyValue.create(SecureRandom::new);
@@ -128,13 +127,12 @@ class WsClientImpl implements WsClient {
         ClientWsConnection session;
         try (HttpClientResponse response = upgradeResponse.response()) {
             ClientResponseHeaders responseHeaders = response.headers();
-            if (!responseHeaders.contains(HEADER_CONN_UPGRADE)
-                    && !responseHeaders.contains(HEADER_CONN_UPGRADE_LOWERCASE)) {
-                throw new WsClientException("Failed to upgrade to WebSocket, expected one of "
-                        + "[Connection: Upgrade, Connection: upgrade] header. Headers: " + responseHeaders);
+            if (!responseHeaders.containsToken(HEADER_CONN_UPGRADE)) {
+                throw new WsClientException("Failed to upgrade to WebSocket, expected Connection: Upgrade token. Headers: "
+                                                    + responseHeaders);
             }
-            if (!responseHeaders.contains(HEADER_UPGRADE_WS)) {
-                throw new WsClientException("Failed to upgrade to WebSocket, expected Upgrade: websocket header. Headers: "
+            if (!responseHeaders.containsToken(HEADER_UPGRADE_WS)) {
+                throw new WsClientException("Failed to upgrade to WebSocket, expected Upgrade: websocket token. Headers: "
                                                     + responseHeaders);
             }
             if (!responseHeaders.contains(HEADER_WS_ACCEPT)) {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -550,7 +550,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             // initial request from outside
             io.helidon.http.Headers httpHeaders = upgradeHeaders.httpHeaders();
             boolean hasEntity = httpHeaders.contains(HeaderNames.CONTENT_LENGTH)
-                    || httpHeaders.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+                    || httpHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED);
             // we now have all information needed to execute
             Http2ServerStream stream = stream(1).stream();
             stream.prologue(upgradePrologue);

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -188,7 +188,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
         streamingEntity = true;
 
-        if (request.headers().contains(HeaderValues.TE_TRAILERS)) {
+        if (request.headers().containsToken(HeaderValues.TE_TRAILERS)) {
             headers.add(STREAM_TRAILERS);
         }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -535,7 +535,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
 
     private void handle() {
         Headers httpHeaders = headers.httpHeaders();
-        if (headers.httpHeaders().contains(HeaderValues.EXPECT_100)) {
+        if (httpHeaders.containsToken(HeaderValues.EXPECT_100)) {
             writeState.updateAndGet(s -> s.checkAndMove(WriteState.EXPECTED_100));
         }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadRequestTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webserver.testing.junit5.SetUpServer;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
@@ -78,6 +79,11 @@ class BadRequestTest {
                                        .build());
     }
 
+    @AfterEach
+    void tearDown() {
+        socketClient.disconnect();
+    }
+
     @Test
     void testOk() {
         String response = client.method(Method.GET)
@@ -110,6 +116,80 @@ class BadRequestTest {
 
         ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
         assertThat(headers, hasHeader(LOCATION_ERROR_PAGE));
+    }
+
+    @Test
+    void testRepeatedTransferEncodingWithContentLengthRejected() {
+        assertRejectedSmugglingAttempt("""
+                Transfer-Encoding: gzip\r
+                Transfer-Encoding: chunked\r
+                """);
+    }
+
+    @Test
+    void testCommaSeparatedTransferEncodingWithContentLengthRejected() {
+        assertRejectedSmugglingAttempt("Transfer-Encoding: gzip, chunked\r\n");
+    }
+
+    @Test
+    void testNonChunkedTransferEncodingWithContentLengthRejected() {
+        assertRejectedSmugglingAttempt("Transfer-Encoding: gzip\r\n");
+    }
+
+    @Test
+    void testNonChunkedTransferEncodingWithoutContentLengthRejected() {
+        assertRejectedTransferEncodingAttempt("Transfer-Encoding: gzip\r\n",
+                                             Status.BAD_REQUEST_400,
+                                             "GET / HTTP/1.1\r\n"
+                                                     + "Host: localhost\r\n"
+                                                     + "\r\n");
+    }
+
+    @Test
+    void testAdditionalTransferEncodingBeforeChunkedRejected() {
+        assertRejectedTransferEncodingAttempt("Transfer-Encoding: gzip, chunked\r\n",
+                                             Status.NOT_IMPLEMENTED_501,
+                                             "4\r\n"
+                                                     + "PING\r\n"
+                                                     + "0\r\n"
+                                                     + "\r\n");
+    }
+
+    @Test
+    void testRepeatedChunkedTransferEncodingRejected() {
+        assertRejectedTransferEncodingAttempt("""
+                Transfer-Encoding: chunked\r
+                Transfer-Encoding: chunked\r
+                """,
+                                             Status.BAD_REQUEST_400,
+                                             "4\r\n"
+                                                     + "PING\r\n"
+                                                     + "0\r\n"
+                                                     + "\r\n");
+    }
+
+    @Test
+    void testChunkedTransferEncodingPasses() {
+        socketClient.requestRaw("GET / HTTP/1.1\r\n"
+                                        + "Host: localhost\r\n"
+                                        + "Connection: keep-alive\r\n"
+                                        + "Transfer-Encoding: chunked\r\n"
+                                        + "\r\n"
+                                        + "4\r\n"
+                                        + "PING\r\n"
+                                        + "0\r\n"
+                                        + "\r\n");
+
+        String response = socketClient.receive();
+
+        assertThat(response, containsString("200 OK"));
+        assertThat(response, containsString("Hi"));
+
+        socketClient.request(Method.GET, "/", null, List.of("Accept: text/plain", "Connection: keep-alive"));
+
+        response = socketClient.receive();
+        assertThat(response, containsString("200 OK"));
+        assertThat(response, containsString("Hi"));
     }
 
     @Test
@@ -209,10 +289,57 @@ class BadRequestTest {
                     .build();
         }
         return DirectHandler.TransportResponse.builder()
-                .status(Status.create(Status.BAD_REQUEST_400.code(),
-                                      CUSTOM_REASON_PHRASE))
+                .status(httpStatus.code() == Status.BAD_REQUEST_400.code()
+                                ? Status.create(Status.BAD_REQUEST_400.code(), CUSTOM_REASON_PHRASE)
+                                : httpStatus)
                 .headers(responseHeaders)
                 .entity(CUSTOM_ENTITY)
                 .build();
+    }
+
+    private void assertRejectedSmugglingAttempt(String transferEncodingHeaders) {
+        assertRejectedRequest("GET / HTTP/1.1\r\n"
+                                      + "Host: localhost\r\n"
+                                      + "Connection: keep-alive\r\n"
+                                      + transferEncodingHeaders
+                                      + "Content-Length: 14\r\n"
+                                      + "\r\n"
+                                      + "4\r\n"
+                                      + "PING\r\n"
+                                      + "0\r\n"
+                                      + "\r\n"
+                                      + "GET / HTTP/1.1\r\n"
+                                      + "Host: localhost\r\n"
+                                      + "\r\n");
+    }
+
+    private void assertRejectedTransferEncodingAttempt(String transferEncodingHeaders,
+                                                       Status expectedStatus,
+                                                       String payload) {
+        assertRejectedRequest("GET / HTTP/1.1\r\n"
+                                      + "Host: localhost\r\n"
+                                      + "Connection: keep-alive\r\n"
+                                      + transferEncodingHeaders
+                                      + "\r\n"
+                                      + payload,
+                              expectedStatus);
+    }
+
+    private void assertRejectedRequest(String rawRequest) {
+        assertRejectedRequest(rawRequest, Status.BAD_REQUEST_400);
+    }
+
+    private void assertRejectedRequest(String rawRequest, Status expectedStatus) {
+        socketClient.requestRaw(rawRequest);
+
+        String response = socketClient.receive();
+
+        String expectedStatusLine = expectedStatus.code() == Status.BAD_REQUEST_400.code()
+                ? expectedStatus.code() + " " + CUSTOM_REASON_PHRASE
+                : expectedStatus.code() + " " + expectedStatus.reasonPhrase();
+        assertThat(response, containsString(expectedStatusLine));
+        assertThat(response, containsString("Connection: close"));
+        assertThat(response, containsString(CUSTOM_ENTITY));
+        assertThat(socketClient.receive(), is(""));
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ErrorHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ public final class ErrorHandlers {
         boolean keepAlive = e.keepAlive();
         if (keepAlive && !request.content().consumed()) {
             // there is a chance, that the 100-Continue was already sent! In such a case, we MUST consume entity
-            if (request.headers().contains(HeaderValues.EXPECT_100) && !request.continueSent()) {
+            if (request.headers().containsToken(HeaderValues.EXPECT_100) && !request.continueSent()) {
                 // No content is coming, reset connection
                 request.reset();
             } else {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -20,7 +20,9 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
@@ -301,7 +303,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
      */
     static boolean upgradeHasEntity(WritableHeaders<?> headers) {
         return headers.contains(HeaderNames.CONTENT_LENGTH) && !headers.contains(HeaderValues.CONTENT_LENGTH_ZERO)
-                || headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+                || headers.contains(HeaderNames.TRANSFER_ENCODING);
     }
 
     static void validateHostHeader(HttpPrologue prologue, WritableHeaders<?> headers, boolean fullValidation) {
@@ -504,7 +506,8 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                        LimitAlgorithm.Outcome limitOutcome) {
         EntityStyle entity = EntityStyle.NONE;
 
-        if (headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+        if (headers.contains(HeaderNames.TRANSFER_ENCODING)) {
+            validateRequestTransferEncoding(prologue, headers);
             entity = EntityStyle.CHUNKED;
             this.currentEntitySize = -1;
         } else if (headers.contains(HeaderNames.CONTENT_LENGTH)) {
@@ -542,7 +545,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                                                    sendListener,
                                                                    writer,
                                                                    request,
-                                                                   !headers.contains(HeaderValues.CONNECTION_CLOSE),
+                                                                   !headers.containsToken(HeaderValues.CONNECTION_CLOSE),
                                                                    http1Config.sendKeepAliveHeader(),
                                                                    http1Config.validateResponseHeaders());
 
@@ -554,7 +557,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         boolean expectContinue = false;
 
         // Expect: 100-continue
-        if (headers.contains(HeaderValues.EXPECT_100)) {
+        if (headers.containsToken(HeaderValues.EXPECT_100)) {
             if (this.http1Config.continueImmediately()) {
                 try {
                     writer.writeNow(BufferData.create(CONTINUE_100));
@@ -612,7 +615,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                                                                writer,
                                                                request,
                                                                !request.headers()
-                                                                       .contains(HeaderValues.CONNECTION_CLOSE),
+                                                                       .containsToken(HeaderValues.CONNECTION_CLOSE),
                                                                http1Config.sendKeepAliveHeader(),
                                                                http1Config.validateResponseHeaders());
 
@@ -632,7 +635,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
     }
 
     private void consumeEntity(Http1ServerRequest request, Http1ServerResponse response, CountDownLatch entityReadLatch) {
-        if (response.headers().contains(HeaderValues.CONNECTION_CLOSE) || request.content().consumed()) {
+        if (response.headers().containsToken(HeaderValues.CONNECTION_CLOSE) || request.content().consumed()) {
             // we do not care about request entity if connection is getting closed
             entityReadLatch.countDown();
             return;
@@ -648,6 +651,69 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
             }
             throw new CloseConnectionException("Failed to consume request entity, must close", e);
         }
+    }
+
+    private void validateRequestTransferEncoding(HttpPrologue prologue, WritableHeaders<?> headers) {
+        if (headers.contains(HeaderNames.CONTENT_LENGTH)) {
+            throw invalidRequestFraming(prologue,
+                                        headers,
+                                        "Transfer-Encoding and Content-Length headers must not be combined");
+        }
+
+        List<String> transferEncodings = requestTransferEncodings(headers);
+        if (transferEncodings.isEmpty()) {
+            throw invalidRequestFraming(prologue, headers, "Transfer-Encoding header must contain a value");
+        }
+
+        String finalTransferEncoding = transferEncodings.get(transferEncodings.size() - 1);
+        if (!"chunked".equals(finalTransferEncoding)) {
+            throw invalidRequestFraming(prologue, headers, "Final Transfer-Encoding for requests must be chunked");
+        }
+
+        long chunkedCount = transferEncodings.stream()
+                .filter("chunked"::equals)
+                .count();
+        if (chunkedCount > 1) {
+            throw invalidRequestFraming(prologue, headers, "Chunked Transfer-Encoding must not be applied more than once");
+        }
+
+        if (transferEncodings.size() > 1) {
+            throw unsupportedRequestTransferEncoding(prologue, headers);
+        }
+    }
+
+    private List<String> requestTransferEncodings(WritableHeaders<?> headers) {
+        List<String> transferEncodings = new ArrayList<>();
+        for (String headerValue : headers.values(HeaderNames.TRANSFER_ENCODING)) {
+            String trimmed = headerValue.trim();
+            if (!trimmed.isEmpty()) {
+                transferEncodings.add(trimmed.toLowerCase(Locale.ROOT));
+            }
+        }
+        return transferEncodings;
+    }
+
+    private RequestException invalidRequestFraming(HttpPrologue prologue,
+                                                   WritableHeaders<?> headers,
+                                                   String message) {
+        return RequestException.builder()
+                .type(EventType.BAD_REQUEST)
+                .status(Status.BAD_REQUEST_400)
+                .request(DirectTransportRequest.create(prologue, headers))
+                .setKeepAlive(false)
+                .message(message)
+                .build();
+    }
+
+    private RequestException unsupportedRequestTransferEncoding(HttpPrologue prologue,
+                                                               WritableHeaders<?> headers) {
+        return RequestException.builder()
+                .type(EventType.BAD_REQUEST)
+                .status(Status.NOT_IMPLEMENTED_501)
+                .request(DirectTransportRequest.create(prologue, headers))
+                .setKeepAlive(false)
+                .message("Unsupported request transfer encoding")
+                .build();
     }
 
     private void handleRequestException(RequestException e) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -112,7 +112,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             // A 204 response is terminated by the end of the header section; it cannot contain content or trailers
             // ditto for 205, and 304
             if ((headers.contains(HeaderNames.CONTENT_LENGTH) && !headers.contains(HeaderValues.CONTENT_LENGTH_ZERO))
-                         || headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+                         || headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
                 status = noEntityInternalError(status);
             }
         }
@@ -254,7 +254,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
 
     @Override
     public ServerResponseTrailers trailers() {
-        if (request.headers().contains(HeaderValues.TE_TRAILERS) || headers.contains(HeaderNames.TRAILER)) {
+        if (request.headers().containsToken(HeaderValues.TE_TRAILERS) || headers.contains(HeaderNames.TRAILER)) {
             return trailers;
         }
         throw new IllegalStateException(
@@ -387,7 +387,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
 
         boolean forcedChunkedEncoding = false;
 
-        if (headers.contains(HeaderNames.TRANSFER_ENCODING) && headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+        if (headers.contains(HeaderNames.TRANSFER_ENCODING) && headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
             headers.remove(HeaderNames.CONTENT_LENGTH);
             // chunked enforced (and even if empty entity, will be used)
             forcedChunkedEncoding = true;
@@ -461,7 +461,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
     }
 
     boolean keepConnectionOpen() {
-        return keepAlive && !headers.contains(HeaderValues.CONNECTION_CLOSE);
+        return keepAlive && !headers.containsToken(HeaderValues.CONNECTION_CLOSE);
     }
 
     private static Status noEntityInternalError(Status status) {
@@ -542,7 +542,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                 forcedChunked = true;
             } else {
                 isChunked = !headers.contains(HeaderNames.CONTENT_LENGTH);
-                forcedChunked = headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+                forcedChunked = headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED);
             }
         }
 
@@ -601,7 +601,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             this.closed = true;
             boolean sendTrailers =
                     (isChunked || forcedChunked)
-                    && (request.headers().contains(HeaderValues.TE_TRAILERS)
+                    && (request.headers().containsToken(HeaderValues.TE_TRAILERS)
                                 || headers.contains(HeaderNames.TRAILER));
 
             if (firstByte) {
@@ -729,7 +729,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             }
 
             if (firstByte) {
-                if (request.headers().contains(HeaderValues.TE_TRAILERS)) {
+                if (request.headers().containsToken(HeaderValues.TE_TRAILERS)) {
                     // proper stream with multiple buffers, write status amd headers
                     headers.add(STREAM_TRAILERS);
                 }
@@ -789,7 +789,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                     headers.set(HeaderValues.TRANSFER_ENCODING_CHUNKED);
                 } else {
                     // Add chunked encoding, if it's not part of existing transfer-encoding headers
-                    if (!headers.contains(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+                    if (!headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
                         headers.add(HeaderValues.TRANSFER_ENCODING_CHUNKED);
                     }
                 }


### PR DESCRIPTION
Backport of `bb86c217bfc65d7afacca906be72340cfe5b8131` from `release-4.4.1`.

This carries the tokenized HTTP header handling fixes and the HTTP/1 redirect probe framing fix into `helidon-4.x`.
