### PR TITLE
Remove MP-generated config schema pages

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
@@ -61,8 +61,6 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigMappers;
 import io.helidon.config.ConfigValue;
-import io.helidon.config.metadata.Configured;
-import io.helidon.config.metadata.ConfiguredOption;
 import io.helidon.config.mp.spi.MpConfigFilter;
 import io.helidon.config.mp.spi.MpConfigSourceProvider;
 import io.helidon.config.mp.spi.MpMetaConfigProvider;
@@ -79,7 +77,6 @@ import static io.helidon.config.mp.MpMetaConfig.MetaConfigSource;
 /**
  * Configuration builder.
  */
-@Configured(prefix = "mp.config", root = true)
 class MpConfigBuilder implements Builder<MpConfigBuilder, Config>, ConfigBuilder {
     private static final System.Logger LOGGER = System.getLogger(MpConfigBuilder.class.getName());
     private static final String DEFAULT_CONFIG_SOURCE = "META-INF/microprofile-config.properties";
@@ -346,7 +343,6 @@ class MpConfigBuilder implements Builder<MpConfigBuilder, Config>, ConfigBuilder
      * @param profile name of the profile, such as {@code dev, test}
      * @return updated builder instance
      */
-    @ConfiguredOption(key = "profile", type = String.class, description = "Configure an explicit profile name.")
     public MpConfigBuilder profile(String profile) {
         this.profile = profile;
         return this;

--- a/docs/src/main/asciidoc/mp/jwt.adoc
+++ b/docs/src/main/asciidoc/mp/jwt.adoc
@@ -97,7 +97,7 @@ The following interfaces and annotations are used to work with JWT in Helidon MP
 |`5`
 |Clock skew to be accounted for in token expiration and max age validations in seconds
 
-|[[afc4c7251-mp-jwt-decrypt-key-algorithm]] xref:{rootdir}/config/io_helidon_microprofile_jwt_auth_JwtAuthProviderMp_jwt_decrypt_key_algorithm.adoc[`mp.jwt.decrypt.key.algorithm`]
+|<<MpJwtDecryptKeyAlgorithmAllowedValues,`mp.jwt.decrypt.key.algorithm`>>
 |`algorithm`
 |{nbsp}
 |Expected key management algorithm supported by the MP JWT endpoint
@@ -117,7 +117,7 @@ The following interfaces and annotations are used to work with JWT in Helidon MP
 |{nbsp}
 |Expected audiences of incoming tokens
 
-|[[aa1a7fcb1-security-providers-mp-jwt-auth-atn-token-jwk-resource]] xref:{rootdir}/config/io_helidon_common_configurable_Resource.adoc[`security.providers.mp-jwt-auth.atn-token.jwk.resource`]
+|xref:{rootdir}/config/io_helidon_common_configurable_Resource.adoc[`security.providers.mp-jwt-auth.atn-token.jwk.resource`]
 |`Resource`
 |{nbsp}
 |JWK resource for authenticating the request
@@ -142,7 +142,7 @@ The following interfaces and annotations are used to work with JWT in Helidon MP
 |{nbsp}
 |Default JWT key ID which should be used
 
-|[[a044b1acf-security-providers-mp-jwt-auth-sign-token]] xref:{rootdir}/config/io_helidon_security_providers_common_OutboundConfig.adoc[`security.providers.mp-jwt-auth.sign-token`]
+|xref:{rootdir}/config/io_helidon_security_providers_common_OutboundConfig.adoc[`security.providers.mp-jwt-auth.sign-token`]
 |`OutboundConfig`
 |{nbsp}
 |Configuration of outbound rules
@@ -157,7 +157,7 @@ The following interfaces and annotations are used to work with JWT in Helidon MP
 |{nbsp}
 |Path to public key
 
-|[[a9043a809-security-providers-mp-jwt-auth-atn-token-handler]] xref:{rootdir}/config/io_helidon_security_util_TokenHandler.adoc[`security.providers.mp-jwt-auth.atn-token.handler`]
+|xref:{rootdir}/config/io_helidon_security_util_TokenHandler.adoc[`security.providers.mp-jwt-auth.atn-token.handler`]
 |`TokenHandler`
 |{nbsp}
 |Token handler to extract username from request
@@ -182,7 +182,7 @@ The following interfaces and annotations are used to work with JWT in Helidon MP
 |{nbsp}
 |Maximal expected token age in seconds
 
-|[[a26e9ec7f-security-providers-mp-jwt-auth-principal-type]] xref:{rootdir}/config/io_helidon_security_SubjectType.adoc[`security.providers.mp-jwt-auth.principal-type`]
+|xref:{rootdir}/config/io_helidon_security_SubjectType.adoc[`security.providers.mp-jwt-auth.principal-type`]
 |`SubjectType`
 |`USER`
 |Principal type this provider extracts (and also propagates)
@@ -191,6 +191,19 @@ The following interfaces and annotations are used to work with JWT in Helidon MP
 |`Boolean`
 |`false`
 |Whether authentication is required
+
+|===
+
+==== Allowed values for `mp.jwt.decrypt.key.algorithm` [[MpJwtDecryptKeyAlgorithmAllowedValues]]
+
+|===
+|Value|Description
+
+|`RSA-OAEP`
+|RSA-OAEP Algorithm
+
+|`RSA-OAEP-256`
+|RSA-OAEP-256 Algorithm
 
 |===
 

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -56,9 +56,6 @@ import io.helidon.common.LazyValue;
 import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.Keys;
 import io.helidon.config.Config;
-import io.helidon.config.metadata.Configured;
-import io.helidon.config.metadata.ConfiguredOption;
-import io.helidon.config.metadata.ConfiguredValue;
 import io.helidon.http.HeaderNames;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
@@ -630,9 +627,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
      * Fluent API builder for {@link JwtAuthProvider}.
      */
     @SuppressWarnings("removal")
-    @Configured(description = "MP-JWT Auth configuration is defined by the spec (options prefixed with `mp.jwt.`), "
-            + "and we add a few configuration options for the security provider (options prefixed with "
-            + "`security.providers.mp-jwt-auth.`)")
     public static class Builder implements io.helidon.common.Builder<Builder, JwtAuthProvider> {
         private static final String HELIDON_CONFIG_PREFIX = "security.providers.mp-jwt-auth.";
         private static final String CONFIG_PUBLIC_KEY = "mp.jwt.verify.publickey";
@@ -971,7 +965,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param propagate whether to propagate identity (true) or not (false)
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "propagate", value = "true")
         public Builder propagate(boolean propagate) {
             this.propagate = propagate;
             return this;
@@ -983,7 +976,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param authenticate whether to authenticate (true) or not (false)
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "authenticate", value = "true")
         public Builder authenticate(boolean authenticate) {
             this.authenticate = authenticate;
             return this;
@@ -998,7 +990,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param allowImpersonation set to true to allow impersonation
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "allow-impersonation", value = "false")
         public Builder allowImpersonation(boolean allowImpersonation) {
             this.allowImpersonation = allowImpersonation;
             return this;
@@ -1010,7 +1001,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param subjectType type of principal
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "principal-type", value = "USER")
         public Builder subjectType(SubjectType subjectType) {
             this.subjectType = subjectType;
 
@@ -1032,7 +1022,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param tokenHandler token handler instance
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "atn-token.handler")
         public Builder atnTokenHandler(TokenHandler tokenHandler) {
             this.atnTokenHandler = tokenHandler;
 
@@ -1047,7 +1036,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param optional whether authentication is optional (true) or required (false)
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "optional", value = "false")
         public Builder optional(boolean optional) {
             this.optional = optional;
             return this;
@@ -1060,7 +1048,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          *               to add our configuration.
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "sign-token")
         public Builder outboundConfig(OutboundConfig config) {
             this.outboundConfig = config;
             return this;
@@ -1105,7 +1092,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param publicKey String representation
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_PUBLIC_KEY)
         public Builder publicKey(String publicKey) {
             // from MP specification - if defined, get rid of publicKeyPath from Helidon Config,
             // as we must fail if both are defined using MP configuration options
@@ -1121,8 +1107,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param publicKeyPath Public key path
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_PUBLIC_KEY_PATH)
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "atn-token.verify-key")
         public Builder publicKeyPath(String publicKeyPath) {
             this.publicKeyPath = publicKeyPath;
             return this;
@@ -1145,7 +1129,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param defaultKeyId Default JWT key ID
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "atn-token.default-key-id")
         public Builder defaultKeyId(String defaultKeyId) {
             this.defaultKeyId = defaultKeyId;
             return this;
@@ -1170,9 +1153,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param config configuration to load from
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "atn-token.jwk.resource",
-                          type = Resource.class,
-                          description = "JWK resource for authenticating the request")
         public Builder config(Config config) {
             config.get("optional").asBoolean().ifPresent(this::optional);
             config.get("authenticate").asBoolean().ifPresent(this::authenticate);
@@ -1222,7 +1202,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param header header name which should be used
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_JWT_HEADER, value = "Authorization")
         public Builder jwtHeader(String header) {
             if (HeaderNames.COOKIE.defaultCase().equalsIgnoreCase(header)) {
                 useCookie = true;
@@ -1242,7 +1221,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param cookieProperty cookie property name
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_COOKIE_PROPERTY_NAME, value = "Bearer")
         public Builder cookieProperty(String cookieProperty) {
             this.cookieProperty = cookieProperty;
             return this;
@@ -1254,7 +1232,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param issuer name of issuer
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_EXPECTED_ISSUER)
         public Builder expectedIssuer(String issuer) {
             this.expectedIssuer = issuer;
             return this;
@@ -1268,7 +1245,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @deprecated use {@link #addExpectedAudience(String)} instead
          */
         @Deprecated(forRemoval = true, since = "2.4.0")
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "atn-token.jwt-audience")
         public Builder expectedAudience(String audience) {
             return addExpectedAudience(audience);
         }
@@ -1290,9 +1266,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param audiences expected audiences to use
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_EXPECTED_AUDIENCES,
-                          type = String.class,
-                          kind = ConfiguredOption.Kind.LIST)
         public Builder expectedAudiences(Collection<String> audiences) {
             this.expectedAudiences.clear();
             this.expectedAudiences.addAll(audiences);
@@ -1305,7 +1278,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param expectedMaxTokenAge expected maximal token age in seconds
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_EXPECTED_MAX_TOKEN_AGE)
         public Builder expectedMaxTokenAge(int expectedMaxTokenAge) {
             this.expectedMaxTokenAge = Duration.ofSeconds(expectedMaxTokenAge);
             return this;
@@ -1318,7 +1290,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param decryptKeyLocation private key location
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_JWT_DECRYPT_KEY_LOCATION)
         public Builder decryptKeyLocation(String decryptKeyLocation) {
             this.decryptKeyLocation = decryptKeyLocation;
             return this;
@@ -1332,9 +1303,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param decryptionKeyAlgorithm expected decryption key algorithm
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_JWT_DECRYPT_KEY_ALGORITHM,
-                          allowedValues = {@ConfiguredValue(value = "RSA-OAEP", description = "RSA-OAEP Algorithm"),
-                                  @ConfiguredValue(value = "RSA-OAEP-256", description = "RSA-OAEP-256 Algorithm")})
         public Builder decryptKeyAlgorithm(String decryptionKeyAlgorithm) {
             this.decryptionKeyAlgorithm = decryptionKeyAlgorithm;
             return this;
@@ -1347,7 +1315,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param loadOnStartup load verification keys on server startup
          * @return updated builder instance
          */
-        @ConfiguredOption(key = HELIDON_CONFIG_PREFIX + "load-on-startup", value = "false")
         public Builder loadOnStartup(boolean loadOnStartup) {
             this.loadOnStartup = loadOnStartup;
             return this;
@@ -1359,7 +1326,6 @@ public class JwtAuthProvider implements AuthenticationProvider, OutboundSecurity
          * @param clockSkew clock skew
          * @return updated builder instance
          */
-        @ConfiguredOption(key = CONFIG_CLOCK_SKEW, value = "5")
         public Builder clockSkew(int clockSkew) {
             this.clockSkew = Duration.ofSeconds(clockSkew);
             return this;

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Objects;
 
 import io.helidon.common.context.Contexts;
-import io.helidon.config.metadata.Configured;
-import io.helidon.config.metadata.ConfiguredOption;
 import io.helidon.config.mp.MpConfigSources;
 import io.helidon.microprofile.cdi.HelidonContainer;
 
@@ -120,7 +118,6 @@ public interface Server {
     /**
      * Builder to build {@link Server} instance.
      */
-    @Configured(prefix = "server", description = "Configuration of Helidon Microprofile Server", root = true)
     final class Builder implements io.helidon.common.Builder<Builder, Server> {
         private static final System.Logger STARTUP_LOGGER = System.getLogger("io.helidon.microprofile.startup.builder");
 
@@ -251,7 +248,6 @@ public interface Server {
          * @param host hostname
          * @return modified builder
          */
-        @ConfiguredOption
         public Builder host(String host) {
             this.host = host;
             return this;
@@ -278,7 +274,6 @@ public interface Server {
          * @param port port
          * @return modified builder
          */
-        @ConfiguredOption
         public Builder port(int port) {
             this.port = port;
             return this;


### PR DESCRIPTION
Remove MP-generated config schema pages

### Description
    
Drop config metadata annotations from MP config, MP server, and MP-JWT
so the docs no longer generate the `mp` root, the MP server page, or
the MP-JWT config pages.

Keep the JWT decrypt key algorithm values documented inline in the MP
JWT guide and link the option to the local allowed-values subsection.

### Documentation

These changes impact the config schema and the generated config reference documentation.