### PR TITLE
Deprecate Micronaut integrations (4.x)

### DIFF
--- a/integrations/micronaut/cdi-processor/src/main/java/io/helidon/integrations/micronaut/cdi/processor/ApplicationScopedTransformer.java
+++ b/integrations/micronaut/cdi-processor/src/main/java/io/helidon/integrations/micronaut/cdi/processor/ApplicationScopedTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,10 @@ import jakarta.inject.Singleton;
 
 /**
  * Transforms CDI ApplicationScoped annotation into Micronaut Singleton.
+ *
+ * @deprecated use the Helidon Declarative programming model instead
  */
+@Deprecated(forRemoval = true, since = "4.4.5")
 public class ApplicationScopedTransformer implements NamedAnnotationTransformer {
     @Override
     public String getName() {

--- a/integrations/micronaut/cdi-processor/src/main/java/io/helidon/integrations/micronaut/cdi/processor/DependentTransformer.java
+++ b/integrations/micronaut/cdi-processor/src/main/java/io/helidon/integrations/micronaut/cdi/processor/DependentTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,10 @@ import jakarta.inject.Scope;
 /**
  * Transforms CDI Dependent annotation into Micronaut RequestScope (as the integration module does not
  * use this bean from Micronaut, the scope is not relevant, we only use it to get ExecutableMethod metadata).
+ *
+ * @deprecated use the Helidon Declarative programming model instead
  */
+@Deprecated(forRemoval = true, since = "4.4.5")
 public class DependentTransformer implements NamedAnnotationTransformer {
     @Override
     public String getName() {

--- a/integrations/micronaut/cdi-processor/src/main/java/io/helidon/integrations/micronaut/cdi/processor/RequestScopedTransformer.java
+++ b/integrations/micronaut/cdi-processor/src/main/java/io/helidon/integrations/micronaut/cdi/processor/RequestScopedTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,10 @@ import jakarta.inject.Scope;
 
 /**
  * Transforms CDI RequestScoped annotation into Micronaut RequestScope.
+ *
+ * @deprecated use the Helidon Declarative programming model instead
  */
+@Deprecated(forRemoval = true, since = "4.4.5")
 public class RequestScopedTransformer implements NamedAnnotationTransformer {
     @Override
     public String getName() {

--- a/integrations/micronaut/cdi-processor/src/main/java/io/helidon/integrations/micronaut/cdi/processor/package-info.java
+++ b/integrations/micronaut/cdi-processor/src/main/java/io/helidon/integrations/micronaut/cdi/processor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/cdi/README.md
+++ b/integrations/micronaut/cdi/README.md
@@ -1,6 +1,11 @@
 CDI integration with Micronaut
 ---
 
+> [!WARNING]
+> `helidon-integrations-micronaut-cdi` and `helidon-integrations-micronaut-cdi-processor` are deprecated and will be
+> removed in a future Helidon release. Use the Helidon Declarative programming model instead.
+> `helidon-integrations-micronaut-data` is also deprecated; use `helidon-data` instead.
+
 #Introduction
 
 Goals of this integration:
@@ -63,4 +68,3 @@ The `helidon-integrations-micronaut-cdi-processor` must be used whenever integra
     </configuration>
 </plugin>
 ```
- 

--- a/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautCdiException.java
+++ b/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautCdiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@ package io.helidon.integrations.micronaut.cdi;
 
 /**
  * Exception thrown by Micronaut CDI integration, when a checked exception must be consumed.
+ *
+ * @deprecated use the Helidon Declarative programming model instead
  */
+@Deprecated(forRemoval = true, since = "4.4.5")
 public class MicronautCdiException extends RuntimeException {
     MicronautCdiException(String message) {
         super(message);

--- a/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautCdiExtension.java
+++ b/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,10 @@ import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
  * Extension integrating CDI with Micronaut.
  * This extensions adds Micronaut beans to be injectable into CDI beans (limited to {@link jakarta.inject.Singleton}
  * scope), and adds support for invoking Micronaut interceptors.
+ *
+ * @deprecated use the Helidon Declarative programming model instead
  */
+@Deprecated(forRemoval = true, since = "4.4.5")
 public class MicronautCdiExtension implements Extension {
     private static final System.Logger LOGGER = System.getLogger(MicronautCdiExtension.class.getName());
     private static final String MICRONAUT_BEAN_PREFIX = "micronaut-";

--- a/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautIntercepted.java
+++ b/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautIntercepted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,13 @@ import jakarta.enterprise.util.AnnotationLiteral;
 /**
  * Used to add interceptors to existing CDI beans to be intercepted by Micronaut interceptors.
  * DO NOT USE DIRECTLY. Usage is computed by this CDI extension.
+ *
+ * @deprecated use the Helidon Declarative programming model instead
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Internal
+@Deprecated(forRemoval = true, since = "4.4.5")
 public @interface MicronautIntercepted {
     /**
      * Literal used to obtain an instance of the annotation.

--- a/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautInterceptor.java
+++ b/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,12 +35,15 @@ import jakarta.interceptor.InvocationContext;
 /**
  * A CDI interceptor that invokes all Micronaut interceptors.
  * DO NOT USE DIRECTLY. Usage is computed by this CDI extension.
+ *
+ * @deprecated use the Helidon Declarative programming model instead
  */
 // interceptor binding is defined in code of extension, not on annotation
 @MicronautIntercepted
 @Interceptor
 @Priority(Interceptor.Priority.LIBRARY_BEFORE)
 @Internal
+@Deprecated(forRemoval = true, since = "4.4.5")
 public class MicronautInterceptor {
     private static final System.Logger LOGGER = System.getLogger(MicronautInterceptor.class.getName());
 

--- a/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/package-info.java
+++ b/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/cdi/src/main/java/module-info.java
+++ b/integrations/micronaut/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 /**
  * Integration of Micronaut into CDI.
+ *
+ * @deprecated use the Helidon Declarative programming model instead
  */
+@Deprecated(forRemoval = true, since = "4.4.5")
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module io.helidon.integrations.micronaut.cdi {
 

--- a/integrations/micronaut/data/src/main/java/io/helidon/integrations/micronaut/cdi/data/MicronautDataCdiExtension.java
+++ b/integrations/micronaut/data/src/main/java/io/helidon/integrations/micronaut/cdi/data/MicronautDataCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,10 @@ import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
 /**
  * CDI Extension that adds Micronaut data specific features.
  * Currently adds support for injecting {@link java.sql.Connection}.
+ *
+ * @deprecated use {@code helidon-data} instead
  */
+@Deprecated(forRemoval = true, since = "4.4.5")
 public class MicronautDataCdiExtension implements Extension {
     /**
      * Default constructor required by {@link java.util.ServiceLoader}.

--- a/integrations/micronaut/data/src/main/java/io/helidon/integrations/micronaut/cdi/data/package-info.java
+++ b/integrations/micronaut/data/src/main/java/io/helidon/integrations/micronaut/cdi/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/data/src/main/java/module-info.java
+++ b/integrations/micronaut/data/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 import io.helidon.common.features.api.Features;
 import io.helidon.common.features.api.HelidonFlavor;
-import io.helidon.common.features.api.Preview;
 
 /**
  * Integration with Micronaut Data.
+ *
+ * @deprecated use {@code helidon-data} instead
  */
-@Features.Preview
 @Features.Name("Micronaut Data")
 @Features.Description("Micronaut Data integration")
 @Features.Flavor(HelidonFlavor.MP)
 @Features.Path({"CDI", "Micronaut", "Data"})
+@Deprecated(forRemoval = true, since = "4.4.5")
 @SuppressWarnings({ "requires-automatic"})
 module io.helidon.integrations.micronaut.data {
 


### PR DESCRIPTION
Related to #11565

Deprecates the Micronaut CDI, Micronaut Data, and Micronaut CDI processor integrations. The replacement guidance points Micronaut Data users to helidon-data and the remaining Micronaut integrations to the Helidon Declarative programming model.