### PR TITLE
Implement gRPC per-call deadline support (fixes #11698)

### DIFF
--- a/grpc/core/pom.xml
+++ b/grpc/core/pom.xml
@@ -86,5 +86,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common.testing</groupId>
+            <artifactId>helidon-common-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHeadersUtil.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHeadersUtil.java
@@ -17,6 +17,7 @@
 package io.helidon.grpc.core;
 
 import java.util.Base64;
+import java.util.Optional;
 
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -114,21 +115,21 @@ public class GrpcHeadersUtil {
      * @param timeoutNanos timeout in nanoseconds
      * @return encoded header value such as {@code "500m"}, or {@code null} if {@code timeoutNanos <= 0}
      */
-    public static String encodeTimeout(long timeoutNanos) {
+    public static Optional<String> encodeTimeout(long timeoutNanos) {
         if (timeoutNanos <= 0) {
-            return null;
+            return Optional.empty();
         }
         // Walk from largest to smallest unit; pick the first where the value
         // is positive, fits in 8 digits, and the division is exact (no truncation).
         for (int i = 0; i < NANOS_PER_UNIT.length; i++) {
             long value = timeoutNanos / NANOS_PER_UNIT[i];
             if (value > 0 && value <= MAX_TIMEOUT_VALUE && timeoutNanos % NANOS_PER_UNIT[i] == 0) {
-                return value + String.valueOf(TIMEOUT_UNITS[i]);
+                return Optional.of(value + String.valueOf(TIMEOUT_UNITS[i]));
             }
         }
         // Nanoseconds with possible truncation to 8 digits (last resort for values
         // that do not align to any unit boundary within 8 digits)
-        return Math.min(timeoutNanos, MAX_TIMEOUT_VALUE) + "n";
+        return Optional.of(Math.min(timeoutNanos, MAX_TIMEOUT_VALUE) + "n");
     }
 
     /**

--- a/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHeadersUtil.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHeadersUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,8 +101,8 @@ public class GrpcHeadersUtil {
 
     // Per spec: TimeoutValue is a positive integer, at most 8 ASCII digits
     private static final long MAX_TIMEOUT_VALUE = 99_999_999L;
-    private static final char[] TIMEOUT_UNITS   = { 'H',                 'M',              'S',           'm',       'u',    'n' };
-    private static final long[] NANOS_PER_UNIT  = { 3_600_000_000_000L,  60_000_000_000L,  1_000_000_000L, 1_000_000L, 1_000L, 1L };
+    private static final char[] TIMEOUT_UNITS = {'H', 'M', 'S', 'm', 'u', 'n'};
+    private static final long[] NANOS_PER_UNIT = {3_600_000_000_000L, 60_000_000_000L, 1_000_000_000L, 1_000_000L, 1_000L, 1L};
 
     /**
      * Encodes a timeout as a {@code grpc-timeout} header value.

--- a/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHeadersUtil.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHeadersUtil.java
@@ -18,6 +18,7 @@ package io.helidon.grpc.core;
 
 import java.util.Base64;
 
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2Headers;
@@ -77,5 +78,96 @@ public class GrpcHeadersUtil {
             }
         });
         return metadata;
+    }
+
+    /**
+     * The {@code grpc-timeout} header name.
+     *
+     * <p>Defined in the
+     * <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md">gRPC over HTTP/2 spec</a>:
+     * <pre>
+     * Timeout → "grpc-timeout" TimeoutValue TimeoutUnit
+     * TimeoutValue → {positive integer as ASCII string of at most 8 digits}
+     * TimeoutUnit → Hour / Minute / Second / Millisecond / Microsecond / Nanosecond
+     *   Hour        → "H"
+     *   Minute      → "M"
+     *   Second      → "S"
+     *   Millisecond → "m"
+     *   Microsecond → "u"
+     *   Nanosecond  → "n"
+     * </pre>
+     */
+    public static final HeaderName GRPC_TIMEOUT = HeaderNames.create("grpc-timeout");
+
+    // Per spec: TimeoutValue is a positive integer, at most 8 ASCII digits
+    private static final long MAX_TIMEOUT_VALUE = 99_999_999L;
+    private static final char[] TIMEOUT_UNITS   = { 'H',                 'M',              'S',           'm',       'u',    'n' };
+    private static final long[] NANOS_PER_UNIT  = { 3_600_000_000_000L,  60_000_000_000L,  1_000_000_000L, 1_000_000L, 1_000L, 1L };
+
+    /**
+     * Encodes a timeout as a {@code grpc-timeout} header value.
+     *
+     * <p>Picks the largest unit where the numeric value is both positive and
+     * fits in 8 ASCII digits, and the conversion is exact (no loss of precision).
+     * See <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md">spec</a>.
+     *
+     * @param timeoutNanos timeout in nanoseconds
+     * @return encoded header value such as {@code "500m"}, or {@code null} if {@code timeoutNanos <= 0}
+     */
+    public static String encodeTimeout(long timeoutNanos) {
+        if (timeoutNanos <= 0) {
+            return null;
+        }
+        // Walk from largest to smallest unit; pick the first where the value
+        // is positive, fits in 8 digits, and the division is exact (no truncation).
+        for (int i = 0; i < NANOS_PER_UNIT.length; i++) {
+            long value = timeoutNanos / NANOS_PER_UNIT[i];
+            if (value > 0 && value <= MAX_TIMEOUT_VALUE && timeoutNanos % NANOS_PER_UNIT[i] == 0) {
+                return value + String.valueOf(TIMEOUT_UNITS[i]);
+            }
+        }
+        // Nanoseconds with possible truncation to 8 digits (last resort for values
+        // that do not align to any unit boundary within 8 digits)
+        return Math.min(timeoutNanos, MAX_TIMEOUT_VALUE) + "n";
+    }
+
+    /**
+     * Decodes a {@code grpc-timeout} header value to nanoseconds.
+     *
+     * <p>See <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md">spec</a>.
+     *
+     * @param value header value such as {@code "500m"}
+     * @return timeout in nanoseconds
+     * @throws IllegalArgumentException if the value is null, empty, malformed, or overflows
+     */
+    public static long decodeTimeout(String value) {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("grpc-timeout value is null or empty");
+        }
+        char unit = value.charAt(value.length() - 1);
+        String digits = value.substring(0, value.length() - 1);
+        if (digits.isEmpty()) {
+            throw new IllegalArgumentException("grpc-timeout has no numeric value: " + value);
+        }
+        long numericValue;
+        try {
+            numericValue = Long.parseLong(digits);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("grpc-timeout has invalid digits: " + value, e);
+        }
+        if (numericValue < 0) {
+            throw new IllegalArgumentException("grpc-timeout must be a positive integer: " + value);
+        }
+        for (int i = 0; i < TIMEOUT_UNITS.length; i++) {
+            if (unit == TIMEOUT_UNITS[i]) {
+                try {
+                    return Math.multiplyExact(numericValue, NANOS_PER_UNIT[i]);
+                } catch (ArithmeticException e) {
+                    throw new IllegalArgumentException(
+                            "grpc-timeout value overflows long: " + value, e);
+                }
+            }
+        }
+        throw new IllegalArgumentException("grpc-timeout has unknown unit '" + unit + "': " + value);
     }
 }

--- a/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHeadersUtilTest.java
+++ b/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHeadersUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHeadersUtilTest.java
+++ b/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHeadersUtilTest.java
@@ -30,14 +30,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class GrpcHeadersUtilTest {
 
     @Test
-    void testUpdateHeaders() {
+    void updateHeaders() {
         Metadata metadata = new Metadata();
         Metadata.Key<String> key = Metadata.Key.of("cookie", Metadata.ASCII_STRING_MARSHALLER);
         metadata.put(key, "sugar");
@@ -52,7 +54,7 @@ class GrpcHeadersUtilTest {
     }
 
     @Test
-    void testUpdateBinaryHeaders() {
+    void updateBinaryHeaders() {
         Metadata metadata = new Metadata();
         Metadata.Key<byte[]> key = Metadata.Key.of("secret-bin", Metadata.BINARY_BYTE_MARSHALLER);
         byte[] mySecret = "my-secret".getBytes(StandardCharsets.UTF_8);
@@ -66,7 +68,7 @@ class GrpcHeadersUtilTest {
     }
 
     @Test
-    void testToMetadata() {
+    void toMetadata() {
         WritableHeaders<?> headers = WritableHeaders.create();
         headers.add(HeaderNames.COOKIE, "sugar", "almond");
         Http2Headers http2Headers = mock(Http2Headers.class);
@@ -78,5 +80,176 @@ class GrpcHeadersUtilTest {
         metadata.getAll(key).forEach(values::add);
         assertThat(values, hasItem("sugar"));
         assertThat(values, hasItem("almond"));
+    }
+
+    @Test
+    void encodeTimeoutHours() {
+        // 2 hours in nanos
+        assertThat(GrpcHeadersUtil.encodeTimeout(7_200_000_000_000L), is("2H"));
+    }
+
+    @Test
+    void encodeTimeoutMinutes() {
+        // 2 minutes in nanos = 120_000_000_000L
+        assertThat(GrpcHeadersUtil.encodeTimeout(120_000_000_000L), is("2M"));
+    }
+
+    @Test
+    void encodeTimeoutSeconds() {
+        // 5 seconds in nanos = 5_000_000_000L
+        assertThat(GrpcHeadersUtil.encodeTimeout(5_000_000_000L), is("5S"));
+    }
+
+    @Test
+    void encodeTimeoutMilliseconds() {
+        // 500ms in nanos = 500_000_000L
+        assertThat(GrpcHeadersUtil.encodeTimeout(500_000_000L), is("500m"));
+    }
+
+    @Test
+    void encodeTimeoutMicroseconds() {
+        // 500us in nanos = 500_000L
+        assertThat(GrpcHeadersUtil.encodeTimeout(500_000L), is("500u"));
+    }
+
+    @Test
+    void encodeTimeoutNanoseconds() {
+        // 500ns -- only nanoseconds fit
+        assertThat(GrpcHeadersUtil.encodeTimeout(500L), is("500n"));
+    }
+
+    @Test
+    void encodeTimeoutNanosecondsMinimum() {
+        assertThat(GrpcHeadersUtil.encodeTimeout(1L), is("1n"));
+    }
+
+    @Test
+    void encodeTimeoutPicksLargestExactUnit() {
+        // 1_000_000ns = 1ms exactly, should encode as "1m" not "1000u" or "1000000n"
+        assertThat(GrpcHeadersUtil.encodeTimeout(1_000_000L), is("1m"));
+    }
+
+    @Test
+    void encodeTimeoutDoesNotTruncate() {
+        // 1_500_000_000ns = 1.5s -- not an exact number of seconds.
+        // Must encode as "1500m" (milliseconds), not "1S" (which would lose 500ms)
+        assertThat(GrpcHeadersUtil.encodeTimeout(1_500_000_000L), is("1500m"));
+    }
+
+    @Test
+    void encodeTimeoutEightDigitBoundary() {
+        // 99_999_999ms in nanos. Should encode as "99999999m" (exactly 8 digits).
+        assertThat(GrpcHeadersUtil.encodeTimeout(99_999_999_000_000L), is("99999999m"));
+    }
+
+    @Test
+    void encodeTimeoutReturnsNullForZero() {
+        assertThat(GrpcHeadersUtil.encodeTimeout(0L), is(nullValue()));
+    }
+
+    @Test
+    void encodeTimeoutReturnsNullForNegative() {
+        assertThat(GrpcHeadersUtil.encodeTimeout(-1L), is(nullValue()));
+    }
+
+    @Test
+    void decodeTimeoutHours() {
+        assertThat(GrpcHeadersUtil.decodeTimeout("1H"), is(3_600_000_000_000L));
+    }
+
+    @Test
+    void decodeTimeoutMinutes() {
+        assertThat(GrpcHeadersUtil.decodeTimeout("2M"), is(120_000_000_000L));
+    }
+
+    @Test
+    void decodeTimeoutSeconds() {
+        assertThat(GrpcHeadersUtil.decodeTimeout("5S"), is(5_000_000_000L));
+    }
+
+    @Test
+    void decodeTimeoutMilliseconds() {
+        assertThat(GrpcHeadersUtil.decodeTimeout("500m"), is(500_000_000L));
+    }
+
+    @Test
+    void decodeTimeoutMicroseconds() {
+        assertThat(GrpcHeadersUtil.decodeTimeout("500u"), is(500_000L));
+    }
+
+    @Test
+    void decodeTimeoutNanoseconds() {
+        assertThat(GrpcHeadersUtil.decodeTimeout("500n"), is(500L));
+    }
+
+    @Test
+    void decodeTimeoutMaxEightDigits() {
+        assertThat(GrpcHeadersUtil.decodeTimeout("99999999n"), is(99_999_999L));
+    }
+
+    @Test
+    void decodeTimeoutRejectsNull() {
+        assertThrows(IllegalArgumentException.class,
+                () -> GrpcHeadersUtil.decodeTimeout(null));
+    }
+
+    @Test
+    void decodeTimeoutRejectsEmptyString() {
+        assertThrows(IllegalArgumentException.class,
+                () -> GrpcHeadersUtil.decodeTimeout(""));
+    }
+
+    @Test
+    void decodeTimeoutRejectsUnknownUnit() {
+        assertThrows(IllegalArgumentException.class,
+                () -> GrpcHeadersUtil.decodeTimeout("100x"));
+    }
+
+    @Test
+    void decodeTimeoutRejectsNoDigits() {
+        assertThrows(IllegalArgumentException.class,
+                () -> GrpcHeadersUtil.decodeTimeout("m"));
+    }
+
+    @Test
+    void decodeTimeoutRejectsNegativeValue() {
+        // gRPC spec says TimeoutValue is a positive integer
+        assertThrows(IllegalArgumentException.class,
+                () -> GrpcHeadersUtil.decodeTimeout("-5S"));
+    }
+
+    @Test
+    void decodeTimeoutRejectsOverflow() {
+        // 99_999_999 hours * 3_600_000_000_000 nanos/hour overflows long
+        assertThrows(IllegalArgumentException.class,
+                () -> GrpcHeadersUtil.decodeTimeout("99999999H"));
+    }
+
+    @Test
+    void roundTripUnitAligned() {
+        // Values that align exactly to a unit boundary
+        long[] testValues = {
+                3_600_000_000_000L,  // 1 hour
+                60_000_000_000L,     // 1 minute
+                1_000_000_000L,      // 1 second
+                1_000_000L,          // 1 millisecond
+                1_000L,              // 1 microsecond
+                1L,                  // 1 nanosecond
+        };
+        for (long nanos : testValues) {
+            String encoded = GrpcHeadersUtil.encodeTimeout(nanos);
+            long decoded = GrpcHeadersUtil.decodeTimeout(encoded);
+            assertThat("round-trip for " + nanos + "ns (encoded: " + encoded + ")",
+                    decoded, is(nanos));
+        }
+    }
+
+    @Test
+    void roundTripNonRoundMilliseconds() {
+        // 1500ms — not an exact number of seconds, encodes as "1500m"
+        long nanos = 1_500_000_000L;
+        String encoded = GrpcHeadersUtil.encodeTimeout(nanos);
+        assertThat(encoded, is("1500m"));
+        assertThat(GrpcHeadersUtil.decodeTimeout(encoded), is(nanos));
     }
 }

--- a/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHeadersUtilTest.java
+++ b/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHeadersUtilTest.java
@@ -28,9 +28,10 @@ import io.helidon.http.http2.Http2Headers;
 import io.grpc.Metadata;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -39,7 +40,7 @@ import static org.mockito.Mockito.when;
 class GrpcHeadersUtilTest {
 
     @Test
-    void updateHeaders() {
+    void testUpdateHeaders() {
         Metadata metadata = new Metadata();
         Metadata.Key<String> key = Metadata.Key.of("cookie", Metadata.ASCII_STRING_MARSHALLER);
         metadata.put(key, "sugar");
@@ -54,7 +55,7 @@ class GrpcHeadersUtilTest {
     }
 
     @Test
-    void updateBinaryHeaders() {
+    void testUpdateBinaryHeaders() {
         Metadata metadata = new Metadata();
         Metadata.Key<byte[]> key = Metadata.Key.of("secret-bin", Metadata.BINARY_BYTE_MARSHALLER);
         byte[] mySecret = "my-secret".getBytes(StandardCharsets.UTF_8);
@@ -68,7 +69,7 @@ class GrpcHeadersUtilTest {
     }
 
     @Test
-    void toMetadata() {
+    void testToMetadata() {
         WritableHeaders<?> headers = WritableHeaders.create();
         headers.add(HeaderNames.COOKIE, "sugar", "almond");
         Http2Headers http2Headers = mock(Http2Headers.class);
@@ -85,71 +86,71 @@ class GrpcHeadersUtilTest {
     @Test
     void encodeTimeoutHours() {
         // 2 hours in nanos
-        assertThat(GrpcHeadersUtil.encodeTimeout(7_200_000_000_000L), is("2H"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(7_200_000_000_000L), optionalValue(is("2H")));
     }
 
     @Test
     void encodeTimeoutMinutes() {
         // 2 minutes in nanos = 120_000_000_000L
-        assertThat(GrpcHeadersUtil.encodeTimeout(120_000_000_000L), is("2M"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(120_000_000_000L), optionalValue(is("2M")));
     }
 
     @Test
     void encodeTimeoutSeconds() {
         // 5 seconds in nanos = 5_000_000_000L
-        assertThat(GrpcHeadersUtil.encodeTimeout(5_000_000_000L), is("5S"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(5_000_000_000L), optionalValue(is("5S")));
     }
 
     @Test
     void encodeTimeoutMilliseconds() {
         // 500ms in nanos = 500_000_000L
-        assertThat(GrpcHeadersUtil.encodeTimeout(500_000_000L), is("500m"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(500_000_000L), optionalValue(is("500m")));
     }
 
     @Test
     void encodeTimeoutMicroseconds() {
         // 500us in nanos = 500_000L
-        assertThat(GrpcHeadersUtil.encodeTimeout(500_000L), is("500u"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(500_000L), optionalValue(is("500u")));
     }
 
     @Test
     void encodeTimeoutNanoseconds() {
         // 500ns -- only nanoseconds fit
-        assertThat(GrpcHeadersUtil.encodeTimeout(500L), is("500n"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(500L), optionalValue(is("500n")));
     }
 
     @Test
     void encodeTimeoutNanosecondsMinimum() {
-        assertThat(GrpcHeadersUtil.encodeTimeout(1L), is("1n"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(1L), optionalValue(is("1n")));
     }
 
     @Test
     void encodeTimeoutPicksLargestExactUnit() {
         // 1_000_000ns = 1ms exactly, should encode as "1m" not "1000u" or "1000000n"
-        assertThat(GrpcHeadersUtil.encodeTimeout(1_000_000L), is("1m"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(1_000_000L), optionalValue(is("1m")));
     }
 
     @Test
     void encodeTimeoutDoesNotTruncate() {
         // 1_500_000_000ns = 1.5s -- not an exact number of seconds.
         // Must encode as "1500m" (milliseconds), not "1S" (which would lose 500ms)
-        assertThat(GrpcHeadersUtil.encodeTimeout(1_500_000_000L), is("1500m"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(1_500_000_000L), optionalValue(is("1500m")));
     }
 
     @Test
     void encodeTimeoutEightDigitBoundary() {
         // 99_999_999ms in nanos. Should encode as "99999999m" (exactly 8 digits).
-        assertThat(GrpcHeadersUtil.encodeTimeout(99_999_999_000_000L), is("99999999m"));
+        assertThat(GrpcHeadersUtil.encodeTimeout(99_999_999_000_000L), optionalValue(is("99999999m")));
     }
 
     @Test
-    void encodeTimeoutReturnsNullForZero() {
-        assertThat(GrpcHeadersUtil.encodeTimeout(0L), is(nullValue()));
+    void encodeTimeoutReturnsEmptyForZero() {
+        assertThat(GrpcHeadersUtil.encodeTimeout(0L), optionalEmpty());
     }
 
     @Test
-    void encodeTimeoutReturnsNullForNegative() {
-        assertThat(GrpcHeadersUtil.encodeTimeout(-1L), is(nullValue()));
+    void encodeTimeoutReturnsEmptyForNegative() {
+        assertThat(GrpcHeadersUtil.encodeTimeout(-1L), optionalEmpty());
     }
 
     @Test
@@ -237,7 +238,7 @@ class GrpcHeadersUtilTest {
                 1L,                  // 1 nanosecond
         };
         for (long nanos : testValues) {
-            String encoded = GrpcHeadersUtil.encodeTimeout(nanos);
+            String encoded = GrpcHeadersUtil.encodeTimeout(nanos).get();
             long decoded = GrpcHeadersUtil.decodeTimeout(encoded);
             assertThat("round-trip for " + nanos + "ns (encoded: " + encoded + ")",
                     decoded, is(nanos));
@@ -248,7 +249,7 @@ class GrpcHeadersUtilTest {
     void roundTripNonRoundMilliseconds() {
         // 1500ms — not an exact number of seconds, encodes as "1500m"
         long nanos = 1_500_000_000L;
-        String encoded = GrpcHeadersUtil.encodeTimeout(nanos);
+        String encoded = GrpcHeadersUtil.encodeTimeout(nanos).get();
         assertThat(encoded, is("1500m"));
         assertThat(GrpcHeadersUtil.decodeTimeout(encoded), is(nanos));
     }

--- a/webclient/grpc/pom.xml
+++ b/webclient/grpc/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.helidon.common.LazyValue;
@@ -67,8 +68,11 @@ import io.helidon.webclient.http2.StreamTimeoutException;
 
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
+import io.grpc.Context;
+import io.grpc.Deadline;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
 
 import static io.helidon.metrics.api.Meter.Scope.VENDOR;
 import static java.lang.System.Logger.Level.DEBUG;
@@ -119,6 +123,13 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
     private volatile MethodMetrics methodMetrics;
     private volatile long startMillis;
 
+    /**
+     * The lesser of the {@link CallOptions} deadline and the ambient {@link Context} deadline,
+     * or {@code null} when neither is set. When {@code null}, no {@code grpc-timeout} header
+     * is sent and no deadline timer is started.
+     */
+    private final Deadline effectiveDeadline;
+
     private AtomicLong bytesSent;
     private AtomicLong bytesRcvd;
 
@@ -135,6 +146,19 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         this.abortPollTimeExpired = grpcClient.prototype().protocolConfig().abortPollTimeExpired();
         this.heartbeatPeriod = grpcClient.prototype().protocolConfig().heartbeatPeriod();
         this.clientUriSupplier = grpcClient.prototype().clientUriSupplier().orElse(null);
+
+        // Compute effective deadline as min(callOptions, context).
+        // Gives automatic deadline propagation: if a server handler makes an outbound
+        // gRPC call, the remaining deadline from its context is automatically inherited.
+        Deadline optionsDeadline = callOptions.getDeadline();
+        Deadline contextDeadline = Context.current().getDeadline();
+        if (optionsDeadline == null) {
+            this.effectiveDeadline = contextDeadline;
+        } else if (contextDeadline == null) {
+            this.effectiveDeadline = optionsDeadline;
+        } else {
+            this.effectiveDeadline = optionsDeadline.minimum(contextDeadline);
+        }
     }
 
     @Override
@@ -143,13 +167,21 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
 
         this.responseListener = responseListener;
 
-        // init metrics
+        // init metrics before any early return so that all attempts are counted
         if (grpcConfig.enableMetrics()) {
             initMetrics();
             bytesSent = new AtomicLong(0L);
             bytesRcvd = new AtomicLong(0L);
             startMillis = System.currentTimeMillis();
             methodMetrics.callStarted.increment();
+        }
+
+        // Fail fast if deadline already expired — avoids wasting a TCP connection
+        if (effectiveDeadline != null && effectiveDeadline.isExpired()) {
+            responseListener.onClose(Status.DEADLINE_EXCEEDED
+                    .withDescription("deadline expired before call started"), EMPTY_METADATA);
+            unblockUnaryExecutor();
+            return;
         }
 
         // obtain HTTP2 connection
@@ -195,6 +227,14 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
 
         // send HEADERS frame
         WritableHeaders<?> headers = setupHeaders(metadata, clientUri.authority(), methodDescriptor.getFullMethodName());
+        // Write grpc-timeout header after metadata conversion so it cannot be overwritten
+        if (effectiveDeadline != null) {
+            long timeoutNanos = effectiveDeadline.timeRemaining(TimeUnit.NANOSECONDS);
+            String encoded = GrpcHeadersUtil.encodeTimeout(timeoutNanos);
+            if (encoded != null) {
+                headers.set(GrpcHeadersUtil.GRPC_TIMEOUT, encoded);
+            }
+        }
         clientStream.writeHeaders(Http2Headers.create(headers), false);
     }
 
@@ -280,6 +320,10 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
                 // ignored
             }
         }
+    }
+
+    Deadline effectiveDeadline() {
+        return effectiveDeadline;
     }
 
     GrpcClientImpl grpcClient() {

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -230,10 +230,8 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         // Write grpc-timeout header after metadata conversion so it cannot be overwritten
         if (effectiveDeadline != null) {
             long timeoutNanos = effectiveDeadline.timeRemaining(TimeUnit.NANOSECONDS);
-            String encoded = GrpcHeadersUtil.encodeTimeout(timeoutNanos);
-            if (encoded != null) {
-                headers.set(GrpcHeadersUtil.GRPC_TIMEOUT, encoded);
-            }
+            GrpcHeadersUtil.encodeTimeout(timeoutNanos)
+                    .ifPresent(encoded -> headers.set(GrpcHeadersUtil.GRPC_TIMEOUT, encoded));
         }
         clientStream.writeHeaders(Http2Headers.create(headers), false);
     }

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -320,6 +320,9 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         }
     }
 
+    /**
+     * @return {@code null} if this Call has no effective deadline.
+     */
     Deadline effectiveDeadline() {
         return effectiveDeadline;
     }

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Header;
@@ -32,6 +33,7 @@ import io.helidon.http.http2.Http2Headers;
 import io.helidon.webclient.http2.StreamTimeoutException;
 
 import io.grpc.CallOptions;
+import io.grpc.Deadline;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
@@ -56,9 +58,13 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
     private final CountDownLatch startReadBarrier = new CountDownLatch(1);
     private final CountDownLatch startWriteBarrier = new CountDownLatch(1);
 
-    private volatile Future<?> readStreamFuture;
-    private volatile Future<?> writeStreamFuture;
-    private volatile Future<?> heartbeatFuture;
+    // Initialized to completed futures so cancel() is safe to call before startStreamingThreads() runs
+    private volatile Future<?> readStreamFuture = CompletableFuture.completedFuture(null);
+    private volatile Future<?> writeStreamFuture = CompletableFuture.completedFuture(null);
+    private volatile Future<?> heartbeatFuture = CompletableFuture.completedFuture(null);
+
+    private final AtomicBoolean closeCalled = new AtomicBoolean(false);
+    private volatile Future<?> deadlineFuture = CompletableFuture.completedFuture(null);
 
     GrpcClientCall(GrpcChannel grpcChannel, MethodDescriptor<ReqT, ResT> methodDescriptor, CallOptions callOptions) {
         super(grpcChannel, methodDescriptor, callOptions);
@@ -75,11 +81,14 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
     @Override
     public void cancel(String message, Throwable cause) {
         socket().log(LOGGER, DEBUG, "cancel called %s", message);
-        responseListener().onClose(Status.CANCELLED, EMPTY_METADATA);
+        if (closeCalled.compareAndSet(false, true)) {
+            responseListener().onClose(Status.CANCELLED, EMPTY_METADATA);
+            close();
+        }
         readStreamFuture.cancel(true);
         writeStreamFuture.cancel(true);
         heartbeatFuture.cancel(true);
-        close();
+        deadlineFuture.cancel(true);
     }
 
     @Override
@@ -157,7 +166,10 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
             } catch (Throwable e) {
                 socket().log(LOGGER, ERROR, e.getMessage(), e);
                 Status errorStatus = Status.UNKNOWN.withDescription(e.getMessage()).withCause(e);
-                responseListener().onClose(errorStatus, EMPTY_METADATA);
+                if (closeCalled.compareAndSet(false, true)) {
+                    deadlineFuture.cancel(true);
+                    responseListener().onClose(errorStatus, EMPTY_METADATA);
+                }
             }
             socket().log(LOGGER, DEBUG, "[Writing thread] exiting");
         });
@@ -230,18 +242,51 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
                         status = Status.fromCodeValue(trailers.get(STATUS_NAME).getInt());
                     }
                 }
-                responseListener().onClose(status, EMPTY_METADATA);
+                if (closeCalled.compareAndSet(false, true)) {
+                    deadlineFuture.cancel(true);
+                    responseListener().onClose(status, EMPTY_METADATA);
+                }
             } catch (StreamTimeoutException e) {
-                responseListener().onClose(Status.DEADLINE_EXCEEDED, EMPTY_METADATA);
+                if (closeCalled.compareAndSet(false, true)) {
+                    deadlineFuture.cancel(true);
+                    responseListener().onClose(Status.DEADLINE_EXCEEDED, EMPTY_METADATA);
+                }
             } catch (Throwable e) {
                 socket().log(LOGGER, ERROR, e.getMessage(), e);
                 Status errorStatus = Status.UNKNOWN.withDescription(e.getMessage()).withCause(e);
-                responseListener().onClose(errorStatus, EMPTY_METADATA);
+                if (closeCalled.compareAndSet(false, true)) {
+                    deadlineFuture.cancel(true);
+                    responseListener().onClose(errorStatus, EMPTY_METADATA);
+                }
             } finally {
                 close();
             }
             socket().log(LOGGER, DEBUG, "[Reading thread] exiting");
         });
+
+        // Deadline enforcement virtual thread
+        Deadline deadline = effectiveDeadline();
+        if (deadline != null && !deadline.isExpired()) {
+            deadlineFuture = executor.submit(() -> {
+                try {
+                    long remainingNanos = deadline.timeRemaining(TimeUnit.NANOSECONDS);
+                    if (remainingNanos > 0) {
+                        Thread.sleep(Duration.ofNanos(remainingNanos));
+                    }
+                    if (closeCalled.compareAndSet(false, true)) {
+                        socket().log(LOGGER, DEBUG, "[Deadline thread] deadline exceeded");
+                        responseListener().onClose(Status.DEADLINE_EXCEEDED
+                                .withDescription("deadline exceeded"), EMPTY_METADATA);
+                        readStreamFuture.cancel(true);
+                        writeStreamFuture.cancel(true);
+                        heartbeatFuture.cancel(true);
+                        close();
+                    }
+                } catch (InterruptedException e) {
+                    // Call completed before deadline — timer cancelled normally
+                }
+            });
+        }
     }
 
     private void close() {

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcClientCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,26 +111,7 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
     }
 
     protected void startStreamingThreads() {
-        // heartbeat thread
-        Duration period = heartbeatPeriod();
-        if (!period.isZero()) {
-            heartbeatFuture = executor.submit(() -> {
-                try {
-                    startWriteBarrier.await();
-                    socket().log(LOGGER, DEBUG, "[Heartbeat thread] started with period " + period);
-                    while (isRemoteOpen()) {
-                        Thread.sleep(period);
-                        if (sendingQueue.isEmpty()) {
-                            sendingQueue.add(PING_FRAME);
-                        }
-                    }
-                } catch (Throwable t) {
-                    socket().log(LOGGER, DEBUG, "[Heartbeat thread] exception " + t.getMessage());
-                }
-            });
-        } else {
-            heartbeatFuture = CompletableFuture.completedFuture(null);
-        }
+        startHeartbeatThread();
 
         // write streaming thread
         writeStreamFuture = executor.submit(() -> {
@@ -264,7 +245,32 @@ class GrpcClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
             socket().log(LOGGER, DEBUG, "[Reading thread] exiting");
         });
 
-        // Deadline enforcement virtual thread
+        startDeadlineThread();
+    }
+
+    private void startHeartbeatThread() {
+        Duration period = heartbeatPeriod();
+        if (!period.isZero()) {
+            heartbeatFuture = executor.submit(() -> {
+                try {
+                    startWriteBarrier.await();
+                    socket().log(LOGGER, DEBUG, "[Heartbeat thread] started with period " + period);
+                    while (isRemoteOpen()) {
+                        Thread.sleep(period);
+                        if (sendingQueue.isEmpty()) {
+                            sendingQueue.add(PING_FRAME);
+                        }
+                    }
+                } catch (Throwable t) {
+                    socket().log(LOGGER, DEBUG, "[Heartbeat thread] exception " + t.getMessage());
+                }
+            });
+        } else {
+            heartbeatFuture = CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private void startDeadlineThread() {
         Deadline deadline = effectiveDeadline();
         if (deadline != null && !deadline.isExpired()) {
             deadlineFuture = executor.submit(() -> {

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcUnaryClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcUnaryClientCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcUnaryClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcUnaryClientCall.java
@@ -17,6 +17,11 @@
 package io.helidon.webclient.grpc;
 
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Header;
@@ -24,6 +29,7 @@ import io.helidon.http.Headers;
 import io.helidon.http.http2.Http2Headers;
 
 import io.grpc.CallOptions;
+import io.grpc.Deadline;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 
@@ -40,7 +46,9 @@ import static java.lang.System.Logger.Level.DEBUG;
 class GrpcUnaryClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
     private static final System.Logger LOGGER = System.getLogger(GrpcUnaryClientCall.class.getName());
 
-    private volatile boolean closeCalled;
+    private final AtomicBoolean closeCalled = new AtomicBoolean(false);
+    // Initialize to completed future so cancel() is safe before startStreamingThreads() runs
+    private volatile Future<?> deadlineFuture = CompletableFuture.completedFuture(null);
     private volatile boolean requestSent;
     private volatile boolean responseReceived;
     private volatile Http2Headers responseHeaders;
@@ -134,17 +142,41 @@ class GrpcUnaryClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
 
     @Override
     protected void startStreamingThreads() {
-        // no-op
+        Deadline deadline = effectiveDeadline();
+        if (deadline != null && !deadline.isExpired()) {
+            ExecutorService executor = grpcClient().webClient().executor();
+            deadlineFuture = executor.submit(() -> {
+                try {
+                    long remainingNanos = deadline.timeRemaining(TimeUnit.NANOSECONDS);
+                    if (remainingNanos > 0) {
+                        Thread.sleep(java.time.Duration.ofNanos(remainingNanos));
+                    }
+                    if (closeCalled.compareAndSet(false, true)) {
+                        socket().log(LOGGER, DEBUG, "[Deadline thread] deadline exceeded");
+                        responseListener().onClose(Status.DEADLINE_EXCEEDED
+                                .withDescription("deadline exceeded"), EMPTY_METADATA);
+                        clientStream().cancel();
+                        connection().close();
+                        unblockUnaryExecutor();
+                    }
+                } catch (InterruptedException e) {
+                    // Call completed before deadline — timer cancelled normally
+                }
+            });
+        } else {
+            deadlineFuture = CompletableFuture.completedFuture(null);
+        }
     }
 
     private void close(Status status) {
-        if (!closeCalled) {
+        if (closeCalled.compareAndSet(false, true)) {
             socket().log(LOGGER, DEBUG, "closing client call");
+            // Cancel deadline timer (always safe — initialized to completedFuture)
+            deadlineFuture.cancel(true);
             responseListener().onClose(status, EMPTY_METADATA);
             clientStream().cancel();
             connection().close();
 
-            // update metrics
             if (enableMetrics() && status == Status.OK) {
                 MethodMetrics methodMetrics = methodMetrics();
                 methodMetrics.callDuration().record(
@@ -154,7 +186,6 @@ class GrpcUnaryClientCall<ReqT, ResT> extends GrpcBaseClientCall<ReqT, ResT> {
             }
 
             unblockUnaryExecutor();
-            closeCalled = true;
         }
     }
 }

--- a/webclient/grpc/src/test/java/io/helidon/webclient/grpc/DeadlineMetricsTest.java
+++ b/webclient/grpc/src/test/java/io/helidon/webclient/grpc/DeadlineMetricsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.grpc;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.grpc.ClientCall;
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Tag;
+
+import io.grpc.CallOptions;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Verifies that a call rejected before I/O (already-expired deadline) still increments
+ * the {@code grpc.client.attempt.started} counter.
+ */
+class DeadlineMetricsTest {
+
+    private static final MethodDescriptor<byte[], byte[]> METHOD =
+            MethodDescriptor.<byte[], byte[]>newBuilder()
+                    .setType(MethodDescriptor.MethodType.UNARY)
+                    .setFullMethodName("TestService/TestMethod")
+                    .setRequestMarshaller(ByteMarshaller.INSTANCE)
+                    .setResponseMarshaller(ByteMarshaller.INSTANCE)
+                    .build();
+
+    @Test
+    void preStartDeadlineCountsAsAttempt() {
+        GrpcClient grpcClient = GrpcClient.builder()
+                .baseUri("http://localhost:19999")   // no server needed — fails before connecting
+                .enableMetrics(true)
+                .build();
+        GrpcChannel channel = new GrpcChannel(grpcClient);
+
+        MeterRegistry registry = MetricsFactory.getInstance().globalRegistry();
+        Tag grpcMethod = Tag.create("grpc.method", "TestService/TestMethod");
+        Tag grpcTarget = Tag.create("grpc.target", channel.baseUri().toString());
+
+        long before = registry.counter("grpc.client.attempt.started", List.of(grpcMethod, grpcTarget))
+                .map(Counter::count)
+                .orElse(0L);
+
+        // Already-expired deadline: start() inits metrics then returns before opening a connection
+        AtomicReference<Status> closedStatus = new AtomicReference<>();
+        var call = channel.newCall(METHOD, CallOptions.DEFAULT.withDeadlineAfter(0, TimeUnit.NANOSECONDS));
+        call.start(new ClientCall.Listener<>() {
+            @Override
+            public void onClose(Status status, Metadata trailers) {
+                closedStatus.set(status);
+            }
+        }, new Metadata());
+
+        assertThat("call should have been closed", closedStatus.get(), is(notNullValue()));
+        assertThat("status should be DEADLINE_EXCEEDED",
+                closedStatus.get().getCode(), is(Status.Code.DEADLINE_EXCEEDED));
+
+        Optional<Counter> counter = registry.counter("grpc.client.attempt.started",
+                List.of(grpcMethod, grpcTarget));
+        assertThat("attempt.started counter should exist", counter.isPresent(), is(true));
+        assertThat("pre-start deadline failure should increment attempt.started by 1",
+                counter.get().count() - before, is(1L));
+    }
+
+    /** Minimal marshaller for byte arrays — never called in the fail-fast deadline path. */
+    private enum ByteMarshaller implements MethodDescriptor.Marshaller<byte[]> {
+        INSTANCE;
+
+        @Override
+        public InputStream stream(byte[] value) {
+            return new java.io.ByteArrayInputStream(value);
+        }
+
+        @Override
+        public byte[] parse(InputStream stream) {
+            try {
+                return stream.readAllBytes();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/ContextSettingServerInterceptor.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/ContextSettingServerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/ContextSettingServerInterceptor.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/ContextSettingServerInterceptor.java
@@ -19,13 +19,19 @@ package io.helidon.webserver.grpc;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.Weight;
 import io.helidon.grpc.core.ContextKeys;
+import io.helidon.grpc.core.GrpcHeadersUtil;
 import io.helidon.grpc.core.InterceptorWeights;
 
 import io.grpc.Context;
 import io.grpc.Contexts;
+import io.grpc.Deadline;
+import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -40,6 +46,14 @@ import static io.helidon.grpc.core.GrpcHelper.extractMethodName;
 class ContextSettingServerInterceptor implements ServerInterceptor {
 
     private static final ContextSettingServerInterceptor INSTANCE = new ContextSettingServerInterceptor();
+    private static final Metadata.Key<String> TIMEOUT_KEY =
+            Metadata.Key.of("grpc-timeout", Metadata.ASCII_STRING_MARSHALLER);
+    private static final ScheduledExecutorService DEADLINE_SCHEDULER =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "helidon-grpc-deadline-scheduler");
+                t.setDaemon(true);
+                return t;
+            });
 
     private ContextSettingServerInterceptor() {
     }
@@ -60,6 +74,20 @@ class ContextSettingServerInterceptor implements ServerInterceptor {
                 io.helidon.common.context.Contexts.context();
         context = context.withValue(ContextKeys.HELIDON_CONTEXT,
                 helidonContext.orElseGet(io.helidon.common.context.Context::create));
+
+        // parse grpc-timeout header and set deadline in context
+        String timeoutValue = headers.get(TIMEOUT_KEY);
+        Context.CancellableContext cancellableContext = null;
+        if (timeoutValue != null) {
+            try {
+                long timeoutNanos = GrpcHeadersUtil.decodeTimeout(timeoutValue);
+                cancellableContext = context.withDeadline(
+                        Deadline.after(timeoutNanos, TimeUnit.NANOSECONDS), DEADLINE_SCHEDULER);
+                context = cancellableContext;
+            } catch (IllegalArgumentException ignored) {
+                // malformed header — ignore and proceed without deadline
+            }
+        }
 
         if (helidonContext.isPresent()) {
             GrpcServiceDescriptor serviceDescriptor = helidonContext.get()
@@ -88,7 +116,30 @@ class ContextSettingServerInterceptor implements ServerInterceptor {
         }
 
         // intercept with new context
-        return Contexts.interceptCall(context, call, headers, next);
+        ServerCall.Listener<ReqT> listener = Contexts.interceptCall(context, call, headers, next);
+        if (cancellableContext != null) {
+            Context.CancellableContext ctxToCancel = cancellableContext;
+            return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(listener) {
+                @Override
+                public void onComplete() {
+                    try {
+                        super.onComplete();
+                    } finally {
+                        ctxToCancel.cancel(null);
+                    }
+                }
+
+                @Override
+                public void onCancel() {
+                    try {
+                        super.onCancel();
+                    } finally {
+                        ctxToCancel.cancel(null);
+                    }
+                }
+            };
+        }
+        return listener;
     }
 
     @Override

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/ContextSettingServerInterceptor.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/ContextSettingServerInterceptor.java
@@ -19,8 +19,8 @@ package io.helidon.webserver.grpc;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.Weight;
@@ -49,11 +49,9 @@ class ContextSettingServerInterceptor implements ServerInterceptor {
     private static final Metadata.Key<String> TIMEOUT_KEY =
             Metadata.Key.of("grpc-timeout", Metadata.ASCII_STRING_MARSHALLER);
     private static final ScheduledExecutorService DEADLINE_SCHEDULER =
-            Executors.newSingleThreadScheduledExecutor(r -> {
-                Thread t = new Thread(r, "helidon-grpc-deadline-scheduler");
-                t.setDaemon(true);
-                return t;
-            });
+            new ScheduledThreadPoolExecutor(1, Thread.ofVirtual()
+                    .name("helidon-grpc-deadline-scheduler-", 0)
+                    .factory());
 
     private ContextSettingServerInterceptor() {
     }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -63,6 +64,7 @@ import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 
 import io.grpc.Codec;
 import io.grpc.Compressor;
+import io.grpc.Deadline;
 import io.grpc.CompressorRegistry;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
@@ -129,6 +131,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private long startMillis;
 
     private volatile boolean callCancelled;
+    private volatile Deadline requestDeadline;
     private final AtomicReference<Http2StreamState> currentStreamState = new AtomicReference<>();
 
     GrpcProtocolHandler(ConnectionContext connectionContext,
@@ -157,6 +160,17 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
             // setup compression
             initCompression(serverCall, httpHeaders);
+
+            // parse grpc-timeout to enable DEADLINE_EXCEEDED detection on cancellation
+            String timeoutValue = httpHeaders.first(GrpcHeadersUtil.GRPC_TIMEOUT).orElse(null);
+            if (timeoutValue != null) {
+                try {
+                    long timeoutNanos = GrpcHeadersUtil.decodeTimeout(timeoutValue);
+                    requestDeadline = Deadline.after(timeoutNanos, TimeUnit.NANOSECONDS);
+                } catch (IllegalArgumentException ignored) {
+                    // malformed grpc-timeout header — proceed without deadline tracking
+                }
+            }
 
             // init metrics
             if (grpcConfig.enableMetrics()) {
@@ -483,14 +497,22 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
 
             @Override
             public void close(Status status, Metadata trailers) {
-                // prepare trailers, may override status code to CANCELLED
+                // prepare trailers; if the call was cancelled, status may be overridden to CANCELLED or DEADLINE_EXCEEDED
                 WritableHeaders<?> writable = WritableHeaders.create();
                 if (!headersSent) {
                     writable.set(GRPC_CONTENT_TYPE);
                 }
                 GrpcHeadersUtil.updateHeaders(writable, trailers);
-                int statusValue = callCancelled ? Status.CANCELLED.getCode().value()
-                        : status.getCode().value();
+                int statusValue;
+                if (callCancelled) {
+                    // Both deadline expiry and explicit client cancel arrive as RST_STREAM, so the `status`
+                    // argument cannot distinguish them. Check whether the client's stated timeout elapsed.
+                    statusValue = (requestDeadline != null && requestDeadline.isExpired())
+                            ? Status.DEADLINE_EXCEEDED.getCode().value()
+                            : Status.CANCELLED.getCode().value();
+                } else {
+                    statusValue = status.getCode().value();
+                }
                 writable.set(HeaderValues.create(GrpcStatus.STATUS_NAME, statusValue));
                 String description = status.getDescription();
                 if (description != null) {

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -64,8 +64,8 @@ import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 
 import io.grpc.Codec;
 import io.grpc.Compressor;
-import io.grpc.Deadline;
 import io.grpc.CompressorRegistry;
+import io.grpc.Deadline;
 import io.grpc.Decompressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.KnownLength;
@@ -503,17 +503,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                     writable.set(GRPC_CONTENT_TYPE);
                 }
                 GrpcHeadersUtil.updateHeaders(writable, trailers);
-                int statusValue;
-                if (callCancelled) {
-                    // Both deadline expiry and explicit client cancel arrive as RST_STREAM, so the `status`
-                    // argument cannot distinguish them. Check whether the client's stated timeout elapsed.
-                    statusValue = (requestDeadline != null && requestDeadline.isExpired())
-                            ? Status.DEADLINE_EXCEEDED.getCode().value()
-                            : Status.CANCELLED.getCode().value();
-                } else {
-                    statusValue = status.getCode().value();
-                }
-                writable.set(HeaderValues.create(GrpcStatus.STATUS_NAME, statusValue));
+                writable.set(HeaderValues.create(GrpcStatus.STATUS_NAME, resolvedStatusCode(status)));
                 String description = status.getDescription();
                 if (description != null) {
                     writable.set(HeaderValues.create(GrpcStatus.MESSAGE_NAME, description));
@@ -567,6 +557,17 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
                 return writeBufferData;
             }
         };
+    }
+
+    // Both deadline expiry and explicit client cancel arrive as RST_STREAM, so the status
+    // argument from close() cannot distinguish them — check whether the deadline elapsed instead.
+    private int resolvedStatusCode(Status status) {
+        if (callCancelled) {
+            return (requestDeadline != null && requestDeadline.isExpired())
+                    ? Status.DEADLINE_EXCEEDED.getCode().value()
+                    : Status.CANCELLED.getCode().value();
+        }
+        return status.getCode().value();
     }
 
     /**

--- a/webserver/tests/grpc/src/main/java/io/helidon/webserver/tests/grpc/SlowService.java
+++ b/webserver/tests/grpc/src/main/java/io/helidon/webserver/tests/grpc/SlowService.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.tests.grpc;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.protobuf.Descriptors;
+import io.helidon.webserver.grpc.GrpcService;
+import io.helidon.webserver.grpc.slow.Slow;
+import io.helidon.webserver.grpc.slow.Slow.SlowRequest;
+import io.helidon.webserver.grpc.slow.Slow.SlowResponse;
+import io.grpc.Context;
+import io.grpc.Deadline;
+import io.grpc.stub.StreamObserver;
+
+/**
+ * A test gRPC service that sleeps for a configurable duration before responding.
+ * Used to verify deadline enforcement on both client and server side.
+ *
+ * <p>The last deadline seen by a handler is stored in {@link #lastSeenDeadline}
+ * for test assertions. Reset it to {@code null} before each test that checks it.
+ */
+class SlowService implements GrpcService {
+
+    /** The last deadline seen in Context by a handler invocation. Reset before each test. */
+    static final AtomicReference<Deadline> lastSeenDeadline = new AtomicReference<>();
+
+    @Override
+    public Descriptors.FileDescriptor proto() {
+        return Slow.getDescriptor();
+    }
+
+    @Override
+    public void update(Routing router) {
+        router.unary("Slow", this::slow)
+                .serverStream("SlowStream", this::slowStream);
+    }
+
+    private void slow(SlowRequest request, StreamObserver<SlowResponse> observer) {
+        // Capture deadline inside the handler where Context is set by ContextSettingServerInterceptor
+        lastSeenDeadline.set(Context.current().getDeadline());
+        try {
+            Thread.sleep(request.getDelayMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        observer.onNext(SlowResponse.newBuilder().setText(request.getText()).build());
+        observer.onCompleted();
+    }
+
+    private void slowStream(SlowRequest request, StreamObserver<SlowResponse> observer) {
+        lastSeenDeadline.set(Context.current().getDeadline());
+        try {
+            Thread.sleep(request.getDelayMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        observer.onNext(SlowResponse.newBuilder().setText(request.getText()).build());
+        observer.onCompleted();
+    }
+}

--- a/webserver/tests/grpc/src/main/proto/slow.proto
+++ b/webserver/tests/grpc/src/main/proto/slow.proto
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+option java_package = "io.helidon.webserver.grpc.slow";
+
+service SlowService {
+  // Unary call that sleeps for the requested duration before responding
+  rpc Slow (SlowRequest) returns (SlowResponse) {}
+  // Server-streaming call that sleeps before responding
+  rpc SlowStream (SlowRequest) returns (stream SlowResponse) {}
+}
+
+message SlowRequest {
+  // How long the server should sleep in milliseconds before responding
+  int64 delay_millis = 1;
+  // Text to echo back in the response
+  string text = 2;
+}
+
+message SlowResponse {
+  string text = 1;
+}

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/DeadlineTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/DeadlineTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver.tests.grpc;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.grpc.slow.Slow.SlowRequest;
+import io.helidon.webserver.grpc.slow.Slow.SlowResponse;
+import io.helidon.webserver.grpc.slow.SlowServiceGrpc;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import io.grpc.Context;
+import io.grpc.Deadline;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ServerTest
+class DeadlineTest extends BaseServiceTest {
+
+    private SlowServiceGrpc.SlowServiceBlockingStub blockingStub;
+    private SlowServiceGrpc.SlowServiceStub asyncStub;
+
+    DeadlineTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new SlowService()));
+    }
+
+    @BeforeEach
+    @Override
+    void beforeEach() {
+        super.beforeEach();
+        blockingStub = SlowServiceGrpc.newBlockingStub(channel);
+        asyncStub = SlowServiceGrpc.newStub(channel);
+        SlowService.lastSeenDeadline.set(null);
+    }
+
+    @AfterEach
+    @Override
+    void afterEach() throws InterruptedException {
+        super.afterEach();
+    }
+
+    @Test
+    void unaryDeadlineExceeded() {
+        // Server sleeps 2s, client deadline is 200ms → DEADLINE_EXCEEDED
+        SlowRequest request = SlowRequest.newBuilder().setDelayMillis(2000).setText("hello").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                () -> blockingStub.withDeadlineAfter(200, TimeUnit.MILLISECONDS).slow(request));
+
+        assertThat(ex.getStatus().getCode(), is(Status.Code.DEADLINE_EXCEEDED));
+    }
+
+    @Test
+    void alreadyExpiredDeadline() {
+        // Deadline of 0ns — should fail immediately without opening a connection
+        SlowRequest request = SlowRequest.newBuilder().setDelayMillis(0).setText("hello").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                () -> blockingStub.withDeadlineAfter(0, TimeUnit.NANOSECONDS).slow(request));
+
+        assertThat(ex.getStatus().getCode(), is(Status.Code.DEADLINE_EXCEEDED));
+    }
+
+    @Test
+    void callCompletesWithinDeadline() {
+        // Server responds quickly (10ms), deadline is generous (5s) → normal response
+        SlowRequest request = SlowRequest.newBuilder().setDelayMillis(10).setText("hello").build();
+
+        SlowResponse response = blockingStub.withDeadlineAfter(5, TimeUnit.SECONDS).slow(request);
+
+        assertThat(response.getText(), is("hello"));
+    }
+
+    @Test
+    void streamingDeadlineExceeded() throws InterruptedException {
+        // Server-streaming call: 200ms deadline, server sleeps 2s → DEADLINE_EXCEEDED
+        SlowRequest request = SlowRequest.newBuilder().setDelayMillis(2000).setText("hello").build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        asyncStub.withDeadlineAfter(200, TimeUnit.MILLISECONDS)
+                .slowStream(request, new StreamObserver<SlowResponse>() {
+                    @Override public void onNext(SlowResponse value) {}
+
+                    @Override
+                    public void onError(Throwable t) {
+                        error.set(t);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        latch.countDown();
+                    }
+                });
+
+        assertThat("should receive error within timeout", latch.await(5, TimeUnit.SECONDS), is(true));
+        assertThat("should have received an error", error.get(), is(notNullValue()));
+        assertThat(Status.fromThrowable(error.get()).getCode(), is(Status.Code.DEADLINE_EXCEEDED));
+    }
+
+    @Test
+    void serverSeesDeadlineInContext() {
+        // After the call, SlowService.lastSeenDeadline should be non-null
+        SlowRequest request = SlowRequest.newBuilder().setDelayMillis(10).setText("hello").build();
+
+        blockingStub.withDeadlineAfter(5, TimeUnit.SECONDS).slow(request);
+
+        Deadline deadline = SlowService.lastSeenDeadline.get();
+        assertThat("server should see a deadline in Context", deadline, is(notNullValue()));
+        long remainingMs = deadline.timeRemaining(TimeUnit.MILLISECONDS);
+        assertThat("remaining time should be positive", remainingMs > 0, is(true));
+        assertThat("remaining time should be less than original 5s", remainingMs < 5000, is(true));
+    }
+
+    @Test
+    void serverSeesNoDeadlineWhenNoneSet() {
+        SlowRequest request = SlowRequest.newBuilder().setDelayMillis(10).setText("hello").build();
+
+        blockingStub.slow(request);  // No deadline on stub
+
+        assertThat("server should see null deadline when none sent",
+                SlowService.lastSeenDeadline.get(), is(nullValue()));
+    }
+
+    @Test
+    void stubLevelDeadlineExceeded() {
+        // Deadline is configured once on the stub, not per-call. The countdown starts at stub creation.
+        SlowServiceGrpc.SlowServiceBlockingStub timedStub =
+                SlowServiceGrpc.newBlockingStub(channel)
+                        .withDeadlineAfter(200, TimeUnit.MILLISECONDS);
+        SlowRequest request = SlowRequest.newBuilder().setDelayMillis(2000).setText("hello").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                () -> timedStub.slow(request));
+
+        assertThat(ex.getStatus().getCode(), is(Status.Code.DEADLINE_EXCEEDED));
+    }
+
+    @Test
+    void callOptionsDeadlineTighterThanContext() throws Exception {
+        // Context has 5s, CallOptions has 200ms → effective deadline is 200ms
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            Context ctx = Context.current()
+                    .withDeadline(Deadline.after(5, TimeUnit.SECONDS), scheduler);
+            ctx.run(() -> {
+                SlowRequest request = SlowRequest.newBuilder()
+                        .setDelayMillis(2000).setText("hello").build();
+                StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                        () -> blockingStub
+                                .withDeadlineAfter(200, TimeUnit.MILLISECONDS)
+                                .slow(request));
+                assertThat(ex.getStatus().getCode(), is(Status.Code.DEADLINE_EXCEEDED));
+            });
+        } finally {
+            scheduler.shutdown();
+        }
+    }
+
+    @Test
+    void contextDeadlineTighterThanCallOptions() throws Exception {
+        // Context has 200ms, CallOptions has 5s → effective deadline is 200ms
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            Context ctx = Context.current()
+                    .withDeadline(Deadline.after(200, TimeUnit.MILLISECONDS), scheduler);
+            ctx.run(() -> {
+                SlowRequest request = SlowRequest.newBuilder()
+                        .setDelayMillis(2000).setText("hello").build();
+                StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                        () -> blockingStub
+                                .withDeadlineAfter(5, TimeUnit.SECONDS)
+                                .slow(request));
+                assertThat(ex.getStatus().getCode(), is(Status.Code.DEADLINE_EXCEEDED));
+            });
+        } finally {
+            scheduler.shutdown();
+        }
+    }
+}

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/DeadlineTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/DeadlineTest.java
@@ -162,7 +162,10 @@ class DeadlineTest extends BaseServiceTest {
 
     @Test
     void stubLevelDeadlineExceeded() {
-        // Deadline is configured once on the stub, not per-call. The countdown starts at stub creation.
+        // withDeadlineAfter calls Deadline.after() immediately, fixing the expiry to the instant
+        // the stub is configured. The countdown therefore starts at stub-creation time, not at
+        // call-invocation time. See CallOptions.withDeadlineAfter:
+        // https://github.com/grpc/grpc-java/blob/v1.73.0/api/src/main/java/io/grpc/CallOptions.java#L177-L179
         SlowServiceGrpc.SlowServiceBlockingStub timedStub =
                 SlowServiceGrpc.newBlockingStub(channel)
                         .withDeadlineAfter(200, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Helidon's gRPC client stored CallOptions but never called getDeadline(). The grpc-timeout HTTP/2 header was never written on outbound calls and never parsed on inbound ones, so stub.withDeadlineAfter() silently did nothing and
Context.current().getDeadline() was always null in server handlers.

## Header encoding/decoding (grpc/core)

The gRPC over HTTP/2 spec defines a compact timeout format: a positive integer up to 8 ASCII digits followed by a unit suffix (H/M/S/m/u/n). GrpcHeadersUtil.encodeTimeout() picks the largest unit where the value fits in 8 digits, keeping wire overhead minimal. decodeTimeout() is the inverse. Both are used by client and server; unit tests cover all six units, the 8-digit boundary, round-trips, and malformed-input rejection.

## Client-side enforcement (webclient/grpc)

GrpcBaseClientCall now computes an effective deadline as min(CallOptions.getDeadline(), Context.current().getDeadline()). Taking the minimum of both sources gives automatic deadline propagation for free: a server handler that makes an outbound gRPC call inherits the remaining context deadline without any manual wiring.

The fail-fast check in start() runs before clientConnection() so an already-expired deadline returns DEADLINE_EXCEEDED without opening a TCP connection. When a live deadline is set, grpc-timeout is written into the outbound HEADERS frame after metadata conversion to prevent metadata from accidentally overwriting it.

A virtual thread (Thread.sleep) enforces the deadline at runtime. Virtual threads park without holding a carrier thread, which fits Helidon 4.x's threading model and avoids a ScheduledExecutorService.

Both GrpcClientCall (streaming) and GrpcUnaryClientCall (unary) lacked a race-safe close guard: the streaming call had none at all, and the unary call used volatile boolean, which has a TOCTOU window when the deadline thread and the read thread both see false before either writes true. Both now use AtomicBoolean.compareAndSet so exactly one thread wins and calls responseListener.onClose().

## Server-side enforcement (webserver/grpc)

ContextSettingServerInterceptor is already the assembly point for the gRPC Context before Contexts.interceptCall(). Adding deadline parsing here means every handler type — GrpcService, BindableService, and interceptor-wrapped handlers — gets deadline enforcement automatically.

Context.withDeadline() returns a CancellableContext that schedules a ScheduledFuture. If the call completes before the deadline the timer must be explicitly canceled; otherwise the ScheduledFuture holds a live reference until the original deadline fires. A ForwardingServerCallListener wraps onComplete and onCancel to call CancellableContext.cancel() in a finally block.

GrpcProtocolHandler previously returned CANCELLED (code 1) whenever the call was canceled by the client. A deadline expiry is semantically DEADLINE_EXCEEDED (code 4). The requestDeadline field is set at init() time from the grpc-timeout header; at close() time, if callCancelled is true and the deadline has expired, DEADLINE_EXCEEDED is returned instead.

### Documentation

 I don't think there's anything to document here since this isn't an API change.
