### PR TITLE
Align gRPC server inbound message size limit with ecosystem defaults and improve oversized message error handling

### DIFF
--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcConfigBlueprint.java
@@ -80,11 +80,13 @@ interface GrpcConfigBlueprint extends ProtocolConfig {
     }
 
     /**
-     * Max size of gRPC reading buffer. If receiving an entity larger than this,
-     * processing will be aborted. This can help prevent DoS attacks. Default
-     * set to 2 MB.
+     * Max inbound message size. If receiving a message larger than this,
+     * processing will be aborted with a {@code RESOURCE_EXHAUSTED} status.
+     * This can help prevent DoS attacks. Matches the gRPC ecosystem standard of
+     * 4 MB ({@code GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE} in grpc-java,
+     * https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/GrpcUtil.java#L212).
      */
     @Option.Configured
-    @Option.DefaultInt(2 * 1024 * 1024)
+    @Option.DefaultInt(4 * 1024 * 1024)
     int maxReadBufferSize();
 }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcProtocolHandler.java
@@ -72,6 +72,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 
 import static io.helidon.http.HeaderNames.CONTENT_TYPE;
 import static io.helidon.http.http2.Http2Flag.DataFlags;
@@ -116,6 +117,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     private final StreamFlowControl flowControl;
     private final GrpcConfig grpcConfig;
 
+    private ServerCall<REQ, RES> serverCall;
     private volatile ServerCall.Listener<REQ> listener;
     private BufferData entityBytes;
     private BufferData readBufferData = BufferData.create(INITIAL_BUFFER_SIZE);
