### PR TITLE
Deprecate HTTP Digest Authentication provider (4.x)

### DIFF
--- a/docs/src/main/asciidoc/includes/security/providers/http-digest-auth.adoc
+++ b/docs/src/main/asciidoc/includes/security/providers/http-digest-auth.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2024 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,11 @@ ifndef::rootdir[:rootdir: {docdir}/../../..]
 :keywords: helidon, security, digest
 :feature-name: HTTP Digest Authentication Security Provider
 
-HTTP Digest authentication support
+[.line-through]#HTTP Digest authentication support#
+
+This provider is deprecated and will be removed in a future version of Helidon without replacement.
+It is kept in Helidon 4 for backward compatibility only, relies on obsolete MD5 hash,
+and should not be used in production.
 
 ==== Setup
 
@@ -80,6 +84,4 @@ The user store is defined so you never need the clear text password of the user.
 
 _Note on security of HTTP Digest Authentication_
 
-These authentication schemes
-should be _obsolete_, though they provide a very easy way to test a protected resource.
-
+This authentication scheme is obsolete and should only be used for local testing or short-lived compatibility work.

--- a/docs/src/main/asciidoc/mp/security/providers.adoc
+++ b/docs/src/main/asciidoc/mp/security/providers.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ Helidon provides the following security providers for endpoint protection:
 
 |<<OIDC Provider,OIDC Provider>> |Authentication |✅ |Open ID Connect supporting JWT, Scopes, Groups and OIDC code flow
 |<<HTTP Basic Authentication Provider,HTTP Basic Authentication>> |Authentication |✅ |HTTP Basic Authentication support
-|<<HTTP Digest Authentication Provider,HTTP Digest Authentication>> |Authentication |🚫 |HTTP Digest Authentication support
+|<<HTTP Digest Authentication Provider,HTTP Digest Authentication>> |Authentication |🚫 |*Deprecated!* HTTP Digest Authentication support
 |<<Header Authentication Provider,Header Assertion>> |Authentication |✅ |Asserting a user based on a header value
 |<<HTTP Signatures Provider,HTTP Signatures>> |Authentication |✅ |Protecting service to service communication through signatures
 |<<IDCS Role Mapper,IDCS Roles>> |Role Mapping |🚫 |Retrieves roles from IDCS provider for authenticated user
@@ -78,4 +78,3 @@ include::{rootdir}/includes/security/providers/abac.adoc[]
 include::{rootdir}/includes/security/providers/google-login.adoc[]
 
 include::{rootdir}/includes/security/providers/jwt.adoc[]
-

--- a/docs/src/main/asciidoc/se/security/providers.adoc
+++ b/docs/src/main/asciidoc/se/security/providers.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ Helidon provides the following security providers for endpoint protection:
 
 |<<OIDC Provider,OIDC Provider>> |Authentication |✅ |Open ID Connect supporting JWT, Scopes, Groups and OIDC code flow
 |<<HTTP Basic Authentication Provider,HTTP Basic Authentication>> |Authentication |✅ |HTTP Basic Authentication support
-|<<HTTP Digest Authentication Provider,HTTP Digest Authentication>> |Authentication |🚫 |HTTP Digest Authentication support
+|<<HTTP Digest Authentication Provider,HTTP Digest Authentication>> |Authentication |🚫 |*Deprecated!* HTTP Digest Authentication support
 |<<Header Authentication Provider,Header Assertion>> |Authentication |✅ |Asserting a user based on a header value
 |<<HTTP Signatures Provider,HTTP Signatures>> |Authentication |✅ |Protecting service to service communication through signatures
 |<<IDCS Role Mapper,IDCS Roles>> |Role Mapping |🚫 |Retrieves roles from IDCS provider for authenticated user

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/ConfigUserStore.java
@@ -134,6 +134,7 @@ public class ConfigUserStore implements SecureUserStore {
         }
 
         @Override
+        @Deprecated(since = "4.5.0", forRemoval = true)
         public Optional<String> digestHa1(String realm, HttpDigest.Algorithm algorithm) {
             return Optional.of(DigestToken.ha1(algorithm, realm, login(), password));
         }

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigest.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigest.java
@@ -22,13 +22,21 @@ import io.helidon.config.Config;
 
 /**
  * Digest specific enums.
+ *
+ * @deprecated HTTP Digest authentication relies on obsolete MD5-based authentication and will be removed in a future
+ *             version without replacement
  */
