### PR TITLE
Send te: trailers on every gRPC client request (#11700)

### DIFF
--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcBaseClientCall.java
@@ -84,6 +84,12 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
     static final Metadata EMPTY_METADATA = new Metadata();
     static final Header GRPC_ACCEPT_ENCODING = HeaderValues.create(HeaderNames.ACCEPT_ENCODING, "gzip");
     static final Header GRPC_CONTENT_TYPE = HeaderValues.create(HeaderNames.CONTENT_TYPE, "application/grpc");
+    // Listed in the gRPC-over-HTTP/2 Call-Definition as a non-optional field.
+    // Used to detect incompatible proxies: intermediaries that do not support HTTP/2 trailers
+    // may silently strip grpc-status and trailing metadata. RFC 7540 §8.1.2.2 permits TE in
+    // HTTP/2 headers only with the value "trailers".
+    // See: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+    static final Header GRPC_TE_TRAILERS = HeaderValues.create(HeaderNames.TE, "trailers");
     static final HeaderName STATUS_NAME = HeaderNames.createFromLowercase("grpc-status");
 
     static final BufferData PING_FRAME = BufferData.create("PING");
@@ -207,6 +213,7 @@ abstract class GrpcBaseClientCall<ReqT, ResT> extends ClientCall<ReqT, ResT> {
         headers.set(Http2Headers.SCHEME_NAME, "http");
         headers.set(GRPC_CONTENT_TYPE);
         headers.set(GRPC_ACCEPT_ENCODING);
+        headers.set(GRPC_TE_TRAILERS);
         return headers;
     }
 

--- a/webclient/grpc/src/test/java/io/helidon/webclient/grpc/GrpcBaseClientCallTest.java
+++ b/webclient/grpc/src/test/java/io/helidon/webclient/grpc/GrpcBaseClientCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/grpc/src/test/java/io/helidon/webclient/grpc/GrpcBaseClientCallTest.java
+++ b/webclient/grpc/src/test/java/io/helidon/webclient/grpc/GrpcBaseClientCallTest.java
@@ -40,5 +40,6 @@ class GrpcBaseClientCallTest {
         assertThat(headers.get(Http2Headers.PATH_NAME).get(), is("/foo"));
         assertThat(headers.get(Http2Headers.SCHEME_NAME).get(), is("http"));
         assertThat(headers.get(HeaderNames.COOKIE).get(), is("sugar"));
+        assertThat(headers.get(HeaderNames.TE).get(), is("trailers"));
     }
 }

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcTeTrailersTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcTeTrailersTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.grpc.tests;
+
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.webclient.grpc.GrpcClient;
+import io.helidon.webclient.grpc.GrpcClientMethodDescriptor;
+import io.helidon.webclient.grpc.GrpcServiceDescriptor;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Verifies that the Helidon gRPC webclient sends the {@code te: trailers} header on the wire.
+ *
+ * <p>The gRPC-over-HTTP/2 spec lists {@code TE} in the Call-Definition as a non-optional field.
+ * Intermediaries use it to decide whether to forward HTTP/2 trailers end-to-end, so its absence
+ * causes proxies to silently drop {@code grpc-status} and trailing metadata.
+ *
+ * <p>This test uses a server-side {@link ServerInterceptor} to capture the raw {@link Metadata}
+ * as received by the server, which proves the header survived the full client encoding pipeline,
+ * not just that it was added to a {@link io.helidon.http.WritableHeaders} in-process.
+ */
+@ServerTest
+class GrpcTeTrailersTest {
+
+    private static final Metadata.Key<String> TE_KEY =
+            Metadata.Key.of("te", Metadata.ASCII_STRING_MARSHALLER);
+
+    private static final AtomicReference<Metadata> capturedMetadata = new AtomicReference<>();
+
+    private final GrpcClient grpcClient;
+    private final GrpcServiceDescriptor serviceDescriptor;
+
+    GrpcTeTrailersTest(WebServer server) {
+        this.grpcClient = GrpcClient.builder()
+                .tls(t -> t.enabled(false))
+                .baseUri("http://localhost:" + server.port())
+                .build();
+        this.serviceDescriptor = GrpcServiceDescriptor.builder()
+                .serviceName("StringService")
+                .putMethod("Upper",
+                        GrpcClientMethodDescriptor.unary("StringService", "Upper")
+                                .requestType(Strings.StringMessage.class)
+                                .responseType(Strings.StringMessage.class)
+                                .build())
+                .build();
+    }
+
+    @SetUpRoute
+    static void setUpRoute(GrpcRouting.Builder routing) {
+        routing.intercept(new MetadataCapturingInterceptor())
+                .unary(Strings.getDescriptor(), "StringService", "Upper", GrpcTeTrailersTest::upper);
+    }
+
+    @Test
+    void teTrailersHeaderIsSentToServer() {
+        grpcClient.serviceClient(serviceDescriptor)
+                .unary("Upper", Strings.StringMessage.newBuilder().setText("hello").build());
+
+        Metadata metadata = capturedMetadata.get();
+        assertThat("server interceptor was not called", metadata, notNullValue());
+        assertThat(metadata.get(TE_KEY), is("trailers"));
+    }
+
+    private static void upper(Strings.StringMessage req, StreamObserver<Strings.StringMessage> observer) {
+        observer.onNext(Strings.StringMessage.newBuilder()
+                .setText(req.getText().toUpperCase(Locale.ROOT))
+                .build());
+        observer.onCompleted();
+    }
+
+    private static class MetadataCapturingInterceptor implements ServerInterceptor {
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            capturedMetadata.set(headers);
+            return next.startCall(call, headers);
+        }
+    }
+}


### PR DESCRIPTION
The gRPC-over-HTTP/2 spec lists TE as a non-optional field in Call-Definition. Without it, HTTP/2-aware intermediaries (Envoy, AWS ALB, GCP LB, nginx) may silently strip trailers, discarding grpc-status and trailing metadata from every RPC. Direct connections are unaffected, but any production deployment with a proxy in the path is broken in a way that is hard to diagnose: calls appear to hang or fail with no status code.

grpc-java hardcodes te: trailers alongside content-type in every outbound HEADERS frame (GrpcHttp2OutboundHeaders.clientRequestHeaders).

Adds GRPC_TE_TRAILERS constant to GrpcBaseClientCall and sets it in setupHeaders(). Verified by a server-side ServerInterceptor in an integration test that captures the raw Metadata received over the wire, proving the header survives the full HTTP/2 encoding pipeline and not just that it was added to a WritableHeaders object in-process.

### Documentation

No API changes or behavior changes needed from consumers. Closes an implementation gap relative to reference grpc-java.