@@ -152,7 +154,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
     @Override
     public void init() {
         try {
-            ServerCall<REQ, RES> serverCall = createServerCall();
+            serverCall = createServerCall();
             Headers httpHeaders = headers.httpHeaders();
 
             // setup compression
@@ -282,6 +284,16 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
             }
         } catch (CloseConnectionException e) {
             throw e;
+        } catch (StatusRuntimeException e) {
+            if (isPeerCancellation(e)) {
+                throw new ServerConnectionException("gRPC call cancelled by remote peer", e);
+            }
+            // Close the call with the embedded gRPC status (e.g. RESOURCE_EXHAUSTED for oversized messages).
+            // This sends status trailers back to the client rather than abruptly cancelling.
+            // See: MessageDeframer.processHeader() in
+            // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+            LOGGER.log(System.Logger.Level.DEBUG, "gRPC call closed with status: {0}", e.getStatus());
+            serverCall.close(e.getStatus(), new Metadata());
         } catch (Exception e) {
             if (isPeerCancellation(e)) {
                 throw new ServerConnectionException("gRPC call cancelled by remote peer", e);
@@ -296,7 +308,14 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolSelector.SubProto
         int capacity = readBufferData.capacity();
         if (length > capacity) {
             if (length > grpcConfig.maxReadBufferSize()) {
-                throw new IllegalStateException("gRPC message size exceeds max read buffer size");
+                // Throw RESOURCE_EXHAUSTED for oversized messages so the status
+                // propagates back to the client as gRPC trailers.
+                // See: MessageDeframer.processHeader() in
+                // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+                throw Status.RESOURCE_EXHAUSTED
+                        .withDescription("gRPC message exceeds maximum size "
+                                + grpcConfig.maxReadBufferSize() + ": " + length)
+                        .asRuntimeException();
             }
             readBufferData = BufferData.create(length);
         }

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -187,6 +187,13 @@ class GrpcProtocolHandlerTest {
     }
 
     @Test
+    void defaultMaxReadBufferSizeMatchesGrpcEcosystemStandard() {
+        // Matches GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE in grpc-java:
+        // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/GrpcUtil.java#L212
+        assertThat(GrpcConfig.create().maxReadBufferSize(), is(4 * 1024 * 1024));
+    }
+
+    @Test
     void testCloseSuppressesTrailerWriteDisconnect() {
         ServerCall<String, String> serverCall = createServerCall(closeFailingWriter());
         serverCall.sendHeaders(new Metadata());

--- a/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
+++ b/webserver/grpc/src/test/java/io/helidon/webserver/grpc/GrpcProtocolHandlerTest.java
@@ -52,6 +52,7 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -191,6 +192,23 @@ class GrpcProtocolHandlerTest {
         // Matches GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE in grpc-java:
         // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/GrpcUtil.java#L212
         assertThat(GrpcConfig.create().maxReadBufferSize(), is(4 * 1024 * 1024));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void oversizedMessageThrowsResourceExhausted() {
+        // grpc-java throws RESOURCE_EXHAUSTED (not a plain Java exception) for oversized messages.
+        // See: MessageDeframer.processHeader() in
+        // https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+        int limit = 100 * 1024;
+        GrpcProtocolHandler<?, ?> handler = new GrpcProtocolHandler<>(new UnimplementedGrpcConnectionContext(),
+                                                                       Http2Headers.create(WritableHeaders.create()),
+                                                                       null, 1, null,
+                                                                       Http2StreamState.OPEN, null,
+                                                                       GrpcConfig.builder().maxReadBufferSize(limit).build());
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class,
+                                                  () -> handler.allocateReadBuffer(limit + 1));
+        assertThat(ex.getStatus().getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
     }
 
     @Test

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMaxMessageSizeErrorTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/GrpcMaxMessageSizeErrorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.grpc;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.webserver.Router;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.grpc.GrpcConfig;
+import io.helidon.webserver.grpc.GrpcRouting;
+import io.helidon.webserver.grpc.uploads.UploadServiceGrpc;
+import io.helidon.webserver.grpc.uploads.Uploads.Ack;
+import io.helidon.webserver.grpc.uploads.Uploads.Data;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Verifies that an oversized inbound message causes the server to close the call
+ * with gRPC status {@code RESOURCE_EXHAUSTED}, matching grpc-java's behavior in
+ * {@code MessageDeframer.processHeader()}:
+ * https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+ */
+@ServerTest
+class GrpcMaxMessageSizeErrorTest extends BaseServiceTest {
+
+    private static final int LIMIT = 256 * 1024;
+
+    // One byte over the configured limit
+    private static final byte[] DATA_OVER_LIMIT = new byte[LIMIT + 1];
+
+    private UploadServiceGrpc.UploadServiceStub stub;
+
+    GrpcMaxMessageSizeErrorTest(WebServer server) {
+        super(server);
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder serverBuilder) {
+        serverBuilder.addProtocol(GrpcConfig.builder().maxReadBufferSize(LIMIT).build());
+    }
+
+    @SetUpRoute
+    static void routing(Router.RouterBuilder<?> router) {
+        router.addRouting(GrpcRouting.builder().service(new UploadService()));
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        super.beforeEach();
+        stub = UploadServiceGrpc.newStub(channel);
+    }
+
+    @AfterEach
+    void afterEach() throws InterruptedException {
+        super.afterEach();
+        stub = null;
+    }
+
+    @Test
+    void oversizedMessageReturnsResourceExhausted() throws Throwable {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        StreamObserver<Data> request = stub.upload(new StreamObserver<>() {
+            @Override
+            public void onNext(Ack value) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                errorRef.set(t);
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+
+        request.onNext(Data.newBuilder()
+                .setPayload(ByteString.copyFrom(DATA_OVER_LIMIT))
+                .build());
+
+        assertThat("Server did not respond within timeout", latch.await(10, TimeUnit.SECONDS), is(true));
+        assertThat("Expected an error response", errorRef.get(), is(notNullValue()));
+
+        // grpc-java uses RESOURCE_EXHAUSTED (not CANCELLED or UNKNOWN) for oversized messages.
+        // See: https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/MessageDeframer.java#L388-L393
+        Status status = Status.fromThrowable(errorRef.get());
+        assertThat(status.getCode(), is(Status.Code.RESOURCE_EXHAUSTED));
+    }
+}

--- a/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/UploadServiceTest.java
+++ b/webserver/tests/grpc/src/test/java/io/helidon/webserver/tests/grpc/UploadServiceTest.java
@@ -49,7 +49,8 @@ class UploadServiceTest extends BaseServiceTest {
     private static final byte[] DATA_250K = new byte[250 * 1024];
     private static final byte[] DATA_500K = new byte[500 * 1024];
 
-    private static final byte[] DATA_2100K = new byte[2100 * 1024];     // over default limit
+    // 5 MB: over the default 4 MB limit
+    private static final byte[] DATA_5000K = new byte[5000 * 1024];
 
     static {
         Arrays.fill(DATA_50K,  (byte) 'A');
@@ -136,7 +137,7 @@ class UploadServiceTest extends BaseServiceTest {
         requestRef.set(request);
 
         // upload data with size over default limit in GrpcConfig
-        Stream.of(DATA_2100K)
+        Stream.of(DATA_5000K)
                 .map(b -> Uploads.Data.newBuilder()
                         .setPayload(ByteString.copyFrom(b))
                         .build())


### PR DESCRIPTION
This PR addresses two related issues with gRPC inbound message size handling.

**#11719 — Default max message size (2 MB → 4 MB)**

`GrpcConfig.maxReadBufferSize()` previously defaulted to 2 MB. Other gRPC implementations default to 4 MB:
- grpc-java: [`GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE`](https://github.com/grpc/grpc-java/blob/v1.73.0/core/src/main/java/io/grpc/internal/GrpcUtil.java#L212)
- grpc-go: `defaultMaxRecvMsgSize` in `rpc_util.go`

Messages between 2 MB and 4 MB would succeed against any of those servers but be rejected by Helidon with default configuration. The default is now 4 MB to match. The limit remains configurable via `GrpcConfig.Builder.maxReadBufferSize()`.

**#11720 — RESOURCE_EXHAUSTED status for oversized messages**

When a message exceeded the size limit, the server threw a plain exception, which was caught and converted to `listener.onCancel()` and an ERROR log. The client received `CANCELLED` or `UNKNOWN` with no indication of the cause.

`allocateReadBuffer()` now throws `StatusRuntimeException(RESOURCE_EXHAUSTED)` with a description of the limit and actual size, following the convention established by grpc-java's `MessageDeframer.processHeader()`. A dedicated `catch (StatusRuntimeException)` block in `data()` closes the call with the correct status trailers and logs at DEBUG rather than ERROR.

**Testing**

- `GrpcProtocolHandlerTest.defaultMaxReadBufferSizeMatchesGrpcEcosystemStandard` — unit test asserting the 4 MB default
- `GrpcProtocolHandlerTest.oversizedMessageThrowsResourceExhausted` — unit test asserting `allocateReadBuffer()` throws `RESOURCE_EXHAUSTED`
- `GrpcMaxMessageSizeErrorTest.oversizedMessageReturnsResourceExhausted` — integration test verifying the client receives `Status.RESOURCE_EXHAUSTED`

**Documentation**

The maximum inbound message size the server tolerates by default increased from 2MB to 4MB. This is not a new feature or an API change, but an implementation detail change that could be of interest to some users.