### PR TITLE
2.x: Upgrade eclipselink, asm, byte-buddy for Java 25 support

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -46,11 +46,12 @@
         <!-- commons-codec is for dependency convergence only -->
         <version.lib.commons-codec>1.15</version.lib.commons-codec>
         <!-- Force upgrade byte-buddy for Java 21. Remove after upgrading hibernate -->
-        <version.lib.byte-buddy>1.14.6</version.lib.byte-buddy>
+        <version.lib.byte-buddy>1.17.5</version.lib.byte-buddy>
         <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.cron-utils>9.2.1</version.lib.cron-utils>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
-        <version.lib.eclipselink>2.7.13</version.lib.eclipselink>
+        <version.lib.eclipselink>2.7.15</version.lib.eclipselink>
+        <version.lib.eclipselink.asm>9.8.0</version.lib.eclipselink.asm>
         <version.lib.el-api>3.0.3</version.lib.el-api>
         <version.lib.el-impl>3.0.4</version.lib.el-impl>
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
@@ -777,6 +778,12 @@
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.jpa</artifactId>
                 <version>${version.lib.eclipselink}</version>
+            </dependency>
+            <!-- Force upgrade ASM for Java 25 support -->
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.asm</artifactId>
+                <version>${version.lib.eclipselink.asm}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <version.lib.arquillian>1.4.0.Final</version.lib.arquillian>
         <version.lib.arquillian-weld-embedded>2.0.0.Final</version.lib.arquillian-weld-embedded>
         <version.lib.asciidoctor.diagram>1.5.18</version.lib.asciidoctor.diagram>
-        <version.lib.asm>6.0</version.lib.asm>
+        <version.lib.asm>9.8</version.lib.asm>
         <version.lib.checkstyle>8.29</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <!-- Silence javadoc error org.jboss.logging.annotations.Message$Format not found -->
@@ -115,7 +115,7 @@
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>
         <version.plugin.resources>2.7</version.plugin.resources>
         <version.plugin.scm-publish-plugin>3.0.0</version.plugin.scm-publish-plugin>
-        <version.plugin.shade>3.0.0</version.plugin.shade>
+        <version.plugin.shade>3.5.0</version.plugin.shade>
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>


### PR DESCRIPTION
### Description

Upgrades for Java 25 support in Helidon 2

- EclipseLink to 2.7.15
- ASM to 9.8.0
- ByteBuddy to  1.17.5
