### PR TITLE
Graceful handling of exceptions when writing to response

### DIFF
--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -502,7 +502,14 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                 if (!headersSent) {
                     http2Headers.status(io.helidon.http.Status.OK_200);
                 }
-                writeHeaders(http2Headers, HeaderFlags.create(END_OF_HEADERS | END_OF_STREAM));
+                try {
+                    writeHeaders(http2Headers, HeaderFlags.create(END_OF_HEADERS | END_OF_STREAM));
+                } catch (CloseConnectionException e) {
+                    callCancelled = true;
+                    currentStreamState.updateAndGet(
+                            current -> nextStreamState(current, Http2StreamState.HALF_CLOSED_LOCAL));
+                    return;
+                }
                 currentStreamState.updateAndGet(
                         current -> nextStreamState(current, Http2StreamState.HALF_CLOSED_LOCAL));
 

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.FlowControl;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
@@ -54,7 +56,9 @@ import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.Metrics;
 import io.helidon.metrics.api.Tag;
 import io.helidon.metrics.api.Timer;
+import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 
 import io.grpc.Codec;
@@ -173,7 +177,12 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                     listener.onReady();
                     bytesReceived = 0L;
                 });
+        } catch (CloseConnectionException e) {
+            throw e;
         } catch (Throwable e) {
+            if (isPeerCancellation(e)) {
+                throw new ServerConnectionException("gRPC call cancelled by remote peer", e);
+            }
             LOGGER.log(ERROR, "Failed to initialize grpc protocol handler", e);
             throw e;
         }
@@ -271,7 +280,12 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                     methodMetrics.recvMessageSize.record(bytesReceived);
                 }
             }
+        } catch (CloseConnectionException e) {
+            throw e;
         } catch (Exception e) {
+            if (isPeerCancellation(e)) {
+                throw new ServerConnectionException("gRPC call cancelled by remote peer", e);
+            }
             listener.onCancel();
             LOGGER.log(ERROR, "Failed to process grpc request: " + data.debugDataHex(true), e);
         }
@@ -334,6 +348,26 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         return identityCompressor;
     }
 
+    private boolean isPeerCancellation(Throwable throwable) {
+        return callCancelled && Status.fromThrowable(throwable).getCode() == Status.Code.CANCELLED;
+    }
+
+    private void writeHeaders(Http2Headers http2Headers, HeaderFlags flags) {
+        try {
+            streamWriter.writeHeaders(http2Headers, streamId, flags, outboundFlowControl());
+        } catch (UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write grpc response headers", e);
+        }
+    }
+
+    private void writeData(Http2FrameData frameData) {
+        streamWriter.writeData(frameData, outboundFlowControl());
+    }
+
+    private FlowControl.Outbound outboundFlowControl() {
+        return flowControl == null ? FlowControl.Outbound.NOOP : flowControl.outbound();
+    }
+
     private void addNumMessages(int n) {
         numMessages.getAndAdd(n);
     }
@@ -368,7 +402,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         };
     }
 