+@Deprecated(since = "4.5.0", forRemoval = true)
 public class HttpDigest {
     /**
      * Http digest algorithm.
      * See <a href="https://tools.ietf.org/html/rfc2617#page-9">https://tools.ietf.org/html/rfc2617#page-9</a>.
      * Only {@link #MD5} is supported.
+     *
+     * @deprecated HTTP Digest authentication relies on obsolete MD5-based authentication and will be removed in a
+     *             future version without replacement
      */
+    @Deprecated(since = "4.5.0", forRemoval = true)
     public enum Algorithm {
         /**
          * MD5 algorithm.
@@ -54,7 +62,11 @@ public class HttpDigest {
     /**
      * Http digest QOP (quality of protection).
      * See <a href="https://tools.ietf.org/html/rfc2617#page-9">https://tools.ietf.org/html/rfc2617#page-9</a>.
+     *
+     * @deprecated HTTP Digest authentication relies on obsolete MD5-based authentication and will be removed in a
+     *             future version without replacement
      */
+    @Deprecated(since = "4.5.0", forRemoval = true)
     public enum Qop {
         /**
          * Legacy approach - used internally to parse headers. Do not use this option when

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthProvider.java
@@ -48,8 +48,12 @@ import io.helidon.security.spi.SecurityProvider;
 
 /**
  * Http authentication security provider.
- * Provides support for username and password authentication, with support for roles list.
+ * Provides support for HTTP Digest username and password authentication, with support for role mapping.
+ *
+ * @deprecated HTTP Digest authentication relies on obsolete MD5-based authentication and will be removed in a future
+ *             version without replacement
  */
+@Deprecated(since = "4.5.0", forRemoval = true)
 public final class HttpDigestAuthProvider implements AuthenticationProvider {
     static final String HEADER_AUTHENTICATION_REQUIRED = "WWW-Authenticate";
     static final String HEADER_AUTHENTICATION = "authorization";
@@ -291,10 +295,14 @@ public final class HttpDigestAuthProvider implements AuthenticationProvider {
 
     /**
      * {@link HttpDigestAuthProvider} fluent API builder.
+     *
+     * @deprecated HTTP Digest authentication relies on obsolete MD5-based authentication and will be removed in a
+     *             future version without replacement
      */
     @Configured(prefix = HttpDigestAuthService.PROVIDER_CONFIG_KEY,
                 description = "Http digest authentication security provider",
                 provides = {SecurityProvider.class, AuthenticationProvider.class})
+    @Deprecated(since = "4.5.0", forRemoval = true)
     public static final class Builder implements io.helidon.common.Builder<Builder, HttpDigestAuthProvider> {
 
         private static final String DEFAULT_REALM = "Helidon";

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthService.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthService.java
@@ -22,7 +22,11 @@ import io.helidon.security.spi.SecurityProviderService;
 
 /**
  * Digest authentication service.
+ *
+ * @deprecated HTTP Digest authentication relies on obsolete MD5-based authentication and will be removed in a future
+ *             version without replacement
  */
+@Deprecated(since = "4.5.0", forRemoval = true)
 public class HttpDigestAuthService implements SecurityProviderService {
     static final String PROVIDER_CONFIG_KEY = "http-digest-auth";
 

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/SecureUserStore.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/SecureUserStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,11 @@ public interface SecureUserStore {
          * @param realm configured realm
          * @param algorithm algorithm of the hash (current only MD5 supported by Helidon)
          * @return a digest to use for validation of incoming request
+         * @deprecated HTTP Digest authentication relies on obsolete MD5-based authentication and will be removed in a
+         *             future version without replacement; to have a future proof implementation of this interface, do not
+         *             implement this method
          */
+        @Deprecated(since = "4.5.0", forRemoval = true)
         default Optional<String> digestHa1(String realm, HttpDigest.Algorithm algorithm) {
             return Optional.empty();
         }


### PR DESCRIPTION
Resolves #11715

Deprecates the HTTP Digest authentication provider and related digest-only API surface in Helidon 4 without removing runtime support.
The docs now mark HTTP Digest authentication as deprecated, obsolete, and not intended for production use.

Related to #11696 and adapts the 27.x removal work from #11716 for `helidon-4.x`.
