### PR TITLE
[4.x] Fix explicit classloader loading for HTTP parameter providers

### DIFF
--- a/declarative/codegen/pom.xml
+++ b/declarative/codegen/pom.xml
@@ -55,5 +55,15 @@
             <groupId>io.helidon.service</groupId>
             <artifactId>helidon-service-codegen</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
@@ -88,16 +88,7 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
     private static final String RESPONSE_PARAM_NAME = "helidonDeclarative__server_res";
     private static final String METHOD_RESPONSE_NAME = "helidonDeclarative__response";
     private static final List<HttpParameterCodegenProvider> PARAM_PROVIDERS =
-            HelidonServiceLoader.builder(ServiceLoader.load(HttpParameterCodegenProvider.class))
-                    .addService(new ParamProviderHttpEntity())
-                    .addService(new ParamProviderHttpHeader())
-                    .addService(new ParamProviderHttpPathParam())
-                    .addService(new ParamProviderHttpQuery())
-                    .addService(new ParamProviderHttpReqRes())
-                    .addService(new ParamProviderSecurityContext())
-                    .addService(new ParamProviderContext())
-                    .build()
-                    .asList();
+            loadParamProviders(RestServerExtension.class.getClassLoader());
 
     private final RegistryCodegenContext ctx;
 
@@ -117,6 +108,19 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
         for (ServerEndpoint endpoint : endpoints) {
             process(roundContext, endpoint);
         }
+    }
+
+    static List<HttpParameterCodegenProvider> loadParamProviders(ClassLoader classLoader) {
+        return HelidonServiceLoader.builder(ServiceLoader.load(HttpParameterCodegenProvider.class, classLoader))
+                .addService(new ParamProviderHttpEntity())
+                .addService(new ParamProviderHttpHeader())
+                .addService(new ParamProviderHttpPathParam())
+                .addService(new ParamProviderHttpQuery())
+                .addService(new ParamProviderHttpReqRes())
+                .addService(new ParamProviderSecurityContext())
+                .addService(new ParamProviderContext())
+                .build()
+                .asList();
     }
 
     private static void addSetupMethod(ClassModel.Builder endpointService, String path) {

--- a/declarative/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/RestServerExtensionTest.java
+++ b/declarative/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/RestServerExtensionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.webserver;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.declarative.codegen.http.webserver.spi.HttpParameterCodegenProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RestServerExtensionTest {
+
+    @Test
+    void testExplicitClassLoader() throws IOException {
+        Path tempDir = Files.createTempDirectory("rest-server-extension-test");
+        Path servicesFile = tempDir.resolve("META-INF/services/")
+                .resolve(HttpParameterCodegenProvider.class.getName());
+        Files.createDirectories(servicesFile.getParent());
+        Files.writeString(servicesFile,
+                          TestHttpParameterCodegenProvider.class.getName() + "\n",
+                          StandardCharsets.UTF_8);
+
+        ClassLoader providerLoader = new URLClassLoader(new URL[]{tempDir.toUri().toURL()},
+                                                        RestServerExtensionTest.class.getClassLoader());
+        List<HttpParameterCodegenProvider> explicitProviders = RestServerExtension.loadParamProviders(providerLoader);
+        boolean foundTestProvider = explicitProviders.stream().anyMatch(TestHttpParameterCodegenProvider.class::isInstance);
+        assertThat(foundTestProvider, is(true));
+    }
+
+    public static class TestHttpParameterCodegenProvider implements HttpParameterCodegenProvider {
+
+        @Override
+        public boolean codegen(ParameterCodegenContext context) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Description

Load HttpParameterCodegenProvider implementations in RestServerExtension using an explicit classloader instead of the default ServiceLoader lookup. This avoids missing providers during annotation processing when the processor classpath differs from the thread context loader. Add a focused unit test covering the explicit classloader path and update the module test dependencies to use Hamcrest assertions in the new test.

### Documentation
None