-    private ServerCall<REQ, RES> createServerCall() {
+    ServerCall<REQ, RES> createServerCall() {
         return new ServerCall<REQ, RES>() {
 
             private long bytesSent;
@@ -398,10 +432,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                 // write headers frame
                 Http2Headers http2Headers = Http2Headers.create(writable);
                 http2Headers.status(io.helidon.http.Status.OK_200);
-                streamWriter.writeHeaders(http2Headers,
-                                          streamId,
-                                          HeaderFlags.create(END_OF_HEADERS),
-                                          flowControl.outbound());
+                writeHeaders(http2Headers, HeaderFlags.create(END_OF_HEADERS));
                 headersSent = true;
             }
 
@@ -440,8 +471,10 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                                                                       streamId);
 
                     // write data frame
-                    streamWriter.writeData(new Http2FrameData(header, bufferData), flowControl.outbound());
+                    writeData(new Http2FrameData(header, bufferData));
                     bytesSent += writeLength;
+                } catch (UncheckedIOException e) {
+                    throw new ServerConnectionException("Failed to write grpc response data", e);
                 } catch (IOException e) {
                     listener.onCancel();
                     LOGGER.log(ERROR, "Failed to respond to grpc request: " + route.method(), e);
@@ -469,10 +502,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                 if (!headersSent) {
                     http2Headers.status(io.helidon.http.Status.OK_200);
                 }
-                streamWriter.writeHeaders(http2Headers,
-                                          streamId,
-                                          HeaderFlags.create(END_OF_HEADERS | END_OF_STREAM),
-                                          flowControl.outbound());
+                writeHeaders(http2Headers, HeaderFlags.create(END_OF_HEADERS | END_OF_STREAM));
                 currentStreamState.updateAndGet(
                         current -> nextStreamState(current, Http2StreamState.HALF_CLOSED_LOCAL));
 
@@ -491,7 +521,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
             @Override
             public boolean isCancelled() {
-                return currentStreamState.get() == Http2StreamState.CLOSED;
+                return callCancelled || currentStreamState.get() == Http2StreamState.CLOSED;
             }
 
             @Override

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -16,24 +16,48 @@
 
 package io.helidon.webserver.grpc;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+
+import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.PeerInfo;
+import io.helidon.grpc.core.WeightedBag;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2StreamState;
-
+import io.helidon.http.http2.Http2StreamWriter;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
+import io.helidon.webserver.ServerConnectionException;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.Status;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.util.concurrent.ExecutorService;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GrpcProtocolHandlerTest {
 
@@ -104,6 +128,199 @@ class GrpcProtocolHandlerTest {
         Http2StreamState next = GrpcProtocolHandler.nextStreamState(
                 Http2StreamState.HALF_CLOSED_REMOTE, Http2StreamState.HALF_CLOSED_LOCAL);
         assertThat(next, is(Http2StreamState.CLOSED));
+    }
+
+    @Test
+    void testSendHeadersWrapsUncheckedIOException() {
+        ServerCall<String, String> serverCall = createServerCall(headersFailingWriter());
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> serverCall.sendHeaders(new Metadata()));
+
+        assertThat(exception.getCause(), instanceOf(UncheckedIOException.class));
+    }
+
+    @Test
+    void testSendMessageWrapsUncheckedIOException() {
+        ServerCall<String, String> serverCall = createServerCall(dataFailingWriter());
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> serverCall.sendMessage("hello"));
+
+        assertThat(exception.getCause(), instanceOf(UncheckedIOException.class));
+    }
+
+    @Test
+    void testCancelledPeerDoesNotLeakGrpcCancellationStacktrace() {
+        ServerCall.Listener<String> listener = new ServerCall.Listener<>() {
+            @Override
+            public void onHalfClose() {
+                throw Status.CANCELLED.asRuntimeException();
+            }
+        };
+
+        GrpcProtocolHandler<String, String> handler = new GrpcProtocolHandler<>(new UnimplementedGrpcConnectionContext(),
+                                                                                Http2Headers.create(WritableHeaders.create()),
+                                                                                noOpWriter(),
+                                                                                1,
+                                                                                null,
+                                                                                Http2StreamState.OPEN,
+                                                                                route(listener),
+                                                                                GrpcConfig.create());
+        handler.init();
+        handler.rstStream(new Http2RstStream(io.helidon.http.http2.Http2ErrorCode.CANCEL));
+
+        Http2FrameHeader header = Http2FrameHeader.create(0,
+                                                          Http2FrameTypes.DATA,
+                                                          Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                          1);
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> handler.data(header, BufferData.empty()));
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(RuntimeException.class)),
+                () -> assertThat(Status.fromThrowable(exception.getCause()).getCode(), is(Status.Code.CANCELLED))
+        );
+    }
+
+    private static ServerCall<String, String> createServerCall(Http2StreamWriter streamWriter) {
+        GrpcProtocolHandler<String, String> handler = new GrpcProtocolHandler<>(new UnimplementedGrpcConnectionContext(),
+                                                                                Http2Headers.create(WritableHeaders.create()),
+                                                                                streamWriter,
+                                                                                1,
+                                                                                null,
+                                                                                Http2StreamState.OPEN,
+                                                                                route(new ServerCall.Listener<>() {
+                                                                                }),
+                                                                                GrpcConfig.create());
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(GRPC_ACCEPT_ENCODING, "identity");
+        handler.initCompression(null, headers);
+        return handler.createServerCall();
+    }
+
+    private static GrpcRouteHandler<String, String> route(ServerCall.Listener<String> listener) {
+        ServerMethodDefinition<String, String> definition =
+                ServerMethodDefinition.create(stringMethodDescriptor(), new ServerCallHandler<>() {
+                    @Override
+                    public ServerCall.Listener<String> startCall(ServerCall<String, String> call, Metadata headers) {
+                        return listener;
+                    }
+                });
+        return GrpcRouteHandler.methodDefinition(definition, null, WeightedBag.create());
+    }
+
+    private static MethodDescriptor<String, String> stringMethodDescriptor() {
+        MethodDescriptor.Marshaller<String> marshaller = new MethodDescriptor.Marshaller<>() {
+            @Override
+            public InputStream stream(String value) {
+                return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+            }
+
+            @Override
+            public String parse(InputStream stream) {
+                try {
+                    return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        };
+        return MethodDescriptor.<String, String>newBuilder()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName("test.Test/Call")
+                .setRequestMarshaller(marshaller)
+                .setResponseMarshaller(marshaller)
+                .build();
+    }
+
+    private static Http2StreamWriter headersFailingWriter() {
+        return new Http2StreamWriter() {
+            @Override
+            public void write(Http2FrameData frame) {
+            }
+
+            @Override
+            public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers,
+                                    int streamId,
+                                    Http2Flag.HeaderFlags flags,
+                                    FlowControl.Outbound flowControl) {
+                throw new UncheckedIOException(new IOException("Broken pipe"));
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers,
+                                    int streamId,
+                                    Http2Flag.HeaderFlags flags,
+                                    Http2FrameData dataFrame,
+                                    FlowControl.Outbound flowControl) {
+                throw new UnsupportedOperationException("Unused");
+            }
+        };
+    }
+
+    private static Http2StreamWriter dataFailingWriter() {
+        return new Http2StreamWriter() {
+            @Override
+            public void write(Http2FrameData frame) {
+            }
+
+            @Override
+            public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+                throw new UncheckedIOException(new IOException("Broken pipe"));
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers,
+                                    int streamId,
+                                    Http2Flag.HeaderFlags flags,
+                                    FlowControl.Outbound flowControl) {
+                return 0;
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers,
+                                    int streamId,
+                                    Http2Flag.HeaderFlags flags,
+                                    Http2FrameData dataFrame,
+                                    FlowControl.Outbound flowControl) {
+                throw new UnsupportedOperationException("Unused");
+            }
+        };
+    }
+
+    private static Http2StreamWriter noOpWriter() {
+        return new Http2StreamWriter() {
+            @Override
+            public void write(Http2FrameData frame) {
+            }
+
+            @Override
+            public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers,
+                                    int streamId,
+                                    Http2Flag.HeaderFlags flags,
+                                    FlowControl.Outbound flowControl) {
+                return 0;
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers,
+                                    int streamId,
+                                    Http2Flag.HeaderFlags flags,
+                                    Http2FrameData dataFrame,
+                                    FlowControl.Outbound flowControl) {
+                return 0;
+            }
+        };
     }
 
     private static class UnimplementedGrpcConnectionContext implements ConnectionContext {

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -57,6 +58,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GrpcProtocolHandlerTest {
@@ -184,6 +186,15 @@ class GrpcProtocolHandlerTest {
         );
     }
 
+    @Test
+    void testCloseSuppressesTrailerWriteDisconnect() {
+        ServerCall<String, String> serverCall = createServerCall(closeFailingWriter());
+        serverCall.sendHeaders(new Metadata());
+
+        assertDoesNotThrow(() -> serverCall.close(Status.OK, new Metadata()));
+        assertThat(serverCall.isCancelled(), is(true));
+    }
+
     private static ServerCall<String, String> createServerCall(Http2StreamWriter streamWriter) {
         GrpcProtocolHandler<String, String> handler = new GrpcProtocolHandler<>(new UnimplementedGrpcConnectionContext(),
                                                                                 Http2Headers.create(WritableHeaders.create()),
@@ -281,6 +292,39 @@ class GrpcProtocolHandlerTest {
                                     Http2Flag.HeaderFlags flags,
                                     FlowControl.Outbound flowControl) {
                 return 0;
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers,
+                                    int streamId,
+                                    Http2Flag.HeaderFlags flags,
+                                    Http2FrameData dataFrame,
+                                    FlowControl.Outbound flowControl) {
+                throw new UnsupportedOperationException("Unused");
+            }
+        };
+    }
+
+    private static Http2StreamWriter closeFailingWriter() {
+        AtomicInteger headerWrites = new AtomicInteger();
+        return new Http2StreamWriter() {
+            @Override
+            public void write(Http2FrameData frame) {
+            }
+
+            @Override
+            public void writeData(Http2FrameData frame, FlowControl.Outbound flowControl) {
+            }
+
+            @Override
+            public int writeHeaders(Http2Headers headers,
+                                    int streamId,
+                                    Http2Flag.HeaderFlags flags,
+                                    FlowControl.Outbound flowControl) {
+                if (headerWrites.incrementAndGet() == 1) {
+                    return 0;
+                }
+                throw new UncheckedIOException(new IOException("Broken pipe"));
             }
 
             @Override

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -133,7 +133,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         this.connectionWriter = new Http2ConnectionWriter(ctx,
                                                           ctx.dataWriter(),
                                                           List.of(new Http2LoggingFrameListener("send")));
-        this.connectionChecks = new Http2ConnectionChecks(http2Config, connectionWriter, this);
+        this.connectionChecks = new Http2ConnectionChecks(http2Config, this);
         this.subProviders = subProviders;
         this.requestDynamicTable = Http2Headers.DynamicTable.create(
                 serverSettings.value(Http2Setting.HEADER_TABLE_SIZE));
@@ -764,7 +764,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         state = State.READ_FRAME;
     }
 
-    private void writeConnectionFrame(Http2FrameData frame) {
+    void writeConnectionFrame(Http2FrameData frame) {
         try {
             connectionWriter.write(frame);
         } catch (UncheckedIOException e) {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -60,6 +60,7 @@ import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.http.http2.WindowSize;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 import io.helidon.webserver.spi.ServerConnection;
@@ -185,7 +186,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             Http2GoAway frame = new Http2GoAway(0,
                                                 e.code(),
                                                 sendErrorDetails ? e.getMessage() : "");
-            connectionWriter.write(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
+            writeConnectionFrame(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
             state = State.FINISHED;
         } catch (CloseConnectionException
                  | InterruptedException
@@ -199,7 +200,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             Http2GoAway frame = new Http2GoAway(0,
                                                 Http2ErrorCode.INTERNAL,
                                                 sendErrorDetails ? e.getClass().getName() + ": " + e.getMessage() : "");
-            connectionWriter.write(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
+            writeConnectionFrame(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
             state = State.FINISHED;
             throw e;
         }
@@ -226,7 +227,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                 Http2GoAway frame = new Http2GoAway(0,
                                                     Http2ErrorCode.FLOW_CONTROL,
                                                     "Window " + initialWindowSize + " size too large");
-                connectionWriter.write(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
+                writeConnectionFrame(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
             }
 
             //6.9.1/1 - changing the flow-control window for streams that are not yet active
@@ -355,7 +356,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         }
         if (state != State.FINISHED) {
             Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.NO_ERROR, "Idle timeout");
-            connectionWriter.write(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
+            writeConnectionFrame(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
         }
     }
 
@@ -464,13 +465,13 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     }
 
     private void writeServerSettings() {
-        connectionWriter.write(serverSettings.toFrameData(serverSettings, 0, Http2Flag.SettingsFlags.create(0)));
+        writeConnectionFrame(serverSettings.toFrameData(serverSettings, 0, Http2Flag.SettingsFlags.create(0)));
 
         // Initial window size for connection is not configurable, subsequent update win update is needed
         int connectionWinSizeUpd = http2Config.initialWindowSize() - WindowSize.DEFAULT_WIN_SIZE;
         if (connectionWinSizeUpd > 0) {
             Http2WindowUpdate windowUpdate = new Http2WindowUpdate(http2Config.initialWindowSize() - WindowSize.DEFAULT_WIN_SIZE);
-            connectionWriter.write(windowUpdate.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
+            writeConnectionFrame(windowUpdate.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
         }
 
         state = State.READ_FRAME;
@@ -491,13 +492,13 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             // overall connection
             if (increment == 0) {
                 Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.PROTOCOL, "Window size 0");
-                connectionWriter.write(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
+                writeConnectionFrame(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
             }
 
             long size = flowControl.incrementOutboundConnectionWindowSize(increment);
             if (size > WindowSize.MAX_WIN_SIZE || size < 0) {
                 Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.FLOW_CONTROL, "Window size too big.");
-                connectionWriter.write(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
+                writeConnectionFrame(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
             }
         } else {
             try {
@@ -511,7 +512,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
 
     // Used in inbound flow control instance to write WINDOW_UPDATE frame.
     private void writeWindowUpdateFrame(int streamId, Http2WindowUpdate windowUpdateFrame) {
-        connectionWriter.write(windowUpdateFrame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+        writeConnectionFrame(windowUpdateFrame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
     }
 
     private void doSettings() {
@@ -535,7 +536,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     private void ackSettings() {
         Http2Flag.SettingsFlags flags = Http2Flag.SettingsFlags.create(Http2Flag.ACK);
         Http2FrameHeader header = Http2FrameHeader.create(0, Http2FrameTypes.SETTINGS, flags, 0);
-        connectionWriter.write(new Http2FrameData(header, BufferData.empty()));
+        writeConnectionFrame(new Http2FrameData(header, BufferData.empty()));
         state = State.READ_FRAME;
 
         if (upgradeHeaders != null) {
@@ -748,15 +749,27 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         }
     }
 
-    private void writePingAck() {
+    void pendingPing(Http2Ping ping) {
+        this.ping = ping;
+    }
+
+    void writePingAck() {
         BufferData frame = ping.data();
         Http2FrameHeader header = Http2FrameHeader.create(frame.available(),
                                                           Http2FrameTypes.PING,
                                                           Http2Flag.PingFlags.create(Http2Flag.ACK),
                                                           0);
         ping = null;
-        connectionWriter.write(new Http2FrameData(header, frame));
+        writeConnectionFrame(new Http2FrameData(header, frame));
         state = State.READ_FRAME;
+    }
+
+    private void writeConnectionFrame(Http2FrameData frame) {
+        try {
+            connectionWriter.write(frame);
+        } catch (UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write HTTP/2 connection frame", e);
+        }
     }
 
     private void goAwayFrame() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConnectionChecks.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConnectionChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package io.helidon.webserver.http2;
 
-import io.helidon.http.http2.Http2ConnectionWriter;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2GoAway;
@@ -28,7 +27,6 @@ class Http2ConnectionChecks {
 
     // No fancy client settings needed for goaway
     private final Http2Settings clientSettings = Http2Settings.builder().build();
-    private final Http2ConnectionWriter writer;
     private final Http2Connection connection;
     private final long rapidResetCheckPeriod;
     private final int maxRapidResets;
@@ -36,10 +34,9 @@ class Http2ConnectionChecks {
     private long rapidResetPeriodStart = 0;
     private long serverSideResetCounter = 0;
 
-    Http2ConnectionChecks(Http2Config http2Config, Http2ConnectionWriter connectionWriter, Http2Connection connection) {
+    Http2ConnectionChecks(Http2Config http2Config, Http2Connection connection) {
         this.rapidResetCheckPeriod = http2Config.rapidResetCheckPeriod().toNanos();
         this.maxRapidResets = http2Config.maxRapidResets();
-        this.writer = connectionWriter;
         this.connection = connection;
     }
 
@@ -79,9 +76,12 @@ class Http2ConnectionChecks {
             LOGGER.log(System.Logger.Level.DEBUG, msg + " Closing connection " + connection + " with GOAWAY");
         }
         Http2GoAway frame = new Http2GoAway(0, Http2ErrorCode.ENHANCE_YOUR_CALM, msg);
-        writer.write(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
-        // Finish to avoid implicit goaway after close
-        connection.finish();
+        try {
+            connection.writeConnectionFrame(frame.toFrameData(clientSettings, 0, Http2Flag.NoFlags.create()));
+        } finally {
+            // Finish to avoid implicit GOAWAY after close, even if the peer is already gone.
+            connection.finish();
+        }
         // Avoid further processing changing the connection state
         throw new CloseConnectionException("Enhance your calm.");
     }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Upgrader.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Upgrader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http2;
 
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -29,6 +30,7 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2Settings;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http1.spi.Http1Upgrader;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 import io.helidon.webserver.spi.ServerConnection;
@@ -97,9 +99,16 @@ public class Http2Upgrader implements Http1Upgrader {
 
         connection.upgradeConnectionData(newPrologue, http2Headers);
         connection.expectPreface();
-        DataWriter dataWriter = ctx.dataWriter();
-        dataWriter.writeNow(BufferData.create(SWITCHING_PROTOCOLS_BYTES));
+        writeUpgradeResponse(ctx.dataWriter());
         return connection;
+    }
+
+    private static void writeUpgradeResponse(DataWriter dataWriter) {
+        try {
+            dataWriter.writeNow(BufferData.create(SWITCHING_PROTOCOLS_BYTES));
+        } catch (UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write HTTP/2 upgrade response", e);
+        }
     }
 
     /**

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http2;
+
+import java.io.UncheckedIOException;
+import java.net.SocketException;
+import java.util.List;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.http.http2.Http2Ping;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.ServerConnectionException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Http2ConnectionTest {
+
+    @Test
+    void pingAckWrapsUncheckedIOException() {
+        DataWriter writer = mock(DataWriter.class);
+        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
+                .when(writer)
+                .writeNow(any(BufferData.class));
+
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.listenerContext()).thenReturn(mock(ListenerContext.class));
+        when(ctx.dataWriter()).thenReturn(writer);
+        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+
+        Http2Connection connection = new Http2Connection(ctx, Http2Config.create(), List.of());
+        connection.pendingPing(Http2Ping.create());
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           connection::writePingAck);
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
+                () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
+        );
+    }
+}

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -66,4 +66,33 @@ class Http2ConnectionTest {
                 () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
         );
     }
+
+    @Test
+    void closeConnectionWrapsUncheckedIOException() {
+        DataWriter writer = mock(DataWriter.class);
+        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
+                .when(writer)
+                .writeNow(any(BufferData.class));
+
+        Http2Config config = Http2Config.builder()
+                .maxRapidResets(0)
+                .build();
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.router()).thenReturn(Router.empty());
+        when(ctx.listenerContext()).thenReturn(mock(ListenerContext.class));
+        when(ctx.dataWriter()).thenReturn(writer);
+        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+
+        Http2Connection connection = new Http2Connection(ctx, config, List.of());
+        Http2ConnectionChecks checks = new Http2ConnectionChecks(config, connection);
+
+        checks.madeYouResetCheck(0);
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> checks.madeYouResetCheck(0));
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
+                () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
+        );
+    }
 }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/UpgradeSettingsTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/UpgradeSettingsTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.http2;
 
+import java.io.UncheckedIOException;
+import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -41,6 +43,7 @@ import io.helidon.http.http2.Http2Util;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
+import io.helidon.webserver.ServerConnectionException;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,13 +53,16 @@ import static io.helidon.http.http2.Http2Setting.INITIAL_WINDOW_SIZE;
 import static io.helidon.http.http2.Http2Setting.MAX_CONCURRENT_STREAMS;
 import static io.helidon.http.http2.Http2Setting.MAX_FRAME_SIZE;
 import static io.helidon.http.http2.Http2Setting.MAX_HEADER_LIST_SIZE;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -166,6 +172,31 @@ class UpgradeSettingsTest {
         assertThat(goAway.errorCode(), is(Http2ErrorCode.PROTOCOL));
         assertThat(new String(payloadBytes, 8, payloadBytes.length - 8, StandardCharsets.UTF_8),
                    is("Frame size must be between 2^14 and 2^24-1, but is: 0"));
+    }
+
+    @Test
+    void upgradeWriteWrapsUncheckedIOException() {
+        DataWriter dataWriter = mock(DataWriter.class);
+        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
+                .when(dataWriter)
+                .writeNow(any(BufferData.class));
+
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        when(connectionContext.router()).thenReturn(Router.empty());
+        when(connectionContext.listenerContext()).thenReturn(mock(ListenerContext.class));
+        when(connectionContext.dataWriter()).thenReturn(dataWriter);
+        when(connectionContext.dataReader()).thenReturn(mock(DataReader.class));
+
+        WritableHeaders<?> headers = WritableHeaders.create().add(HeaderValues.create("HTTP2-Settings", "AAEAABAAAAIAAAAB"));
+        Http2Upgrader http2Upgrader = Http2Upgrader.create(Http2Config.create());
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> http2Upgrader.upgrade(connectionContext, prologue, headers));
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
+                () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
+        );
     }
 
     Http2Settings upgrade(String http2Settings) {

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentHandler.java
@@ -44,6 +44,7 @@ import io.helidon.http.PathMatchers;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.Status;
+import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
@@ -233,6 +234,8 @@ abstract class StaticContentHandler implements StaticContentService {
             if (!doHandle(method, requestPath, request, response, mapped)) {
                 response.next();
             }
+        } catch (CloseConnectionException e) {
+            throw e;
         } catch (HttpException httpException) {
             if (httpException.status().code() == Status.NOT_FOUND_404.code()) {
                 // Prefer to next() before NOT_FOUND

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentHandlerTest.java
@@ -17,6 +17,7 @@
 package io.helidon.webserver.staticcontent;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -37,6 +38,7 @@ import io.helidon.http.RoutedPath;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.Status;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
@@ -49,6 +51,7 @@ import static io.helidon.http.HeaderNames.IF_NONE_MATCH;
 import static io.helidon.http.HeaderNames.LOCATION;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -203,6 +206,22 @@ class StaticContentHandlerTest {
     }
 
     @Test
+    void handlePreservesServerConnectionException() {
+        ServerRequest request = mockRequestWithPath(Method.GET, "/foo/some.txt");
+        ServerResponse response = mock(ServerResponse.class);
+        ServerConnectionException expected = new ServerConnectionException("Failed to write response",
+                                                                          new UncheckedIOException(new IOException(
+                                                                                  "Broken pipe")));
+        ThrowingContentHandler handler = ThrowingContentHandler.create(expected);
+
+        ServerConnectionException actual = assertThrows(ServerConnectionException.class,
+                                                        () -> handler.handle(request, response));
+
+        assertThat(actual, is(expected));
+        verify(response, never()).next();
+    }
+
+    @Test
     void classpathHandleSpaces() {
         ServerRequest request = mockRequestWithPath(Method.GET, "foo/I have spaces.txt");
         ServerResponse response = mock(ServerResponse.class);
@@ -328,5 +347,31 @@ class StaticContentHandlerTest {
             return returnValue;
         }
 
+    }
+
+    static class ThrowingContentHandler extends FileSystemContentHandler {
+        private final RuntimeException exception;
+
+        ThrowingContentHandler(FileSystemHandlerConfig config, RuntimeException exception) {
+            super(config);
+            this.exception = exception;
+        }
+
+        static ThrowingContentHandler create(RuntimeException exception) {
+            return new ThrowingContentHandler(FileSystemHandlerConfig.builder()
+                                                    .location(Paths.get("."))
+                                                    .build(),
+                                             exception);
+        }
+
+        @Override
+        boolean doHandle(Method method,
+                         String requestedResource,
+                         ServerRequest req,
+                         ServerResponse res,
+                         String rawPath,
+                         Path path) {
+            throw exception;
+        }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -34,6 +34,7 @@ import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.concurrency.limits.Limit;
 import io.helidon.common.concurrency.limits.LimitAlgorithm;
 import io.helidon.common.mapper.MapperException;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.common.task.InterruptableTask;
 import io.helidon.common.tls.TlsUtils;
 import io.helidon.common.uri.UriValidator;
@@ -753,8 +754,8 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         sendListener.data(ctx, buffer);
         try {
             writer.write(buffer);
-        } catch (UncheckedIOException uioe) {
-            throw new ServerConnectionException("Failed to write request exception", uioe);
+        } catch (SocketWriterException | UncheckedIOException writeException) {
+            throw new ServerConnectionException("Failed to write request exception", writeException);
         }
 
         if (response.status() == Status.INTERNAL_SERVER_ERROR_500) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -34,6 +34,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.DateTime;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
@@ -218,7 +219,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             bytesWritten = bufferData.available();
             isSent = true;
             request.reset();
-            dataWriter.write(bufferData);
+            writeResponse(dataWriter, bufferData, "Failed to write response");
             afterSend();
         } else {
             // we should skip encoders if no data is written (e.g. for GZIP)
@@ -393,6 +394,14 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         }
         for (Header header : headers) {
             header.writeHttp1Header(buffer);
+        }
+    }
+
+    private static void writeResponse(DataWriter dataWriter, BufferData bufferData, String message) {
+        try {
+            dataWriter.write(bufferData);
+        } catch (SocketWriterException | UncheckedIOException e) {
+            throw new ServerConnectionException(message, e);
         }
     }
 
@@ -647,7 +656,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                 writeHeaders(trailers, buffer, this.validateHeaders);
                 buffer.write('\r');        // "\r\n" - empty line after headers
                 buffer.write('\n');
-                dataWriter.write(buffer);
+                writeResponse(dataWriter, buffer, "Failed to write response trailers");
             }
 
             responseCloseRunnable.run();
@@ -683,7 +692,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         private void terminatingChunk(boolean trailers) {
             BufferData terminatingChunk = BufferData.create(trailers ? TERMINATING_CHUNK_TRAILERS : TERMINATING_CHUNK);
             sendListener.data(ctx, terminatingChunk);
-            dataWriter.write(terminatingChunk);
+            writeResponse(dataWriter, terminatingChunk, "Failed to write terminating chunk");
         }
 
         private void write(BufferData buffer) throws IOException {
@@ -710,7 +719,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                     // write single buffer headers and payload part
                     growing.write(buffer);
                     responseBytesTotal += growing.available();
-                    dataWriter.write(growing);
+                    writeResponse(dataWriter, growing, "Failed to write response");
                 } else {
                     // if not chunked, always write
                     writeContent(buffer);
@@ -772,7 +781,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
 
             sendListener.data(ctx, bufferData);
             responseBytesTotal += bufferData.available();
-            dataWriter.write(bufferData);
+            writeResponse(dataWriter, bufferData, "Failed to write response");
         }
 
         private void sendHeadersAndPrepare() {
@@ -800,7 +809,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             nonEntityBytes(headers, usedStatus, bufferData, keepAlive, validateHeaders);
             sendListener.data(ctx, bufferData);
             responseBytesTotal += bufferData.available();
-            dataWriter.write(bufferData);
+            writeResponse(dataWriter, bufferData, "Failed to write response headers");
         }
 
         private void writeChunked(BufferData buffer) {
@@ -817,7 +826,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
 
             sendListener.data(ctx, toWrite);
             responseBytesTotal += toWrite.available();
-            dataWriter.write(toWrite);
+            writeResponse(dataWriter, toWrite, "Failed to write chunked response data");
         }
 
         private void checkContentLength(BufferData ignored) throws IOException {
@@ -833,7 +842,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             checkContentLength(buffer);
             sendListener.data(ctx, buffer);
             responseBytesTotal += buffer.available();
-            dataWriter.write(buffer);
+            writeResponse(dataWriter, buffer, "Failed to write response content");
         }
     }
 
@@ -881,7 +890,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             closingDelegate.closing();     // inform of imminent call to close for last flush
             try {
                 delegate.close();
-            } catch (IOException | UncheckedIOException e) {
+            } catch (IOException | UncheckedIOException | SocketWriterException e) {
                 throw new ServerConnectionException("Failed to close server output stream", e);
             }
         }
@@ -894,7 +903,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
             try {
                 flush();
                 closingDelegate.commit();
-            } catch (IOException | UncheckedIOException e) {
+            } catch (IOException | UncheckedIOException | SocketWriterException e) {
                 throw new ServerConnectionException("Failed to flush server output stream", e);
             }
         }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http1;
+
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+
+import javax.net.ssl.SSLException;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.SocketWriterException;
+import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.http.media.MediaContext;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.ServerConnectionException;
+import io.helidon.webserver.WebServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Http1ServerResponseTest {
+
+    @Test
+    void directSendWrapsUncheckedIOException() {
+        Http1ServerResponse response = createResponse(new UncheckedIOException(new SocketException("Broken pipe")));
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> response.send("hello".getBytes(StandardCharsets.UTF_8)));
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
+                () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
+        );
+    }
+
+    @Test
+    void directSendWrapsSocketWriterException() {
+        Http1ServerResponse response =
+                createResponse(new SocketWriterException(new UncheckedIOException(new SSLException("Engine is closed"))));
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> response.send("hello".getBytes(StandardCharsets.UTF_8)));
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(SocketWriterException.class)),
+                () -> assertThat(exception.getCause().getCause(), instanceOf(UncheckedIOException.class)),
+                () -> assertThat(exception.getCause().getCause().getCause(), instanceOf(SSLException.class))
+        );
+    }
+
+    @Test
+    void streamingCommitWrapsSocketWriterException() throws Exception {
+        Http1ServerResponse response = createResponse(
+                new SocketWriterException(new UncheckedIOException(new SocketException("Connection reset by peer"))));
+
+        OutputStream outputStream = response.outputStream();
+        outputStream.write("hello".getBytes(StandardCharsets.UTF_8));
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class, response::commit);
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(SocketWriterException.class)),
+                () -> assertThat(exception.getCause().getCause(), instanceOf(UncheckedIOException.class)),
+                () -> assertThat(exception.getCause().getCause().getCause(), instanceOf(SocketException.class))
+        );
+    }
+
+    private static Http1ServerResponse createResponse(RuntimeException writerFailure) {
+        DataWriter dataWriter = mock(DataWriter.class);
+        doThrow(writerFailure).when(dataWriter).write(any(BufferData.class));
+
+        Http1ServerRequest request = mock(Http1ServerRequest.class);
+        when(request.headers()).thenReturn(ServerRequestHeaders.create(WritableHeaders.create()));
+
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
+        when(listenerContext.mediaContext()).thenReturn(MediaContext.create());
+        when(listenerContext.config()).thenReturn(WebServer.builder().buildPrototype());
+
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.listenerContext()).thenReturn(listenerContext);
+
+        return new Http1ServerResponse(ctx,
+                                       mock(Http1ConnectionListener.class),
+                                       dataWriter,
+                                       request,
+                                       true,
+                                       true);
+    }
+}

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsConnection.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.websocket;
 
+import java.io.UncheckedIOException;
 import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -32,6 +33,7 @@ import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.spi.ServerConnection;
 import io.helidon.websocket.ClientWsFrame;
 import io.helidon.websocket.ServerWsFrame;
@@ -134,6 +136,8 @@ public class WsConnection implements ServerConnection, WsSession {
         } catch (LimitException e) {
             close(WsCloseCodes.TRY_AGAIN_LATER, "Too Many Concurrent Requests");
             return;
+        } catch (CloseConnectionException e) {
+            throw e;
         } catch (Exception e) {
             close(WsCloseCodes.UNEXPECTED_CONDITION, e.getMessage());
             return;
@@ -336,8 +340,16 @@ public class WsConnection implements ServerConnection, WsSession {
             }
         }
         sendBuffer.write(frame.payloadData());
-        ctx.dataWriter().writeNow(sendBuffer);
+        writeFrame(sendBuffer);
         return this;
+    }
+
+    private void writeFrame(BufferData frameData) {
+        try {
+            ctx.dataWriter().writeNow(frameData);
+        } catch (UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write websocket frame", e);
+        }
     }
 
     private enum ContinuationType {

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgrader.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgrader.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.websocket;
 
+import java.io.UncheckedIOException;
 import java.lang.System.Logger.Level;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -27,6 +28,7 @@ import java.util.Set;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.DirectHandler;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
@@ -38,6 +40,7 @@ import io.helidon.http.NotFoundException;
 import io.helidon.http.RequestException;
 import io.helidon.http.WritableHeaders;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http1.spi.Http1Upgrader;
 import io.helidon.webserver.spi.ServerConnection;
 import io.helidon.websocket.WsListener;
@@ -171,24 +174,27 @@ public class WsUpgrader implements Http1Upgrader {
         }
 
         // write switch protocol response including headers from listener
-        DataWriter dataWriter = ctx.dataWriter();
         String switchingProtocols = SWITCHING_PROTOCOL_PREFIX + hash(ctx, wsKey);
-        dataWriter.write(BufferData.create(switchingProtocols.getBytes(US_ASCII)));
-        BufferData separator = BufferData.create(HEADERS_SEPARATOR);
-        dataWriter.write(separator);
-        upgradeHeaders.ifPresent(hs -> {
-            BufferData headerData = BufferData.growing(128);
-            hs.forEach(h -> h.writeHttp1Header(headerData));
-            dataWriter.write(headerData);
-        });
-        dataWriter.write(separator.rewind());
-        dataWriter.flush();
+        BufferData responseData = BufferData.growing(128);
+        responseData.write(switchingProtocols.getBytes(US_ASCII));
+        responseData.write(HEADERS_SEPARATOR);
+        upgradeHeaders.ifPresent(hs -> hs.forEach(h -> h.writeHttp1Header(responseData)));
+        responseData.write(HEADERS_SEPARATOR);
+        writeUpgradeResponse(ctx.dataWriter(), responseData);
 
         if (LOGGER.isLoggable(Level.TRACE)) {
             LOGGER.log(Level.TRACE, "Upgraded to websocket version " + version);
         }
 
         return WsConnection.create(ctx, prologue, upgradeHeaders.orElse(EMPTY_HEADERS), wsKey, wsListener);
+    }
+
+    private static void writeUpgradeResponse(DataWriter dataWriter, BufferData responseData) {
+        try {
+            dataWriter.writeNow(responseData);
+        } catch (SocketWriterException | UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write websocket upgrade response", e);
+        }
     }
 
     protected boolean anyOrigin() {

--- a/webserver/websocket/src/test/java/io/helidon/webserver/websocket/WsConnectionTest.java
+++ b/webserver/websocket/src/test/java/io/helidon/webserver/websocket/WsConnectionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.websocket;
+
+import java.io.UncheckedIOException;
+import java.net.SocketException;
+import java.util.List;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.http.Headers;
+import io.helidon.http.HttpPrologue;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.ServerConnectionException;
+import io.helidon.websocket.WsListener;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WsConnectionTest {
+
+    @Test
+    void sendWrapsUncheckedIOException() {
+        DataWriter dataWriter = mock(DataWriter.class);
+        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
+                .when(dataWriter)
+                .writeNow(any(BufferData.class));
+
+        WsConnection connection = createConnection(dataWriter);
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> connection.send("hello", true));
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
+                () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
+        );
+    }
+
+    private static WsConnection createConnection(DataWriter dataWriter) {
+        ListenerConfig listenerConfig = mock(ListenerConfig.class);
+        when(listenerConfig.protocols()).thenReturn(List.of(WsConfig.builder().build()));
+
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.config()).thenReturn(listenerConfig);
+
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.listenerContext()).thenReturn(listenerContext);
+        when(ctx.dataReader()).thenReturn(mock(DataReader.class));
+        when(ctx.dataWriter()).thenReturn(dataWriter);
+
+        return WsConnection.create(ctx,
+                                   mock(HttpPrologue.class),
+                                   mock(Headers.class),
+                                   "key",
+                                   mock(WsListener.class));
+    }
+}

--- a/webserver/websocket/src/test/java/io/helidon/webserver/websocket/WsUpgraderTest.java
+++ b/webserver/websocket/src/test/java/io/helidon/webserver/websocket/WsUpgraderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.websocket;
+
+import java.io.UncheckedIOException;
+import java.net.SocketException;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.Router;
+import io.helidon.webserver.ServerConnectionException;
+import io.helidon.websocket.WsListener;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WsUpgraderTest {
+
+    @Test
+    void upgradeWriteWrapsUncheckedIOException() {
+        DataWriter dataWriter = mock(DataWriter.class);
+        doThrow(new UncheckedIOException(new SocketException("Broken pipe")))
+                .when(dataWriter)
+                .writeNow(any(BufferData.class));
+
+        ConnectionContext ctx = mock(ConnectionContext.class);
+        when(ctx.dataWriter()).thenReturn(dataWriter);
+        when(ctx.router()).thenReturn(Router.builder()
+                                           .addRouting(WsRouting.builder()
+                                                               .endpoint("/chat", new WsListener() {
+                                                               }))
+                                           .build());
+
+        WritableHeaders<?> headers = WritableHeaders.create()
+                .add(HeaderValues.create(WsUpgrader.WS_KEY, "dGhlIHNhbXBsZSBub25jZQ=="))
+                .add(HeaderValues.create(WsUpgrader.WS_VERSION, WsUpgrader.SUPPORTED_VERSION));
+        HttpPrologue prologue = HttpPrologue.create("http/1.1",
+                                                    "http",
+                                                    "1.1",
+                                                    Method.GET,
+                                                    "/chat",
+                                                    false);
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> WsUpgrader.create(WsConfig.builder().build())
+                                                                   .upgrade(ctx, prologue, headers));
+
+        assertAll(
+                () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
+                () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
+        );
+    }
+}


### PR DESCRIPTION
Resolves #11653

Wrap dead-peer write failures across the remaining affected server protocols so they surface as graceful connection-close exceptions instead of raw transport or cancellation stack traces. This covers HTTP/1 response writes, HTTP/2 connection ping acknowledgments, WebSocket frame writes, and gRPC header/data/trailer writes plus peer-cancelled callback paths.
